### PR TITLE
Fix time_updated default :sweat:

### DIFF
--- a/backend/alembic/versions/47433d30de82_create_indexattempt_table.py
+++ b/backend/alembic/versions/47433d30de82_create_indexattempt_table.py
@@ -47,6 +47,7 @@ def upgrade() -> None:
         sa.Column(
             "time_updated",
             sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
             server_onupdate=sa.text("now()"),  # type: ignore
             nullable=True,
         ),

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -73,7 +73,7 @@ class IndexAttempt(Base):
         DateTime(timezone=True), server_default=func.now()
     )
     time_updated: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now()
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
     status: Mapped[IndexingStatus] = mapped_column(Enum(IndexingStatus))
     document_ids: Mapped[list[str] | None] = mapped_column(


### PR DESCRIPTION
Modifying existing migration to not create an unnecessary one line migration. Since this is not deployed for production use cases yet, it should be fine