### PR TITLE
Fix backend Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim-bullseye
 
 RUN apt-get update \
-    && apt-get install -y git cmake pkg-config libprotobuf-c-dev protobuf-compiler libprotobuf-dev libgoogle-perftools-dev build-essential \
+    && apt-get install -y git cmake pkg-config libprotobuf-c-dev protobuf-compiler libprotobuf-dev libgoogle-perftools-dev libpq-dev build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements/default.txt /tmp/requirements.txt

--- a/backend/Dockerfile.background
+++ b/backend/Dockerfile.background
@@ -1,7 +1,7 @@
 FROM python:3.11-slim-bullseye
 
 RUN apt-get update \
-    && apt-get install -y git cmake pkg-config libprotobuf-c-dev protobuf-compiler libprotobuf-dev libgoogle-perftools-dev build-essential cron \
+    && apt-get install -y git cmake pkg-config libprotobuf-c-dev protobuf-compiler libprotobuf-dev libgoogle-perftools-dev libpq-dev build-essential cron \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements/default.txt /tmp/requirements.txt


### PR DESCRIPTION
Need to install `libpq-dev` to be able to `pip install psycopg2`. 