### PR TITLE
Update the generative model inference temperature to 1

### DIFF
--- a/backend/danswer/direct_qa/question_answer.py
+++ b/backend/danswer/direct_qa/question_answer.py
@@ -336,7 +336,7 @@ class OpenAIChatCompletionQA(QAModel):
         try:
             response = openai.ChatCompletion.create(
                 messages=messages,
-                temperature=0,
+                temperature=1,
                 top_p=1,
                 frequency_penalty=0,
                 presence_penalty=0,


### PR DESCRIPTION
This PR changes the temperature param from 0 to 1 to get nondeterministic model outputs. This will help evaluate how close to wrong the answers are for when they are right and vise versa for when they are wrong. Since the model does not report certainty for the answers, this is a hacky proxy for that metric for now.