### PR TITLE
Replace IDs with names in Slack connector

### DIFF
--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -1,10 +1,15 @@
+import re
 import time
 from collections.abc import Callable
 from typing import Any
 from typing import cast
 
+from danswer.utils.logging import setup_logger
+from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
+
+logger = setup_logger()
 
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
@@ -72,3 +77,53 @@ def make_slack_api_rate_limited(
         raise Exception(f"Max retries ({max_retries}) exceeded")
 
     return rate_limited_call
+
+
+class UserIdReplacer:
+    """Utility class to replace user IDs with usernames in a message.
+    Handles caching, so the same request is not made multiple times
+    for the same user ID"""
+
+    def __init__(self, client: WebClient) -> None:
+        self._client = client
+        self._user_id_to_name_map: dict[str, str] = {}
+
+    def _get_slack_user_name(self, user_id: str) -> str:
+        if user_id not in self._user_id_to_name_map:
+            try:
+                response = make_slack_api_rate_limited(self._client.users_info)(
+                    user=user_id
+                )
+                # prefer display name if set, since that is what is shown in Slack
+                self._user_id_to_name_map[user_id] = (
+                    response["user"]["profile"]["display_name"]
+                    or response["user"]["profile"]["real_name"]
+                )
+            except SlackApiError as e:
+                logger.exception(
+                    f"Error fetching data for user {user_id}: {e.response['error']}"
+                )
+                raise
+
+        return self._user_id_to_name_map[user_id]
+
+    def replace_user_ids_with_names(self, message: str) -> str:
+        # Find user IDs in the message
+        user_ids = re.findall("<@(.*?)>", message)
+
+        # Iterate over each user ID found
+        for user_id in user_ids:
+            try:
+                if user_id in self._user_id_to_name_map:
+                    user_name = self._user_id_to_name_map[user_id]
+                else:
+                    user_name = self._get_slack_user_name(user_id)
+
+                # Replace the user ID with the username in the message
+                message = message.replace(f"<@{user_id}>", f"@{user_name}")
+            except Exception:
+                logger.exception(
+                    f"Unable to replace user ID with username for user_id '{user_id}"
+                )
+
+        return message

--- a/backend/danswer/listeners/slack_listener.py
+++ b/backend/danswer/listeners/slack_listener.py
@@ -68,13 +68,13 @@ def _process_quotes(
     for quote_dict in quotes.values():
         doc_id = str(quote_dict.get("document_id", ""))
         doc_link = quote_dict.get("link")
-        doc_name = quote_dict.get("semantic_identifier")
+        doc_name = str(quote_dict.get("semantic_identifier", ""))
         if doc_link and doc_name and doc_id and doc_id not in doc_identifiers:
-            doc_identifiers.append(str(doc_id))
+            doc_identifiers.append(doc_id)
             custom_semantic_identifier = _build_custom_semantic_identifier(
                 semantic_identifier=doc_name,
-                blurb=quote_dict.get("blurb", ""),
-                source=quote_dict.get("source_type", ""),
+                blurb=str(quote_dict.get("blurb", "")),
+                source=str(quote_dict.get("source_type", "")),
             )
             quote_lines.append(f"- <{doc_link}|{custom_semantic_identifier}>")
 


### PR DESCRIPTION
Tags are returned as `<@{USER_ID}>` by the Slack APIs. This PR replaces `<@{USER_ID}>` with `{DISPLAY_NAME}` to improve the display in the UI.