### PR TITLE
Added shell command to start frontend for windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,11 @@ To start the frontend, navigate to `danswer/web` and run:
 ```bash
 DISABLE_AUTH=true npm run dev
 ```
+_for Windows, run:_
+```bash
+$env:DISABLE_AUTH = "true"; npm run dev
+```
+
 
 The first time running Danswer, you will need to run the migrations. Navigate to `danswer/backend` and run:
 ```bash


### PR DESCRIPTION
**Getting error when trying to start frontend on windows**
<img width="450" alt="image" src="https://github.com/danswer-ai/danswer/assets/75850633/163c7e71-f9e7-483e-b9c0-b453de330347">

**Solution:**
Added command which can run enable frontend in windows
<img width="477" alt="image" src="https://github.com/danswer-ai/danswer/assets/75850633/f80e0526-2059-4d65-9d16-6f29c1143b31">
