### PR TITLE
cache models for faster development cycles in docker compose

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -29,6 +29,9 @@ services:
     volumes:
       - local_dynamic_storage:/home/storage
       - file_connector_tmp_storage:/home/file_connector_storage
+      - model_cache_torch:/root/.cache/torch/
+      - model_cache_nltk:/root/nltk_data/
+      - model_cache_huggingface:/root/.cache/huggingface/
   background:
     image: danswer/danswer-backend:latest
     build:
@@ -49,6 +52,10 @@ services:
     volumes:
       - local_dynamic_storage:/home/storage
       - file_connector_tmp_storage:/home/file_connector_storage
+      - model_cache_torch:/root/.cache/torch/
+      - model_cache_nltk:/root/nltk_data/
+      - model_cache_huggingface:/root/.cache/huggingface/
+
   web_server:
     image: danswer/danswer-web-server:latest
     build:
@@ -115,3 +122,6 @@ volumes:
   db_volume:
   qdrant_volume:
   typesense_volume:
+  model_cache_torch:
+  model_cache_nltk:
+  model_cache_huggingface:


### PR DESCRIPTION
Otherwise we will redownload all models on every start. This speeds up image start significantly.