### PR TITLE
catch crash when deleting a datasource

### DIFF
--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -92,6 +92,10 @@ def run_indexing_jobs(db_session: Session) -> None:
     new_indexing_attempts = get_not_started_index_attempts(db_session)
     logger.info(f"Found {len(new_indexing_attempts)} new indexing tasks.")
     for attempt in new_indexing_attempts:
+        if attempt.connector is None:
+            logger.warning(f"Skipping index task as connector has been deleted: {attempt}")
+            mark_attempt_failed(attempt, db_session, failure_reason="Connector is null")
+            continue
         logger.info(
             f"Starting new indexing attempt for connector: '{attempt.connector.name}', "
             f"with config: '{attempt.connector.connector_specific_config}', and "


### PR DESCRIPTION
Danswer background crashes when the index task for a deleted source is still in the task queue. Without this is won't recover without manual database cleanup.