### PR TITLE
prevent crash when semantic_identifier is None

### DIFF
--- a/backend/danswer/search/semantic_search.py
+++ b/backend/danswer/search/semantic_search.py
@@ -33,7 +33,7 @@ def chunks_to_search_docs(chunks: list[InferenceChunk] | None) -> list[SearchDoc
                 blurb=chunk.blurb,
                 source_type=chunk.source_type,
             )
-            for chunk in chunks
+            for chunk in chunks if chunk.semantic_identifier
         ]
         if chunks
         else []


### PR DESCRIPTION
This is a workaround around intermittent issues where sementic_identifier becomes None for some reason. It usually recovers when documents are rescraped.

Obviously, we do not yet understand the issue and are interested in a better solution.