### PR TITLE
Fix: Don't include archived Slack channels

### DIFF
--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -44,10 +44,10 @@ def get_channel_info(client: WebClient, channel_id: str) -> ChannelType:
     ]
 
 
-def get_channels(client: WebClient) -> list[ChannelType]:
+def get_channels(client: WebClient, exclude_archived: bool = True) -> list[ChannelType]:
     """Get all channels in the workspace"""
     channels: list[dict[str, Any]] = []
-    for result in _make_slack_api_call(client.conversations_list):
+    for result in _make_slack_api_call(client.conversations_list, exclude_archived=exclude_archived):
         channels.extend(result["channels"])
     return channels
 


### PR DESCRIPTION
Prevent the Slack connector from including archived channels.

Solves https://github.com/danswer-ai/danswer/issues/205