### PR TITLE
Prevent too many tokens to GPT

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -115,9 +115,11 @@ ENABLE_MINI_CHUNK = False
 # Mini chunks for fine-grained embedding, calculated as 128 tokens for 4 additional vectors for 512 chunk size above
 # Not rounded down to not lose any context in full chunk.
 MINI_CHUNK_SIZE = 512
-# Each chunk includes an additional 5 words from previous chunk
-# in extreme cases, may cause some words at the end to be truncated by embedding model
-CHUNK_OVERLAP = 5
+# Each chunk includes an additional CHUNK_WORD_OVERLAP words from previous chunk
+CHUNK_WORD_OVERLAP = 5
+# When trying to finish the last word in the chunk or counting back CHUNK_WORD_OVERLAP backwards,
+# This is the max number of characters allowed in either direction
+CHUNK_MAX_CHAR_OVERLAP = 50
 
 
 #####

--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -80,7 +80,7 @@ class WebConnector(LoadConnector):
                 continue
             visited_links.add(current_url)
 
-            logger.info(f"Indexing {current_url}")
+            logger.info(f"Visiting {current_url}")
 
             try:
                 current_visit_time = datetime.now().strftime("%B %d, %Y, %H:%M:%S")

--- a/backend/danswer/direct_qa/open_ai.py
+++ b/backend/danswer/direct_qa/open_ai.py
@@ -2,6 +2,7 @@ import json
 from abc import ABC
 from collections.abc import Callable
 from collections.abc import Generator
+from copy import copy
 from functools import wraps
 from typing import Any
 from typing import cast
@@ -92,16 +93,20 @@ def _handle_openai_exceptions_wrapper(openai_call: F, query: str) -> F:
 
 def _tiktoken_trim_chunks(
     chunks: list[InferenceChunk], model_version: str, max_chunk_toks: int = 512
-) -> None:
+) -> list[InferenceChunk]:
     """Edit chunks that have too high token count. Generally due to parsing issues or
     characters from another language that are 1 char = 1 token
     Trimming by tokens leads to information loss but currently no better way of handling
     """
     encoder = tiktoken.encoding_for_model(model_version)
-    for chunk in chunks:
+    new_chunks = copy(chunks)
+    for ind, chunk in enumerate(new_chunks):
         tokens = encoder.encode(chunk.content)
         if len(tokens) > max_chunk_toks:
-            chunk.content = encoder.decode(tokens[:max_chunk_toks])
+            new_chunk = copy(chunk)
+            new_chunk.content = encoder.decode(tokens[:max_chunk_toks])
+            new_chunks[ind] = new_chunk
+    return new_chunks
 
 
 # used to check if the QAModel is an OpenAI model
@@ -138,7 +143,7 @@ class OpenAICompletionQA(OpenAIQAModel):
     def answer_question(
         self, query: str, context_docs: list[InferenceChunk]
     ) -> tuple[DanswerAnswer, list[DanswerQuote]]:
-        _tiktoken_trim_chunks(context_docs, self.model_version)
+        context_docs = _tiktoken_trim_chunks(context_docs, self.model_version)
 
         filled_prompt = self.prompt_processor.fill_prompt(
             query, context_docs, self.include_metadata
@@ -168,7 +173,7 @@ class OpenAICompletionQA(OpenAIQAModel):
     def answer_question_stream(
         self, query: str, context_docs: list[InferenceChunk]
     ) -> Generator[dict[str, Any] | None, None, None]:
-        _tiktoken_trim_chunks(context_docs, self.model_version)
+        context_docs = _tiktoken_trim_chunks(context_docs, self.model_version)
 
         filled_prompt = self.prompt_processor.fill_prompt(
             query, context_docs, self.include_metadata
@@ -234,7 +239,7 @@ class OpenAIChatCompletionQA(OpenAIQAModel):
         query: str,
         context_docs: list[InferenceChunk],
     ) -> tuple[DanswerAnswer, list[DanswerQuote]]:
-        _tiktoken_trim_chunks(context_docs, self.model_version)
+        context_docs = _tiktoken_trim_chunks(context_docs, self.model_version)
 
         messages = self.prompt_processor.fill_prompt(
             query, context_docs, self.include_metadata
@@ -272,7 +277,7 @@ class OpenAIChatCompletionQA(OpenAIQAModel):
     def answer_question_stream(
         self, query: str, context_docs: list[InferenceChunk]
     ) -> Generator[dict[str, Any] | None, None, None]:
-        _tiktoken_trim_chunks(context_docs, self.model_version)
+        context_docs = _tiktoken_trim_chunks(context_docs, self.model_version)
 
         messages = self.prompt_processor.fill_prompt(
             query, context_docs, self.include_metadata

--- a/backend/danswer/search/semantic_search.py
+++ b/backend/danswer/search/semantic_search.py
@@ -58,7 +58,7 @@ def semantic_reranking(
 
     logger.debug(f"Reranked similarity scores: {ranked_sim_scores}")
 
-    return ranked_chunks
+    return list(ranked_chunks)
 
 
 @log_function_time()

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -37,6 +37,7 @@ sentence-transformers==2.2.2
 slack-sdk==3.20.2
 SQLAlchemy[mypy]==2.0.12
 tensorflow==2.12.0
+tiktoken==0.4.0
 transformers==4.30.1
 typesense==0.15.1
 uvicorn==0.21.1


### PR DESCRIPTION
This change introduces 2 new things:
1. Intelligent chunking would sometimes introduce too many new tokens because of the way words are broken up. Sometimes due to parsing issues, words are not separated so the default 5 overlap words introduce too many tokens. Set a strict limit on forward and backwards inclusions for every chunk.
2. Use Tiktoken library from OpenAI to unsure that the prompts never fail due to too many tokens.