### PR TITLE
Improve indexing status display

### DIFF
--- a/backend/alembic/versions/5e84129c8be3_add_docs_indexed_column_to_index_.py
+++ b/backend/alembic/versions/5e84129c8be3_add_docs_indexed_column_to_index_.py
@@ -1,0 +1,36 @@
+"""Add docs_indexed_column + time_started to index_attempt table
+
+Revision ID: 5e84129c8be3
+Revises: e6a4bbc13fe4
+Create Date: 2023-08-10 21:43:09.069523
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5e84129c8be3"
+down_revision = "e6a4bbc13fe4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "index_attempt",
+        sa.Column("num_docs_indexed", sa.Integer()),
+    )
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "time_started",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("index_attempt", "time_started")
+    op.drop_column("index_attempt", "num_docs_indexed")

--- a/backend/alembic/versions/e6a4bbc13fe4_add_index_for_retrieving_latest_index_.py
+++ b/backend/alembic/versions/e6a4bbc13fe4_add_index_for_retrieving_latest_index_.py
@@ -1,0 +1,32 @@
+"""Add index for retrieving latest index_attempt
+
+Revision ID: e6a4bbc13fe4
+Revises: b082fec533f0
+Create Date: 2023-08-10 12:37:23.335471
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e6a4bbc13fe4"
+down_revision = "b082fec533f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        op.f("ix_index_attempt_latest_for_connector_credential_pair"),
+        "index_attempt",
+        ["connector_id", "credential_id", "time_created"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_index_attempt_latest_for_connector_credential_pair"),
+        table_name="index_attempt",
+    )

--- a/backend/danswer/background/connector_deletion.py
+++ b/backend/danswer/background/connector_deletion.py
@@ -88,6 +88,7 @@ def _delete_connector_credential_pair(
         return num_docs_deleted
 
     num_docs_deleted = _delete_singly_indexed_docs()
+    logger.info(f"Deleted {num_docs_deleted} documents from document stores")
 
     def _update_multi_indexed_docs() -> None:
         # if a document is indexed by multiple connector_credential_pairs, we should
@@ -132,8 +133,8 @@ def _delete_connector_credential_pair(
         # categorize into groups of updates to try and batch them more efficiently
         update_groups: dict[tuple[str, ...], list[str]] = {}
         for document_id, allowed_users_lst in document_id_to_allowed_users.items():
-            # if document_id in document_ids_not_needing_update:
-            #     continue
+            if document_id in document_ids_not_needing_update:
+                continue
 
             allowed_users_lst.remove(to_be_deleted_user)
             allowed_users = tuple(sorted(set(allowed_users_lst)))

--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -328,7 +328,6 @@ class SlackPollConnector(PollConnector):
             raise ConnectorMissingCredentialError("Slack")
 
         documents: list[Document] = []
-        seen_doc_ids = set()
         for document in get_all_docs(
             client=self.client,
             workspace=self.workspace,
@@ -339,10 +338,6 @@ class SlackPollConnector(PollConnector):
             oldest=str(start) if start else None,
             latest=str(end),
         ):
-            if document.id in seen_doc_ids:
-                logger.info("DUPLICATE FOUND")
-                logger.info(document)
-            seen_doc_ids.add(document.id)
             documents.append(document)
             if len(documents) >= self.batch_size:
                 yield documents

--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -328,6 +328,7 @@ class SlackPollConnector(PollConnector):
             raise ConnectorMissingCredentialError("Slack")
 
         documents: list[Document] = []
+        seen_doc_ids = set()
         for document in get_all_docs(
             client=self.client,
             workspace=self.workspace,
@@ -338,6 +339,10 @@ class SlackPollConnector(PollConnector):
             oldest=str(start) if start else None,
             latest=str(end),
         ):
+            if document.id in seen_doc_ids:
+                logger.info("DUPLICATE FOUND")
+                logger.info(document)
+            seen_doc_ids.add(document.id)
             documents.append(document)
             if len(documents) >= self.batch_size:
                 yield documents

--- a/backend/danswer/db/connector_credential_pair.py
+++ b/backend/danswer/db/connector_credential_pair.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from danswer.db.connector import fetch_connector_by_id
 from danswer.db.credentials import fetch_credential_by_id
 from danswer.db.models import ConnectorCredentialPair
+from danswer.db.models import IndexAttempt
 from danswer.db.models import IndexingStatus
 from danswer.db.models import User
 from danswer.server.models import StatusResponse

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -185,12 +185,18 @@ class IndexAttempt(Base):
         nullable=True,
     )
     status: Mapped[IndexingStatus] = mapped_column(Enum(IndexingStatus))
+    num_docs_indexed: Mapped[int] = mapped_column(Integer, default=0)
     error_msg: Mapped[str | None] = mapped_column(
         String(), default=None
     )  # only filled if status = "failed"
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+    )
+    # when the actual indexing run began
+    # NOTE: will use the api_server clock rather than DB server clock
+    time_started: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), default=None
     )
     time_updated: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/danswer/server/models.py
+++ b/backend/danswer/server/models.py
@@ -17,6 +17,7 @@ from danswer.db.models import Connector
 from danswer.db.models import Credential
 from danswer.db.models import DeletionAttempt
 from danswer.db.models import DeletionStatus
+from danswer.db.models import IndexAttempt
 from danswer.db.models import IndexingStatus
 from danswer.search.models import QueryFlow
 from danswer.search.models import SearchType
@@ -124,6 +125,28 @@ class IndexAttemptRequest(BaseModel):
     connector_specific_config: dict[str, Any]
 
 
+class IndexAttemptSnapshot(BaseModel):
+    status: IndexingStatus | None
+    num_docs_indexed: int
+    error_msg: str | None
+    time_started: str | None
+    time_updated: str
+
+    @classmethod
+    def from_index_attempt_db_model(
+        cls, index_attempt: IndexAttempt
+    ) -> "IndexAttemptSnapshot":
+        return IndexAttemptSnapshot(
+            status=index_attempt.status,
+            num_docs_indexed=index_attempt.num_docs_indexed or 0,
+            error_msg=index_attempt.error_msg,
+            time_started=index_attempt.time_started.isoformat()
+            if index_attempt.time_started
+            else None,
+            time_updated=index_attempt.time_updated.isoformat(),
+        )
+
+
 class DeletionAttemptSnapshot(BaseModel):
     connector_id: int
     status: DeletionStatus
@@ -215,6 +238,8 @@ class ConnectorIndexingStatus(BaseModel):
     last_status: IndexingStatus | None
     last_success: datetime | None
     docs_indexed: int
+    error_msg: str | None
+    latest_index_attempt: IndexAttemptSnapshot | None
     deletion_attempts: list[DeletionAttemptSnapshot]
     is_deletable: bool
 

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -5,12 +5,18 @@ import useSWR from "swr";
 import { BasicTable } from "@/components/admin/connectors/BasicTable";
 import { LoadingAnimation } from "@/components/Loading";
 import { timeAgo } from "@/lib/time";
-import { NotebookIcon, XSquareIcon } from "@/components/icons/icons";
+import {
+  NotebookIcon,
+  QuestionIcon,
+  XSquareIcon,
+} from "@/components/icons/icons";
 import { fetcher } from "@/lib/fetcher";
 import { getSourceMetadata } from "@/components/source";
 import { CheckCircle, XCircle } from "@phosphor-icons/react";
 import { HealthCheckBanner } from "@/components/health/healthcheck";
 import { ConnectorIndexingStatus } from "@/lib/types";
+import { useState } from "react";
+import { getDocsProcessedPerMinute } from "@/lib/indexAttempt";
 
 const getSourceDisplay = (
   connectorIndexingStatus: ConnectorIndexingStatus<any, any>
@@ -59,6 +65,33 @@ const getSourceDisplay = (
   return sourceMetadata.displayName;
 };
 
+const ErrorDisplay = ({ message }: { message: string }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  return (
+    <div
+      onMouseEnter={() => {
+        setIsHovered(true);
+      }}
+      onMouseLeave={() => setIsHovered(false)}
+      className="relative"
+    >
+      {isHovered && (
+        <div className="absolute pt-8 top-0 left-0">
+          <div className="bg-gray-700 px-3 pb-3 pt-2 rounded shadow-lg text-xs">
+            <div className="text-sm text-red-600 mb-1 flex">Error Message:</div>
+
+            {message}
+          </div>
+        </div>
+      )}
+      <div className="text-red-600 flex cursor-default">
+        <QuestionIcon className="my-auto mr-1" size={18} />
+        Error
+      </div>
+    </div>
+  );
+};
+
 function Main() {
   const {
     data: indexAttemptData,
@@ -102,7 +135,9 @@ function Main() {
         const sourceMetadata = getSourceMetadata(
           connectorIndexingStatus.connector.source
         );
-        let statusDisplay = <div className="text-gray-400">In Progress...</div>;
+        let statusDisplay = (
+          <div className="text-gray-400">Initializing...</div>
+        );
         if (connectorIndexingStatus.connector.disabled) {
           statusDisplay = (
             <div className="text-red-600 flex">
@@ -119,9 +154,33 @@ function Main() {
           );
         } else if (connectorIndexingStatus.last_status === "failed") {
           statusDisplay = (
-            <div className="text-red-600 flex">
-              <XCircle className="my-auto mr-1" size="18" />
-              Error
+            <ErrorDisplay message={connectorIndexingStatus.error_msg} />
+          );
+        } else if (connectorIndexingStatus.last_status === "not_started") {
+          statusDisplay = <div className="text-gray-400">Scheduled</div>;
+        } else if (connectorIndexingStatus.last_status === "in_progress") {
+          const docsPerMinute = getDocsProcessedPerMinute(
+            connectorIndexingStatus.latest_index_attempt
+          )?.toFixed(2);
+          statusDisplay = (
+            <div className="text-gray-400">
+              <b>In Progress...</b>{" "}
+              {connectorIndexingStatus?.latest_index_attempt
+                ?.num_docs_indexed ? (
+                <div className="text-xs mt-0.5">
+                  <div>
+                    Current Run:{" "}
+                    {
+                      connectorIndexingStatus.latest_index_attempt
+                        .num_docs_indexed
+                    }{" "}
+                    docs indexed
+                  </div>
+                  {docsPerMinute && (
+                    <div>Speed: ~{docsPerMinute} docs / min</div>
+                  )}
+                </div>
+              ) : null}
             </div>
           );
         }
@@ -132,7 +191,7 @@ function Main() {
             : "-",
           connector: (
             <a
-              className="text-blue-500 flex"
+              className="text-blue-500 flex w-fit"
               href={sourceMetadata.adminPageLink}
             >
               {sourceMetadata.icon({ size: 20 })}

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -164,12 +164,12 @@ function Main() {
           )?.toFixed(2);
           statusDisplay = (
             <div className="text-gray-400">
-              <b>In Progress...</b>{" "}
+              In Progress...{" "}
               {connectorIndexingStatus?.latest_index_attempt
                 ?.num_docs_indexed ? (
                 <div className="text-xs mt-0.5">
                   <div>
-                    Current Run:{" "}
+                    <i>Current Run:</i>{" "}
                     {
                       connectorIndexingStatus.latest_index_attempt
                         .num_docs_indexed
@@ -177,7 +177,9 @@ function Main() {
                     docs indexed
                   </div>
                   {docsPerMinute && (
-                    <div>Speed: ~{docsPerMinute} docs / min</div>
+                    <div>
+                      <i>Speed:</i> ~{docsPerMinute} docs / min
+                    </div>
                   )}
                 </div>
               ) : null}

--- a/web/src/components/admin/connectors/table/ConnectorsTable.tsx
+++ b/web/src/components/admin/connectors/table/ConnectorsTable.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import { LinkBreakIcon, LinkIcon, TrashIcon } from "@/components/icons/icons";
 import { updateConnector } from "@/lib/connector";
 import { AttachCredentialButtonForTable } from "@/components/admin/connectors/buttons/AttachCredentialButtonForTable";
-import { scheduleDeletionJobForConnector } from "@/lib/documentDeletion";
 import { DeleteColumn } from "./DeleteColumn";
 
 interface StatusRowProps<ConnectorConfigType, ConnectorCredentialType> {

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -12,6 +12,7 @@ import {
   Brain,
   PencilSimple,
   X,
+  Question,
 } from "@phosphor-icons/react";
 import { SiBookstack } from "react-icons/si";
 import { FaFile, FaGlobe } from "react-icons/fa";
@@ -95,6 +96,13 @@ export const InfoIcon = ({
   className = defaultTailwindCSS,
 }: IconProps) => {
   return <Info size={size} className={className} />;
+};
+
+export const QuestionIcon = ({
+  size = 16,
+  className = defaultTailwindCSS,
+}: IconProps) => {
+  return <Question size={size} className={className} />;
 };
 
 export const BrainIcon = ({

--- a/web/src/lib/indexAttempt.ts
+++ b/web/src/lib/indexAttempt.ts
@@ -1,0 +1,26 @@
+import { IndexAttemptSnapshot } from "./types";
+
+export const getDocsProcessedPerMinute = (
+  indexAttempt: IndexAttemptSnapshot | null
+): number | null => {
+  if (
+    !indexAttempt ||
+    !indexAttempt.time_started ||
+    !indexAttempt.time_updated ||
+    indexAttempt.num_docs_indexed === 0
+  ) {
+    return null;
+  }
+
+  const timeStarted = new Date(indexAttempt.time_started);
+  const timeUpdated = new Date(indexAttempt.time_updated);
+  const timeDiff = timeUpdated.getTime() - timeStarted.getTime();
+  const seconds = timeDiff / 1000;
+  // due to some issues with `time_updated` having delayed updates,
+  // the docs / min will be really high at first. To avoid this,
+  // we can wait a little bit to let the updated_at catch up a bit
+  if (seconds < 10) {
+    return null;
+  }
+  return (indexAttempt.num_docs_indexed / seconds) * 60;
+};

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -87,6 +87,14 @@ export interface FileConfig {
 
 export interface NotionConfig {}
 
+export interface IndexAttemptSnapshot {
+  status: ValidStatuses | null;
+  num_docs_indexed: number;
+  error_msg: string | null;
+  time_started: string | null;
+  time_updated: string;
+}
+
 export interface ConnectorIndexingStatus<
   ConnectorConfigType,
   ConnectorCredentialType
@@ -98,6 +106,8 @@ export interface ConnectorIndexingStatus<
   last_status: ValidStatuses | null;
   last_success: string | null;
   docs_indexed: number;
+  error_msg: string;
+  latest_index_attempt: IndexAttemptSnapshot | null;
   deletion_attempts: DeletionAttemptSnapshot[];
   is_deletable: boolean;
 }


### PR DESCRIPTION
Adds:
- actual error message in UI for indexing failure
- if a connector is disabled, stops indexing immediately (after the current batch of documents) to allow for deletion
- adds num docs indexed for the current run + a speed

<img width="1436" alt="Screenshot 2023-08-12 at 2 14 10 PM" src="https://github.com/danswer-ai/danswer/assets/25087905/569683dd-ca79-4e83-a28c-8ee433c4bdd0">
