### PR TITLE
Cleanup for Mintlify Websites

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -124,10 +124,10 @@ FILE_CONNECTOR_TMP_STORAGE_PATH = os.environ.get(
 )
 # TODO these should be available for frontend configuration, via advanced options expandable
 WEB_CONNECTOR_IGNORED_CLASSES = os.environ.get(
-    "WEB_CONNECTOR_IGNORED_CLASSES", "sidebar,header,footer"
+    "WEB_CONNECTOR_IGNORED_CLASSES", "sidebar,footer"
 ).split(",")
 WEB_CONNECTOR_IGNORED_ELEMENTS = os.environ.get(
-    "WEB_CONNECTOR_IGNORED_ELEMENTS", "nav,header,footer,meta,script,style,symbol,aside"
+    "WEB_CONNECTOR_IGNORED_ELEMENTS", "nav,footer,meta,script,style,symbol,aside"
 ).split(",")
 WEB_CONNECTOR_OAUTH_CLIENT_ID = os.environ.get("WEB_CONNECTOR_OAUTH_CLIENT_ID")
 WEB_CONNECTOR_OAUTH_CLIENT_SECRET = os.environ.get("WEB_CONNECTOR_OAUTH_CLIENT_SECRET")


### PR DESCRIPTION
Lots of doc sites using Mintlify can be cleaned up in the same way.
Default turned on for other sites because it's fairly generally applicable.
Also allowing Headers to be included in website parsing again as sometimes the info is relevant.