### PR TITLE
Fix Slackbot Tagging people or groups

### DIFF
--- a/backend/danswer/bots/slack/blocks.py
+++ b/backend/danswer/bots/slack/blocks.py
@@ -96,9 +96,7 @@ def build_documents_blocks(
 
         section_blocks.append(
             SectionBlock(
-                fields=[
-                    f"<{d.link}|{doc_sem_id}>:\n>{remove_slack_text_interactions(match_str)}",
-                ]
+                text=f"<{d.link}|{doc_sem_id}>:\n>{remove_slack_text_interactions(match_str)}"
             ),
         )
 

--- a/backend/danswer/bots/slack/utils.py
+++ b/backend/danswer/bots/slack/utils.py
@@ -117,4 +117,5 @@ def remove_slack_text_interactions(slack_str: str) -> str:
     slack_str = UserIdReplacer.replace_channels_basic(slack_str)
     slack_str = UserIdReplacer.replace_special_mentions(slack_str)
     slack_str = UserIdReplacer.replace_links(slack_str)
+    slack_str = UserIdReplacer.add_zero_width_whitespace_after_tag(slack_str)
     return slack_str

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -199,5 +199,5 @@ class UserIdReplacer:
 
     @staticmethod
     def add_zero_width_whitespace_after_tag(message: str) -> str:
-        """Add a 0 width whitespace after ever @"""
+        """Add a 0 width whitespace after every @"""
         return message.replace("@", "@\u200B")

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -196,3 +196,8 @@ class UserIdReplacer:
                 )
                 message = message.replace(f"<{possible_link}>", link_display)
         return message
+
+    @staticmethod
+    def add_zero_width_whitespace_after_tag(message: str) -> str:
+        """Add a 0 width whitespace after ever @"""
+        return message.replace("@", "@\u200B")


### PR DESCRIPTION
Add whitespace after the @ symbol so that it never matches the special slack pattern