### PR TITLE
Offer a Build with Zulip Disabled

### DIFF
--- a/.github/workflows/docker-build-push-backend-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-backend-container-on-tag.yml
@@ -30,5 +30,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          danswer/danswer-backend:${{ github.ref_name }}
-          danswer/danswer-backend:latest
+          danswer/danswer-backend-no-zulip:${{ github.ref_name }}
+          danswer/danswer-backend-no-zulip:latest

--- a/.github/workflows/docker-build-push-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-web-container-on-tag.yml
@@ -30,5 +30,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          danswer/danswer-web-server:${{ github.ref_name }}
-          danswer/danswer-web-server:latest
+          danswer/danswer-web-server-no-zulip:${{ github.ref_name }}
+          danswer/danswer-web-server-no-zulip:latest

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Pull, Tag and Push Web Server Image
       run: |
-        docker buildx imagetools create -t danswer/danswer-web-server:latest danswer/danswer-web-server:${{ github.event.inputs.version }}
+        docker buildx imagetools create -t danswer/danswer-web-server-no-zulip:latest danswer/danswer-web-server-no-zulip:${{ github.event.inputs.version }}
 
     - name: Pull, Tag and Push API Server Image
       run: |
-        docker buildx imagetools create -t danswer/danswer-backend:latest danswer/danswer-backend:${{ github.event.inputs.version }}
+        docker buildx imagetools create -t danswer/danswer-backend-no-zulip:latest danswer/danswer-backend-no-zulip:${{ github.event.inputs.version }}

--- a/backend/danswer/connectors/factory.py
+++ b/backend/danswer/connectors/factory.py
@@ -86,6 +86,10 @@ def instantiate_connector(
     credentials: dict[str, Any],
 ) -> tuple[BaseConnector, dict[str, Any] | None]:
     connector_class = identify_connector_class(source, input_type)
+
+    if isinstance(connector_class, ZulipConnector):
+        raise ValueError("Zulip is disabled on this branch")
+
     connector = connector_class(**connector_specific_config)
     new_credentials = connector.load_credentials(credentials)
 

--- a/backend/danswer/connectors/zulip/connector.py
+++ b/backend/danswer/connectors/zulip/connector.py
@@ -5,8 +5,6 @@ from typing import Any
 from typing import List
 from typing import Tuple
 
-from zulip import Client
-
 from danswer.configs.app_configs import INDEX_BATCH_SIZE
 from danswer.configs.constants import DocumentSource
 from danswer.connectors.interfaces import GenerateDocumentsOutput
@@ -28,6 +26,23 @@ from danswer.utils.logger import setup_logger
 # 2. Add end date support once https://github.com/zulip/zulip/issues/25436 is solved
 
 logger = setup_logger()
+
+
+class DummyZulipClient:
+    """Due to certain container security scan not distinguishing Zulip client/server and mismarking
+    Zulip client as having a server only vulnerability this branch has zulip disabled"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Zulip client library not installed.")
+
+
+try:
+    from zulip import Client  # type:ignore
+except ImportError:
+    logger.warning(
+        "Zulip is not installed on this branch, please check out Danswer main to use Zulip"
+    )
+    Client = DummyZulipClient
 
 
 class ZulipConnector(LoadConnector, PollConnector):

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -52,4 +52,4 @@ tiktoken==0.4.0
 transformers==4.30.1
 typesense==0.15.1
 uvicorn==0.21.1
-zulip==0.8.2
+#zulip==0.8.2

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   api_server:
-    image: danswer/danswer-backend:latest
+    image: danswer/danswer-backend-no-zulip:latest
     build:
       context: ../../backend
       dockerfile: Dockerfile
@@ -44,7 +44,7 @@ services:
       - model_cache_nltk:/root/nltk_data/
       - model_cache_huggingface:/root/.cache/huggingface/
   background:
-    image: danswer/danswer-backend:latest
+    image: danswer/danswer-backend-no-zulip:latest
     build:
       context: ../../backend
       dockerfile: Dockerfile
@@ -79,7 +79,7 @@ services:
       - model_cache_nltk:/root/nltk_data/
       - model_cache_huggingface:/root/.cache/huggingface/
   web_server:
-    image: danswer/danswer-web-server:latest
+    image: danswer/danswer-web-server-no-zulip:latest
     build:
       context: ../../web
       dockerfile: Dockerfile

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   api_server:
-    image: danswer/danswer-backend:latest
+    image: danswer/danswer-backend-no-zulip:latest
     build:
       context: ../../backend
       dockerfile: Dockerfile
@@ -25,7 +25,7 @@ services:
       - model_cache_nltk:/root/nltk_data/
       - model_cache_huggingface:/root/.cache/huggingface/
   background:
-    image: danswer/danswer-backend:latest
+    image: danswer/danswer-backend-no-zulip:latest
     build:
       context: ../../backend
       dockerfile: Dockerfile
@@ -46,7 +46,7 @@ services:
       - model_cache_nltk:/root/nltk_data/
       - model_cache_huggingface:/root/.cache/huggingface/
   web_server:
-    image: danswer/danswer-web-server:latest
+    image: danswer/danswer-web-server-no-zulip:latest
     build:
       context: ../../web
       dockerfile: Dockerfile

--- a/deployment/kubernetes/api_server-service-deployment.yaml
+++ b/deployment/kubernetes/api_server-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: api-server
-        image: danswer/danswer-backend:latest
+        image: danswer/danswer-backend-no-zulip:latest
         imagePullPolicy: IfNotPresent
         command:
           - "/bin/sh"

--- a/deployment/kubernetes/background-deployment.yaml
+++ b/deployment/kubernetes/background-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: background
-        image: danswer/danswer-backend:latest
+        image: danswer/danswer-backend-no-zulip:latest
         imagePullPolicy: IfNotPresent
         command: ["/usr/bin/supervisord"]
         env:

--- a/deployment/kubernetes/web_server-service-deployment.yaml
+++ b/deployment/kubernetes/web_server-service-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: web-server
-        image: danswer/danswer-web-server:latest
+        image: danswer/danswer-web-server-no-zulip:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/web/src/app/admin/connectors/zulip/page.tsx
+++ b/web/src/app/admin/connectors/zulip/page.tsx
@@ -90,16 +90,7 @@ const MainSection = () => {
       ) : (
         <>
           <p className="text-sm mb-4">
-            To use the Zulip connector, you must first provide content of the
-            zuliprc config file. For more details on setting up the Danswer
-            Zulip connector, see the{" "}
-            <a
-              className="text-blue-500"
-              href="https://docs.danswer.dev/connectors/zulip"
-            >
-              docs
-            </a>
-            .
+            WARNING: THIS CONNECTOR IS DISABLED ON THE BACKEND, THIS WILL NOT WORK
           </p>
           <div className="border-solid border-gray-600 border rounded-md p-6 mt-2">
             <CredentialForm<ZulipCredentialJson>

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -163,6 +163,7 @@ export default async function AdminLayout({
                   ),
                   link: "/admin/connectors/bookstack",
                 },
+                /*
                 {
                   name: (
                     <div className="flex">
@@ -172,6 +173,7 @@ export default async function AdminLayout({
                   ),
                   link: "/admin/connectors/zulip",
                 },
+                */
                 {
                   name: (
                     <div className="flex">

--- a/web/src/components/source.tsx
+++ b/web/src/components/source.tsx
@@ -90,12 +90,14 @@ export const getSourceMetadata = (sourceType: ValidSources): SourceMetadata => {
         displayName: "Notion",
         adminPageLink: "/admin/connectors/notion",
       };
+    /*
     case "zulip":
       return {
         icon: ZulipIcon,
         displayName: "Zulip",
         adminPageLink: "/admin/connectors/zulip",
       };
+    */
     case "guru":
       return {
         icon: GuruIcon,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -19,7 +19,7 @@ export type ValidSources =
   | "slab"
   | "notion"
   | "guru"
-  | "zulip"
+  //| "zulip"
   | "linear"
   | "file";
 export type ValidInputTypes = "load_state" | "poll" | "event";

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -19,7 +19,7 @@ export type ValidSources =
   | "slab"
   | "notion"
   | "guru"
-  //| "zulip"
+  | "zulip"
   | "linear"
   | "file";
 export type ValidInputTypes = "load_state" | "poll" | "event";


### PR DESCRIPTION
Because certain container scan apps can't distinguish between Zulip client and Zulip server, it mistakenly believes there's an upgradable version for a Zulip Server security patch. But this is not the case as the client version and sever version are completely separate and the client neither has the vulnerability or patch.