### PR TITLE
fix: remove \xa0 from code blocks

### DIFF
--- a/backend/danswer/utils/text_processing.py
+++ b/backend/danswer/utils/text_processing.py
@@ -29,7 +29,7 @@ def extract_embedded_json(s: str) -> dict:
 
 
 def clean_up_code_blocks(model_out_raw: str) -> str:
-    return model_out_raw.strip().strip("```").strip()
+    return model_out_raw.strip().strip("```").strip().replace("\\xa0", "")
 
 
 def clean_model_quote(quote: str, trim_length: int) -> str:


### PR DESCRIPTION
Handle quotes with '\xa0' inside (Azure OpenAI answer - GPT3.5-turbo). Avoids to get the error:

```
Error occurred in call to LLM - Invalid \escape: line 1 column 1364 (char 1363) - Traceback (most recent call last):
  File "/app/danswer/direct_qa/answer_question.py", line 147, in answer_qa_query
    d_answer, quotes = qa_model.answer_question(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/danswer/direct_qa/qa_block.py", line 281, in answer_question
    return self._qa_handler.process_llm_output(model_out, trimmed_context_docs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/danswer/direct_qa/qa_block.py", line 171, in process_llm_output
    return process_answer(
           ^^^^^^^^^^^^^^^
  File "/app/danswer/direct_qa/qa_utils.py", line 162, in process_answer
    answer, quote_strings = separate_answer_quotes(answer_clean, is_json_prompt)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/danswer/direct_qa/qa_utils.py", line 87, in separate_answer_quotes
    model_raw_json = json.loads(answer_raw)
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Invalid \escape: line 1 column 1364 (char 1363)
```