### PR TITLE
Fix Divide by Zero Edge Case

### DIFF
--- a/backend/danswer/configs/model_configs.py
+++ b/backend/danswer/configs/model_configs.py
@@ -38,6 +38,9 @@ CROSS_ENCODER_MODEL_ENSEMBLE = [
     "cross-encoder/ms-marco-MiniLM-L-4-v2",
     "cross-encoder/ms-marco-TinyBERT-L-2-v2",
 ]
+# For score normalizing purposes, only way is to know the expected ranges
+CROSS_ENCODER_RANGE_MAX = 12
+CROSS_ENCODER_RANGE_MIN = -12
 CROSS_EMBED_CONTEXT_SIZE = 512
 
 


### PR DESCRIPTION
If a single doc is returned, the normalize before boosting step causes divide by zero if reranking is skipped.
Also for reranking this could happen with bad model configs, though this is unlikely