### PR TITLE
Provide Env variable to have chat flow always use the tools prompt

### DIFF
--- a/backend/danswer/configs/chat_configs.py
+++ b/backend/danswer/configs/chat_configs.py
@@ -1,0 +1,3 @@
+import os
+
+FORCE_TOOL_PROMPT = os.environ.get("FORCE_TOOL_PROMPT", "").lower() == "true"


### PR DESCRIPTION
This only has an effect for contextual chat.  However, we can forcibly use the tools prompt now even if no tools are configured.