### PR TITLE
Comments on advanced DanswerBot options

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -221,22 +221,19 @@ LOG_ALL_MODEL_INTERACTIONS = (
 #####
 # Danswer Slack Bot Configs
 #####
-DANSWER_BOT_NUM_DOCS_TO_DISPLAY = int(
-    os.environ.get("DANSWER_BOT_NUM_DOCS_TO_DISPLAY", "5")
-)
 DANSWER_BOT_NUM_RETRIES = int(os.environ.get("DANSWER_BOT_NUM_RETRIES", "5"))
 DANSWER_BOT_ANSWER_GENERATION_TIMEOUT = int(
     os.environ.get("DANSWER_BOT_ANSWER_GENERATION_TIMEOUT", "90")
 )
-DANSWER_BOT_DISPLAY_ERROR_MSGS = os.environ.get(
-    "DANSWER_BOT_DISPLAY_ERROR_MSGS", ""
-).lower() not in [
-    "false",
-    "",
-]
+# Number of docs to display in "Reference Documents"
+DANSWER_BOT_NUM_DOCS_TO_DISPLAY = int(
+    os.environ.get("DANSWER_BOT_NUM_DOCS_TO_DISPLAY", "5")
+)
+# If the LLM fails to answer, Danswer can still show the "Reference Documents"
 DANSWER_BOT_DISABLE_DOCS_ONLY_ANSWER = os.environ.get(
     "DANSWER_BOT_DISABLE_DOCS_ONLY_ANSWER", ""
 ).lower() not in ["false", ""]
+# When Danswer is considering a message, what emoji does it react with
 DANSWER_REACT_EMOJI = os.environ.get("DANSWER_REACT_EMOJI") or "eyes"
 # Should DanswerBot send an apology message if it's not able to find an answer
 # That way the user isn't confused as to why DanswerBot reacted but then said nothing
@@ -244,6 +241,14 @@ DANSWER_REACT_EMOJI = os.environ.get("DANSWER_REACT_EMOJI") or "eyes"
 NOTIFY_SLACKBOT_NO_ANSWER = (
     os.environ.get("NOTIFY_SLACKBOT_NO_ANSWER", "").lower() == "true"
 )
+# Mostly for debugging purposes but it's for explaining what went wrong
+# if DanswerBot couldn't find an answer
+DANSWER_BOT_DISPLAY_ERROR_MSGS = os.environ.get(
+    "DANSWER_BOT_DISPLAY_ERROR_MSGS", ""
+).lower() not in [
+    "false",
+    "",
+]
 # Default is only respond in channels that are included by a slack config set in the UI
 DANSWER_BOT_RESPOND_EVERY_CHANNEL = (
     os.environ.get("DANSWER_BOT_RESPOND_EVERY_CHANNEL", "").lower() == "true"
@@ -254,6 +259,7 @@ DANSWER_BOT_RESPOND_EVERY_CHANNEL = (
 ENABLE_DANSWERBOT_REFLEXION = (
     os.environ.get("ENABLE_DANSWERBOT_REFLEXION", "").lower() == "true"
 )
+# Add the per document feedback blocks that affect the document rankings via boosting
 ENABLE_SLACK_DOC_FEEDBACK = (
     os.environ.get("ENABLE_SLACK_DOC_FEEDBACK", "").lower() == "true"
 )


### PR DESCRIPTION
More advanced and less used options for configuring the Slack Bot are only configurable via Environment variables. This PR adds descriptions since the Danswer docs will just refer the user to the file directly