### PR TITLE
Update Danswer Docs Pointers

### DIFF
--- a/web/src/app/admin/connectors/document360/page.tsx
+++ b/web/src/app/admin/connectors/document360/page.tsx
@@ -96,15 +96,14 @@ const MainSection = () => {
         <>
           <p className="text-sm mb-4">
             To use the Document360 connector, you must first provide the API
-            token and portal ID corresponding to your Document360 setup. For
-            more details, see the{" "}
+            token and portal ID corresponding to your Document360 setup. See setup guide{" "}
             <a
               className="text-blue-500"
-              href="https://apidocs.document360.com/apidocs/api-token"
+              href="https://docs.danswer.dev/connectors/document360"
             >
-              official Document360 documentation
+              here
             </a>
-            .
+            {" "}for more detail.
           </p>
           <div className="border-solid border-gray-600 border rounded-md p-6 mt-2">
             <CredentialForm<Document360CredentialJson>

--- a/web/src/app/admin/connectors/linear/page.tsx
+++ b/web/src/app/admin/connectors/linear/page.tsx
@@ -106,7 +106,7 @@ const Main = () => {
             To use the Linear connector, first follow the guide{" "}
             <a
               className="text-blue-500"
-              href="https://docs.danswer.dev/connectors/jira#setting-up"
+              href="https://docs.danswer.dev/connectors/linear"
             >
               here
             </a>{" "}

--- a/web/src/app/admin/connectors/slab/page.tsx
+++ b/web/src/app/admin/connectors/slab/page.tsx
@@ -107,7 +107,7 @@ const Main = () => {
             To use the Slab connector, first follow the guide{" "}
             <a
               className="text-blue-500"
-              href="https://docs.danswer.dev/connectors/slab#setting-up"
+              href="https://docs.danswer.dev/connectors/slab"
             >
               here
             </a>{" "}


### PR DESCRIPTION
New pages now available on https://docs.danswer.dev/
This change points the page references in the UI to the new pages