### PR TITLE
Increasing OpenAi  api key verification timeout

### DIFF
--- a/backend/danswer/direct_qa/llm_utils.py
+++ b/backend/danswer/direct_qa/llm_utils.py
@@ -37,7 +37,7 @@ def check_model_api_key_is_valid(model_api_key: str) -> bool:
     if not model_api_key:
         return False
 
-    llm = get_default_llm(api_key=model_api_key, timeout=5)
+    llm = get_default_llm(api_key=model_api_key, timeout=10)
 
     # try for up to 2 timeouts (e.g. 10 seconds in total)
     for _ in range(2):


### PR DESCRIPTION
Openapi API key verification timeout is too short and can causes an error that increasing the timeout solves.