### PR TITLE
Google Drive shared files indexing fix

### DIFF
--- a/backend/danswer/connectors/google_drive/connector.py
+++ b/backend/danswer/connectors/google_drive/connector.py
@@ -99,7 +99,7 @@ def _run_drive_file_query(
                     file = service.files().get(
                         fileId=file["shortcutDetails"]["targetId"],
                         supportsAllDrives=include_shared,
-                        fields="mimeType, id, name, webViewLink, shortcutDetails",
+                        fields="mimeType, id, name, modifiedTime, webViewLink, shortcutDetails",
                     )
                     file = file.execute()
                 except HttpError:


### PR DESCRIPTION
"modifiedTime" attribute is missing from file object and making the Gdrive connector unable to index shared files