### PR TITLE
Added connector configuration link and external link icon to web connectors page.

### DIFF
--- a/web/src/app/admin/connectors/web/page.tsx
+++ b/web/src/app/admin/connectors/web/page.tsx
@@ -4,7 +4,7 @@ import useSWR, { useSWRConfig } from "swr";
 import * as Yup from "yup";
 
 import { LoadingAnimation } from "@/components/Loading";
-import { GlobeIcon } from "@/components/icons/icons";
+import { GlobeIcon, GearIcon, ArrowSquareOutIcon } from "@/components/icons/icons";
 import { fetcher } from "@/lib/fetcher";
 import {
   SelectorFormField,
@@ -32,7 +32,7 @@ export default function Web() {
     "/api/manage/admin/connector/indexing-status",
     fetcher
   );
-
+  
   const webIndexingStatuses: ConnectorIndexingStatus<WebConfig, {}>[] =
     connectorIndexingStatuses?.filter(
       (connectorIndexingStatus) =>
@@ -119,13 +119,16 @@ export default function Web() {
             {
               header: "Base URL",
               key: "base_url",
-              getValue: (ccPairConfig) => {
+              getValue: (ccPairStatus: ConnectorIndexingStatus<WebConfig, any>) => {
                 const connectorConfig =
-                  ccPairConfig.connector.connector_specific_config;
+                  ccPairStatus.connector.connector_specific_config;
                 return (
-                  <a className="text-blue-500" href={connectorConfig.base_url}>
+                  <div className="flex w-fit"><a className="text-blue-500 ml-1 my-auto flex" href={connectorConfig.base_url}>
                     {connectorConfig.base_url}
+                    <ArrowSquareOutIcon className="my-auto flex flex-shrink-0 text-blue-500" />
                   </a>
+                  <a className="my-auto" href={`/admin/connector/${ccPairStatus.cc_pair_id}`}><GearIcon className="ml-2 my-auto flex flex-shrink-0 text-gray-400" /></a>
+                  </div>
                 );
               },
             },

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -12,6 +12,8 @@ import {
   X,
   Question,
   Users,
+  Gear,
+  ArrowSquareOut,
 } from "@phosphor-icons/react";
 import {
   FiCheck,
@@ -82,6 +84,20 @@ export const UsersIcon = ({
 }: IconProps) => {
   return <Users size={size} className={className} />;
 };
+
+export const GearIcon = ({
+  size = 16,
+  className = defaultTailwindCSS,
+}: IconProps) => {
+  return <Gear size={size} className={className} />;
+};
+
+export const ArrowSquareOutIcon = ({
+  size = 16,
+  className = defaultTailwindCSS,
+}: IconProps) => {
+  return <ArrowSquareOut size={size} className={className} />;
+}
 
 export const TrashIcon = ({
   size = 16,


### PR DESCRIPTION
New: <img width="1390" alt="SCR-20231113-jvhx" src="https://github.com/danswer-ai/danswer/assets/6219801/5970cdd7-8981-400f-88f2-08b2ddfd71f3">
specifically 
<img width="305" alt="image" src="https://github.com/danswer-ai/danswer/assets/6219801/10e5346d-e31c-4084-8612-d0251b4c420b">

Added a gear icon that links to the connector's configuration page. The base URL still links to the base URL, but now features an external link indicator icon.

Previously: 
<img width="1376" alt="SCR-20231113-jvqe" src="https://github.com/danswer-ai/danswer/assets/6219801/6985d2c6-5b5e-49e4-8dfb-1223e54b7dc5">
<img width="398" alt="image" src="https://github.com/danswer-ai/danswer/assets/6219801/2d75df7a-8492-463b-b387-ff89286bc3a7">

This change was made with the goal of improving UX and general usability. It reduces admin confusion when navigating the indexing status and web connectors pages, as the connector URLs on those pages both link to different places (external base url and connector configuration).