### PR TITLE
add config to force the answer language

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -3,7 +3,6 @@ import os
 from danswer.configs.constants import AuthType
 from danswer.configs.constants import DocumentIndexType
 
-
 #####
 # App Configs
 #####
@@ -189,6 +188,10 @@ NUM_DOCUMENT_TOKENS_FED_TO_CHAT = int(
 # For selecting a different LLM question-answering prompt format
 # Valid values: default, cot, weak
 QA_PROMPT_OVERRIDE = os.environ.get("QA_PROMPT_OVERRIDE") or None
+# Set the default answer language if the generative AI is unable to identify
+# the source (query) language. By default, the Generative AI should answer in
+# the same language as the query.
+QA_PROMPT_DEFAULT_LANGUAGE = os.environ.get("QA_PROMPT_DEFAULT_LANGUAGE") or "English"
 # 1 / (1 + DOC_TIME_DECAY * doc-age-in-years), set to 0 to have no decay
 # Capped in Vespa at 0.5
 DOC_TIME_DECAY = float(

--- a/backend/danswer/prompts/direct_qa_prompts.py
+++ b/backend/danswer/prompts/direct_qa_prompts.py
@@ -1,12 +1,12 @@
 import json
 
+from danswer.configs.app_configs import QA_PROMPT_DEFAULT_LANGUAGE
 from danswer.prompts.constants import ANSWER_PAT
 from danswer.prompts.constants import GENERAL_SEP_PAT
 from danswer.prompts.constants import QUESTION_PAT
 from danswer.prompts.constants import QUOTE_PAT
 from danswer.prompts.constants import THOUGHT_PAT
 from danswer.prompts.constants import UNCERTAINTY_PAT
-
 
 QA_HEADER = """
 You are a question answering system that is constantly learning and improving.
@@ -15,9 +15,10 @@ accurate and detailed answers to diverse queries.
 """.strip()
 
 
-REQUIRE_JSON = """
+REQUIRE_JSON = f"""
 You ALWAYS responds with only a json containing an answer and quotes that support the answer.
-Your responses are as INFORMATIVE and DETAILED as possible.
+Your responses are as INFORMATIVE and DETAILED as possible. If my query is NOT in English,
+you have to answer in the language used. If not sure, answer in {QA_PROMPT_DEFAULT_LANGUAGE}.
 """.strip()
 
 


### PR DESCRIPTION
Hi,

Sometimes, the generative AI seems confused regarding the language for the answer. It happens when the selected sources are in a different language than the question.

For example, my question is in French, but the selected sources are in English. In this case, the answer will be in English. I'm expecting an answer to my question in French.

I'm not sure it's the best way to implement this feature, but as it is, it works in my case.