### PR TITLE
add missing dependencies in model_server dockerfile

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -11,9 +11,11 @@ RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
 WORKDIR /app
 # Needed for model configs and defaults
 COPY ./danswer/configs /app/danswer/configs
+COPY ./danswer/dynamic_configs /app/danswer/dynamic_configs
 # Utils used by model server
 COPY ./danswer/utils/logger.py /app/danswer/utils/logger.py
 COPY ./danswer/utils/timing.py /app/danswer/utils/timing.py
+COPY ./danswer/utils/telemetry.py /app/danswer/utils/telemetry.py
 # Version information
 COPY ./danswer/__init__.py /app/danswer/__init__.py
 # Shared implementations for running NLP models locally


### PR DESCRIPTION
The model_server dockerfile is out of date of the dependencies required to run it.

Point of clarification:
Is there any utility for having this be a separate image? Would it make more sense to just add the model_server to the primary backend image just like `background` and `api-server`.