### PR TITLE
Update Vespa to 8.267.29

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -166,7 +166,7 @@ services:
       - db_volume:/var/lib/postgresql/data
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
-    image: vespaengine/vespa:8.249.12
+    image: vespaengine/vespa:8.267.29
     restart: always
     ports:
       - "19071:19071"

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -71,7 +71,7 @@ services:
       - db_volume:/var/lib/postgresql/data
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
-    image: vespaengine/vespa:8.249.12
+    image: vespaengine/vespa:8.267.29
     restart: always
     ports:
       - "19071:19071"

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -71,7 +71,7 @@ services:
       - db_volume:/var/lib/postgresql/data
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
-    image: vespaengine/vespa:8.249.12
+    image: vespaengine/vespa:8.267.29
     restart: always
     ports:
       - "19071:19071"

--- a/deployment/kubernetes/vespa-service-deployment.yaml
+++ b/deployment/kubernetes/vespa-service-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: vespa
-        image: vespaengine/vespa:8.249.12
+        image: vespaengine/vespa:8.267.29
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
Vespa `8.249.12` contains a vulnerable Zookeeper version (https://nvd.nist.gov/vuln/detail/CVE-2023-44981) and should be updated to resolve.