### PR TITLE
Slack bot improve source feedback

### DIFF
--- a/backend/danswer/configs/danswerbot_configs.py
+++ b/backend/danswer/configs/danswerbot_configs.py
@@ -48,7 +48,3 @@ ENABLE_DANSWERBOT_REFLEXION = (
 )
 # Currently not support chain of thought, probably will add back later
 DANSWER_BOT_DISABLE_COT = True
-# Add the per document feedback blocks that affect the document rankings via boosting
-ENABLE_SLACK_DOC_FEEDBACK = (
-    os.environ.get("ENABLE_SLACK_DOC_FEEDBACK", "").lower() == "true"
-)

--- a/backend/danswer/danswerbot/slack/blocks.py
+++ b/backend/danswer/danswerbot/slack/blocks.py
@@ -15,7 +15,6 @@ from danswer.chat.models import DanswerQuote
 from danswer.configs.constants import DocumentSource
 from danswer.configs.constants import SearchFeedbackType
 from danswer.configs.danswerbot_configs import DANSWER_BOT_NUM_DOCS_TO_DISPLAY
-from danswer.configs.danswerbot_configs import ENABLE_SLACK_DOC_FEEDBACK
 from danswer.danswerbot.slack.constants import DISLIKE_BLOCK_ACTION_ID
 from danswer.danswerbot.slack.constants import FEEDBACK_DOC_BUTTON_BLOCK_ACTION_ID
 from danswer.danswerbot.slack.constants import LIKE_BLOCK_ACTION_ID
@@ -82,7 +81,7 @@ def build_doc_feedback_block(
     return ButtonElement(
         action_id=FEEDBACK_DOC_BUTTON_BLOCK_ACTION_ID,
         value=feedback_id,
-        text="Source feedback"
+        text="Source feedback",
     )
 
 
@@ -104,7 +103,6 @@ def build_documents_blocks(
     documents: list[SavedSearchDoc],
     message_id: int | None,
     num_docs_to_display: int = DANSWER_BOT_NUM_DOCS_TO_DISPLAY,
-    include_feedback: bool = ENABLE_SLACK_DOC_FEEDBACK,
 ) -> list[Block]:
     seen_docs_identifiers = set()
     section_blocks: list[Block] = [HeaderBlock(text="Reference Documents")]
@@ -137,10 +135,8 @@ def build_documents_blocks(
 
         block_text = header_line + updated_at_line + body_text
 
-        section_blocks.append(SectionBlock(text=block_text))
-
         feedback: ButtonElement | dict = {}
-        if include_feedback and message_id is not None:
+        if message_id is not None:
             feedback = build_doc_feedback_block(
                 message_id=message_id,
                 document_id=d.document_id,

--- a/backend/danswer/danswerbot/slack/blocks.py
+++ b/backend/danswer/danswerbot/slack/blocks.py
@@ -118,7 +118,7 @@ def build_documents_blocks(
         updated_at_line = ""
         if d.updated_at is not None:
             updated_at_line = (
-                f"Updated {timeago.format(d.updated_at, datetime.now(pytz.utc))}\n"
+                f"_Updated {timeago.format(d.updated_at, datetime.now(pytz.utc))}_\n"
             )
 
         body_text = f">{remove_slack_text_interactions(match_str)}"

--- a/backend/danswer/danswerbot/slack/blocks.py
+++ b/backend/danswer/danswerbot/slack/blocks.py
@@ -57,15 +57,15 @@ def get_document_feedback_blocks() -> Block:
         accessory=RadioButtonsElement(
             options=[
                 Option(
-                    text="Boost :heavy_plus_sign:",
+                    text=":thumbsup: Boost",
                     value=SearchFeedbackType.ENDORSE.value,
                 ),
                 Option(
-                    text="Down-Boost :heavy_minus_sign:",
+                    text=":thumbsdown: Down-Boost",
                     value=SearchFeedbackType.REJECT.value,
                 ),
                 Option(
-                    text="Hide :heavy_multiplication_x:",
+                    text=":palms_up_together: Hide",
                     value=SearchFeedbackType.HIDE.value,
                 ),
             ]

--- a/backend/danswer/danswerbot/slack/constants.py
+++ b/backend/danswer/danswerbot/slack/constants.py
@@ -1,3 +1,5 @@
 LIKE_BLOCK_ACTION_ID = "feedback-like"
 DISLIKE_BLOCK_ACTION_ID = "feedback-dislike"
+FEEDBACK_DOC_BUTTON_BLOCK_ACTION_ID = "feedback-doc-button"
 SLACK_CHANNEL_ID = "channel_id"
+VIEW_DOC_FEEDBACK_ID = "view-doc-feedback"

--- a/backend/danswer/danswerbot/slack/handlers/handle_feedback.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_feedback.py
@@ -1,18 +1,60 @@
 from slack_sdk import WebClient
+from slack_sdk.models.views import View
+from slack_sdk.socket_mode import SocketModeClient
+from slack_sdk.socket_mode.request import SocketModeRequest
 from sqlalchemy.orm import Session
 
 from danswer.configs.constants import SearchFeedbackType
+from danswer.danswerbot.slack.blocks import get_document_feedback_blocks
 from danswer.danswerbot.slack.constants import DISLIKE_BLOCK_ACTION_ID
 from danswer.danswerbot.slack.constants import LIKE_BLOCK_ACTION_ID
-from danswer.danswerbot.slack.utils import decompose_block_id
+from danswer.danswerbot.slack.constants import VIEW_DOC_FEEDBACK_ID
+from danswer.danswerbot.slack.utils import build_feedback_id
+from danswer.danswerbot.slack.utils import decompose_feedback_id
 from danswer.db.engine import get_sqlalchemy_engine
 from danswer.db.feedback import create_chat_message_feedback
 from danswer.db.feedback import create_doc_retrieval_feedback
 from danswer.document_index.factory import get_default_document_index
+from danswer.utils.logger import setup_logger
+
+logger_base = setup_logger()
+
+
+def handle_doc_feedback_button(
+    req: SocketModeRequest,
+    client: SocketModeClient,
+) -> None:
+    if not (actions := req.payload.get("actions")):
+        logger_base.error("Missing actions. Unable to build the source feedback view")
+        return
+
+    # Extracts the feedback_id coming from the 'source feedback' button
+    # and generates a new one for the View, to keep track of the doc info
+    query_event_id, doc_id, doc_rank = decompose_feedback_id(actions[0].get("value"))
+    external_id = build_feedback_id(query_event_id, doc_id, doc_rank)
+
+    channel_id = req.payload["container"]["channel_id"]
+    thread_ts = req.payload["container"]["thread_ts"]
+
+    data = View(
+        type="modal",
+        callback_id=VIEW_DOC_FEEDBACK_ID,
+        external_id=external_id,
+        # We use the private metadata to keep track of the channel id and thread ts
+        private_metadata=f"{channel_id}_{thread_ts}",
+        title="Source Feedback",
+        blocks=[get_document_feedback_blocks()],
+        submit="send",
+        close="cancel",
+    )
+
+    client.web_client.views_open(
+        trigger_id=req.payload["trigger_id"], view=data.to_dict()
+    )
 
 
 def handle_slack_feedback(
-    block_id: str,
+    feedback_id: str,
     feedback_type: str,
     client: WebClient,
     user_id_to_post_confirmation: str,
@@ -21,7 +63,7 @@ def handle_slack_feedback(
 ) -> None:
     engine = get_sqlalchemy_engine()
 
-    message_id, doc_id, doc_rank = decompose_block_id(block_id)
+    message_id, doc_id, doc_rank = decompose_feedback_id(feedback_id)
 
     with Session(engine) as db_session:
         if feedback_type in [LIKE_BLOCK_ACTION_ID, DISLIKE_BLOCK_ACTION_ID]:
@@ -32,12 +74,20 @@ def handle_slack_feedback(
                 user_id=None,  # no "user" for Slack bot for now
                 db_session=db_session,
             )
-        if feedback_type in [
+        elif feedback_type in [
             SearchFeedbackType.ENDORSE.value,
             SearchFeedbackType.REJECT.value,
+            SearchFeedbackType.HIDE.value,
         ]:
             if doc_id is None or doc_rank is None:
                 raise ValueError("Missing information for Document Feedback")
+
+            if feedback_type == SearchFeedbackType.ENDORSE.value:
+                feedback = SearchFeedbackType.ENDORSE
+            elif feedback_type == SearchFeedbackType.REJECT.value:
+                feedback = SearchFeedbackType.REJECT
+            else:
+                feedback = SearchFeedbackType.HIDE
 
             create_doc_retrieval_feedback(
                 message_id=message_id,
@@ -46,10 +96,10 @@ def handle_slack_feedback(
                 document_index=get_default_document_index(),
                 db_session=db_session,
                 clicked=False,  # Not tracking this for Slack
-                feedback=SearchFeedbackType.ENDORSE
-                if feedback_type == SearchFeedbackType.ENDORSE.value
-                else SearchFeedbackType.REJECT,
+                feedback=feedback,
             )
+        else:
+            logger_base.error(f"Feedback type '{feedback_type}' not supported")
 
     # post message to slack confirming that feedback was received
     client.chat_postEphemeral(

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -112,7 +112,7 @@ def respond_in_thread(
                 raise RuntimeError(f"Failed to post message: {response}")
 
 
-def build_feedback_block_id(
+def build_feedback_id(
     message_id: int,
     document_id: str | None = None,
     document_rank: int | None = None,
@@ -125,19 +125,21 @@ def build_feedback_block_id(
             raise ValueError(
                 "Separator pattern should not already exist in document id"
             )
-        block_id = ID_SEPARATOR.join([str(message_id), document_id, str(document_rank)])
+        feedback_id = ID_SEPARATOR.join(
+            [str(message_id), document_id, str(document_rank)]
+        )
     else:
-        block_id = str(message_id)
+        feedback_id = str(message_id)
 
-    return unique_prefix + ID_SEPARATOR + block_id
+    return unique_prefix + ID_SEPARATOR + feedback_id
 
 
-def decompose_block_id(block_id: str) -> tuple[int, str | None, int | None]:
+def decompose_feedback_id(feedback_id: str) -> tuple[int, str | None, int | None]:
     """Decompose into query_id, document_id, document_rank, see above function"""
     try:
-        components = block_id.split(ID_SEPARATOR)
+        components = feedback_id.split(ID_SEPARATOR)
         if len(components) != 2 and len(components) != 4:
-            raise ValueError("Block ID does not contain right number of elements")
+            raise ValueError("Feedback ID does not contain right number of elements")
 
         if len(components) == 2:
             return int(components[-1]), None, None
@@ -146,7 +148,36 @@ def decompose_block_id(block_id: str) -> tuple[int, str | None, int | None]:
 
     except Exception as e:
         logger.error(e)
-        raise ValueError("Received invalid Feedback Block Identifier")
+        raise ValueError("Received invalid Feedback Identifier")
+
+
+def get_view_values(state_values: dict[str, Any]) -> dict[str, str]:
+    """Extract view values
+
+    Args:
+        state_values (dict): The Slack view-submission values
+
+    Returns:
+        dict: keys/values of the view state content
+    """
+    view_values = {}
+    for _, view_data in state_values.items():
+        for k, v in view_data.items():
+            if (
+                "selected_option" in v
+                and isinstance(v["selected_option"], dict)
+                and "value" in v["selected_option"]
+            ):
+                view_values[k] = v["selected_option"]["value"]
+            elif "selected_options" in v and isinstance(v["selected_options"], list):
+                view_values[k] = [
+                    x["value"] for x in v["selected_options"] if "value" in x
+                ]
+            elif "selected_date" in v:
+                view_values[k] = v["selected_date"]
+            elif "value" in v:
+                view_values[k] = v["value"]
+    return view_values
 
 
 def translate_vespa_highlight_to_slack(match_strs: list[str], used_chars: int) -> str:

--- a/backend/danswer/db/feedback.py
+++ b/backend/danswer/db/feedback.py
@@ -114,10 +114,15 @@ def create_doc_retrieval_feedback(
         else:
             raise ValueError("Unhandled document feedback type")
 
-    if feedback in [SearchFeedbackType.ENDORSE, SearchFeedbackType.REJECT]:
+    if feedback in [
+        SearchFeedbackType.ENDORSE,
+        SearchFeedbackType.REJECT,
+        SearchFeedbackType.HIDE,
+    ]:
         update = UpdateRequest(
             document_ids=[document_id],
             boost=db_doc.boost,
+            hidden=db_doc.hidden
         )
         # Updates are generally batched for efficiency, this case only 1 doc/value is updated
         document_index.update([update])


### PR DESCRIPTION
Hi,

This PR is a rework of the source feedback, as the presentation was not... optimal, from my point of view :) 

This also adds the support to hide the source. I'm using a Slack view as the cleanest way to handle it. Furthermore, we could extend it in the future (like by letting the end-user write a feedback message explaining why he has down-voted it).

![danswer-screen1](https://github.com/danswer-ai/danswer/assets/13381323/fd147d2f-7493-4c29-a644-82ee85581007)
![danswer-screen2](https://github.com/danswer-ai/danswer/assets/13381323/7e69d6e9-7875-4a5f-88ae-ca48720764ef)

