### PR TITLE
Change WEB_DOMAIN default to 127.0.0.1 instead of localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_store
 .venv
 .mypy_cache
+.idea

--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -28,7 +28,7 @@ DISABLE_GENERATIVE_AI = os.environ.get("DISABLE_GENERATIVE_AI", "").lower() == "
 # Web Configs
 #####
 # WEB_DOMAIN is used to set the redirect_uri after login flows
-WEB_DOMAIN = os.environ.get("WEB_DOMAIN") or "http://localhost:3000"
+WEB_DOMAIN = os.environ.get("WEB_DOMAIN") or "http://127.0.0.1:3000"
 
 
 #####

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -18,13 +18,13 @@ services:
     environment:
       # Auth Settings
       - AUTH_TYPE=${AUTH_TYPE:-disabled}
-      - SESSION_EXPIRE_TIME_SECONDS=${SESSION_EXPIRE_TIME_SECONDS:-}
+      - SESSION_EXPIRE_TIME_SECONDS=${SESSION_EXPIRE_TIME_SECONDS:-86400}
       - VALID_EMAIL_DOMAINS=${VALID_EMAIL_DOMAINS:-}
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
       - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
       - REQUIRE_EMAIL_VERIFICATION=${REQUIRE_EMAIL_VERIFICATION:-}
       - SMTP_SERVER=${SMTP_SERVER:-}  # For sending verification emails, if unspecified then defaults to 'smtp.gmail.com'
-      - SMTP_PORT=${SMTP_PORT:-}  # For sending verification emails, if unspecified then defaults to '587'
+      - SMTP_PORT=${SMTP_PORT:-587}  # For sending verification emails, if unspecified then defaults to '587'
       - SMTP_USER=${SMTP_USER:-}
       - SMTP_PASS=${SMTP_PASS:-}
       # Gen AI Settings

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -4,7 +4,7 @@
 
 
 # Could be something like danswer.companyname.com
-WEB_DOMAIN=http://localhost:3000
+WEB_DOMAIN=http://127.0.0.1:3000
 
 
 # Generative AI settings, uncomment as needed, will work with defaults

--- a/deployment/kubernetes/env-configmap.yaml
+++ b/deployment/kubernetes/env-configmap.yaml
@@ -69,5 +69,5 @@ data:
   LOG_VESPA_TIMING_INFORMATION: ""
   # Shared or Non-backend Related
   INTERNAL_URL: "http://api-server-service:80"  # for web server
-  WEB_DOMAIN: "http://localhost:3000"  # for web server and api server
+  WEB_DOMAIN: "http://127.0.0.1:3000"  # for web server and api server
   DOMAIN: "localhost"  # for nginx

--- a/web/README.md
+++ b/web/README.md
@@ -17,4 +17,4 @@ yarn dev
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://127.0.0.1:3000](http://127.0.0.1:3000) with your browser to see the result.


### PR DESCRIPTION
This commit replaces the default value of WEB_DOMAIN from "http://localhost:3000" to "http://127.0.0.1:3000" in several config files. I'm using windows and for some reason, it won't load with localhost. Others my have the problem, so I thought it might be good to idiotproof it.