### PR TITLE
Add MAIL_FROM env variable

### DIFF
--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -38,6 +38,7 @@ from danswer.configs.app_configs import SMTP_PASS
 from danswer.configs.app_configs import SMTP_PORT
 from danswer.configs.app_configs import SMTP_SERVER
 from danswer.configs.app_configs import SMTP_USER
+from danswer.configs.app_configs import MAIL_FROM
 from danswer.configs.app_configs import VALID_EMAIL_DOMAINS
 from danswer.configs.app_configs import WEB_DOMAIN
 from danswer.configs.constants import AuthType
@@ -111,6 +112,7 @@ def send_user_verification_email(user_email: str, token: str) -> None:
     msg = MIMEMultipart()
     msg["Subject"] = "Danswer Email Verification"
     msg["To"] = user_email
+    msg["From"] = MAIL_FROM
 
     link = f"{WEB_DOMAIN}/auth/verify-email?token={token}"
 

--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -81,6 +81,7 @@ SMTP_SERVER = os.environ.get("SMTP_SERVER") or "smtp.gmail.com"
 SMTP_PORT = int(os.environ.get("SMTP_PORT") or "587")
 SMTP_USER = os.environ.get("SMTP_USER", "your-email@gmail.com")
 SMTP_PASS = os.environ.get("SMTP_PASS", "your-gmail-password")
+MAIL_FROM = os.environ.get("EMAIL_FROM", SMTP_USER)
 
 
 #####

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -27,6 +27,7 @@ services:
       - SMTP_PORT=${SMTP_PORT:-587}  # For sending verification emails, if unspecified then defaults to '587'
       - SMTP_USER=${SMTP_USER:-}
       - SMTP_PASS=${SMTP_PASS:-}
+      - MAIL_FROM=${MAIL_FROM:-}
       # Gen AI Settings
       - GEN_AI_MODEL_PROVIDER=${GEN_AI_MODEL_PROVIDER:-openai}
       - GEN_AI_MODEL_VERSION=${GEN_AI_MODEL_VERSION:-gpt-3.5-turbo}

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -47,6 +47,8 @@ SECRET=
 # The below are only needed if you aren't using gmail as your SMTP
 #SMTP_SERVER=  
 #SMTP_PORT=
+# when missing SMTP_USER used instead
+#MAIL_FROM=
 
 # OpenID Connect (OIDC)
 #OPENID_CONFIG_URL=

--- a/deployment/kubernetes/env-configmap.yaml
+++ b/deployment/kubernetes/env-configmap.yaml
@@ -11,6 +11,7 @@ data:
   SMTP_PORT: "" # For sending verification emails, if unspecified then defaults to '587'
   SMTP_USER: ""  # 'your-email@company.com'
   SMTP_PASS: ""  # 'your-gmail-password'
+  MAIL_FROM: ""  # 'your-email@company.com' SMTP_USER missing used instead
   # Gen AI Settings
   GEN_AI_MODEL_PROVIDER: "openai"
   GEN_AI_MODEL_VERSION: "gpt-3.5-turbo"  # Use GPT-4 if you have it


### PR DESCRIPTION
Add possibility to add `MAIL_FROM` setting with fallback to `SMTP_USER`, as `SMTP_USER` not always a valid email address.