### PR TITLE
Slack Give Resolver Name

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
@@ -223,7 +223,7 @@ def handle_followup_resolved_button(
 
     resolved_block = SectionBlock(
         text=f"{clicker_real_name or clicker_backup_name} has marked this question as resolved! "
-        f':tada:\n You can always click the "I need more help button" to let the team '
+        f'\n\n You can always click the "I need more help button" to let the team '
         f"know that your problem still needs attention."
     )
 

--- a/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
@@ -2,6 +2,7 @@ from typing import Any
 from typing import cast
 
 from slack_sdk import WebClient
+from slack_sdk.models.blocks import SectionBlock
 from slack_sdk.models.views import View
 from slack_sdk.socket_mode import SocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -9,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from danswer.configs.constants import SearchFeedbackType
 from danswer.configs.danswerbot_configs import DANSWER_FOLLOWUP_EMOJI
+from danswer.connectors.slack.utils import make_slack_api_rate_limited
 from danswer.danswerbot.slack.blocks import build_follow_up_resolved_blocks
 from danswer.danswerbot.slack.blocks import get_document_feedback_blocks
 from danswer.danswerbot.slack.config import get_slack_bot_config_for_channel
@@ -189,7 +191,18 @@ def handle_followup_resolved_button(
     client: SocketModeClient,
 ) -> None:
     channel_id = req.payload["container"]["channel_id"]
+    message_ts = req.payload["container"]["message_ts"]
     thread_ts = req.payload["container"]["thread_ts"]
+    clicker_backup_name = req.payload.get("user", {}).get("name", "Someone")
+    clicker_real_name = None
+    try:
+        clicker = client.web_client.users_info(user=req.payload["user"]["id"])
+        clicker_real_name = (
+            cast(dict, clicker.data).get("user", {}).get("profile", {}).get("real_name")
+        )
+    except Exception:
+        # Likely a scope issue
+        pass
 
     update_emote_react(
         emoji=DANSWER_FOLLOWUP_EMOJI,
@@ -197,4 +210,28 @@ def handle_followup_resolved_button(
         message_ts=thread_ts,
         remove=True,
         client=client.web_client,
+    )
+
+    slack_call = make_slack_api_rate_limited(client.web_client.chat_delete)
+    response = slack_call(
+        channel=channel_id,
+        ts=message_ts,
+    )
+
+    if not response.get("ok"):
+        logger_base.error("Unable to delete message for resolved")
+
+    resolved_block = SectionBlock(
+        text=f"{clicker_real_name or clicker_backup_name} has marked this question as resolved! "
+        f':tada:\n You can always click the "I need more help button" to let the team '
+        f"know that your problem still needs attention."
+    )
+
+    respond_in_thread(
+        client=client.web_client,
+        channel=channel_id,
+        text="Your request for help as been addressed!",
+        blocks=[resolved_block],
+        thread_ts=thread_ts,
+        unfurl=False,
     )


### PR DESCRIPTION
When someone marks a thread as resolved, we give the name of the user who did this and remove the previous message which has the button to mark the thread resolved