### PR TITLE
Moshe.download nltk data on start

### DIFF
--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -1,3 +1,4 @@
+import nltk
 import time
 from threading import Event
 from typing import Any
@@ -357,6 +358,11 @@ if __name__ == "__main__":
 
     slack_bot_tokens: SlackBotTokens | None = None
     socket_client: SocketModeClient | None = None
+
+    logger.info("Verifying query preprocessing (NLTK) data is downloaded")
+    nltk.download("stopwords", quiet=True)
+    nltk.download('punkt', quiet=True)
+
     while True:
         try:
             latest_slack_bot_tokens = fetch_tokens()

--- a/backend/danswer/server/manage/administrative.py
+++ b/backend/danswer/server/manage/administrative.py
@@ -219,7 +219,7 @@ def create_deletion_attempt_for_connector_id(
         raise HTTPException(
             status_code=400,
             detail=f"Connector with ID '{connector_id}' and credential ID "
-            f"'{credential_id}' is not deletable. It must be both disabled AND have"
+            f"'{credential_id}' is not deletable. It must be both disabled AND have "
             "no ongoing / planned indexing attempts.",
         )
 

--- a/backend/danswer/server/manage/administrative.py
+++ b/backend/danswer/server/manage/administrative.py
@@ -219,7 +219,7 @@ def create_deletion_attempt_for_connector_id(
         raise HTTPException(
             status_code=400,
             detail=f"Connector with ID '{connector_id}' and credential ID "
-            f"'{credential_id}' is not deletable. It must be both disabled AND have "
+            f"'{credential_id}' is not deletable. It must be both disabled AND have"
             "no ongoing / planned indexing attempts.",
         )
 


### PR DESCRIPTION
When running locally, NLTK is downloaded during boot here `backend/danswer/main.py`  and cached to `model_cache_nltk` docker-compose volume. When running danswerbot and backend in different hosts (or k8s pods), danswerBot raise an exception about missing nltk data missing. This PR addresses the issue