### PR TITLE
Add return contexts

### DIFF
--- a/backend/danswer/chat/models.py
+++ b/backend/danswer/chat/models.py
@@ -91,14 +91,12 @@ class DanswerAnswer(BaseModel):
 
 class QAResponse(SearchResponse, DanswerAnswer):
     quotes: list[DanswerQuote] | None
+    contexts: list[DanswerContexts] | None
     predicted_flow: QueryFlow
     predicted_search: SearchType
     eval_res_valid: bool | None = None
     llm_chunks_indices: list[int] | None = None
     error_msg: str | None = None
-
-
-AnswerQuestionReturn = tuple[DanswerAnswer, DanswerQuotes, DanswerContexts]
 
 
 AnswerQuestionStreamReturn = Iterator[

--- a/backend/danswer/chat/models.py
+++ b/backend/danswer/chat/models.py
@@ -74,6 +74,17 @@ class DanswerQuotes(BaseModel):
     quotes: list[DanswerQuote]
 
 
+class DanswerContext(BaseModel):
+    content: str
+    document_id: str
+    semantic_identifier: str
+    blurb: str
+
+
+class DanswerContexts(BaseModel):
+    contexts: list[DanswerContext]
+
+
 class DanswerAnswer(BaseModel):
     answer: str | None
 
@@ -87,11 +98,11 @@ class QAResponse(SearchResponse, DanswerAnswer):
     error_msg: str | None = None
 
 
-AnswerQuestionReturn = tuple[DanswerAnswer, DanswerQuotes]
+AnswerQuestionReturn = tuple[DanswerAnswer, DanswerQuotes, DanswerContexts]
 
 
 AnswerQuestionStreamReturn = Iterator[
-    DanswerAnswerPiece | DanswerQuotes | StreamingError
+    DanswerAnswerPiece | DanswerQuotes | DanswerContexts | StreamingError
 ]
 
 

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -1,6 +1,6 @@
+import itertools
 from collections.abc import Callable
 from collections.abc import Iterator
-import itertools
 from typing import cast
 
 from sqlalchemy.orm import Session
@@ -237,17 +237,16 @@ def stream_answer_objects(
         contexts = DanswerContexts(
             contexts=[
                 DanswerContext(
-                        content=context_doc.content,
-                        document_id=context_doc.document_id,
-                        semantic_identifier=context_doc.semantic_identifier,
-                        blurb=context_doc.semantic_identifier,
+                    content=context_doc.content,
+                    document_id=context_doc.document_id,
+                    semantic_identifier=context_doc.semantic_identifier,
+                    blurb=context_doc.semantic_identifier,
                 )
                 for context_doc in llm_chunks
             ]
         )
 
         response_packets = itertools.chain(response_packets, [contexts])
-
 
     # Capture outputs and errors
     llm_output = ""
@@ -337,7 +336,7 @@ def get_search_answer(
         elif isinstance(packet, DanswerQuotes):
             qa_response.quotes = packet
         elif isinstance(packet, DanswerContexts):
-            qa_response.quotes = packet
+            qa_response.contexts = packet
         elif isinstance(packet, StreamingError):
             qa_response.error_msg = packet.error
         elif isinstance(packet, ChatMessageDetail):

--- a/backend/danswer/one_shot_answer/interfaces.py
+++ b/backend/danswer/one_shot_answer/interfaces.py
@@ -22,6 +22,5 @@ class QAModel:
         prompt: str,
         llm_context_docs: list[InferenceChunk],
         metrics_callback: Callable[[LLMMetricsContainer], None] | None = None,
-        return_contexts: bool = False,
     ) -> AnswerQuestionStreamReturn:
         raise NotImplementedError

--- a/backend/danswer/one_shot_answer/interfaces.py
+++ b/backend/danswer/one_shot_answer/interfaces.py
@@ -22,5 +22,6 @@ class QAModel:
         prompt: str,
         llm_context_docs: list[InferenceChunk],
         metrics_callback: Callable[[LLMMetricsContainer], None] | None = None,
+        return_contexts: bool = False,
     ) -> AnswerQuestionStreamReturn:
         raise NotImplementedError

--- a/backend/danswer/one_shot_answer/models.py
+++ b/backend/danswer/one_shot_answer/models.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import root_validator
 
+from danswer.chat.models import DanswerContexts
 from danswer.chat.models import DanswerQuotes
 from danswer.chat.models import QADocsResponse
 from danswer.configs.constants import MessageType
@@ -25,6 +26,7 @@ class DirectQARequest(BaseModel):
     persona_id: int
     retrieval_options: RetrievalDetails
     chain_of_thought: bool = False
+    return_contexts: bool = False
 
     @root_validator
     def check_chain_of_thought_and_prompt_id(
@@ -53,3 +55,4 @@ class OneShotQAResponse(BaseModel):
     error_msg: str | None = None
     answer_valid: bool = True  # Reflexion result, default True if Reflexion not run
     chat_message_id: int | None = None
+    contexts: DanswerContexts | None = None


### PR DESCRIPTION
This PR adds optional `return_contexts` parameter to `/api/query/stream-answer-with-quote` endpoint. If set to `true`, list of contexts are returned back as an additional output. `DanswerContexts` implementation and handling is similar to `DanswerQuotes`.

Returned contexts are useful for evaluating RAG pipelines (notably the retrieval part) with tools like [ragas](https://github.com/explodinggradients/ragas)

I might add some scripts for easy evaluation with ragas since that might be useful for others, but not sure where to place them yet (don't want to add new dependencies here).

I'll leave some comments to the code where your input would be appreciated.