### PR TITLE
Update Document360 Connector

### DIFF
--- a/backend/danswer/connectors/document360/connector.py
+++ b/backend/danswer/connectors/document360/connector.py
@@ -130,7 +130,7 @@ class Document360Connector(LoadConnector, PollConnector):
                 continue
 
             authors = [
-                author["email_id"]
+                {"name": author.get("name", "Unknown"), "email": author["email_id"]}
                 for author in article_details.get("authors", [])
                 if author["email_id"]
             ]


### PR DESCRIPTION
expects primary_owners to be a list of dictionaries, but it's being provided with a list of strings instead.

https://github.com/danswer-ai/danswer/issues/1111