### PR TITLE
Trace sqla get_session

### DIFF
--- a/backend/danswer/db/engine.py
+++ b/backend/danswer/db/engine.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncGenerator
 from collections.abc import Generator
 from datetime import datetime
 
+from ddtrace import tracer
 from sqlalchemy import text
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine import Engine
@@ -68,6 +69,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     return _ASYNC_ENGINE
 
 
+@tracer.wrap("db.get_session")
 def get_session() -> Generator[Session, None, None]:
     with Session(get_sqlalchemy_engine(), expire_on_commit=False) as session:
         yield session


### PR DESCRIPTION
Wraps `get_session()` in a trace span so we can monitor db connection latency.