### PR TITLE
fix: sitemap connector URLs extraction integrity 

### DIFF
--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -100,10 +100,12 @@ def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:
     response.raise_for_status()
 
     soup = BeautifulSoup(response.content, "html.parser")
-    urls = [loc_tag.text for loc_tag in soup.find_all("loc")]
+    return [_ensure_absolute_url(sitemap_url, loc_tag.text) for loc_tag in soup.find_all("loc")]
 
-    return urls
-
+def _ensure_absolute_url(source_url:str, maybe_relative_url: str) -> str:
+    if not urlparse(maybe_relative_url).netloc:
+        return urljoin(source_url, maybe_relative_url)
+    return maybe_relative_url
 
 def _ensure_valid_url(url: str) -> str:
     if "://" not in url:


### PR DESCRIPTION

### Overview
The sitemap extractor assumes URLs integrity and will fail to navigate relative URLs in cases where `<loc>` tags are not absolute.


### Reproducing it

Index https://karpenter.sh/docs/sitemap.xml


```
connector.py 233 : [Attempt ID: 40] Failed to fetch '/v0.35/concepts/nodeclasses/': Protocol error (Page.navigate): Cannot navigate to invalid URL
connector.py 172 : [Attempt ID: 40] Visiting /v0.34/concepts/nodeclasses/
connector.py 233 : [Attempt ID: 40] Failed to fetch '/v0.34/concepts/nodeclasses/': Protocol error (Page.navigate): Cannot navigate to invalid URL
connector.py 172 : [Attempt ID: 40] Visiting /v0.33/concepts/nodeclasses/
connector.py 233 : [Attempt ID: 40] Failed to fetch '/v0.33/concepts/nodeclasses/': Protocol error (Page.navigate): Cannot navigate to invalid URL
```


### Changes

- Defined `_ensure_absolute_url` helper function to convert potentially relative  URLS to absolute. Uses `urlllib.urljoin` which _should be_ idempotent within the sitemaps protocol context.

- Extended `extract_urls_from_sitemap` to implement URLS normalization via `_ensure_absolute_url(sitemap_url, loc_tag.text)`





