### PR TITLE
Fix broken link when specified in metadata

### DIFF
--- a/backend/danswer/connectors/file/connector.py
+++ b/backend/danswer/connectors/file/connector.py
@@ -98,7 +98,7 @@ def _process_file(
         Document(
             id=f"FILE_CONNECTOR__{file_name}",  # add a prefix to avoid conflicts with other connectors
             sections=[
-                Section(link=metadata.get("link"), text=file_content_raw.strip())
+                Section(link=file_metadata.get("link"), text=file_content_raw.strip())
             ],
             source=DocumentSource.FILE,
             semantic_identifier=file_display_name_override or file_name,


### PR DESCRIPTION
This fixes issue #1195 

Please check to see if additional lines where the reference to metadata.get() should be file_metadata.get(), as described in the issue.