### PR TITLE
Fix: Added check for internet connection to web connector

### DIFF
--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -1,4 +1,5 @@
 import io
+import socket
 from enum import Enum
 from typing import Any
 from typing import cast
@@ -40,6 +41,15 @@ class WEB_CONNECTOR_VALID_SETTINGS(str, Enum):
     # Given a file upload where every line is a URL, parse all the URLs provided
     UPLOAD = "upload"
 
+def check_internet_connection() -> bool:
+    dns_servers = [("1.1.1.1", 53), ("8.8.8.8", 53)]
+    for server in dns_servers:
+        try:
+            socket.create_connection(server, timeout=3)
+            return True
+        except OSError: # try the next server
+            continue 
+    raise Exception("Unable to contact DNS server - check your internet connection")
 
 def is_valid_url(url: str) -> bool:
     try:
@@ -163,6 +173,7 @@ class WebConnector(LoadConnector):
         base_url = to_visit[0]  # For the recursive case
         doc_batch: list[Document] = []
 
+        check_internet_connection()
         playwright, context = start_playwright()
         restart_playwright = False
         while to_visit:


### PR DESCRIPTION
Fix for issue #1161 

Runs `check_internet_connection()` before indexing any documents with playwright and raises an Exception if you are unable to reach cloudflare and google DNS. The raised exception keeps existing documents from being overwritten in the event that there is no internet connection.

![image](https://github.com/danswer-ai/danswer/assets/22831508/59f08f6d-3e7a-46d0-892d-d9bdd157f6f7)
