### PR TITLE
Bugfix: Support more Confluence Cloud hostname (*.jira.com)

### DIFF
--- a/backend/danswer/connectors/confluence/connector.py
+++ b/backend/danswer/connectors/confluence/connector.py
@@ -75,7 +75,7 @@ def _extract_confluence_keys_from_datacenter_url(wiki_url: str) -> tuple[str, st
 
 
 def extract_confluence_keys_from_url(wiki_url: str) -> tuple[str, str, bool]:
-    is_confluence_cloud = ".atlassian.net/wiki/spaces/" in wiki_url or ".jira.com/wiki/spaces/" in wiki_url o
+    is_confluence_cloud = ".atlassian.net/wiki/spaces/" in wiki_url or ".jira.com/wiki/spaces/" in wiki_url
 
     try:
         if is_confluence_cloud:

--- a/backend/danswer/connectors/confluence/connector.py
+++ b/backend/danswer/connectors/confluence/connector.py
@@ -75,7 +75,7 @@ def _extract_confluence_keys_from_datacenter_url(wiki_url: str) -> tuple[str, st
 
 
 def extract_confluence_keys_from_url(wiki_url: str) -> tuple[str, str, bool]:
-    is_confluence_cloud = ".atlassian.net/wiki/spaces/" in wiki_url
+    is_confluence_cloud = ".atlassian.net/wiki/spaces/" in wiki_url or ".jira.com/wiki/spaces/" in wiki_url o
 
     try:
         if is_confluence_cloud:

--- a/web/src/app/admin/connectors/confluence/page.tsx
+++ b/web/src/app/admin/connectors/confluence/page.tsx
@@ -43,7 +43,7 @@ const extractSpaceFromDataCenterUrl = (wikiUrl: string): string => {
 // Copied from the `extract_confluence_keys_from_url` function
 const extractSpaceFromUrl = (wikiUrl: string): string | null => {
   try {
-    if (wikiUrl.includes(".atlassian.net/wiki/spaces/")) {
+    if (wikiUrl.includes(".atlassian.net/wiki/spaces/") || wikiUrl.includes(".jira.com/wiki/spaces/")) {
       return extractSpaceFromCloudUrl(wikiUrl);
     }
     return extractSpaceFromDataCenterUrl(wikiUrl);


### PR DESCRIPTION
The current confluence cloud connector only support <company name>.atlassian.net host name.

My company has a <company name>.jira.com Confluence Cloud domain. The proposed fix allows to parse Confluence properly.