### PR TITLE
Update sharepoint connector to work with less permissions

### DIFF
--- a/backend/danswer/connectors/sharepoint/connector.py
+++ b/backend/danswer/connectors/sharepoint/connector.py
@@ -125,15 +125,12 @@ class SharepointConnector(LoadConnector, PollConnector):
 
         site_object_list: list[Site] = []
 
-        sites_object = self.graph_client.sites.get().execute_query()
-
         if len(self.requested_site_list) > 0:
             for requested_site in self.requested_site_list:
-                adjusted_string = "/" + requested_site.replace(" ", "")
-                for site_object in sites_object:
-                    if site_object.web_url.endswith(adjusted_string):
-                        site_object_list.append(site_object)
+                site_object = self.graph_client.sites.get_by_url(requested_site)
+                site_object_list.append(site_object)
         else:
+            sites_object = self.graph_client.sites.get().execute_query()
             site_object_list.extend(sites_object)
 
         return site_object_list

--- a/web/src/app/admin/connectors/sharepoint/page.tsx
+++ b/web/src/app/admin/connectors/sharepoint/page.tsx
@@ -223,9 +223,9 @@ const MainSection = () => {
               name: "sites",
               label: "Sites:",
               subtext:
-                "Specify 0 or more sites to index. For example, specifying the site " +
-                "'support' for the 'danswerai' sharepoint will cause us to only index documents " +
-                "within the 'https://danswerai.sharepoint.com/sites/support' site. " +
+                "Specify 0 or more sites' URL to index. For example, specifying the site " +
+                "'https://danswerai.sharepoint.com/sites/support' will cause us to only index documents " +
+                "within the 'support' site. " +
                 "If no sites are specified, all sites in your organization will be indexed.",
             })}
             validationSchema={Yup.object().shape({


### PR DESCRIPTION
The SharePoint connector currently requires an excessive amount of permissions to function effectively. Specifically, the Sites.FullControl.All permission level is not acceptable for most companies, as it grants the Service Principal unrestricted access to all sites. Even the Sites.ReadAll permission level is not ideal, as it allows access to all company sites.

To address this issue, this pull request introduces changes that avoid scanning all sites when a specific site has been defined. By doing so, the Service Principal only requires Sites.Selected permissions and can be added to the site's Access Control List as a read-only user. This approach aligns with the best practice of least privilege.

I have also modified the way a site is defined. Instead of just the site name, the URL is now required because I was unable to find a way to obtain the root URL with the restricted permissions.