### PR TITLE
fix: Stop reading Notion pages on polling

### DIFF
--- a/backend/danswer/connectors/notion/connector.py
+++ b/backend/danswer/connectors/notion/connector.py
@@ -433,8 +433,8 @@ class NotionConnector(LoadConnector, PollConnector):
             )
             if len(pages) > 0:
                 yield from batch_generator(self._read_pages(pages), self.batch_size)
-            if db_res.has_more:
-                query_dict["start_cursor"] = db_res.next_cursor
+                if db_res.has_more:
+                    query_dict["start_cursor"] = db_res.next_cursor
             else:
                 break
 


### PR DESCRIPTION
After some discovery on how the Notion connector works it seems like the `poll_source` keeps fetching using the `_search_notion` method, even when the `_filter_pages_by_time` returns not pages. As the search uses the sort parameter, we can assume that when the filter returns an empty list, we can just `break` the flow, as all following calls will return documents older than the `end`, hence doing a lot of not required API calls to the Notion API.

Actually, in the `load_from_state` function it's done similarly 

https://github.com/danswer-ai/danswer/blob/b59912884bed7a32a0858d2e634d5402647c5ea6/backend/danswer/connectors/notion/connector.py#L405

in fact, in this case you could think that the `_filter_pages_by_time` has an infinitely past `end`, hence always returning all the pages from the search.