### PR TITLE
fix: Consider  Hubspot ticket notes body

### DIFF
--- a/backend/danswer/connectors/hubspot/connector.py
+++ b/backend/danswer/connectors/hubspot/connector.py
@@ -94,6 +94,8 @@ class HubSpotConnector(LoadConnector, PollConnector):
                         note = api_client.crm.objects.notes.basic_api.get_by_id(
                             note_id=note.id, properties=["content", "hs_body_preview"]
                         )
+                        if note.properties["hs_body_preview"] is None:
+                            continue
                         associated_notes.append(note.properties["hs_body_preview"])
 
             associated_emails_str = " ,".join(associated_emails)


### PR DESCRIPTION
Consider the case where the Hubspot ticket note body value might be `None`, and
only adding to the list when it's set.

Example object returned

```json
...
    "id": "19203161741",
    "properties": {
        "hs_createdate": "2022-02-09T17:23:27.436Z",
        "hs_lastmodifieddate": "2022-02-09T17:23:27.436Z",
        "hs_object_id": "19203161741"
...
```