### PR TITLE
Update init-letsencrypt.sh to support subdomain configurations

### DIFF
--- a/deployment/docker_compose/init-letsencrypt.sh
+++ b/deployment/docker_compose/init-letsencrypt.sh
@@ -21,7 +21,13 @@ docker_compose_cmd() {
 # Assign appropriate Docker Compose command
 COMPOSE_CMD=$(docker_compose_cmd)
 
-domains=("$DOMAIN" "www.$DOMAIN")
+# Only add www to domain list if domain wasn't explicitly set as a subdomain
+if [[ ! $DOMAIN == www.* ]]; then
+    domains=("$DOMAIN" "www.$DOMAIN")
+else
+    domains=("$DOMAIN")
+fi
+
 rsa_key_size=4096
 data_path="../data/certbot"
 email="$EMAIL" # Adding a valid address is strongly recommended


### PR DESCRIPTION
Sometimes a user wants to specify an explicit subdomain for the establishment of the SSL certificate. In this case, you do not want to append www to the domain in the list of domains to test the Let's Encrypt certification process against.