### PR TITLE
fix(gitignore): properly ignore celery-generated file

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,4 +8,4 @@ api_keys.py
 .env
 vespa-app.zip
 dynamic_config_storage/
-celerybeat-schedule
+celerybeat-schedule*


### PR DESCRIPTION
Tiniest PR to ensure versioning is tidied up by fixing the ignoring of the celery-generated file in dev mode (currently not working properly).