### PR TITLE
fix(config): password auth to be url-encoded to avoid Digital Ocean deployment errors

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 
 from danswer.configs.constants import AuthType
 from danswer.configs.constants import DocumentIndexType
@@ -113,7 +114,10 @@ except ValueError:
 # Below are intended to match the env variables names used by the official postgres docker image
 # https://hub.docker.com/_/postgres
 POSTGRES_USER = os.environ.get("POSTGRES_USER") or "postgres"
-POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD") or "password"
+# URL-encode the password for asyncpg to avoid issues with special characters on some machines.
+POSTGRES_PASSWORD = urllib.parse.quote_plus(
+    os.environ.get("POSTGRES_PASSWORD") or "password"
+)
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST") or "localhost"
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT") or "5432"
 POSTGRES_DB = os.environ.get("POSTGRES_DB") or "postgres"


### PR DESCRIPTION
## What

This PR resolves an issue on certain machines where deployment fails because the `api_server` fails to connect to the `postgres` server inside the `relational_db` container due to how `asyncpg` handles the database URL.

This issue was observed on a DigitalOcean droplet running Ubuntu with Docker 25.0.3 (8 vCPUs, 16G RAM, 480GB disk), following the "[Deploy to Digital Ocean](https://docs.danswer.dev/production/digitalocean)" guide. The failure manifested as the Let's Encrypt script hanging with the message: `Nginx is not ready yet, retrying in 5 seconds...`.

Logs from the `nginx` container pointed to an issue in the `api_server`, where Alembic encountered an error:

```
# full stack trace removed for brevity...
...
socket.gaierror: [Errno -2] Name or service not known
```

## How

The issue was resolved by URL-encoding the database password in the `configs` module. The problem was diagnosed by running various manual and programmatic tests within Docker-powered builds, including:

1. Verifying and logging environment variables on both containers.
2. Ensuring the `api_server` could ping the `relational_db`.
3. Testing both `psycopg2` and `asyncpg` connections using a custom script in `api_server`.

These tests narrowed the issue down to an authentication problem with `asyncpg`, which occurred when the password was not URL-encoded. This did not affect `psycopg2`.

The issue was reproduced consistently with various password patterns, affecting both simple, alpha-numerical ones and more complex ones with special characters like `@` or dashes.

## Tested On

1. DigitalOcean droplet (Ubuntu, Docker 25.0.3, 8 vCPUs, 16G RAM, 480GB disk).
2. Local machine (macOS Sonoma 14.4.1, Docker 25.0.5), where a prior unpatched installation had been functioning correctly.

## Steps to Reproduce

1. Follow the steps in the [Deploy to Digital Ocean](https://docs.danswer.dev/production/digitalocean) guide.
2. Check the logs in the `api_server` container using `docker logs danswer-stack-api_server-1` and observe the error trace.

