### PR TITLE
User Management: Add User Demotion Functionality

### DIFF
--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -45,59 +45,90 @@ const UsersTable = () => {
             <TableHeaderCell>Role</TableHeaderCell>
             <TableHeaderCell>
               <div className="flex">
-                <div className="ml-auto">Promote</div>
+                <div className="ml-auto">Actions</div>
               </div>
             </TableHeaderCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {users.map((user) => {
-            return (
-              <TableRow key={user.id}>
-                <TableCell>{user.email}</TableCell>
-                <TableCell>
-                  <i>{user.role === "admin" ? "Admin" : "User"}</i>
-                </TableCell>
-                <TableCell>
-                  <div className="flex">
-                    <div className="ml-auto">
-                      <Button
-                        onClick={async () => {
-                          const res = await fetch(
-                            "/api/manage/promote-user-to-admin",
-                            {
-                              method: "PATCH",
-                              headers: {
-                                "Content-Type": "application/json",
-                              },
-                              body: JSON.stringify({
-                                user_email: user.email,
-                              }),
-                            }
-                          );
-                          if (!res.ok) {
-                            const errorMsg = await res.text();
-                            setPopup({
-                              message: `Unable to promote user - ${errorMsg}`,
-                              type: "error",
-                            });
-                          } else {
-                            mutate("/api/manage/users");
-                            setPopup({
-                              message: "User promoted to admin!",
-                              type: "success",
-                            });
+          {users.map((user) => (
+            <TableRow key={user.id}>
+              <TableCell>{user.email}</TableCell>
+              <TableCell>
+                <i>{user.role === "admin" ? "Admin" : "User"}</i>
+              </TableCell>
+              <TableCell>
+                <div className="flex justify-end space-x-2">
+                  {user.role !== "admin" && (
+                    <Button
+                      onClick={async () => {
+                        const res = await fetch(
+                          "/api/manage/promote-user-to-admin",
+                          {
+                            method: "PATCH",
+                            headers: {
+                              "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify({
+                              user_email: user.email,
+                            }),
                           }
-                        }}
-                      >
-                        Promote to Admin!
-                      </Button>
-                    </div>
-                  </div>
-                </TableCell>
-              </TableRow>
-            );
-          })}
+                        );
+                        if (!res.ok) {
+                          const errorMsg = await res.text();
+                          setPopup({
+                            message: `Unable to promote user - ${errorMsg}`,
+                            type: "error",
+                          });
+                        } else {
+                          mutate("/api/manage/users");
+                          setPopup({
+                            message: "User promoted to admin!",
+                            type: "success",
+                          });
+                        }
+                      }}
+                    >
+                      Promote to Admin!
+                    </Button>
+                  )}
+                  {user.role === "admin" && (
+                    <Button
+                      onClick={async () => {
+                        const res = await fetch(
+                          "/api/manage/demote-admin-to-user",
+                          {
+                            method: "PATCH",
+                            headers: {
+                              "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify({
+                              user_email: user.email,
+                            }),
+                          }
+                        );
+                        if (!res.ok) {
+                          const errorMsg = await res.text();
+                          setPopup({
+                            message: `Unable to demote admin - ${errorMsg}`,
+                            type: "error",
+                          });
+                        } else {
+                          mutate("/api/manage/users");
+                          setPopup({
+                            message: "Admin demoted to user!",
+                            type: "success",
+                          });
+                        }
+                      }}
+                    >
+                      Demote to User
+                    </Button>
+                  )}
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
         </TableBody>
       </Table>
     </div>


### PR DESCRIPTION
# Description
This PR is a small addition to provide the ability to _demote_ an admin user. Currently, there is no means within the UI to revoke this permission.

**The following is a demonstration. The left screen is `test@test.com` and the right is `test2@test.com`:**

![Demo](https://github.com/danswer-ai/danswer/assets/4227041/d9eda5d6-9200-42ad-8895-b86731cb18d7)

In order to prevent a case where there are _no_ admins, admins cannot demote themselves. 

This partially addresses https://github.com/danswer-ai/danswer/issues/1300