### PR TITLE
Add OAuth env vars to API Server deployment

### DIFF
--- a/deployment/kubernetes/api_server-service-deployment.yaml
+++ b/deployment/kubernetes/api_server-service-deployment.yaml
@@ -41,6 +41,17 @@ spec:
         - containerPort: 8080
         # There are some extra values since this is shared between services
         # There are no conflicts though, extra env variables are simply ignored
+        env:
+        - name: OAUTH_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: danswer-secrets
+              key: google_oauth_client_id
+        - name: OAUTH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: danswer-secrets
+              key: google_oauth_client_secret
         envFrom:
         - configMapRef:
             name: env-configmap

--- a/deployment/kubernetes/secrets.yaml
+++ b/deployment/kubernetes/secrets.yaml
@@ -7,5 +7,5 @@ type: Opaque
 data:
   postgres_user: cG9zdGdyZXM= # "postgres" base64 encoded
   postgres_password: cGFzc3dvcmQ= # "password" base64 encoded
-  google_oauth_client_id: # You will need to provide this, use echo -n "your-client-id" | base64
-  google_oauth_client_secret: # You will need to provide this, use echo -n "your-client-id" | base64
+  google_oauth_client_id: ZXhhbXBsZS1jbGllbnQtaWQ= # "example-client-id" base64 encoded. You will need to provide this, use echo -n "your-client-id" | base64
+  google_oauth_client_secret: example_google_oauth_secret # "example-client-secret" base64 encoded. You will need to provide this, use echo -n "your-client-id" | base64


### PR DESCRIPTION
Without adding the env vars to the API Server deployment, the google secrets cannot be used for authentication.

Fixes #1406