### PR TITLE
Set ignore_danswer_metadata=False when calling read_text_file in fille connector

### DIFF
--- a/backend/danswer/connectors/file/connector.py
+++ b/backend/danswer/connectors/file/connector.py
@@ -69,7 +69,7 @@ def _process_file(
 
     if is_text_file_extension(file_name):
         encoding = detect_encoding(file)
-        file_content_raw, file_metadata = read_text_file(file, encoding=encoding)
+        file_content_raw, file_metadata = read_text_file(file, encoding=encoding, ignore_danswer_metadata=False)
 
     # Using the PDF reader function directly to pass in password cleanly
     elif extension == ".pdf":


### PR DESCRIPTION
Relates to #1195.

This fixes an issue where metadata specified in a #DANSWER_METADATA line in a file read by the file connector is ignored.

To test this:

- Index a file using the file connector that contains a `#DANSWER_METADATA` tag
- Without this fix the metadata like 'link' or 'file_display_name' are ignored and when you do a search the default information is used.
- With this fix the display name and link in search results will be taken from the metadata tag.