### PR TITLE
fix sharepoint connector missing objects

### DIFF
--- a/backend/danswer/connectors/sharepoint/connector.py
+++ b/backend/danswer/connectors/sharepoint/connector.py
@@ -107,7 +107,7 @@ class SharepointConnector(LoadConnector, PollConnector):
             site_list_objects = site_object.lists.get().execute_query()
             for site_list_object in site_list_objects:
                 try:
-                    query = site_list_object.drive.root.get_files(True)
+                    query = site_list_object.drive.root.get_files(True, 1000)
                     if filter_str:
                         query = query.filter(filter_str)
                     driveitems = query.execute_query()

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -33,7 +33,7 @@ llama-index==0.9.45
 Mako==1.2.4
 msal==1.26.0
 nltk==3.8.1
-Office365-REST-Python-Client==2.5.4
+Office365-REST-Python-Client==2.5.9
 oauthlib==3.2.2
 openai==1.14.3 
 openpyxl==3.1.2


### PR DESCRIPTION
Hi,

Currently, the Sharepoint connector returns only 200 drive item objects. This issue is related to the Office365 library (https://github.com/vgrem/Office365-REST-Python-Client/issues/844). 
This PR upgrades the library and sets the highest limit.