### PR TITLE
Slack: add support to rephrase user message

### DIFF
--- a/backend/danswer/configs/danswerbot_configs.py
+++ b/backend/danswer/configs/danswerbot_configs.py
@@ -73,3 +73,7 @@ DANSWER_BOT_MAX_WAIT_TIME = int(os.environ.get("DANSWER_BOT_MAX_WAIT_TIME") or 1
 DANSWER_BOT_FEEDBACK_REMINDER = int(
     os.environ.get("DANSWER_BOT_FEEDBACK_REMINDER") or 0
 )
+# Set to True to rephrase the Slack users messages
+DANSWER_BOT_REPHRASE_MESSAGE = (
+    os.environ.get("DANSWER_BOT_REPHRASE_MESSAGE", "").lower() == "true"
+)

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -208,8 +208,11 @@ def build_request_details(
 
         if DANSWER_BOT_REPHRASE_MESSAGE:
             logger.info(f"Rephrasing Slack message. Original message: {msg}")
-            msg = rephrase_slack_message(msg)
-            logger.info(f"Rephrased message: {msg}")
+            try:
+                msg = rephrase_slack_message(msg)
+                logger.info(f"Rephrased message: {msg}")
+            except Exception as e:
+                logger.error(f"Error while trying to rephrase the Slack message: {e}")
 
         if tagged:
             logger.info("User tagged DanswerBot")

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -204,8 +204,6 @@ def build_request_details(
 
         msg = remove_danswer_bot_tag(msg, client=client.web_client)
 
-        logger.info(f"DANSWER_BOT_REPHRASE_MESSAGE: {DANSWER_BOT_REPHRASE_MESSAGE}")
-
         if DANSWER_BOT_REPHRASE_MESSAGE:
             logger.info(f"Rephrasing Slack message. Original message: {msg}")
             try:

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -10,6 +10,7 @@ from slack_sdk.socket_mode.response import SocketModeResponse
 from sqlalchemy.orm import Session
 
 from danswer.configs.constants import MessageType
+from danswer.configs.danswerbot_configs import DANSWER_BOT_REPHRASE_MESSAGE
 from danswer.configs.danswerbot_configs import DANSWER_BOT_RESPOND_EVERY_CHANNEL
 from danswer.configs.danswerbot_configs import NOTIFY_SLACKBOT_NO_ANSWER
 from danswer.danswerbot.slack.config import get_slack_bot_config_for_channel
@@ -40,6 +41,7 @@ from danswer.danswerbot.slack.utils import get_channel_name_from_id
 from danswer.danswerbot.slack.utils import get_danswer_bot_app_id
 from danswer.danswerbot.slack.utils import read_slack_thread
 from danswer.danswerbot.slack.utils import remove_danswer_bot_tag
+from danswer.danswerbot.slack.utils import rephrase_slack_message
 from danswer.danswerbot.slack.utils import respond_in_thread
 from danswer.db.embedding_model import get_current_db_embedding_model
 from danswer.db.engine import get_sqlalchemy_engine
@@ -201,6 +203,13 @@ def build_request_details(
         thread_ts = event.get("thread_ts")
 
         msg = remove_danswer_bot_tag(msg, client=client.web_client)
+
+        logger.info(f"DANSWER_BOT_REPHRASE_MESSAGE: {DANSWER_BOT_REPHRASE_MESSAGE}")
+
+        if DANSWER_BOT_REPHRASE_MESSAGE:
+            logger.info(f"Rephrasing Slack message. Original message: {msg}")
+            msg = rephrase_slack_message(msg)
+            logger.info(f"Rephrased message: {msg}")
 
         if tagged:
             logger.info("User tagged DanswerBot")

--- a/backend/danswer/prompts/miscellaneous_prompts.py
+++ b/backend/danswer/prompts/miscellaneous_prompts.py
@@ -11,6 +11,20 @@ Query:
 {query}
 """.strip()
 
+SLACK_LANGUAGE_REPHRASE_PROMPT = """
+As an AI assistant employed by an organization, \
+your role is to transform user messages into concise \
+inquiries suitable for a Large Language Model (LLM) that \
+retrieves pertinent materials within a Retrieval-Augmented \
+Generation (RAG) framework. Ensure to reply in the identical \
+language as the original request. When faced with multiple \
+questions within a single query, distill them into a singular, \
+unified question, disregarding any direct mentions.
+
+Query:
+{query}
+""".strip()
+
 
 # Use the following for easy viewing of prompts
 if __name__ == "__main__":


### PR DESCRIPTION
Hello,

We've been utilizing Danswer to actively monitor and respond to user Slack messages, but we've encountered poor results because often the end user doesn't craft their messages with the understanding that a bot is interpreting them.

To enhance the quality of our responses, this Pull Request introduces an additional step that rephrases user messages for clarity before processing.