### PR TITLE
Improve text for what happens in the background on the web connector regarding to PDF files & links.

### DIFF
--- a/web/src/app/admin/connectors/web/page.tsx
+++ b/web/src/app/admin/connectors/web/page.tsx
@@ -58,7 +58,7 @@ export default function Web() {
       </Title>
       <p className="text-sm mb-2">
         We re-fetch the latest state of the website once a day.<br>
-        This will also index pdf,docx,xlsx,pptx,eml and epub (but will not follow links inside the documents).
+        This will also index pdf files (but will not follow links inside the documents).
       </p>
       <Card>
         <ConnectorForm<WebConfig>

--- a/web/src/app/admin/connectors/web/page.tsx
+++ b/web/src/app/admin/connectors/web/page.tsx
@@ -57,7 +57,8 @@ export default function Web() {
         Step 1: Specify which websites to index
       </Title>
       <p className="text-sm mb-2">
-        We re-fetch the latest state of the website once a day.
+        We re-fetch the latest state of the website once a day.<br>
+        This will also index pdf,docx,xlsx,pptx,eml and epub (but will not follow links inside the documents).
       </p>
       <Card>
         <ConnectorForm<WebConfig>


### PR DESCRIPTION
## 📍 AS IS
From the current interface (see screenshot) it is not clear if linked documents are indexed.
  ![image](https://github.com/danswer-ai/danswer/assets/592312/5ba1a0b2-1d0c-4d25-9a0e-cef2996cf7de)
  
## 🔍 Source code: 
It seems from the [web/connector.py code](https://github.com/danswer-ai/danswer/blob/main/backend/danswer/connectors/web/connector.py#L247) that pdf contents are indexed but links from the pdf not. 

```
 if current_url.split(".")[-1] == "pdf":
                    # PDF files are not checked for links
                    response = requests.get(current_url)
                    page_text = pdf_to_text(file=io.BytesIO(response.content))

                    doc_batch.append(
                        Document(
                            id=current_url,
                            sections=[Section(link=current_url, text=page_text)],
                            source=DocumentSource.WEB,
                            semantic_identifier=current_url.split(".")[-1],
                            metadata={},
                        )
                    )
```
## 📦 In the commit: 
This commit clarifies this in the copy in the connector screen.

## ❓ Questions I have: 
- [the extract_file_text.py](https://github.com/danswer-ai/danswer/blob/main/backend/danswer/file_processing/extract_file_text.py#L43) supports also docx/pptx/xlsx/.eml/epub: I think it would be great to have the possibility to also index linked docx files or pptx files (maybe as a checkbox) in the web publisher. 

