### PR TITLE
Fix Helm chart run failures due to low resources

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -316,16 +316,14 @@ vespa:
     # runAsUser: 1000
 
   resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  #   requests:
-  #     cpu: 1500m
-  #     memory: 4000Mi
-  # # limits:
-  # #   cpu: 100m
-  # #   memory: 128Mi
+  # The Vespa Helm chart specifies default resources, which are quite modest. We override
+  # them here to increase chances of the chart running successfully.
+    requests:
+      cpu: 1500m
+      memory: 4000Mi
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Contrary to the comments in `values.yaml` claiming that specifying default resources is left out to the user, resources are being specified for some deployments. The resources for `background`, for example, are too low and cause process restarts in the container.

On the other hand, no resources are specified for `vespa`, and the Vespa Helm chart [specifies resources](https://github.com/unoplat/vespa-helm-charts/blob/e7db599f1272d3ff4752298dba1db14d05b70409/charts/vespa/values.yaml#L90) that are too low.

This PR does the following:

1. Comment out resource specifications for all deployments except `vespa` and fix code style of the commented-out blocks
2. Override resource specifications for `vespa` to allow Vespa to run.