### PR TITLE
adding secrets to helm

### DIFF
--- a/deployment/kubernetes/charts/danswer-stack/Chart.lock
+++ b/deployment/kubernetes/charts/danswer-stack/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 14.3.1
 - name: vespa
   repository: https://unoplat.github.io/vespa-helm-charts
-  version: 0.2.2
+  version: 0.2.3
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.14.0
-digest: sha256:53e138c0ab12193f57a76c2f377e2a5d3d11c394b03eef5f6848dfae6705cb61
-generated: "2024-03-27T12:34:11.548396+05:30"
+digest: sha256:ab17b5d2c3883055cb4a26bf530043521be5220c24f804e954bb428273d16ba8
+generated: "2024-05-24T16:55:30.598279-07:00"

--- a/deployment/kubernetes/charts/danswer-stack/Chart.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.danswer.ai/
 sources:
   - "https://github.com/danswer-ai/danswer"
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.3.72"
 annotations:
   category: Productivity

--- a/deployment/kubernetes/charts/danswer-stack/templates/_helpers.tpl
+++ b/deployment/kubernetes/charts/danswer-stack/templates/_helpers.tpl
@@ -60,3 +60,24 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Set secret name
+*/}}
+{{- define "danswer-stack.secretName" -}}
+{{- default (default "danswer-secrets" .Values.auth.secretName) .Values.auth.existingSecret }}
+{{- end }}
+
+{{/*
+Create env vars from secrets
+*/}}
+{{- define "danswer-stack.envSecrets" -}}
+    {{- range $name, $key := .Values.auth.secretKeys }}
+- name: {{ $name | upper | replace "-" "_" | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "danswer-stack.secretName" $ }}
+      key: {{ default $name $key }}
+    {{- end }}
+{{- end }}
+

--- a/deployment/kubernetes/charts/danswer-stack/templates/api-deployment.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/api-deployment.yaml
@@ -55,6 +55,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.config.envConfigMapName }}
+          env:
+            {{- include "danswer-stack.envSecrets" . | nindent 12}}
           volumeMounts:
             - name: dynamic-storage
               mountPath: /home/storage

--- a/deployment/kubernetes/charts/danswer-stack/templates/background-deployment.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/background-deployment.yaml
@@ -48,6 +48,7 @@ spec:
           env:
             - name: ENABLE_MINI_CHUNK
               value: "{{ .Values.background.enableMiniChunk }}"
+            {{- include "danswer-stack.envSecrets" . | nindent 12}}
           volumeMounts:
             - name: dynamic-storage
               mountPath: /home/storage

--- a/deployment/kubernetes/charts/danswer-stack/templates/configmap.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: env-configmap
+  name: {{ .Values.config.envConfigMapName }}
   labels:
     {{- include "danswer-stack.labels" . | nindent 4 }}
 data:

--- a/deployment/kubernetes/charts/danswer-stack/templates/danswer-secret.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/danswer-secret.yaml
@@ -1,11 +1,11 @@
+{{- if not .Values.auth.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: danswer-secrets
+  name: {{ include "danswer-stack.secretName" . }}
 type: Opaque
-data:
-  postgres_user: cG9zdGdyZXM= # "postgres" base64 encoded
-  postgres_password: cGFzc3dvcmQ= # "password" base64 encoded
-  postgres-password: cGFzc3dvcmQ=
-  google_oauth_client_id: # You will need to provide this, use echo -n "your-client-id" | base64
-  google_oauth_client_secret: # You
+stringData:
+  {{- range $name, $value := .Values.auth.secrets }}
+  {{ $name }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deployment/kubernetes/charts/danswer-stack/templates/indexing-model-deployment.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/indexing-model-deployment.yaml
@@ -34,11 +34,10 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ .Values.config.envConfigMapName }}
-        {{- if .Values.indexCapability.indexingOnly }}
         env:
           - name: INDEXING_ONLY
-            value: "{{ .Values.indexCapability.indexingOnly }}"
-        {{- end }}
+            value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
+          {{- include "danswer-stack.envSecrets" . | nindent 10}}
         volumeMounts:
         {{- range .Values.indexCapability.volumeMounts }}
         - name: {{ .name }}

--- a/deployment/kubernetes/charts/danswer-stack/templates/inference-model-deployment.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/inference-model-deployment.yaml
@@ -30,6 +30,8 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ .Values.config.envConfigMapName }}
+        env:
+          {{- include "danswer-stack.envSecrets" . | nindent 12}}
         volumeMounts:
         {{- range .Values.inferenceCapability.deployment.volumeMounts }}
         - name: {{ .name }}

--- a/deployment/kubernetes/charts/danswer-stack/templates/webserver-deployment.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/templates/webserver-deployment.yaml
@@ -48,6 +48,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.config.envConfigMapName }}
+          env:
+            {{- include "danswer-stack.envSecrets" . | nindent 12}}
           {{- with .Values.webserver.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/kubernetes/charts/danswer-stack/values.yaml
+++ b/deployment/kubernetes/charts/danswer-stack/values.yaml
@@ -85,8 +85,8 @@ postgresql:
   enabled: true
   auth:
     existingSecret: danswer-secrets
-    # secretKeys:
-    #   adminPasswordKey: postgres_password
+    secretKeys:
+      adminPasswordKey: postgres_password #overwriting as postgres typically expects 'postgres-password'
 
 nginx:
   containerPorts:
@@ -392,6 +392,33 @@ persistence:
         - ReadWriteOnce
       size: 1Gi  
 
+auth:
+  # for storing smtp, oauth, slack, and other secrets
+  # keys are lowercased version of env vars (e.g. SMTP_USER -> smtp_user)
+  existingSecret: "" # danswer-secrets
+  # optionally override the secret keys to reference in the secret
+  secretKeys:
+    postgres_password: ""
+    smtp_pass: ""
+    oauth_client_id: ""
+    oauth_client_secret: ""
+    oauth_cookie_secret: ""
+    gen_ai_api_key: ""
+    danswer_bot_slack_app_token: ""
+    danswer_bot_slack_bot_token: ""
+  # will be overridden by the existingSecret if set
+  secretName: "danswer-secrets"
+  # set values as strings, they will be base64 encoded
+  secrets:
+    postgres_password: ""
+    smtp_pass: ""
+    oauth_client_id: ""
+    oauth_client_secret: ""
+    oauth_cookie_secret: ""
+    gen_ai_api_key: ""
+    danswer_bot_slack_app_token: ""
+    danswer_bot_slack_bot_token: ""
+
 configMap:
   AUTH_TYPE: "disabled"  # Change this for production uses unless Danswer is only accessible behind VPN
   SESSION_EXPIRE_TIME_SECONDS: "86400"  # 1 Day Default
@@ -399,13 +426,13 @@ configMap:
   SMTP_SERVER: "" # For sending verification emails, if unspecified then defaults to 'smtp.gmail.com'
   SMTP_PORT: "" # For sending verification emails, if unspecified then defaults to '587'
   SMTP_USER: ""  # 'your-email@company.com'
-  SMTP_PASS: ""  # 'your-gmail-password'
+  # SMTP_PASS: ""  # 'your-gmail-password'
   EMAIL_FROM: ""  # 'your-email@company.com' SMTP_USER missing used instead
   # Gen AI Settings
   GEN_AI_MODEL_PROVIDER: ""
   GEN_AI_MODEL_VERSION: ""
   FAST_GEN_AI_MODEL_VERSION: ""
-  GEN_AI_API_KEY: ""
+  # GEN_AI_API_KEY: ""
   GEN_AI_API_ENDPOINT: ""
   GEN_AI_API_VERSION: ""
   GEN_AI_LLM_PROVIDER_TYPE: ""
@@ -429,9 +456,7 @@ configMap:
   ASYM_PASSAGE_PREFIX: ""
   ENABLE_RERANKING_REAL_TIME_FLOW: ""
   ENABLE_RERANKING_ASYNC_FLOW: ""
-  
   MODEL_SERVER_PORT: ""
-  
   MIN_THREADS_ML_MODELS: ""
   # Indexing Configs
   NUM_INDEXING_WORKERS: ""
@@ -444,8 +469,8 @@ configMap:
   GONG_CONNECTOR_START_TIME: ""
   NOTION_CONNECTOR_ENABLE_RECURSIVE_PAGE_LOOKUP: ""
   # DanswerBot SlackBot Configs
-  DANSWER_BOT_SLACK_APP_TOKEN: ""
-  DANSWER_BOT_SLACK_BOT_TOKEN: ""
+  # DANSWER_BOT_SLACK_APP_TOKEN: ""
+  # DANSWER_BOT_SLACK_BOT_TOKEN: ""
   DANSWER_BOT_DISABLE_DOCS_ONLY_ANSWER: ""
   DANSWER_BOT_DISPLAY_ERROR_MSGS: ""
   DANSWER_BOT_RESPOND_EVERY_CHANNEL: ""


### PR DESCRIPTION
This PR helps separate some secrets out from the standard configmap, the changes include:
- Adding an auth section to the helm values yaml
- Adding to the auth section keys to fill in for various secrets
- Adding these secrets to the various deployments as env vars, to avoid any changes to the backend code
- Incrementing chart version

Fixes #1540 and helps with #971 