### PR TITLE
Added support for Sites.Selected permissions to the SharePoint Connector and enabled the selection of individual subfolders

### DIFF
--- a/web/src/app/admin/connectors/sharepoint/page.tsx
+++ b/web/src/app/admin/connectors/sharepoint/page.tsx
@@ -222,11 +222,16 @@ const MainSection = () => {
             formBodyBuilder={TextArrayFieldBuilder({
               name: "sites",
               label: "Sites:",
-              subtext:
-                "Specify 0 or more sites to index. For example, specifying the site " +
-                "'support' for the 'danswerai' sharepoint will cause us to only index documents " +
-                "within the 'https://danswerai.sharepoint.com/sites/support' site. " +
-                "If no sites are specified, all sites in your organization will be indexed.",
+              subtext: (
+                <>
+                  <br />
+                  <ul>
+                    <li>• If no sites are specified, all sites in your organization will be indexed (Sites.Read.All permission required).</li>
+                    <li>• Specifying &apos;https://danswerai.sharepoint.com/sites/support&apos; for example will only index documents within this site.</li>
+                    <li>• Specifying &apos;https://danswerai.sharepoint.com/sites/support/subfolder&apos; for example will only index documents within this folder.</li>
+                  </ul>
+                </>
+              ),
             })}
             validationSchema={Yup.object().shape({
               sites: Yup.array()

--- a/web/src/components/admin/connectors/Field.tsx
+++ b/web/src/components/admin/connectors/Field.tsx
@@ -214,7 +214,7 @@ export function TextArrayField<T extends Yup.AnyObject>({
 interface TextArrayFieldBuilderProps<T extends Yup.AnyObject> {
   name: string;
   label: string;
-  subtext?: string;
+  subtext?: string | JSX.Element;
   type?: string;
 }
 


### PR DESCRIPTION
This commit enhances the SharePoint Connector with the following features:

1. **Support for Sites.Selected Permissions:**
   - Enables granular access control by supporting Sites.Selected permissions.
   - The existing method using Sites.Read.All permissions remains unchanged and fully functional.
   - Allows administrators to specify certain SharePoint sites which enhances security and compliance with organizational policies.

2. **Subfolder Selection Capability:**
   - Adds functionality to select individual subfolders within a SharePoint site.
   - Provides users with more precise data management options.