### PR TITLE
fix: strip non-alphanum chars from connector slug

### DIFF
--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -206,7 +206,8 @@ function fillSourceMetadata(
     ...partialMetadata,
     adminUrl: `/admin/connectors/${partialMetadata.displayName
       .toLowerCase()
-      .replaceAll(" ", "-")}`,
+      .replaceAll(" ", "-")
+      .replace(/[^0-9a-z-]/g, "")}`,
   };
 }
 


### PR DESCRIPTION
This allows us to use characters like parentheses in `displayName` without fear of having them show up in links.