### PR TITLE
Web connector, but able to authenticate with an Okta tenant

### DIFF
--- a/backend/danswer/configs/constants.py
+++ b/backend/danswer/configs/constants.py
@@ -72,6 +72,7 @@ class DocumentSource(str, Enum):
     INGESTION_API = "ingestion_api"
     SLACK = "slack"
     WEB = "web"
+    WEB_OKTA = "web_okta"
     GOOGLE_DRIVE = "google_drive"
     GMAIL = "gmail"
     REQUESTTRACKER = "requesttracker"

--- a/backend/danswer/connectors/factory.py
+++ b/backend/danswer/connectors/factory.py
@@ -34,6 +34,7 @@ from danswer.connectors.slab.connector import SlabConnector
 from danswer.connectors.slack.connector import SlackPollConnector
 from danswer.connectors.slack.load_connector import SlackLoadConnector
 from danswer.connectors.web.connector import WebConnector
+from danswer.connectors.web_okta.connector import WebOktaConnector
 from danswer.connectors.wikipedia.connector import WikipediaConnector
 from danswer.connectors.zendesk.connector import ZendeskConnector
 from danswer.connectors.zulip.connector import ZulipConnector
@@ -49,6 +50,7 @@ def identify_connector_class(
 ) -> Type[BaseConnector]:
     connector_map = {
         DocumentSource.WEB: WebConnector,
+        DocumentSource.WEB_OKTA: WebOktaConnector,
         DocumentSource.FILE: LocalFileConnector,
         DocumentSource.SLACK: {
             InputType.LOAD_STATE: SlackLoadConnector,

--- a/backend/danswer/connectors/web_okta/connector.py
+++ b/backend/danswer/connectors/web_okta/connector.py
@@ -1,0 +1,332 @@
+import io
+import ipaddress
+import socket
+from enum import Enum
+from typing import Any
+from typing import cast
+from typing import Tuple
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from oauthlib.oauth2 import BackendApplicationClient
+from playwright.sync_api import BrowserContext
+from playwright.sync_api import Playwright
+from playwright.sync_api import sync_playwright
+from requests_oauthlib import OAuth2Session  # type:ignore
+
+from danswer.configs.app_configs import INDEX_BATCH_SIZE
+from danswer.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_ID
+from danswer.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_SECRET
+from danswer.configs.app_configs import WEB_CONNECTOR_OAUTH_TOKEN_URL
+from danswer.configs.app_configs import WEB_CONNECTOR_VALIDATE_URLS
+from danswer.configs.constants import DocumentSource
+from danswer.connectors.interfaces import GenerateDocumentsOutput
+from danswer.connectors.interfaces import LoadConnector
+from danswer.connectors.models import Document
+from danswer.connectors.models import Section
+from danswer.file_processing.extract_file_text import pdf_to_text
+from danswer.file_processing.html_utils import web_html_cleanup
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class WEB_CONNECTOR_VALID_SETTINGS(str, Enum):
+    # Given a base site, index everything under that path
+    RECURSIVE = "recursive"
+    # Given a URL, index only the given page
+    SINGLE = "single"
+    # Given a sitemap.xml URL, parse all the pages in it
+    SITEMAP = "sitemap"
+    # Given a file upload where every line is a URL, parse all the URLs provided
+    UPLOAD = "upload"
+
+
+def protected_url_check(url: str) -> None:
+    """Couple considerations:
+    - DNS mapping changes over time so we don't want to cache the results
+    - Fetching this is assumed to be relatively fast compared to other bottlenecks like reading
+      the page or embedding the contents
+    - To be extra safe, all IPs associated with the URL must be global
+    - This is to prevent misuse and not explicit attacks
+    """
+    if not WEB_CONNECTOR_VALIDATE_URLS:
+        return
+
+    parse = urlparse(url)
+    if parse.scheme != "http" and parse.scheme != "https":
+        raise ValueError("URL must be of scheme https?://")
+
+    if not parse.hostname:
+        raise ValueError("URL must include a hostname")
+
+    try:
+        # This may give a large list of IP addresses for domains with extensive DNS configurations
+        # such as large distributed systems of CDNs
+        info = socket.getaddrinfo(parse.hostname, None)
+    except socket.gaierror as e:
+        raise ConnectionError(f"DNS resolution failed for {parse.hostname}: {e}")
+
+    for address in info:
+        ip = address[4][0]
+        if not ipaddress.ip_address(ip).is_global:
+            raise ValueError(
+                f"Non-global IP address detected: {ip}, skipping page {url}. "
+                f"The Web Connector is not allowed to read loopback, link-local, or private ranges"
+            )
+
+
+def check_internet_connection(url: str) -> None:
+    try:
+        response = requests.get(url, timeout=3)
+        response.raise_for_status()
+    except (requests.RequestException, ValueError):
+        raise Exception(f"Unable to reach {url} - check your internet connection")
+
+
+def is_valid_url(url: str) -> bool:
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
+
+
+def get_internal_links(
+    base_url: str, url: str, soup: BeautifulSoup, should_ignore_pound: bool = True
+) -> set[str]:
+    internal_links = set()
+    for link in cast(list[dict[str, Any]], soup.find_all("a")):
+        href = cast(str | None, link.get("href"))
+        if not href:
+            continue
+
+        if should_ignore_pound and "#" in href:
+            href = href.split("#")[0]
+
+        if not is_valid_url(href):
+            # Relative path handling
+            href = urljoin(url, href)
+
+        if urlparse(href).netloc == urlparse(url).netloc and base_url in href:
+            internal_links.add(href)
+    return internal_links
+
+
+def start_playwright() -> Tuple[Playwright, BrowserContext]:
+    playwright = sync_playwright().start()
+    browser = playwright.chromium.launch(headless=True)
+
+    context = browser.new_context()
+
+    if (
+        WEB_CONNECTOR_OAUTH_CLIENT_ID
+        and WEB_CONNECTOR_OAUTH_CLIENT_SECRET
+        and WEB_CONNECTOR_OAUTH_TOKEN_URL
+    ):
+        client = BackendApplicationClient(client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID)
+        oauth = OAuth2Session(client=client)
+        token = oauth.fetch_token(
+            token_url=WEB_CONNECTOR_OAUTH_TOKEN_URL,
+            client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID,
+            client_secret=WEB_CONNECTOR_OAUTH_CLIENT_SECRET,
+        )
+        context.set_extra_http_headers(
+            {"Authorization": "Bearer {}".format(token["access_token"])}
+        )
+
+    return playwright, context
+
+
+def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:
+    response = requests.get(sitemap_url)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    return [
+        _ensure_absolute_url(sitemap_url, loc_tag.text)
+        for loc_tag in soup.find_all("loc")
+    ]
+
+
+def _ensure_absolute_url(source_url: str, maybe_relative_url: str) -> str:
+    if not urlparse(maybe_relative_url).netloc:
+        return urljoin(source_url, maybe_relative_url)
+    return maybe_relative_url
+
+
+def _ensure_valid_url(url: str) -> str:
+    if "://" not in url:
+        return "https://" + url
+    return url
+
+
+def _read_urls_file(location: str) -> list[str]:
+    with open(location, "r") as f:
+        urls = [_ensure_valid_url(line.strip()) for line in f if line.strip()]
+    return urls
+
+
+class WebConnector(LoadConnector):
+    def __init__(
+        self,
+        base_url: str,  # Can't change this without disrupting existing users
+        web_connector_type: str = WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+        mintlify_cleanup: bool = True,  # Mostly ok to apply to other websites as well
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.mintlify_cleanup = mintlify_cleanup
+        self.batch_size = batch_size
+        self.recursive = False
+
+        if web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value:
+            self.recursive = True
+            self.to_visit_list = [_ensure_valid_url(base_url)]
+            return
+
+        elif web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value:
+            self.to_visit_list = [_ensure_valid_url(base_url)]
+
+        elif web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SITEMAP:
+            self.to_visit_list = extract_urls_from_sitemap(_ensure_valid_url(base_url))
+
+        elif web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.UPLOAD:
+            logger.warning(
+                "This is not a UI supported Web Connector flow, "
+                "are you sure you want to do this?"
+            )
+            self.to_visit_list = _read_urls_file(base_url)
+
+        else:
+            raise ValueError(
+                "Invalid Web Connector Config, must choose a valid type between: " ""
+            )
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        if credentials:
+            logger.warning("Unexpected credentials provided for Web Connector")
+        return None
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        """Traverses through all pages found on the website
+        and converts them into documents"""
+        visited_links: set[str] = set()
+        to_visit: list[str] = self.to_visit_list
+        base_url = to_visit[0]  # For the recursive case
+        doc_batch: list[Document] = []
+
+        # Needed to report error
+        at_least_one_doc = False
+        last_error = None
+
+        playwright, context = start_playwright()
+        restart_playwright = False
+        while to_visit:
+            current_url = to_visit.pop()
+            if current_url in visited_links:
+                continue
+            visited_links.add(current_url)
+
+            try:
+                protected_url_check(current_url)
+            except Exception as e:
+                last_error = f"Invalid URL {current_url} due to {e}"
+                logger.warning(last_error)
+                continue
+
+            logger.info(f"Visiting {current_url}")
+
+            try:
+                check_internet_connection(current_url)
+                if restart_playwright:
+                    playwright, context = start_playwright()
+                    restart_playwright = False
+
+                if current_url.split(".")[-1] == "pdf":
+                    # PDF files are not checked for links
+                    response = requests.get(current_url)
+                    page_text = pdf_to_text(file=io.BytesIO(response.content))
+
+                    doc_batch.append(
+                        Document(
+                            id=current_url,
+                            sections=[Section(link=current_url, text=page_text)],
+                            source=DocumentSource.WEB,
+                            semantic_identifier=current_url.split(".")[-1],
+                            metadata={},
+                        )
+                    )
+                    continue
+
+                page = context.new_page()
+                page_response = page.goto(current_url)
+                final_page = page.url
+                if final_page != current_url:
+                    logger.info(f"Redirected to {final_page}")
+                    protected_url_check(final_page)
+                    current_url = final_page
+                    if current_url in visited_links:
+                        logger.info("Redirected page already indexed")
+                        continue
+                    visited_links.add(current_url)
+
+                content = page.content()
+                soup = BeautifulSoup(content, "html.parser")
+
+                if self.recursive:
+                    internal_links = get_internal_links(base_url, current_url, soup)
+                    for link in internal_links:
+                        if link not in visited_links:
+                            to_visit.append(link)
+
+                if page_response and str(page_response.status)[0] in ("4", "5"):
+                    last_error = f"Skipped indexing {current_url} due to HTTP {page_response.status} response"
+                    logger.info(last_error)
+                    continue
+
+                parsed_html = web_html_cleanup(soup, self.mintlify_cleanup)
+
+                doc_batch.append(
+                    Document(
+                        id=current_url,
+                        sections=[
+                            Section(link=current_url, text=parsed_html.cleaned_text)
+                        ],
+                        source=DocumentSource.WEB,
+                        semantic_identifier=parsed_html.title or current_url,
+                        metadata={},
+                    )
+                )
+
+                page.close()
+            except Exception as e:
+                last_error = f"Failed to fetch '{current_url}': {e}"
+                logger.error(last_error)
+                playwright.stop()
+                restart_playwright = True
+                continue
+
+            if len(doc_batch) >= self.batch_size:
+                playwright.stop()
+                restart_playwright = True
+                at_least_one_doc = True
+                yield doc_batch
+                doc_batch = []
+
+        if doc_batch:
+            playwright.stop()
+            at_least_one_doc = True
+            yield doc_batch
+
+        if not at_least_one_doc:
+            if last_error:
+                raise RuntimeError(last_error)
+            raise RuntimeError("No valid pages found.")
+
+
+if __name__ == "__main__":
+    connector = WebConnector("https://docs.danswer.dev/")
+    document_batches = connector.load_from_state()
+    print(next(document_batches))

--- a/backend/danswer/connectors/web_okta/okta.py
+++ b/backend/danswer/connectors/web_okta/okta.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import Page
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+class Credentials:
+    tenant_url: str
+    username: str
+    password: str
+
+    def __init__(self, tenant_url: str, username: str, password: str):
+        self.tenant_url = tenant_url
+        self.username = username
+        self.password = password
+
+    def is_login_url(self, url: str) -> bool:
+        return url.startswith(self.tenant_url)
+
+def do_login(page: Page, creds: Credentials):
+    logger.info("Waiting for network idle")
+    page.wait_for_load_state("networkidle")
+
+    if not page.url.startswith(creds.tenant_url):
+        raise "Can't login with Okta credentials outside of the Okta tenant URL"
+
+    logger.info(f"Logging in to tenant {creds.tenant_url} as {creds.username}")
+    page.type('input[name="identifier"]', creds.username)
+
+    logger.info("Confirmed we're logging in to the Okta tenant")
+    password_selector = 'input[name="credentials.passcode"]'
+    password_input = page.query_selector(password_selector)
+    if not password_input:
+        logger.info("Password field missing, assuming two-step process")
+        page.click(".button-primary")
+        page.wait_for_load_state("networkidle")
+        page.wait_for_selector(password_selector)
+    page.type(password_selector, creds.password)
+    page.click(".button-primary")
+    page.wait_for_function(f'() => !document.URL.startsWith("{creds.tenant_url}")')

--- a/web/src/app/admin/connectors/web-okta/page.tsx
+++ b/web/src/app/admin/connectors/web-okta/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import useSWR, { useSWRConfig } from "swr";
+import * as Yup from "yup";
+
+import { LoadingAnimation } from "@/components/Loading";
+import {
+  GlobeIcon,
+  GearIcon,
+  ArrowSquareOutIcon,
+} from "@/components/icons/icons";
+import { fetcher } from "@/lib/fetcher";
+import {
+  SelectorFormField,
+  TextFormField,
+} from "@/components/admin/connectors/Field";
+import { HealthCheckBanner } from "@/components/health/healthcheck";
+import { ConnectorIndexingStatus, WebOktaConfig } from "@/lib/types";
+import { ConnectorsTable } from "@/components/admin/connectors/table/ConnectorsTable";
+import { ConnectorForm } from "@/components/admin/connectors/ConnectorForm";
+import { AdminPageTitle } from "@/components/admin/Title";
+import { Card, Title } from "@tremor/react";
+
+const SCRAPE_TYPE_TO_PRETTY_NAME = {
+  recursive: "Recursive",
+  single: "Single Page",
+  sitemap: "Sitemap",
+};
+
+export default function WebOkta() {
+  const { mutate } = useSWRConfig();
+
+  const {
+    data: connectorIndexingStatuses,
+    isLoading: isConnectorIndexingStatusesLoading,
+    error: isConnectorIndexingStatusesError,
+  } = useSWR<ConnectorIndexingStatus<any, any>[]>(
+    "/api/manage/admin/connector/indexing-status",
+    fetcher
+  );
+
+  const webIndexingStatuses: ConnectorIndexingStatus<WebOktaConfig, {}>[] =
+    connectorIndexingStatuses?.filter(
+      (connectorIndexingStatus) =>
+        connectorIndexingStatus.connector.source === "web_okta"
+    ) ?? [];
+
+  return (
+    <div className="mx-auto container">
+      <div className="mb-4">
+        <HealthCheckBanner />
+      </div>
+
+      <AdminPageTitle icon={<GlobeIcon size={32} />} title="Web" />
+
+      <Title className="mb-2 mt-6 ml-auto mr-auto">
+        Step 1: Specify which websites to index
+      </Title>
+      <p className="text-sm mb-2">
+        We re-fetch the latest state of the website once a day.
+      </p>
+      <Card>
+        <ConnectorForm<WebOktaConfig>
+          nameBuilder={(values) => `WebConnector-${values.base_url}`}
+          ccPairNameBuilder={(values) => values.base_url}
+          // Since there is no "real" credential associated with a web connector
+          // we create a dummy one here so that we can associate the CC Pair with a
+          // user. This is needed since the user for a CC Pair is found via the credential
+          // associated with it.
+          shouldCreateEmptyCredentialForConnector={true}
+          source="web_okta"
+          inputType="load_state"
+          formBody={
+            <>
+              <TextFormField
+                name="base_url"
+                label="URL to Index:"
+                autoCompleteDisabled={false}
+              />
+              <TextFormField
+                name="okta_tenant_url"
+                label="Where should we login to Okta? For exanple: https://acmecorp.okta-ema.com"
+                autoCompleteDisabled={false}
+              />
+              <TextFormField
+                name="okta_username"
+                label="The robot's Okta username. MFA must be disabled for this user."
+                autoCompleteDisabled={false}
+              />
+              <TextFormField
+                name="okta_password"
+                type="password"
+                label="The robot's Okta password."
+                autoCompleteDisabled={false}
+              />
+              <div className="w-full">
+                <SelectorFormField
+                  name="web_connector_type"
+                  label="Scrape Method:"
+                  options={[
+                    {
+                      name: "Recursive",
+                      value: "recursive",
+                      description:
+                        "Recursively index all pages that share the same base URL.",
+                    },
+                    {
+                      name: "Single Page",
+                      value: "single",
+                      description: "Index only the specified page.",
+                    },
+                    {
+                      name: "Sitemap",
+                      value: "sitemap",
+                      description:
+                        "Assumes the URL to Index points to a Sitemap. Will try and index all pages that are a mentioned in the sitemap.",
+                    },
+                  ]}
+                />
+              </div>
+            </>
+          }
+          validationSchema={Yup.object().shape({
+            base_url: Yup.string().required(
+              "Please enter the website URL to scrape e.g. https://docs.danswer.dev/"
+            ),
+            web_connector_type: Yup.string()
+              .oneOf(["recursive", "single", "sitemap"])
+              .optional(),
+            okta_tenant_url: Yup.string().required("Please enter the Okta tenant's base URL"),
+            okta_username: Yup.string().required("Please enter the Okta user's username"),
+            okta_password: Yup.string().required("Please enter the Okta user's password"),
+          })}
+          initialValues={{
+            base_url: "",
+            web_connector_type: undefined,
+            okta_tenant_url: "",
+            okta_username: "",
+            okta_password: "",
+          }}
+          refreshFreq={60 * 60 * 24} // 1 day
+        />
+      </Card>
+
+      <Title className="mb-2 mt-6 ml-auto mr-auto">
+        Already Indexed Websites
+      </Title>
+      {isConnectorIndexingStatusesLoading ? (
+        <LoadingAnimation text="Loading" />
+      ) : isConnectorIndexingStatusesError || !connectorIndexingStatuses ? (
+        <div>Error loading indexing history</div>
+      ) : webIndexingStatuses.length > 0 ? (
+        <ConnectorsTable<WebOktaConfig, {}>
+          connectorIndexingStatuses={webIndexingStatuses}
+          specialColumns={[
+            {
+              header: "Base URL",
+              key: "base_url",
+              getValue: (
+                ccPairStatus: ConnectorIndexingStatus<WebOktaConfig, any>
+              ) => {
+                const connectorConfig =
+                  ccPairStatus.connector.connector_specific_config;
+                return (
+                  <div className="flex w-fit">
+                    <a
+                      className="text-blue-500 ml-1 my-auto flex"
+                      href={connectorConfig.base_url}
+                    >
+                      {connectorConfig.base_url}
+                      <ArrowSquareOutIcon className="my-auto flex flex-shrink-0 text-blue-500" />
+                    </a>
+                    <a
+                      className="my-auto"
+                      href={`/admin/connector/${ccPairStatus.cc_pair_id}`}
+                    >
+                      <GearIcon className="ml-2 my-auto flex flex-shrink-0 text-gray-400" />
+                    </a>
+                  </div>
+                );
+              },
+            },
+            {
+              header: "Scrape Method",
+              key: "web_connector_type",
+              getValue: (ccPairStatus) => {
+                const connectorConfig =
+                  ccPairStatus.connector.connector_specific_config;
+                return connectorConfig.web_connector_type
+                  ? SCRAPE_TYPE_TO_PRETTY_NAME[
+                      connectorConfig.web_connector_type
+                    ]
+                  : "Recursive";
+              },
+            },
+          ]}
+          onUpdate={() => mutate("/api/manage/admin/connector/indexing-status")}
+        />
+      ) : (
+        <p className="text-sm">No indexed websites found</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -38,7 +38,7 @@ import {
   FiUploadCloud,
   FiUsers,
 } from "react-icons/fi";
-import { SiBookstack } from "react-icons/si";
+import { SiBookstack, SiOkta } from "react-icons/si";
 import Image from "next/image";
 import jiraSVG from "../../../public/Jira.svg";
 import confluenceSVG from "../../../public/Confluence.svg";
@@ -403,6 +403,13 @@ export const BookstackIcon = ({
 }: IconProps) => {
   return <SiBookstack size={size} className={className + " text-[#0288D1]"} />;
 };
+
+export const WebOktaIcon = ({
+  size = 16,
+  className = defaultTailwindCSS,
+}: IconProps) => {
+  return <SiOkta size={size} className={className + " text-[#0288D1]"} />;
+}
 
 export const ConfluenceIcon = ({
   size = 16,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -27,6 +27,7 @@ import {
   ZendeskIcon,
   ZulipIcon,
   MediaWikiIcon,
+  WebOktaIcon,
   WikipediaIcon,
 } from "@/components/icons/icons";
 import { ValidSources } from "./types";
@@ -47,6 +48,11 @@ const SOURCE_METADATA_MAP: SourceMap = {
   web: {
     icon: GlobeIcon,
     displayName: "Web",
+    category: SourceCategory.ImportedKnowledge,
+  },
+  web_okta: {
+    icon: WebOktaIcon,
+    displayName: "Web (Okta)",
     category: SourceCategory.ImportedKnowledge,
   },
   file: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface MinimalUserSnapshot {
 
 export type ValidSources =
   | "web"
+  | "web_okta"
   | "github"
   | "gitlab"
   | "slack"
@@ -87,6 +88,14 @@ export interface Connector<T> extends ConnectorBase<T> {
 export interface WebConfig {
   base_url: string;
   web_connector_type?: "recursive" | "single" | "sitemap";
+}
+
+export interface WebOktaConfig {
+  base_url: string;
+  web_connector_type?: "recursive" | "single" | "sitemap";
+  okta_tenant_url: string;
+  okta_username: string;
+  okta_password;
 }
 
 export interface GithubConfig {


### PR DESCRIPTION
> [!WARNING]
> Depends on #1590, as `displayName` contains parentheses.

Currently a clone of the web connector which checks whether the browser tab's URL starts with the base URL of the configured Okta tenant, and attempts authentication if it does not. Tested with an SP-initiated SAML flow.

To do:

- [ ] Try and remove the waits for `"networkidle"` states, as they likely hurt scraping performance.
- [ ] More gracefully handle failures in the authentication sequence. 
- [ ] Consider not copying the entire web connector, and instead adding a notion of "authentication providers" to the web connector instead.
- [ ] Find a way to more securely store these credentials, as they're particularly sensitive given we're having to disable MFA.