### PR TITLE
Add option to configure custom OpenAI-compatible model via env vars

### DIFF
--- a/backend/danswer/configs/model_configs.py
+++ b/backend/danswer/configs/model_configs.py
@@ -61,6 +61,8 @@ SEARCH_DISTANCE_CUTOFF = 0
 GEN_AI_MODEL_PROVIDER = os.environ.get("GEN_AI_MODEL_PROVIDER") or "openai"
 # If using Azure, it's the engine name, for example: Danswer
 GEN_AI_MODEL_VERSION = os.environ.get("GEN_AI_MODEL_VERSION")
+# The fallback display name to use for default model when using a custom model provider
+GEN_AI_DISPLAY_NAME = os.environ.get("GEN_AI_DISPLAY_NAME") or "Custom LLM"
 
 # For secondary flows like extracting filters or deciding if a chunk is useful, we don't need
 # as powerful of a model as say GPT-4 so we can use an alternative that is faster and cheaper

--- a/backend/danswer/llm/chat_llm.py
+++ b/backend/danswer/llm/chat_llm.py
@@ -273,9 +273,11 @@ class DefaultMultiLLM(LLM):
             prompt = [_convert_message_to_dict(HumanMessage(content=prompt))]
 
         try:
+            # When custom LLM provider is supplied, model name doesn't require prefix in LiteLLM
+            prefix = f"{self.config.model_provider}/" if not self._custom_llm_provider else ""
             return litellm.completion(
                 # model choice
-                model=f"{self.config.model_provider}/{self.config.model_name}",
+                model=f"{prefix}{self.config.model_name}",
                 api_key=self._api_key,
                 base_url=self._api_base,
                 api_version=self._api_version,

--- a/backend/danswer/llm/llm_initialization.py
+++ b/backend/danswer/llm/llm_initialization.py
@@ -7,6 +7,8 @@ from danswer.configs.model_configs import GEN_AI_API_KEY
 from danswer.configs.model_configs import GEN_AI_API_VERSION
 from danswer.configs.model_configs import GEN_AI_MODEL_PROVIDER
 from danswer.configs.model_configs import GEN_AI_MODEL_VERSION
+from danswer.configs.model_configs import GEN_AI_LLM_PROVIDER_TYPE
+from danswer.configs.model_configs import GEN_AI_DISPLAY_NAME
 from danswer.db.llm import fetch_existing_llm_providers
 from danswer.db.llm import update_default_provider
 from danswer.db.llm import upsert_llm_provider
@@ -28,49 +30,73 @@ def load_llm_providers(db_session: Session) -> None:
     if not GEN_AI_API_KEY or DISABLE_GENERATIVE_AI:
         return
 
-    well_known_provider_name_to_provider = {
-        provider.name: provider
-        for provider in fetch_available_well_known_llms()
-        if provider.name != BEDROCK_PROVIDER_NAME
-    }
+    if GEN_AI_MODEL_PROVIDER == "custom":
+        # Validate that all required env vars are present
+        for var in (GEN_AI_LLM_PROVIDER_TYPE, GEN_AI_API_ENDPOINT, GEN_AI_MODEL_VERSION, GEN_AI_DISPLAY_NAME):
+            if not var:
+                logger.error(
+                    "Cannot auto-transition custom LLM provider due to missing env vars."
+                    "The following env vars must all be set:"
+                    "GEN_AI_LLM_PROVIDER_TYPE, GEN_AI_API_ENDPOINT, GEN_AI_MODEL_VERSION, GEN_AI_DISPLAY_NAME"
+                )
+                return None
+        llm_provider_request = LLMProviderUpsertRequest(
+            name=GEN_AI_DISPLAY_NAME,
+            provider=GEN_AI_MODEL_PROVIDER,
+            api_key=GEN_AI_API_KEY,
+            api_base=GEN_AI_API_ENDPOINT,
+            api_version=GEN_AI_API_VERSION,
+            custom_config={},
+            default_model_name=GEN_AI_MODEL_VERSION,
+            fast_default_model_name=FAST_GEN_AI_MODEL_VERSION,
+        )
 
-    if GEN_AI_MODEL_PROVIDER not in well_known_provider_name_to_provider:
-        logger.error(f"Cannot auto-transition LLM provider: {GEN_AI_MODEL_PROVIDER}")
-        return None
+    else:
 
-    # Azure provider requires custom model names,
-    # OpenAI / anthropic can just use the defaults
-    model_names = (
-        [
-            name
-            for name in [
-                GEN_AI_MODEL_VERSION,
-                FAST_GEN_AI_MODEL_VERSION,
+        well_known_provider_name_to_provider = {
+            provider.name: provider
+            for provider in fetch_available_well_known_llms()
+            if provider.name != BEDROCK_PROVIDER_NAME
+        }
+
+        if GEN_AI_MODEL_PROVIDER not in well_known_provider_name_to_provider:
+            logger.error(f"Cannot auto-transition LLM provider: {GEN_AI_MODEL_PROVIDER}")
+            return None
+
+        # Azure provider requires custom model names,
+        # OpenAI / anthropic can just use the defaults
+        model_names = (
+            [
+                name
+                for name in [
+                    GEN_AI_MODEL_VERSION,
+                    FAST_GEN_AI_MODEL_VERSION,
+                ]
+                if name
             ]
-            if name
-        ]
-        if GEN_AI_MODEL_PROVIDER == AZURE_PROVIDER_NAME
-        else None
-    )
+            if GEN_AI_MODEL_PROVIDER == AZURE_PROVIDER_NAME
+            else None
+        )
 
-    well_known_provider = well_known_provider_name_to_provider[GEN_AI_MODEL_PROVIDER]
-    llm_provider_request = LLMProviderUpsertRequest(
-        name=well_known_provider.display_name,
-        provider=GEN_AI_MODEL_PROVIDER,
-        api_key=GEN_AI_API_KEY,
-        api_base=GEN_AI_API_ENDPOINT,
-        api_version=GEN_AI_API_VERSION,
-        custom_config={},
-        default_model_name=(
-            GEN_AI_MODEL_VERSION
-            or well_known_provider.default_model
-            or well_known_provider.llm_names[0]
-        ),
-        fast_default_model_name=(
-            FAST_GEN_AI_MODEL_VERSION or well_known_provider.default_fast_model
-        ),
-        model_names=model_names,
-    )
+        well_known_provider = well_known_provider_name_to_provider[GEN_AI_MODEL_PROVIDER]
+        llm_provider_request = LLMProviderUpsertRequest(
+            name=well_known_provider.display_name,
+            provider=GEN_AI_MODEL_PROVIDER,
+            api_key=GEN_AI_API_KEY,
+            api_base=GEN_AI_API_ENDPOINT,
+            api_version=GEN_AI_API_VERSION,
+            custom_config={},
+            default_model_name=(
+                GEN_AI_MODEL_VERSION
+                or well_known_provider.default_model
+                or well_known_provider.llm_names[0]
+            ),
+            fast_default_model_name=(
+                FAST_GEN_AI_MODEL_VERSION or well_known_provider.default_fast_model
+            ),
+            model_names=model_names,
+        )
+
     llm_provider = upsert_llm_provider(db_session, llm_provider_request)
     update_default_provider(db_session, llm_provider.id)
     logger.info(


### PR DESCRIPTION
At the moment only 'well known' model providers can be configured automatically via env vars. To configure a custom provider, the admin account must set it up via the UI. This change makes it possible to configure a custom OpenAI compatible model provider (e.g. a HuggingFace model served via vLLM) entirely via the following env vars:
```
GEN_AI_DISPLAY_NAME: "My custom model name"
GEN_AI_MODEL_PROVIDER: custom
GEN_AI_LLM_PROVIDER_TYPE: openai
GEN_AI_MODEL_VERSION: model-org/model-name
GEN_AI_API_ENDPOINT: http://my-self-hosted-model.com
```