### PR TITLE
Implement indexing of simple tables in Word files

### DIFF
--- a/backend/danswer/file_processing/extract_file_text.py
+++ b/backend/danswer/file_processing/extract_file_text.py
@@ -257,11 +257,11 @@ def docx_to_text(file: IO[Any]) -> str:
         return " ".join(p for p in cell_paragraphs if p) or "N/A"
 
     paragraphs = []
-
     doc = docx.Document(file)
     for item in doc.iter_inner_content():
         if isinstance(item, docx.text.paragraph.Paragraph):
             paragraphs.append(item.text)
+
         elif isinstance(item, docx.table.Table):
             if not item.rows or not is_simple_table(item):
                 continue

--- a/backend/danswer/file_processing/extract_file_text.py
+++ b/backend/danswer/file_processing/extract_file_text.py
@@ -254,7 +254,7 @@ def docx_to_text(file: IO[Any]) -> str:
 
     def extract_cell_text(cell: docx.table._Cell) -> str:
         cell_paragraphs = [para.text.strip() for para in cell.paragraphs]
-        return ' '.join(p for p in cell_paragraphs if p)
+        return " ".join(p for p in cell_paragraphs if p) or "N/A"
 
     paragraphs = []
 
@@ -266,17 +266,17 @@ def docx_to_text(file: IO[Any]) -> str:
             if not item.rows or not is_simple_table(item):
                 continue
 
-            # We assume the first row to be the table heading
-            headings = [extract_cell_text(c).rstrip(":") for c in item.rows[0].cells]
-            for row in item.rows[1:]:
-                row_lines = []
-                for i, cell in enumerate(row.cells):
-                    # Squash cell paragraphs into a single line of text
-                    cell_text = extract_cell_text(cell)
-                    row_lines.append(f"{headings[i]}: {cell_text}" if headings[i] else cell_text)
-                paragraphs.append("\n".join(row_lines))
+            # Every row is a new line, joined with a single newline
+            table_content = "\n".join(
+                [
+                    ",\t".join(extract_cell_text(cell) for cell in row.cells)
+                    for row in item.rows
+                ]
+            )
+            paragraphs.append(table_content)
 
-    return TEXT_SECTION_SEPARATOR.join(paragraphs)
+    # Docx already has good spacing between paragraphs
+    return "\n".join(paragraphs)
 
 
 def pptx_to_text(file: IO[Any]) -> str:

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -50,7 +50,7 @@ python-pptx==0.6.23
 pypdf==3.17.0
 pytest-mock==3.12.0
 pytest-playwright==0.3.2
-python-docx==1.1.0
+python-docx==1.1.2
 python-dotenv==1.0.0
 python-multipart==0.0.7
 pywikibot==9.0.0


### PR DESCRIPTION
Right now, tables in Word files are completely skipped from indexing. This PR unwraps any simple tables (no nested tables, no omitted cells) on a row-by-row basis to include them with the indexed text. Some assumptions are made along the way:

1. The first row of the table is the heading
2. Entity attributes are in the table columns, with each table row representing an isolated entity.

Each unwrapped table row may look as follows:

```
No.: 2
Issue: The CD doesn’t play
Comments: The CD doesn’t start playback upon insertion into the drive. Furthermore, the drive LED doesn’t turn on.
```
