### PR TITLE
Fix JIRA comment author email access

### DIFF
--- a/backend/danswer/connectors/danswer_jira/connector.py
+++ b/backend/danswer/connectors/danswer_jira/connector.py
@@ -74,6 +74,7 @@ def _get_comment_strs(
 
             if (
                 hasattr(comment, "author")
+                and hasattr(comment.author, "emailAddress")
                 and comment.author.emailAddress in comment_email_blacklist
             ):
                 continue  # Skip adding comment if author's email is in blacklist


### PR DESCRIPTION
This PR fixes accessing the non-existent `emailAddress` attribute of a `User` object in the JIRA connector which lead to errors of this sort in the logs:

```
connector.py  83 : [Attempt ID: 127] Failed to process comment due to an error: <class 'jira.resources.User'> object has no attribute 'emailAddress' ('User' object is not subscriptable)
```