### PR TITLE
Handle file text extraction errors

### DIFF
--- a/backend/danswer/file_processing/extract_file_text.py
+++ b/backend/danswer/file_processing/extract_file_text.py
@@ -255,23 +255,9 @@ def file_io_to_text(file: IO[Any]) -> str:
     file_content_raw, _ = read_text_file(file, encoding=encoding)
     return file_content_raw
 
-
-def extract_file_text(
-    file_name: str | None,
-    file: IO[Any],
-    break_on_unprocessable: bool = True,
+def _extract_file_text_by_extension(
+    file: IO[Any], extension: str
 ) -> str:
-    if not file_name:
-        return file_io_to_text(file)
-
-    extension = get_file_ext(file_name)
-    if not check_file_ext_is_valid(extension):
-        if break_on_unprocessable:
-            raise RuntimeError(f"Unprocessable file type: {file_name}")
-        else:
-            logger.warning(f"Unprocessable file type: {file_name}")
-            return ""
-
     if extension == ".pdf":
         return pdf_to_text(file=file)
 
@@ -295,3 +281,26 @@ def extract_file_text(
 
     else:
         return file_io_to_text(file)
+
+
+def extract_file_text(
+    file_name: str | None,
+    file: IO[Any],
+    break_on_unprocessable: bool = True,
+) -> str:
+    if not file_name:
+        return file_io_to_text(file)
+
+    extension = get_file_ext(file_name)
+    if not check_file_ext_is_valid(extension):
+        if break_on_unprocessable:
+            raise RuntimeError(f"Unprocessable file type: {file_name}")
+        else:
+            logger.warning(f"Unprocessable file type: {file_name}")
+            return ""
+
+    try:
+        return _extract_file_text_by_extension(file, extension)
+    except Exception:
+        logger.exception(f"Failed to extract text from file: {file_name}")
+        return ""


### PR DESCRIPTION
Hey

When we try to extract text from a file and it raise an exception, a common one was:

```
Traceback (most recent call last):
  File "/app/danswer/background/indexing/run_indexing.py", line 168, in _run_indexing
    for doc_batch in doc_batch_generator:
  File "/app/danswer/connectors/sharepoint/connector.py", line 159, in _fetch_from_sharepoint
    doc_batch.append(_convert_driveitem_to_document(driveitem))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/danswer/connectors/sharepoint/connector.py", line 43, in _convert_driveitem_to_document
    file_text = extract_file_text(
                ^^^^^^^^^^^^^^^^^^
  File "/app/danswer/file_processing/extract_file_text.py", line 286, in extract_file_text
    return xlsx_to_text(file)
           ^^^^^^^^^^^^^^^^^^
  File "/app/danswer/file_processing/extract_file_text.py", line 221, in xlsx_to_text
    workbook = openpyxl.load_workbook(file)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 344, in load_workbook
    reader = ExcelReader(filename, read_only, keep_vba,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 123, in __init__
    self.archive = _validate_archive(fn)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 95, in _validate_archive
    archive = ZipFile(filename, 'r')
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/zipfile.py", line 1302, in __init__
    self._RealGetContents()
  File "/usr/local/lib/python3.11/zipfile.py", line 1369, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```

with the method `openpyxl.load_workbook(file)`.

But this exception make all indexing process failed.

![Capture d’écran de 2024-06-25 15-07-30](https://github.com/danswer-ai/danswer/assets/19774106/e9db2172-fb19-4814-a275-897cfe45a834)

So I suggest to handle errors by logging bad files' names, so that the indexing process will continue:

![Capture d’écran de 2024-06-25 15-45-21](https://github.com/danswer-ai/danswer/assets/19774106/0ef824ee-98fa-4ff8-a9d8-f4da8869f27c)

To go further, I think that grouping all indexing errors to inform users that X files are bad formatted for example, could be a good idea. But I'm not as good in 🐍 