### PR TITLE
Remove unused Helm chart config

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -329,32 +329,6 @@ vespa:
   tolerations: []
   affinity: {}
 
-
-#ingress:
-#  enabled: false
-#  className: ""
-#  annotations: {}
-#    # kubernetes.io/ingress.class: nginx
-#    # kubernetes.io/tls-acme: "true"
-#  hosts:
-#    - host: chart-example.local
-#      paths:
-#        - path: /
-#          pathType: ImplementationSpecific
-#  tls: []
-#  #  - secretName: chart-example-tls
-#  #    hosts:
-#  #      - chart-example.local
-
-persistence:
-  vespa:
-    enabled: true
-    existingClaim: ""
-    storageClassName: ""
-    accessModes:
-      - ReadWriteOnce
-    size: 5Gi
-
 auth:
   # for storing smtp, oauth, slack, and other secrets
   # keys are lowercased version of env vars (e.g. SMTP_USER -> smtp_user)


### PR DESCRIPTION
These config options are no longer used in the Helm chart since https://github.com/danswer-ai/danswer/pull/1552 so removing them will reduce confusion for end users (e.g. I just tried to modify the Vespa volume size on my own deployment using these values and then discovered that they have no effect).