### PR TITLE
Fix "cannot access local variable" for bot direct messages

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -228,6 +228,7 @@ def handle_message(
     # List of user id to send message to, if None, send to everyone in channel
     send_to: list[str] | None = None
     respond_tag_only = False
+    
     respond_team_member_list = None
     respond_slack_group_list = None
 

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -228,7 +228,6 @@ def handle_message(
     # List of user id to send message to, if None, send to everyone in channel
     send_to: list[str] | None = None
     respond_tag_only = False
-    
     respond_team_member_list = None
     respond_slack_group_list = None
 

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -229,6 +229,7 @@ def handle_message(
     send_to: list[str] | None = None
     respond_tag_only = False
     respond_team_member_list = None
+    respond_slack_group_list = None
 
     bypass_acl = False
     if (


### PR DESCRIPTION
On my Danswer installation I noticed this error in the background service when I sent a direct message to the bot user:

```
06/28/2024 09:40:19 AM          listener.py 415 : Failed to process slack event
  File "/app/danswer/danswerbot/slack/listener.py", line 413, in process_slack_event
  File "/app/danswer/danswerbot/slack/listener.py", line 353, in process_message
  File "/app/danswer/danswerbot/slack/handlers/handle_message.py", line 277, in handle_message
    if respond_slack_group_list:
UnboundLocalError: cannot access local variable 'respond_slack_group_list' where it is not associated with a value
```

I'm not familiar with the code or why the error is occuring now but this minor change should fix it (I already tested it on my installation)