### PR TITLE
Add pre ping lifo params to sqlalchemy

### DIFF
--- a/backend/danswer/db/engine.py
+++ b/backend/danswer/db/engine.py
@@ -59,7 +59,9 @@ def get_sqlalchemy_engine() -> Engine:
     global _SYNC_ENGINE
     if _SYNC_ENGINE is None:
         connection_string = build_connection_string(db_api=SYNC_DB_API)
-        _SYNC_ENGINE = create_engine(connection_string, pool_size=40, max_overflow=10)
+        _SYNC_ENGINE = create_engine(
+            connection_string, pool_size=40, max_overflow=10, pool_pre_ping=True, pool_use_lifo=True,
+        )
     return _SYNC_ENGINE
 
 
@@ -68,7 +70,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     if _ASYNC_ENGINE is None:
         connection_string = build_connection_string()
         _ASYNC_ENGINE = create_async_engine(
-            connection_string, pool_size=40, max_overflow=10
+            connection_string, pool_size=40, max_overflow=10, pool_pre_ping=True, pool_use_lifo=True,
         )
     return _ASYNC_ENGINE
 


### PR DESCRIPTION
When setting https://postgresqlco.nf/doc/en/param/idle_session_timeout/ , Postgres kills connections which idle for more than `idle_session_timeout` seconds. Due to the facts that danswer default pool size is pretty big (40 connections), some connections get killed before used, which raise SSL errors.

May be related to:
https://github.com/danswer-ai/danswer/issues/1622
https://github.com/danswer-ai/danswer/issues/1625 

Running in production for 5 days without any issue so far