### PR TITLE
Helm chart: Allow specifying resource constraints for indexing deployment

### DIFF
--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -29,6 +29,10 @@ spec:
         image: danswer/danswer-model-server:latest
         imagePullPolicy: IfNotPresent
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
+        {{- if .Values.indexCapability.resources }}
+        resources:
+            {{- toYaml .Values.indexCapability.resources | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9000
         envFrom:

--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "danswer-stack.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    {{- .Values.indexCapability.updateStrategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
       {{- include "danswer-stack.selectorLabels" . | nindent 6 }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -65,6 +65,14 @@ indexCapability:
     # For example
     # limits:
     #   nvidia.com/gpu: 1
+  # The strategy to use for rolling out deployment updates
+  # If using GPU indexing with a limited number of GPUs available,
+  # this can be set to type: Recreate instead.
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
 
 
 config:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -61,6 +61,11 @@ indexCapability:
     name: indexing-model-storage
     accessMode: "ReadWriteOnce"
     storage: "3Gi"
+  resources:
+    # For example
+    # limits:
+    #   nvidia.com/gpu: 1
+
 
 config:
   envConfigMapName: env-configmap


### PR DESCRIPTION
This allows the indexing model to optionally be deployed to a GPU node