### PR TITLE
sort by date (like we do for MRs), so that the yield followed by return further down in the code makes sense

### DIFF
--- a/backend/danswer/connectors/gitlab/connector.py
+++ b/backend/danswer/connectors/gitlab/connector.py
@@ -200,7 +200,9 @@ class GitlabConnector(LoadConnector, PollConnector):
                 yield mr_doc_batch
 
         if self.include_issues:
-            issues = project.issues.list(state=self.state_filter, order_by="updated_at", sort="desc")
+            issues = project.issues.list(
+                state=self.state_filter, order_by="updated_at", sort="desc"
+            )
 
             for issue_batch in _batch_gitlab_objects(issues, self.batch_size):
                 issue_doc_batch: list[Document] = []

--- a/backend/danswer/connectors/gitlab/connector.py
+++ b/backend/danswer/connectors/gitlab/connector.py
@@ -200,7 +200,7 @@ class GitlabConnector(LoadConnector, PollConnector):
                 yield mr_doc_batch
 
         if self.include_issues:
-            issues = project.issues.list(state=self.state_filter)
+            issues = project.issues.list(state=self.state_filter, order_by="updated_at", sort="desc")
 
             for issue_batch in _batch_gitlab_objects(issues, self.batch_size):
                 issue_doc_batch: list[Document] = []


### PR DESCRIPTION
Without this change, the issues come back in basically random order and we stop collecting as soon as the first one happens to be before our start date -> issues can get lost