### PR TITLE
Use explicit appVersion in Helm chart

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - "https://github.com/danswer-ai/danswer"
 type: application
 version: 0.2.0
-appVersion: "latest"
+appVersion: "v0.3.92"
 annotations:
   category: Productivity
   licenses: MIT
@@ -22,14 +22,13 @@ dependencies:
     version: 14.3.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-  - name: vespa 
+  - name: vespa
     version: 0.2.3
     repository: https://unoplat.github.io/vespa-helm-charts
     condition: vespa.enabled
   - name: nginx
     version: 15.14.0
     repository: oci://registry-1.docker.io/bitnamicharts
-    condition: nginx.enabled  
-    
+    condition: nginx.enabled
 
-    
+

--- a/deployment/helm/templates/api-deployment.yaml
+++ b/deployment/helm/templates/api-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: api-server
           securityContext:
             {{- toYaml .Values.api.securityContext | nindent 12 }}
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.appVersionOverride | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command:
             - "/bin/sh"

--- a/deployment/helm/templates/background-deployment.yaml
+++ b/deployment/helm/templates/background-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: background
           securityContext:
             {{- toYaml .Values.background.securityContext | nindent 12 }}
-          image: "{{ .Values.background.image.repository }}:{{ .Values.background.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.background.image.repository }}:{{ .Values.background.image.tag | default .Values.appVersionOverride | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.background.image.pullPolicy }}
           command: ["/usr/bin/supervisord"]
           resources:

--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: indexing-model-server
-        image: "{{ .Values.indexCapability.deployment.image.repository }}:{{ .Values.indexCapability.deployment.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.indexCapability.deployment.image.repository }}:{{ .Values.indexCapability.deployment.image.tag | default .Values.appVersionOverride | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.indexCapability.deployment.image.pullPolicy }}
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
         ports:

--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -26,8 +26,8 @@ spec:
     spec:
       containers:
       - name: indexing-model-server
-        image: danswer/danswer-model-server:latest
-        imagePullPolicy: IfNotPresent
+        image: "{{ .Values.indexCapability.deployment.image.repository }}:{{ .Values.indexCapability.deployment.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.indexCapability.deployment.image.pullPolicy }}
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
         ports:
         - containerPort: 9000

--- a/deployment/helm/templates/inference-model-deployment.yaml
+++ b/deployment/helm/templates/inference-model-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.inferenceCapability.service.name }}
-        image: "{{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag | default .Values.appVersionOverride | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.inferenceCapability.deployment.image.pullPolicy }}
         command: {{ toYaml .Values.inferenceCapability.deployment.command | nindent 14 }}
         ports:

--- a/deployment/helm/templates/inference-model-deployment.yaml
+++ b/deployment/helm/templates/inference-model-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.inferenceCapability.service.name }}
-        image: {{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag }}
+        image: "{{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.inferenceCapability.deployment.image.pullPolicy }}
         command: {{ toYaml .Values.inferenceCapability.deployment.command | nindent 14 }}
         ports:

--- a/deployment/helm/templates/webserver-deployment.yaml
+++ b/deployment/helm/templates/webserver-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: web-server
           securityContext:
             {{- toYaml .Values.webserver.securityContext | nindent 12 }}
-          image: "{{ .Values.webserver.image.repository }}:{{ .Values.webserver.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.webserver.image.repository }}:{{ .Values.webserver.image.tag | default .Values.appVersionOverride | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.webserver.image.pullPolicy }}
           ports:
             - name: http

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -5,6 +5,7 @@
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+appVersionOverride: # e.g "v0.3.93"
 
 inferenceCapability:
   service:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -24,7 +24,7 @@ inferenceCapability:
         value: inference-model-server
     image:
       repository: danswer/danswer-model-server
-      tag: latest
+      tag:
       pullPolicy: IfNotPresent
     command: ["uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000"]
     port: 9000
@@ -40,6 +40,23 @@ inferenceCapability:
       value: inference-model-server
 
 indexCapability:
+  deployment:
+    image:
+      repository: danswer/danswer-model-server
+      tag:
+      pullPolicy: IfNotPresent
+    resources:
+    # For example
+    # limits:
+    #   nvidia.com/gpu: 1
+    # The strategy to use for rolling out deployment updates
+    # If using GPU indexing with a limited number of GPUs available,
+    # this can be set to type: Recreate instead.
+    updateStrategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
   service:
     type: ClusterIP
     port: 9000
@@ -108,7 +125,7 @@ webserver:
     repository: danswer/danswer-web-server
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    tag:
   deploymentLabels:
     app: web-server
   podAnnotations: {}
@@ -171,7 +188,7 @@ api:
     repository: danswer/danswer-backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    tag:
   deploymentLabels:
     app: api-server
   podAnnotations: {}
@@ -236,7 +253,7 @@ background:
     repository: danswer/danswer-backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: latest
+    tag:
   podAnnotations: {}
   podLabels:
     scope: danswer-backend

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -45,18 +45,6 @@ indexCapability:
       repository: danswer/danswer-model-server
       tag:
       pullPolicy: IfNotPresent
-    resources:
-    # For example
-    # limits:
-    #   nvidia.com/gpu: 1
-    # The strategy to use for rolling out deployment updates
-    # If using GPU indexing with a limited number of GPUs available,
-    # this can be set to type: Recreate instead.
-    updateStrategy:
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
-      type: RollingUpdate
   service:
     type: ClusterIP
     port: 9000


### PR DESCRIPTION
The Helm chart's `appVersion` field is used as the default image tag in the Kubernetes `Deployment` resources for the various Danswer components and the app version is set as `latest`. This is a bad idea because it means that whenever one of the Danswer Kubernetes containers is rescheduled to a new node (e.g. if a node is removed from the cluster or during a rolling cluster upgrade) then a new version of the image might be pulled which can lead to unexpected and difficult to track down issues. Instead, the `appVersion` field should be pinned to a specific Danswer release tag and then explicitly updated when a new Danswer release is tagged so that Helm deployments are consistent and reproducible.