### PR TITLE
fix gpt-4o image issue

### DIFF
--- a/web/src/lib/llm/utils.ts
+++ b/web/src/lib/llm/utils.ts
@@ -15,7 +15,14 @@ export function getFinalLLM(
   let model = defaultProvider?.default_model_name || "";
 
   if (persona) {
-    provider = persona.llm_model_provider_override || provider;
+    // Map "provider override" to actual LLLMProvider
+    if (persona.llm_model_provider_override) {
+      const underlyingProvider = llmProviders.find(
+        (item: LLMProviderDescriptor) =>
+          item.name === persona.llm_model_provider_override
+      );
+      provider = underlyingProvider?.provider || provider;
+    }
     model = persona.llm_model_version_override || model;
   }
 


### PR DESCRIPTION
Fixes image generation issue with custom providers.

We were comparing compatible image models and providers (e.g. `openai`) against user-named "providers" (aka their keys).