### PR TITLE
Fix bug XML files in chat

### DIFF
--- a/backend/danswer/server/query_and_chat/chat_backend.py
+++ b/backend/danswer/server/query_and_chat/chat_backend.py
@@ -484,6 +484,7 @@ def upload_files_for_chat(
         "text/tab-separated-values",
         "application/json",
         "application/xml",
+        "text/xml",
         "application/x-yaml",
     }
     document_content_types = {


### PR DESCRIPTION
At least my navigator (Mozilla/5.0 Gecko/20100101 Firefox/128.0) sends `text/xml` and not `application/xml`, making it impossible to upload XML files in the chat since an error was raised.