### PR TITLE
Generated images come inline as part of the Model response

### DIFF
--- a/backend/danswer/llm/chat_llm.py
+++ b/backend/danswer/llm/chat_llm.py
@@ -292,7 +292,7 @@ class DefaultMultiLLM(LLM):
                 stream=stream,
                 # model params
                 temperature=self._temperature,
-                max_tokens=self._max_output_tokens,
+                max_tokens=self._max_output_tokens if self._max_output_tokens > 0 else None,
                 timeout=self._timeout,
                 **self._model_kwargs,
             )

--- a/backend/danswer/tools/images/image_generation_tool.py
+++ b/backend/danswer/tools/images/image_generation_tool.py
@@ -167,12 +167,13 @@ class ImageGenerationTool(Tool):
             # need to pass in None rather than empty str
             api_base=self.api_base or None,
             api_version=self.api_version or None,
+            response_format="b64_json",
             n=1,
             extra_headers=build_llm_extra_headers(self.additional_headers),
         )
         return ImageGenerationResponse(
             revised_prompt=response.data[0]["revised_prompt"],
-            url=response.data[0]["url"],
+            url="data:image/png;base64," + response.data[0]["b64_json"],
         )
 
     def run(self, **kwargs: str) -> Generator[ToolResponse, None, None]:


### PR DESCRIPTION
This change allows image generation to work on air-gapped environments. The image is received as a base64 string along with the image model response, eliminating the need for a image retrieval step using http.