### PR TITLE
Add GPT-4o-Mini & fix a missing GPT-4o in Model Tests

### DIFF
--- a/backend/danswer/llm/llm_provider_options.py
+++ b/backend/danswer/llm/llm_provider_options.py
@@ -26,6 +26,7 @@ OPENAI_PROVIDER_NAME = "openai"
 OPEN_AI_MODEL_NAMES = [
     "gpt-4",
     "gpt-4o",
+    "gpt-4o-mini",
     "gpt-4-turbo",
     "gpt-4-turbo-preview",
     "gpt-4-1106-preview",

--- a/backend/danswer/tools/utils.py
+++ b/backend/danswer/tools/utils.py
@@ -6,7 +6,7 @@ from danswer.llm.utils import get_default_llm_tokenizer
 from danswer.tools.tool import Tool
 
 
-OPEN_AI_TOOL_CALLING_MODELS = {"gpt-3.5-turbo", "gpt-4-turbo", "gpt-4"}
+OPEN_AI_TOOL_CALLING_MODELS = {"gpt-3.5-turbo", "gpt-4-turbo", "gpt-4", "gpt-4o", "gpt-4o-mini"}
 
 
 def explicit_tool_calling_supported(model_provider: str, model_name: str) -> bool:

--- a/backend/scripts/test-openapi-key.py
+++ b/backend/scripts/test-openapi-key.py
@@ -2,6 +2,8 @@ from openai import OpenAI
 
 
 VALID_MODEL_LIST = [
+    "gpt-4o-mini",
+    "gpt-4o",
     "gpt-4-1106-preview",
     "gpt-4-vision-preview",
     "gpt-4",

--- a/web/src/lib/llm/utils.ts
+++ b/web/src/lib/llm/utils.ts
@@ -36,10 +36,12 @@ export function getFinalLLM(
 
 const MODELS_SUPPORTING_IMAGES = [
   ["openai", "gpt-4o"],
+  ["openai", "gpt-4o-mini"],
   ["openai", "gpt-4-vision-preview"],
   ["openai", "gpt-4-turbo"],
   ["openai", "gpt-4-1106-vision-preview"],
   ["azure", "gpt-4o"],
+  ["azure", "gpt-4o-mini"],
   ["azure", "gpt-4-vision-preview"],
   ["azure", "gpt-4-turbo"],
   ["azure", "gpt-4-1106-vision-preview"],


### PR DESCRIPTION
This adds support for `gpt-4o-mini` at roughly 25 times a lower cost then GPT-4, note this doesn't set 4o-mini to the default but that should be a next step as the accuracy is near identical, max token input is the same, the model runs faster, and saves a massive amount when churning through large amounts of data.