### PR TITLE
Fix empty / reverted embeddings

### DIFF
--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -334,7 +334,7 @@ def _index_vespa_chunk(
 
     embeddings = chunk.embeddings
     embeddings_name_vector_map = {"full_chunk": embeddings.full_embedding}
-    if (chunk.embeddings.full_embedding is None):
+    if chunk.embeddings.full_embedding is None:
         embeddings.full_embedding = chunk.title_embedding
 
     if embeddings.mini_chunk_embeddings:

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -339,7 +339,6 @@ def _index_vespa_chunk(
 
     if embeddings.mini_chunk_embeddings:
         for ind, m_c_embed in enumerate(embeddings.mini_chunk_embeddings):
-            print(type(m_c_embed))
             embeddings_name_vector_map[f"mini_chunk_{ind}"] = m_c_embed
 
     title = document.get_title_for_document_index()

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -331,15 +331,18 @@ def _index_vespa_chunk(
     document = chunk.source_document
     # No minichunk documents in vespa, minichunk vectors are stored in the chunk itself
     vespa_chunk_id = str(get_uuid_from_chunk(chunk))
-
     embeddings = chunk.embeddings
-    embeddings_name_vector_map = {"full_chunk": embeddings.full_embedding}
+
     if chunk.embeddings.full_embedding is None:
         embeddings.full_embedding = chunk.title_embedding
+    embeddings_name_vector_map = {"full_chunk": embeddings.full_embedding}
 
     if embeddings.mini_chunk_embeddings:
         for ind, m_c_embed in enumerate(embeddings.mini_chunk_embeddings):
-            embeddings_name_vector_map[f"mini_chunk_{ind}"] = m_c_embed
+            if m_c_embed is None:
+                embeddings_name_vector_map[f"mini_chunk_{ind}"] = chunk.title_embedding
+            else:
+                embeddings_name_vector_map[f"mini_chunk_{ind}"] = m_c_embed
 
     title = document.get_title_for_document_index()
 

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -334,8 +334,12 @@ def _index_vespa_chunk(
 
     embeddings = chunk.embeddings
     embeddings_name_vector_map = {"full_chunk": embeddings.full_embedding}
+    if (chunk.embeddings.full_embedding is None):
+        embeddings.full_embedding = chunk.title_embedding
+
     if embeddings.mini_chunk_embeddings:
         for ind, m_c_embed in enumerate(embeddings.mini_chunk_embeddings):
+            print(type(m_c_embed))
             embeddings_name_vector_map[f"mini_chunk_{ind}"] = m_c_embed
 
     title = document.get_title_for_document_index()

--- a/backend/danswer/indexing/embedder.py
+++ b/backend/danswer/indexing/embedder.py
@@ -169,5 +169,5 @@ def get_embedding_model_from_db_embedding_model(
         query_prefix=db_embedding_model.query_prefix,
         passage_prefix=db_embedding_model.passage_prefix,
         provider_type=db_embedding_model.provider_type,
-        api_key=db_embedding_model.api_key
+        api_key=db_embedding_model.api_key,
     )

--- a/backend/danswer/indexing/embedder.py
+++ b/backend/danswer/indexing/embedder.py
@@ -168,4 +168,6 @@ def get_embedding_model_from_db_embedding_model(
         normalize=db_embedding_model.normalize,
         query_prefix=db_embedding_model.query_prefix,
         passage_prefix=db_embedding_model.passage_prefix,
+        provider_type=db_embedding_model.provider_type,
+        api_key=db_embedding_model.api_key
     )

--- a/backend/danswer/indexing/embedder.py
+++ b/backend/danswer/indexing/embedder.py
@@ -73,7 +73,7 @@ class DefaultIndexingEmbedder(IndexingEmbedder):
         enable_mini_chunk: bool = ENABLE_MINI_CHUNK,
     ) -> list[IndexChunk]:
         # Cache the Title embeddings to only have to do it once
-        title_embed_dict: dict[str, list[float]] = {}
+        title_embed_dict: dict[str, list[float] | None] = {}
         embedded_chunks: list[IndexChunk] = []
 
         # Create Mini Chunks for more precise matching of details
@@ -93,6 +93,7 @@ class DefaultIndexingEmbedder(IndexingEmbedder):
         embeddings = self.embedding_model.encode(
             chunk_texts, text_type=EmbedTextType.PASSAGE
         )
+        print(f"overall length of the embeddings is {len(embeddings)}")
 
         chunk_titles = {
             chunk.source_document.get_title_for_document_index() for chunk in chunks

--- a/backend/danswer/indexing/embedder.py
+++ b/backend/danswer/indexing/embedder.py
@@ -93,7 +93,6 @@ class DefaultIndexingEmbedder(IndexingEmbedder):
         embeddings = self.embedding_model.encode(
             chunk_texts, text_type=EmbedTextType.PASSAGE
         )
-        print(f"overall length of the embeddings is {len(embeddings)}")
 
         chunk_titles = {
             chunk.source_document.get_title_for_document_index() for chunk in chunks

--- a/backend/danswer/indexing/models.py
+++ b/backend/danswer/indexing/models.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 logger = setup_logger()
 
 
-Embedding = list[float]
+Embedding = list[float] | None
 
 
 class ChunkEmbedding(BaseModel):

--- a/backend/danswer/natural_language_processing/search_nlp_models.py
+++ b/backend/danswer/natural_language_processing/search_nlp_models.py
@@ -90,7 +90,9 @@ class EmbeddingModel:
                 for text in texts
             ]
 
+
         if self.provider_type:
+            # print("I am embedding")
             embed_request = EmbedRequest(
                 model_name=self.model_name,
                 texts=texts,
@@ -105,6 +107,7 @@ class EmbeddingModel:
             response = requests.post(
                 self.embed_server_endpoint, json=embed_request.dict()
             )
+            print()
             try:
                 response.raise_for_status()
             except requests.HTTPError as e:
@@ -112,6 +115,9 @@ class EmbeddingModel:
                 raise HTTPError(f"HTTP error occurred: {error_detail}") from e
             except requests.RequestException as e:
                 raise HTTPError(f"Request failed: {str(e)}") from e
+            embeds = EmbedResponse(**response.json()).embeddings
+            print(len(embeds))
+            print(embeds[-1])
             return EmbedResponse(**response.json()).embeddings
 
         # Batching for local embedding

--- a/backend/danswer/natural_language_processing/search_nlp_models.py
+++ b/backend/danswer/natural_language_processing/search_nlp_models.py
@@ -91,7 +91,6 @@ class EmbeddingModel:
             ]
 
         if self.provider_type:
-            # print("I am embedding")
             embed_request = EmbedRequest(
                 model_name=self.model_name,
                 texts=texts,
@@ -113,9 +112,8 @@ class EmbeddingModel:
                 raise HTTPError(f"HTTP error occurred: {error_detail}") from e
             except requests.RequestException as e:
                 raise HTTPError(f"Request failed: {str(e)}") from e
-            embeds = EmbedResponse(**response.json()).embeddings
+            EmbedResponse(**response.json()).embeddings
 
-            print(embeds[-1])
             return EmbedResponse(**response.json()).embeddings
 
         # Batching for local embedding
@@ -147,7 +145,6 @@ class EmbeddingModel:
             # Normalize embeddings is only configured via model_configs.py, be sure to use right
             # value for the set loss
             embeddings.extend(EmbedResponse(**response.json()).embeddings)
-        print(embeddings[-1])
         return embeddings
 
 

--- a/backend/danswer/natural_language_processing/search_nlp_models.py
+++ b/backend/danswer/natural_language_processing/search_nlp_models.py
@@ -89,7 +89,7 @@ class EmbeddingModel:
                 )
                 for text in texts
             ]
-        
+
         if self.provider_type:
             # print("I am embedding")
             embed_request = EmbedRequest(

--- a/backend/danswer/natural_language_processing/search_nlp_models.py
+++ b/backend/danswer/natural_language_processing/search_nlp_models.py
@@ -106,7 +106,6 @@ class EmbeddingModel:
             response = requests.post(
                 self.embed_server_endpoint, json=embed_request.dict()
             )
-            print()
             try:
                 response.raise_for_status()
             except requests.HTTPError as e:

--- a/backend/danswer/natural_language_processing/search_nlp_models.py
+++ b/backend/danswer/natural_language_processing/search_nlp_models.py
@@ -90,11 +90,6 @@ class EmbeddingModel:
                 for text in texts
             ]
         
-        print("HERE ARE THE TEXTS")
-        print(texts)
-        if ("zz" in texts[0]):
-            texts = [""]
-            print("I CAN CHANGE")
         if self.provider_type:
             # print("I am embedding")
             embed_request = EmbedRequest(

--- a/backend/danswer/search/retrieval/search_runner.py
+++ b/backend/danswer/search/retrieval/search_runner.py
@@ -1,12 +1,12 @@
 import string
 from collections.abc import Callable
+from typing import cast
 
 import nltk  # type:ignore
 from nltk.corpus import stopwords  # type:ignore
 from nltk.stem import WordNetLemmatizer  # type:ignore
 from nltk.tokenize import word_tokenize  # type:ignore
 from sqlalchemy.orm import Session
-from typing import cast
 
 from danswer.configs.chat_configs import HYBRID_ALPHA
 from danswer.configs.chat_configs import MULTILINGUAL_QUERY_EXPANSION
@@ -144,7 +144,9 @@ def doc_index_retrieval(
         if query.search_type == SearchType.SEMANTIC:
             top_chunks = document_index.semantic_retrieval(
                 query=query.query,
-                query_embedding=cast(list[float], query_embedding), # query embeddings should always have vector representations
+                query_embedding=cast(
+                    list[float], query_embedding
+                ),  # query embeddings should always have vector representations
                 filters=query.filters,
                 time_decay_multiplier=query.recency_bias_multiplier,
                 num_to_retrieve=query.num_hits,
@@ -153,7 +155,9 @@ def doc_index_retrieval(
         elif query.search_type == SearchType.HYBRID:
             top_chunks = document_index.hybrid_retrieval(
                 query=query.query,
-                query_embedding=cast(list[float], query_embedding), # query embeddings should always have vector representations
+                query_embedding=cast(
+                    list[float], query_embedding
+                ),  # query embeddings should always have vector representations
                 filters=query.filters,
                 time_decay_multiplier=query.recency_bias_multiplier,
                 num_to_retrieve=query.num_hits,

--- a/backend/danswer/search/retrieval/search_runner.py
+++ b/backend/danswer/search/retrieval/search_runner.py
@@ -6,6 +6,7 @@ from nltk.corpus import stopwords  # type:ignore
 from nltk.stem import WordNetLemmatizer  # type:ignore
 from nltk.tokenize import word_tokenize  # type:ignore
 from sqlalchemy.orm import Session
+from typing import cast
 
 from danswer.configs.chat_configs import HYBRID_ALPHA
 from danswer.configs.chat_configs import MULTILINGUAL_QUERY_EXPANSION
@@ -143,7 +144,7 @@ def doc_index_retrieval(
         if query.search_type == SearchType.SEMANTIC:
             top_chunks = document_index.semantic_retrieval(
                 query=query.query,
-                query_embedding=query_embedding,
+                query_embedding=cast(list[float], query_embedding), # query embeddings should always have vector representations
                 filters=query.filters,
                 time_decay_multiplier=query.recency_bias_multiplier,
                 num_to_retrieve=query.num_hits,
@@ -152,7 +153,7 @@ def doc_index_retrieval(
         elif query.search_type == SearchType.HYBRID:
             top_chunks = document_index.hybrid_retrieval(
                 query=query.query,
-                query_embedding=query_embedding,
+                query_embedding=cast(list[float], query_embedding), # query embeddings should always have vector representations
                 filters=query.filters,
                 time_decay_multiplier=query.recency_bias_multiplier,
                 num_to_retrieve=query.num_hits,

--- a/backend/danswer/server/danswer_api/ingestion.py
+++ b/backend/danswer/server/danswer_api/ingestion.py
@@ -96,6 +96,8 @@ def upsert_ingestion_doc(
         normalize=db_embedding_model.normalize,
         query_prefix=db_embedding_model.query_prefix,
         passage_prefix=db_embedding_model.passage_prefix,
+        api_key=db_embedding_model.api_key,
+        provider_type=db_embedding_model.provider_type,
     )
 
     indexing_pipeline = build_indexing_pipeline(
@@ -132,6 +134,8 @@ def upsert_ingestion_doc(
             normalize=sec_db_embedding_model.normalize,
             query_prefix=sec_db_embedding_model.query_prefix,
             passage_prefix=sec_db_embedding_model.passage_prefix,
+            api_key=sec_db_embedding_model.api_key,
+            provider_type=sec_db_embedding_model.provider_type,
         )
 
         sec_ind_pipeline = build_indexing_pipeline(

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -87,9 +87,7 @@ class CloudEmbedding:
         # OpenAI does not seem to provide truncation option, however
         # the context lengths used by Danswer currently are smaller than the max token length
         # for OpenAI embeddings so it's not a big deal
-        print(f"I am embedding {texts}")
         response = self.client.embeddings.create(input=texts, model=model)
-        print("That was embedded")
         return [embedding.embedding for embedding in response.data]
 
     def _embed_cohere(
@@ -246,8 +244,6 @@ def embed_text(
             non_empty_texts.append(text)
         else:
             empty_indices.append(idx)
-    print(f"Non empty is {non_empty_texts}")
-    print(f"Empty is {empty_indices}")
 
     # Third party API based embedding model
     if provider_type is not None:
@@ -286,7 +282,7 @@ def embed_text(
         raise ValueError(
             "Either model name or provider must be provided to run embeddings."
         )
-    print(f" Length of hte mebddings is {len(embeddings)}")
+
     if embeddings is None:
         raise RuntimeError("Failed to create Embeddings")
     embeddings_with_nulls = []
@@ -303,10 +299,6 @@ def embed_text(
             current_embedding_index += 1
     embeddings = embeddings_with_nulls
 
-    # if not isinstance(embeddings, list):
-    #     embeddings = embeddings.tolist()
-    
-    print("About to hit error?")
     return embeddings
 
 
@@ -345,8 +337,6 @@ async def process_embed_request(
             text_type=embed_request.text_type,
             prefix=prefix,
         )
-        print("RESPONSE IS")
-        print(embeddings)
         return EmbedResponse(embeddings=embeddings)
     except Exception as e:
         exception_detail = f"Error during embedding process:\n{str(e)}"

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -269,10 +269,11 @@ def embed_text(
             text_type=text_type,
         )
 
-    # Locally running model
     elif model_name is not None:
         prefixed_texts = (
-            [f"{prefix}{text}" for text in non_empty_texts] if prefix else texts
+            [f"{prefix}{text}" for text in non_empty_texts]
+            if prefix
+            else non_empty_texts
         )
         local_model = get_embedding_model(
             model_name=model_name, max_context_length=max_context_length
@@ -288,9 +289,10 @@ def embed_text(
 
     if embeddings is None:
         raise RuntimeError("Failed to create Embeddings")
-    embeddings_with_nulls: list[list[float] | None] = []
 
+    embeddings_with_nulls: list[list[float] | None] = []
     current_embedding_index = 0
+
     for idx in range(len(texts)):
         if idx in empty_indices:
             embeddings_with_nulls.append(None)
@@ -301,8 +303,8 @@ def embed_text(
             else:
                 embeddings_with_nulls.append(embedding.tolist())
             current_embedding_index += 1
-    embeddings = embeddings_with_nulls
 
+    embeddings = embeddings_with_nulls
     return embeddings
 
 

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -80,7 +80,9 @@ class CloudEmbedding:
             raise ValueError(f"Unsupported provider: {provider}")
         self.client = _initialize_client(api_key, self.provider, model)
 
-    def _embed_openai(self, texts: list[str], model: str | None) -> list[list[float] | None]:
+    def _embed_openai(
+        self, texts: list[str], model: str | None
+    ) -> list[list[float] | None]:
         if model is None:
             model = DEFAULT_OPENAI_MODEL
 
@@ -134,7 +136,7 @@ class CloudEmbedding:
                     text,
                     embedding_type,
                 )
-                for text in texts 
+                for text in texts
             ],
             auto_truncate=True,  # Also this is default
         )
@@ -236,7 +238,6 @@ def embed_text(
     provider_type: str | None,
     prefix: str | None,
 ) -> list[list[float] | None]:
-    
     non_empty_texts = []
     empty_indices = []
     for idx, text in enumerate(texts):
@@ -270,7 +271,9 @@ def embed_text(
 
     # Locally running model
     elif model_name is not None:
-        prefixed_texts = [f"{prefix}{text}" for text in non_empty_texts] if prefix else texts
+        prefixed_texts = (
+            [f"{prefix}{text}" for text in non_empty_texts] if prefix else texts
+        )
         local_model = get_embedding_model(
             model_name=model_name, max_context_length=max_context_length
         )
@@ -285,17 +288,18 @@ def embed_text(
 
     if embeddings is None:
         raise RuntimeError("Failed to create Embeddings")
-    embeddings_with_nulls = []
-    
+    embeddings_with_nulls: list[list[float] | None] = []
+
     current_embedding_index = 0
     for idx in range(len(texts)):
         if idx in empty_indices:
             embeddings_with_nulls.append(None)
         else:
-            if not isinstance(embeddings[current_embedding_index], list):
-                embeddings_with_nulls.append(embeddings[current_embedding_index].tolist())
-            else: 
-                embeddings_with_nulls.append(embeddings[current_embedding_index])
+            embedding = embeddings[current_embedding_index]
+            if isinstance(embedding, list) or embedding is None:
+                embeddings_with_nulls.append(embedding)
+            else:
+                embeddings_with_nulls.append(embedding.tolist())
             current_embedding_index += 1
     embeddings = embeddings_with_nulls
 

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -240,6 +240,7 @@ def embed_text(
 ) -> list[list[float] | None]:
     non_empty_texts = []
     empty_indices = []
+
     for idx, text in enumerate(texts):
         if text.strip():
             non_empty_texts.append(text)
@@ -247,7 +248,9 @@ def embed_text(
             empty_indices.append(idx)
 
     # Third party API based embedding model
-    if provider_type is not None:
+    if not non_empty_texts:
+        embeddings = []
+    elif provider_type is not None:
         logger.debug(f"Embedding text with provider: {provider_type}")
         if api_key is None:
             raise RuntimeError("API key not provided for cloud model")

--- a/backend/shared_configs/model_server_models.py
+++ b/backend/shared_configs/model_server_models.py
@@ -26,7 +26,7 @@ class RerankRequest(BaseModel):
 
 
 class RerankResponse(BaseModel):
-    scores: list[list[float]]
+    scores: list[list[float] | None]
 
 
 class IntentRequest(BaseModel):

--- a/backend/shared_configs/model_server_models.py
+++ b/backend/shared_configs/model_server_models.py
@@ -17,7 +17,7 @@ class EmbedRequest(BaseModel):
 
 
 class EmbedResponse(BaseModel):
-    embeddings: list[list[float]]
+    embeddings: list[list[float] | None]
 
 
 class RerankRequest(BaseModel):


### PR DESCRIPTION
What this PR does:
- Robustifies embedding classes to maintain updates to 3rd party models
- Deal with empty strings passed to emebdders 

Approach to empty strings:
- Dealt with in `embed_text` to limit need to handling matching indices, etc. in requests to model server or in embedding models themselves
1. Don't pass indices which have no content to the embedding models (instead replace at end with `null`
2.  Deal with `null`s (currently) by replacing with title vector
