### PR TITLE
Add Missing Condition to If Condition for Tool Usage

### DIFF
--- a/backend/danswer/llm/answering/answer.py
+++ b/backend/danswer/llm/answering/answer.py
@@ -287,7 +287,7 @@ class Answer:
         prompt_builder = AnswerPromptBuilder(self.message_history, self.llm.config)
         chosen_tool_and_args: tuple[Tool, dict] | None = None
 
-        if self.force_use_tool:
+        if self.force_use_tool and self.force_use_tool.force_use:
             # if we are forcing a tool, we don't need to check which tools to run
             tool = next(
                 iter(


### PR DESCRIPTION
Currently an Error is thrown, if for example file upload is use, because no tool is selected. This is indicated by setting a flag on the force_use_tool object. This flag is however never checked, resulting in an error.