### PR TITLE
[REFACTOR / FEATURE] Add upload files option in Web connector

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -34,6 +34,12 @@ function buildConfigEntries(
     return {
       base_url: obj.base_url,
     };
+  } else if (sourceType === "web"){
+    return {
+      base_url: obj.base_url,
+      ...(obj.file_locations ? { file_names: obj.file_locations.map(getNameFromPath) } : {}),
+      web_connector_type: obj.web_connector_type,
+    };
   }
   return obj;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -106,7 +106,8 @@ export interface Connector<T> extends ConnectorBase<T> {
 
 export interface WebConfig {
   base_url: string;
-  web_connector_type?: "recursive" | "single" | "sitemap";
+  web_connector_type?: "recursive" | "single" | "sitemap" | "upload";
+  file_locations: string[];
 }
 
 export interface GithubConfig {


### PR DESCRIPTION
The front-end code has been refactored to align with the file connector and google-sites connector.
Add upload files option to the web connector.
Given a file upload where every line is a URL, parse all the URLs provided (you can upload multiple files)
Add of user agent, for some site to scrap, it is needed.
![image](https://github.com/user-attachments/assets/dc8a93ea-0ae5-470e-afe2-19387dc6d0ca)
![image](https://github.com/user-attachments/assets/325410b0-efbb-4ed2-8d59-582e3c3eb7b0)
![image](https://github.com/user-attachments/assets/fdf13676-612d-4f6f-9eae-e153fb87b70b)
