### PR TITLE
Allow removal of max_output_tokens by setting GEN_AI_MAX_OUTPUT_TOKENS=0

### DIFF
--- a/backend/danswer/llm/chat_llm.py
+++ b/backend/danswer/llm/chat_llm.py
@@ -266,7 +266,7 @@ class DefaultMultiLLM(LLM):
                 stream=stream,
                 # model params
                 temperature=self._temperature,
-                max_tokens=self._max_output_tokens,
+                max_tokens=self._max_output_tokens if self._max_output_tokens > 0 else None,
                 timeout=self._timeout,
                 **self._model_kwargs,
             )


### PR DESCRIPTION
## Description
This allows the removal of the explicit max_output_tokens. By setting GEN_AI_MAX_OUTPUT_TOKENS=0 the actual max_output_tokens will be whatever the value supported by the model in use.


## How Has This Been Tested?
Change deployed and tested with different models with different output token values (Ie. gpt-4: 4096, gemini-1.5-pro: 8192)


## Accepted Risk
None known


## Related Issue(s)
None