### PR TITLE
Fix flow where oidc_expiry is different from token expiry

### DIFF
--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -347,6 +347,12 @@ async def double_check_user(
             detail="Access denied. User is not verified.",
         )
 
+    if user.oidc_expiry and user.oidc_expiry < datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied. User's OIDC token has expired.",
+        )
+
     return user
 
 

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from datetime import timezone
 
 from fastapi import APIRouter
 from fastapi import Body
@@ -294,6 +295,12 @@ def verify_user_logged_in(
 
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User Not Authenticated"
+        )
+
+    if user.oidc_expiry and user.oidc_expiry < datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied. User's OIDC token has expired.",
         )
 
     token_created_at = get_current_token_creation(user, db_session)

--- a/backend/danswer/tools/custom/openapi_parsing.py
+++ b/backend/danswer/tools/custom/openapi_parsing.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import cast
 
-from openai import BaseModel
+from pydantic import BaseModel
 
 REQUEST_BODY = "requestBody"
 


### PR DESCRIPTION
## Description
If the OIDC token has expired, treat the user as not authenticated. Currently, the "needs to login" popup appears if you come back to the app after not using for a while, but we should just auto-log them in.


## How Has This Been Tested?
Tested OIDC via Okta locally.


## Accepted Risk
N/A


## Related Issue(s)
N/A


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
