### PR TITLE
Bugfix/pg connections

### DIFF
--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -25,7 +25,7 @@ autorestart=true
 # relatively compute-light (e.g. they tend to just make a bunch of requests to 
 # Vespa / Postgres)
 [program:celery_worker]
-command=celery -A danswer.background.celery.celery_run:celery_app worker --pool=threads --concurrency=16 --loglevel=INFO --logfile=/var/log/celery_worker.log
+command=celery -A danswer.background.celery.celery_run:celery_app worker --pool=threads --concurrency=6 --loglevel=INFO --logfile=/var/log/celery_worker.log
 stdout_logfile=/var/log/celery_worker_supervisor.log
 stdout_logfile_maxbytes=52428800
 redirect_stderr=true

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -290,6 +290,7 @@ services:
 
   relational_db:
     image: postgres:15.2-alpine
+    command: -c 'max_connections=150'
     restart: always
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -300,6 +300,7 @@ services:
 
   relational_db:
     image: postgres:15.2-alpine
+    command: -c 'max_connections=150'
     restart: always
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -143,6 +143,7 @@ services:
 
   relational_db:
     image: postgres:15.2-alpine
+    command: -c 'max_connections=150'
     restart: always
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -86,6 +86,7 @@ services:
 
   relational_db:
     image: postgres:15.2-alpine
+    command: -c 'max_connections=150'
     restart: always
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -144,6 +144,7 @@ services:
 
   relational_db:
     image: postgres:15.2-alpine
+    command: -c 'max_connections=150'
     restart: always
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/deployment/kubernetes/postgres-service-deployment.yaml
+++ b/deployment/kubernetes/postgres-service-deployment.yaml
@@ -40,6 +40,7 @@ spec:
             secretKeyRef:
               name: danswer-secrets
               key: postgres_password
+        args: ["-c", "max_connections=150"]
         ports:
         - containerPort: 5432
         volumeMounts:


### PR DESCRIPTION
## Description
Raise all docker and kubernetes max_connections to 150. lower celery worker concurrency to 6


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
