### PR TITLE
Fix not_applicable

### DIFF
--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -272,11 +272,13 @@ const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Storage,
     docs: "https://docs.danswer.dev/connectors/google_storage",
   },
-  // not_applicable: {
-  //   icon: null,
-  //   displayName: "Not Applicable",
-  //   category: SourceCategory.Other
-  // }
+  // currently used for the Internet Search tool docs, which is why
+  // a globe is used
+  not_applicable: {
+    icon: GlobeIcon,
+    displayName: "Not Applicable",
+    category: SourceCategory.Other,
+  },
 } as SourceMap;
 
 function fillSourceMetadata(


### PR DESCRIPTION
## Description
Adds back `not_applicable` to the `SOURCE_METADATA_MAP` so that if any connectors of this source type are setup it doesn't crash things + so that the web search tool works on chat. 

E.g. fixes:

![image](https://github.com/user-attachments/assets/05a87576-5d0a-47c3-80e8-d3ea279999a1)


## How Has This Been Tested?
Visited the admin panel + tried a web search enabled assistant.


## Accepted Risk
N/A


## Related Issue(s)
N/A


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
