### PR TITLE
Agent search improvements

### DIFF
--- a/backend/danswer/chat/models.py
+++ b/backend/danswer/chat/models.py
@@ -46,15 +46,20 @@ class LLMRelevanceFilterResponse(BaseModel):
     relevant_chunk_indices: list[int]
 
 
-class RelevanceChunk(BaseModel):
+class RelevanceAnalysis(BaseModel):
     # TODO make this document level. Also slight misnomer here as this is actually
     # done at the section level currently rather than the chunk
     relevant: bool | None = None
     content: str | None = None
 
 
-class LLMRelevanceSummaryResponse(BaseModel):
-    relevance_summaries: dict[str, RelevanceChunk]
+class SectionRelevancePiece(RelevanceAnalysis):
+    document_id: str
+    chunk_id: int
+
+
+class DocumentRelevance(BaseModel):
+    relevance_summaries: dict[str, RelevanceAnalysis]
 
 
 class DanswerAnswerPiece(BaseModel):

--- a/backend/danswer/chat/models.py
+++ b/backend/danswer/chat/models.py
@@ -47,7 +47,7 @@ class LLMRelevanceFilterResponse(BaseModel):
 
 
 class RelevanceAnalysis(BaseModel):
-    relevant: bool | None = None
+    relevant: bool
     content: str | None = None
 
 

--- a/backend/danswer/chat/models.py
+++ b/backend/danswer/chat/models.py
@@ -47,8 +47,6 @@ class LLMRelevanceFilterResponse(BaseModel):
 
 
 class RelevanceAnalysis(BaseModel):
-    # TODO make this document level. Also slight misnomer here as this is actually
-    # done at the section level currently rather than the chunk
     relevant: bool | None = None
     content: str | None = None
 

--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -52,6 +52,7 @@ from danswer.llm.factory import get_llms_for_persona
 from danswer.llm.factory import get_main_llm_from_tuple
 from danswer.llm.interfaces import LLMConfig
 from danswer.natural_language_processing.utils import get_tokenizer
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import OptionalSearchSetting
 from danswer.search.enums import QueryFlow
 from danswer.search.enums import SearchType
@@ -60,6 +61,7 @@ from danswer.search.retrieval.search_runner import inference_sections_from_ids
 from danswer.search.utils import chunks_or_sections_to_search_docs
 from danswer.search.utils import dedupe_documents
 from danswer.search.utils import drop_llm_indices
+from danswer.search.utils import relevant_documents_to_indices
 from danswer.server.query_and_chat.models import ChatMessageDetail
 from danswer.server.query_and_chat.models import CreateChatMessageRequest
 from danswer.server.utils import get_json_line
@@ -501,6 +503,7 @@ def stream_chat_message_objects(
                         chunks_above=new_msg_req.chunks_above,
                         chunks_below=new_msg_req.chunks_below,
                         full_doc=new_msg_req.full_doc,
+                        evaluation_type=LLMEvaluationType.BASIC,
                     )
                     tool_dict[db_tool_model.id] = [search_tool]
                 elif tool_cls.__name__ == ImageGenerationTool.__name__:
@@ -629,18 +632,29 @@ def stream_chat_message_objects(
                     )
                     yield qa_docs_response
                 elif packet.id == SECTION_RELEVANCE_LIST_ID:
-                    chunk_indices = packet.response
+                    relevant_chunks = packet.response
 
-                    if reference_db_search_docs is not None and dropped_indices:
-                        chunk_indices = drop_llm_indices(
-                            llm_indices=chunk_indices,
-                            search_docs=reference_db_search_docs,
-                            dropped_indices=dropped_indices,
+                    if reference_db_search_docs is not None:
+                        llm_indices = relevant_documents_to_indices(
+                            relevance_chunks=relevant_chunks,
+                            inference_sections=[
+                                translate_db_search_doc_to_server_search_doc(doc)
+                                for doc in reference_db_search_docs
+                            ],
                         )
 
-                    yield LLMRelevanceFilterResponse(
-                        relevant_chunk_indices=chunk_indices
-                    )
+                        if dropped_indices:
+                            llm_indices = drop_llm_indices(
+                                llm_indices=llm_indices,
+                                search_docs=reference_db_search_docs,
+                                dropped_indices=dropped_indices,
+                            )
+                        print("RELEVANT INDICES")
+                        print(relevant_chunks)
+                        print(llm_indices)
+                        yield LLMRelevanceFilterResponse(
+                            relevant_chunk_indices=llm_indices
+                        )
                 elif packet.id == IMAGE_GENERATION_RESPONSE_ID:
                     img_generation_response = cast(
                         list[ImageGenerationResponse], packet.response

--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -637,7 +637,7 @@ def stream_chat_message_objects(
                     if reference_db_search_docs is not None:
                         llm_indices = relevant_documents_to_indices(
                             relevance_chunks=relevant_chunks,
-                            inference_sections=[
+                            search_docs=[
                                 translate_db_search_doc_to_server_search_doc(doc)
                                 for doc in reference_db_search_docs
                             ],

--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -649,9 +649,7 @@ def stream_chat_message_objects(
                                 search_docs=reference_db_search_docs,
                                 dropped_indices=dropped_indices,
                             )
-                        print("RELEVANT INDICES")
-                        print(relevant_chunks)
-                        print(llm_indices)
+
                         yield LLMRelevanceFilterResponse(
                             relevant_chunk_indices=llm_indices
                         )

--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -653,6 +653,7 @@ def stream_chat_message_objects(
                         yield LLMRelevanceFilterResponse(
                             relevant_chunk_indices=llm_indices
                         )
+
                 elif packet.id == IMAGE_GENERATION_RESPONSE_ID:
                     img_generation_response = cast(
                         list[ImageGenerationResponse], packet.response

--- a/backend/danswer/db/chat.py
+++ b/backend/danswer/db/chat.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from danswer.auth.schemas import UserRole
-from danswer.chat.models import LLMRelevanceSummaryResponse
+from danswer.chat.models import DocumentRelevance
 from danswer.configs.chat_configs import HARD_DELETE_CHATS
 from danswer.configs.constants import MessageType
 from danswer.db.models import ChatMessage
@@ -541,11 +541,11 @@ def get_doc_query_identifiers_from_model(
 def update_search_docs_table_with_relevance(
     db_session: Session,
     reference_db_search_docs: list[SearchDoc],
-    relevance_summary: LLMRelevanceSummaryResponse,
+    relevance_summary: DocumentRelevance,
 ) -> None:
     for search_doc in reference_db_search_docs:
         relevance_data = relevance_summary.relevance_summaries.get(
-            f"{search_doc.document_id}-{search_doc.chunk_ind}"
+            search_doc.document_id
         )
         if relevance_data is not None:
             db_session.execute(

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -14,6 +14,7 @@ from danswer.chat.models import LLMRelevanceFilterResponse
 from danswer.chat.models import QADocsResponse
 from danswer.chat.models import RelevanceAnalysis
 from danswer.chat.models import StreamingError
+from danswer.configs.chat_configs import DISABLE_AGENTIC_SEARCH
 from danswer.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
 from danswer.configs.chat_configs import QA_TIMEOUT
 from danswer.configs.constants import MessageType
@@ -184,7 +185,9 @@ def stream_answer_objects(
     search_tool = SearchTool(
         db_session=db_session,
         user=user,
-        evaluation_type=LLMEvaluationType.AGENTIC,
+        evaluation_type=LLMEvaluationType.SKIP
+        if DISABLE_AGENTIC_SEARCH
+        else LLMEvaluationType.AGENTIC,
         persona=chat_session.persona,
         retrieval_options=query_req.retrieval_options,
         prompt_config=prompt_config,

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -224,7 +224,6 @@ def stream_answer_objects(
     )
 
     # won't be any ImageGenerationDisplay responses since that tool is never passed in
-    dropped_inds: list[int] = []
 
     for packet in cast(AnswerObjectIterator, answer.processed_streamed_output):
         # for one-shot flow, don't currently do anything with these
@@ -367,7 +366,6 @@ def get_search_answer(
             answer += packet.answer_piece
         elif isinstance(packet, QADocsResponse):
             qa_response.docs = packet
-
         elif isinstance(packet, LLMRelevanceFilterResponse):
             qa_response.llm_chunks_indices = packet.relevant_chunk_indices
         elif isinstance(packet, DanswerQuotes):

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -251,7 +251,6 @@ def stream_answer_objects(
                     translate_db_search_doc_to_server_search_doc(db_search_doc)
                     for db_search_doc in reference_db_search_docs
                 ]
-                print(len(response_docs))
 
                 initial_response = QADocsResponse(
                     rephrased_query=rephrased_query,
@@ -271,7 +270,6 @@ def stream_answer_objects(
                 document_based_response = {}
 
                 for evaluation in packet.response:
-                    print(evaluation)
                     document_based_response[evaluation.document_id] = RelevanceAnalysis(
                         relevant=evaluation.relevant, content=evaluation.content
                     )
@@ -369,8 +367,9 @@ def get_search_answer(
             answer += packet.answer_piece
         elif isinstance(packet, QADocsResponse):
             qa_response.docs = packet
-        # elif isinstance(packet, LLMRelevanceFilterResponse):
-        #     qa_response.llm_chunks_indices = packet.relevant_chunks #TODO put back
+
+        elif isinstance(packet, LLMRelevanceFilterResponse):
+            qa_response.llm_chunks_indices = packet.relevant_chunks  # TODO ensure balid
         elif isinstance(packet, DanswerQuotes):
             qa_response.quotes = packet
         elif isinstance(packet, CitationInfo):

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -369,7 +369,9 @@ def get_search_answer(
             qa_response.docs = packet
 
         elif isinstance(packet, LLMRelevanceFilterResponse):
-            qa_response.llm_chunks_indices = packet.relevant_chunks  # TODO ensure balid
+            qa_response.llm_chunks_indices = (
+                packet.relevant_chunk_indices
+            )  # TODO ensure balid
         elif isinstance(packet, DanswerQuotes):
             qa_response.quotes = packet
         elif isinstance(packet, CitationInfo):

--- a/backend/danswer/one_shot_answer/answer_question.py
+++ b/backend/danswer/one_shot_answer/answer_question.py
@@ -369,9 +369,7 @@ def get_search_answer(
             qa_response.docs = packet
 
         elif isinstance(packet, LLMRelevanceFilterResponse):
-            qa_response.llm_chunks_indices = (
-                packet.relevant_chunk_indices
-            )  # TODO ensure balid
+            qa_response.llm_chunks_indices = packet.relevant_chunk_indices
         elif isinstance(packet, DanswerQuotes):
             qa_response.quotes = packet
         elif isinstance(packet, CitationInfo):

--- a/backend/danswer/one_shot_answer/models.py
+++ b/backend/danswer/one_shot_answer/models.py
@@ -9,6 +9,7 @@ from danswer.chat.models import DanswerContexts
 from danswer.chat.models import DanswerQuotes
 from danswer.chat.models import QADocsResponse
 from danswer.configs.constants import MessageType
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.models import ChunkContext
 from danswer.search.models import RetrievalDetails
 
@@ -31,7 +32,8 @@ class DirectQARequest(ChunkContext):
     retrieval_options: RetrievalDetails = Field(default_factory=RetrievalDetails)
     # This is to forcibly skip (or run) the step, if None it uses the system defaults
     skip_rerank: bool | None = None
-    skip_llm_chunk_filter: bool | None = None
+    evaluation_type: LLMEvaluationType = LLMEvaluationType.BASIC
+
     chain_of_thought: bool = False
     return_contexts: bool = False
 

--- a/backend/danswer/search/enums.py
+++ b/backend/danswer/search/enums.py
@@ -25,6 +25,12 @@ class SearchType(str, Enum):
     HYBRID = "hybrid"
 
 
+class LLMEvaluationType(str, Enum):
+    AGENTIC = "agentic"  # applies agentic evaluation
+    BASIC = "basic"  # applies boolean evaluation
+    SKIP = "skip"  # skips evaluation
+
+
 class QueryFlow(str, Enum):
     SEARCH = "search"
     QUESTION_ANSWER = "question-answer"

--- a/backend/danswer/search/models.py
+++ b/backend/danswer/search/models.py
@@ -6,13 +6,13 @@ from pydantic import validator
 
 from danswer.configs.chat_configs import CONTEXT_CHUNKS_ABOVE
 from danswer.configs.chat_configs import CONTEXT_CHUNKS_BELOW
-from danswer.configs.chat_configs import DISABLE_LLM_CHUNK_FILTER
 from danswer.configs.chat_configs import HYBRID_ALPHA
 from danswer.configs.chat_configs import NUM_RERANKED_RESULTS
 from danswer.configs.chat_configs import NUM_RETURNED_HITS
 from danswer.configs.constants import DocumentSource
 from danswer.db.models import Persona
 from danswer.indexing.models import BaseChunk
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import OptionalSearchSetting
 from danswer.search.enums import SearchType
 from shared_configs.configs import ENABLE_RERANKING_REAL_TIME_FLOW
@@ -78,7 +78,7 @@ class SearchRequest(ChunkContext):
     hybrid_alpha: float = HYBRID_ALPHA
     # This is to forcibly skip (or run) the step, if None it uses the system defaults
     skip_rerank: bool | None = None
-    skip_llm_chunk_filter: bool | None = None
+    evaluation_type: LLMEvaluationType = LLMEvaluationType.BASIC
 
     class Config:
         arbitrary_types_allowed = True
@@ -92,7 +92,7 @@ class SearchQuery(ChunkContext):
     offset: int = 0
     search_type: SearchType = SearchType.HYBRID
     skip_rerank: bool = not ENABLE_RERANKING_REAL_TIME_FLOW
-    skip_llm_chunk_filter: bool = DISABLE_LLM_CHUNK_FILTER
+    evaluation_type: LLMEvaluationType
     # Only used if not skip_rerank
     num_rerank: int | None = NUM_RERANKED_RESULTS
     # Only used if not skip_llm_chunk_filter

--- a/backend/danswer/search/models.py
+++ b/backend/danswer/search/models.py
@@ -78,7 +78,7 @@ class SearchRequest(ChunkContext):
     hybrid_alpha: float = HYBRID_ALPHA
     # This is to forcibly skip (or run) the step, if None it uses the system defaults
     skip_rerank: bool | None = None
-    evaluation_type: LLMEvaluationType = LLMEvaluationType.BASIC
+    evaluation_type: LLMEvaluationType = LLMEvaluationType.SKIP
 
     class Config:
         arbitrary_types_allowed = True

--- a/backend/danswer/search/pipeline.py
+++ b/backend/danswer/search/pipeline.py
@@ -356,8 +356,8 @@ class SearchPipeline:
 
         elif self.search_query.evaluation_type == LLMEvaluationType.AGENTIC:
             if DISABLE_AGENTIC_SEARCH:
-                logger.warning(
-                    "Agentic search operation called while DISABLE_AGENTIC_SEARCH is toggled. This should not occur."
+                raise ValueError(
+                    "Agentic search operation called while DISABLE_AGENTIC_SEARCH is enabled."
                 )
                 self._section_relevance = []
 

--- a/backend/danswer/search/pipeline.py
+++ b/backend/danswer/search/pipeline.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from sqlalchemy.orm import Session
 
-from danswer.chat.models import RelevanceChunk
+from danswer.chat.models import SectionRelevancePiece
 from danswer.configs.chat_configs import DISABLE_AGENTIC_SEARCH
 from danswer.configs.chat_configs import MULTILINGUAL_QUERY_EXPANSION
 from danswer.db.embedding_model import get_current_db_embedding_model
@@ -13,9 +13,11 @@ from danswer.db.models import User
 from danswer.document_index.factory import get_default_document_index
 from danswer.llm.answering.models import DocumentPruningConfig
 from danswer.llm.answering.models import PromptConfig
+from danswer.llm.answering.prune_and_merge import _merge_sections
 from danswer.llm.answering.prune_and_merge import ChunkRange
 from danswer.llm.answering.prune_and_merge import merge_chunk_intervals
 from danswer.llm.interfaces import LLM
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import QueryFlow
 from danswer.search.enums import SearchType
 from danswer.search.models import IndexFilters
@@ -29,6 +31,7 @@ from danswer.search.postprocessing.postprocessing import search_postprocessing
 from danswer.search.preprocessing.preprocessing import retrieval_preprocessing
 from danswer.search.retrieval.search_runner import retrieve_chunks
 from danswer.search.utils import inference_section_from_chunks
+from danswer.search.utils import relevant_sections_to_indices
 from danswer.secondary_llm_flows.agentic_evaluation import evaluate_inference_section
 from danswer.utils.logger import setup_logger
 from danswer.utils.threadpool_concurrency import FunctionCall
@@ -84,11 +87,13 @@ class SearchPipeline:
         # Reranking and LLM section selection can be run together
         # If only LLM selection is on, the reranked chunks are yielded immediatly
         self._reranked_sections: list[InferenceSection] | None = None
-        self._relevant_section_indices: list[int] | None = None
+        self._final_context_sections: list[InferenceSection] | None = None
+
+        self._relevant_section_indices: list[SectionRelevancePiece] | None = None
 
         # Generates reranked chunks and LLM selections
         self._postprocessing_generator: (
-            Iterator[list[InferenceSection] | list[int]] | None
+            Iterator[list[InferenceSection] | list[SectionRelevancePiece]] | None
         ) = None
 
     """Pre-processing"""
@@ -332,44 +337,58 @@ class SearchPipeline:
         return self._reranked_sections
 
     @property
-    def relevant_section_indices(self) -> list[int]:
+    def final_context_sections(self) -> list[InferenceSection]:
+        if self._final_context_sections is not None:
+            return self._final_context_sections
+
+        self._final_context_sections = _merge_sections(sections=self.reranked_sections)
+
+        return self._final_context_sections
+
+    @property
+    def relevant_section_indices(self) -> list[SectionRelevancePiece]:
         if self._relevant_section_indices is not None:
             return self._relevant_section_indices
 
+        if self.search_query.evaluation_type == LLMEvaluationType.SKIP:
+            raise ValueError(
+                "You disabled llm evaluation and thus should not be asking ofr relevant section indices!"
+            )
+
+        if self.search_query.evaluation_type == LLMEvaluationType.AGENTIC:
+            if DISABLE_AGENTIC_SEARCH:
+                raise ValueError(
+                    "Agentic search operation called while DISABLE_AGENTIC_SEARCH is toggled"
+                )
+
+            sections = self.final_context_sections
+            functions = [
+                FunctionCall(
+                    evaluate_inference_section,
+                    (section, self.search_query.query, self.llm),
+                )
+                for section in sections
+            ]
+
+            results = run_functions_in_parallel(function_calls=functions)
+
+            response = [value for value in results.values()]
+            self._relevant_section_indices = response
+
+            return self._relevant_section_indices
+
         self._relevant_section_indices = next(
-            cast(Iterator[list[int]], self._postprocessing_generator)
+            cast(Iterator[list[SectionRelevancePiece]], self._postprocessing_generator)
         )
         return self._relevant_section_indices
 
     @property
-    def relevance_summaries(self) -> dict[str, RelevanceChunk]:
-        if DISABLE_AGENTIC_SEARCH:
-            raise ValueError(
-                "Agentic saerch operation called while DISABLE_AGENTIC_SEARCH is toggled"
-            )
-        if len(self.reranked_sections) == 0:
-            logger.warning(
-                "No sections found in agentic search evalution. Returning empty dict."
-            )
-            return {}
-
-        sections = self.reranked_sections
-        functions = [
-            FunctionCall(
-                evaluate_inference_section, (section, self.search_query.query, self.llm)
-            )
-            for section in sections
-        ]
-
-        results = run_functions_in_parallel(function_calls=functions)
-
-        return {
-            next(iter(value)): value[next(iter(value))] for value in results.values()
-        }
-
-    @property
     def section_relevance_list(self) -> list[bool]:
+        llm_indices = relevant_sections_to_indices(
+            relevance_chunks=self.relevant_section_indices,
+            inference_sections=self.final_context_sections,
+        )
         return [
-            True if ind in self.relevant_section_indices else False
-            for ind in range(len(self.reranked_sections))
+            True if ind in llm_indices else False
+            for ind in range(len(self.final_context_sections))
         ]

--- a/backend/danswer/search/postprocessing/postprocessing.py
+++ b/backend/danswer/search/postprocessing/postprocessing.py
@@ -306,15 +306,13 @@ def search_postprocessing(
         if llm_filter_task_id
         else []
     )
-    print("evaluation")
 
     yield [
         SectionRelevancePiece(
             document_id=section.center_chunk.document_id,
             chunk_id=section.center_chunk.chunk_id,
-            relevant=True,
+            relevant=section.center_chunk.unique_id in llm_selected_section_ids,
             content="",
         )
         for section in (reranked_sections or retrieved_sections)
-        if section.center_chunk.unique_id in llm_selected_section_ids
     ]

--- a/backend/danswer/search/preprocessing/preprocessing.py
+++ b/backend/danswer/search/preprocessing/preprocessing.py
@@ -6,6 +6,7 @@ from danswer.configs.chat_configs import FAVOR_RECENT_DECAY_MULTIPLIER
 from danswer.configs.chat_configs import NUM_RETURNED_HITS
 from danswer.db.models import User
 from danswer.llm.interfaces import LLM
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import QueryFlow
 from danswer.search.enums import RecencyBiasSetting
 from danswer.search.models import BaseFilters
@@ -137,18 +138,22 @@ def retrieval_preprocessing(
         access_control_list=user_acl_filters,
     )
 
-    llm_chunk_filter = False
-    if search_request.skip_llm_chunk_filter is not None:
-        llm_chunk_filter = not search_request.skip_llm_chunk_filter
+    llm_evaluation_type = LLMEvaluationType.BASIC
+    if search_request.evaluation_type is not None:
+        llm_evaluation_type = search_request.evaluation_type
     elif persona:
-        llm_chunk_filter = persona.llm_relevance_filter
+        llm_evaluation_type = (
+            LLMEvaluationType.Basic
+            if persona.llm_relevance_filter
+            else LLMEvaluationType.SKIP
+        )
 
     if disable_llm_chunk_filter:
-        if llm_chunk_filter:
+        if llm_evaluation_type:
             logger.info(
                 "LLM chunk filtering would have run but has been globally disabled"
             )
-        llm_chunk_filter = False
+        llm_evaluation_type = LLMEvaluationType.SKIP
 
     skip_rerank = search_request.skip_rerank
     if skip_rerank is None:
@@ -176,7 +181,7 @@ def retrieval_preprocessing(
             num_hits=limit if limit is not None else NUM_RETURNED_HITS,
             offset=offset or 0,
             skip_rerank=skip_rerank,
-            skip_llm_chunk_filter=not llm_chunk_filter,
+            evaluation_type=llm_evaluation_type,
             chunks_above=search_request.chunks_above,
             chunks_below=search_request.chunks_below,
             full_doc=search_request.full_doc,

--- a/backend/danswer/search/utils.py
+++ b/backend/danswer/search/utils.py
@@ -57,7 +57,7 @@ def relevant_sections_to_indices(
 
 
 def relevant_documents_to_indices(
-    relevance_chunks: list[SectionRelevancePiece], search_doc: list[SearchDoc]
+    relevance_chunks: list[SectionRelevancePiece], search_docs: list[SearchDoc]
 ) -> list[int]:
     relevant_set = {
         (chunk.document_id, chunk.chunk_id)
@@ -67,7 +67,7 @@ def relevant_documents_to_indices(
 
     return [
         index
-        for index, section in enumerate(search_doc)
+        for index, section in enumerate(search_docs)
         if (section.document_id, section.chunk_ind) in relevant_set
     ]
 

--- a/backend/danswer/search/utils.py
+++ b/backend/danswer/search/utils.py
@@ -42,34 +42,34 @@ def relevant_sections_to_indices(
     relevance_chunks: list[SectionRelevancePiece],
     inference_sections: list[InferenceSection],
 ) -> list[int]:
-    relevant_indices = []
-    for index, section in enumerate(inference_sections):
-        for relevance_chunk in relevance_chunks:
-            if (
-                section.center_chunk.document_id == relevance_chunk.document_id
-                and section.center_chunk.chunk_id == relevance_chunk.chunk_id
-                and relevance_chunk.relevant
-            ):
-                relevant_indices.append(index)
-                break
+    relevant_set = {
+        (chunk.document_id, chunk.chunk_id)
+        for chunk in relevance_chunks
+        if chunk.relevant
+    }
+    relevant_indices = [
+        index
+        for index, section in enumerate(inference_sections)
+        if (section.center_chunk.document_id, section.center_chunk.chunk_id)
+        in relevant_set
+    ]
     return relevant_indices
 
 
 def relevant_documents_to_indices(
     relevance_chunks: list[SectionRelevancePiece], inference_sections: list[SearchDoc]
 ) -> list[int]:
-    relevant_indices = []
-    for index, section in enumerate(inference_sections):
-        for relevance_chunk in relevance_chunks:
-            if (
-                section.document_id == relevance_chunk.document_id
-                and section.chunk_ind == relevance_chunk.chunk_id
-                and relevance_chunk.relevant
-            ):
-                relevant_indices.append(index)
-                break
+    relevant_set = {
+        (chunk.document_id, chunk.chunk_id)
+        for chunk in relevance_chunks
+        if chunk.relevant
+    }
 
-    return relevant_indices
+    return [
+        index
+        for index, section in enumerate(inference_sections)
+        if (section.document_id, section.chunk_ind) in relevant_set
+    ]
 
 
 def drop_llm_indices(

--- a/backend/danswer/search/utils.py
+++ b/backend/danswer/search/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import TypeVar
 
+from danswer.chat.models import SectionRelevancePiece
 from danswer.db.models import SearchDoc as DBSearchDoc
 from danswer.search.models import InferenceChunk
 from danswer.search.models import InferenceSection
@@ -35,6 +36,40 @@ def dedupe_documents(items: list[T]) -> tuple[list[T], list[int]]:
         else:
             dropped_indices.append(index)
     return deduped_items, dropped_indices
+
+
+def relevant_sections_to_indices(
+    relevance_chunks: list[SectionRelevancePiece],
+    inference_sections: list[InferenceSection],
+) -> list[int]:
+    relevant_indices = []
+    for index, section in enumerate(inference_sections):
+        for relevance_chunk in relevance_chunks:
+            if (
+                section.center_chunk.document_id == relevance_chunk.document_id
+                and section.center_chunk.chunk_id == relevance_chunk.chunk_id
+                and relevance_chunk.relevant
+            ):
+                relevant_indices.append(index)
+                break
+    return relevant_indices
+
+
+def relevant_documents_to_indices(
+    relevance_chunks: list[SectionRelevancePiece], inference_sections: list[SearchDoc]
+) -> list[int]:
+    relevant_indices = []
+    for index, section in enumerate(inference_sections):
+        for relevance_chunk in relevance_chunks:
+            if (
+                section.document_id == relevance_chunk.document_id
+                and section.chunk_ind == relevance_chunk.chunk_id
+                and relevance_chunk.relevant
+            ):
+                relevant_indices.append(index)
+                break
+
+    return relevant_indices
 
 
 def drop_llm_indices(

--- a/backend/danswer/search/utils.py
+++ b/backend/danswer/search/utils.py
@@ -57,7 +57,7 @@ def relevant_sections_to_indices(
 
 
 def relevant_documents_to_indices(
-    relevance_chunks: list[SectionRelevancePiece], inference_sections: list[SearchDoc]
+    relevance_chunks: list[SectionRelevancePiece], search_doc: list[SearchDoc]
 ) -> list[int]:
     relevant_set = {
         (chunk.document_id, chunk.chunk_id)
@@ -67,7 +67,7 @@ def relevant_documents_to_indices(
 
     return [
         index
-        for index, section in enumerate(inference_sections)
+        for index, section in enumerate(search_doc)
         if (section.document_id, section.chunk_ind) in relevant_set
     ]
 

--- a/backend/danswer/secondary_llm_flows/agentic_evaluation.py
+++ b/backend/danswer/secondary_llm_flows/agentic_evaluation.py
@@ -1,6 +1,6 @@
 import re
 
-from danswer.chat.models import RelevanceChunk
+from danswer.chat.models import SectionRelevancePiece
 from danswer.llm.interfaces import LLM
 from danswer.llm.utils import dict_based_prompt_to_langchain_prompt
 from danswer.llm.utils import message_to_string
@@ -32,13 +32,11 @@ def _get_agent_eval_messages(
 
 def evaluate_inference_section(
     document: InferenceSection, query: str, llm: LLM
-) -> dict[str, RelevanceChunk]:
-    results = {}
-
+) -> SectionRelevancePiece:
     document_id = document.center_chunk.document_id
     semantic_id = document.center_chunk.semantic_identifier
     contents = document.combined_content
-    chunk_id = document.center_chunk.chunk_id
+    document.center_chunk.chunk_id
 
     messages = _get_agent_eval_messages(
         title=semantic_id, content=contents, query=query
@@ -64,7 +62,9 @@ def evaluate_inference_section(
     )
     relevant = last_line.strip().lower().startswith("true")
 
-    results[f"{document_id}-{chunk_id}"] = RelevanceChunk(
-        relevant=relevant, content=analysis
+    return SectionRelevancePiece(
+        document_id=document_id,
+        chunk_id=document.center_chunk.chunk_id,
+        relevant=relevant,
+        content=analysis,
     )
-    return results

--- a/backend/danswer/tools/search/search_tool.py
+++ b/backend/danswer/tools/search/search_tool.py
@@ -281,7 +281,7 @@ class SearchTool(Tool):
         # if self.llm_doc_eval and not DISABLE_AGENTIC_SEARCH:
         yield ToolResponse(
             id=SECTION_RELEVANCE_LIST_ID,
-            response=search_pipeline.relevant_section_indices,
+            response=search_pipeline.section_relevance,
         )
 
         final_context_sections = prune_sections(

--- a/backend/danswer/tools/search/search_tool.py
+++ b/backend/danswer/tools/search/search_tool.py
@@ -10,7 +10,6 @@ from danswer.chat.chat_utils import llm_doc_from_inference_section
 from danswer.chat.models import DanswerContext
 from danswer.chat.models import DanswerContexts
 from danswer.chat.models import LlmDoc
-from danswer.configs.chat_configs import DISABLE_AGENTIC_SEARCH
 from danswer.db.models import Persona
 from danswer.db.models import User
 from danswer.dynamic_configs.interface import JSON_ro
@@ -18,7 +17,9 @@ from danswer.llm.answering.models import DocumentPruningConfig
 from danswer.llm.answering.models import PreviousMessage
 from danswer.llm.answering.models import PromptConfig
 from danswer.llm.answering.prune_and_merge import prune_and_merge_sections
+from danswer.llm.answering.prune_and_merge import prune_sections
 from danswer.llm.interfaces import LLM
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import QueryFlow
 from danswer.search.enums import SearchType
 from danswer.search.models import IndexFilters
@@ -78,6 +79,7 @@ class SearchTool(Tool):
         llm: LLM,
         fast_llm: LLM,
         pruning_config: DocumentPruningConfig,
+        evaluation_type: LLMEvaluationType,
         # if specified, will not actually run a search and will instead return these
         # sections. Used when the user selects specific docs to talk to
         selected_sections: list[InferenceSection] | None = None,
@@ -94,6 +96,7 @@ class SearchTool(Tool):
         self.llm = llm
         self.fast_llm = fast_llm
         self.pruning_config = pruning_config
+        self.evaluation_type = evaluation_type
 
         self.selected_sections = selected_sections
 
@@ -221,6 +224,7 @@ class SearchTool(Tool):
         search_pipeline = SearchPipeline(
             search_request=SearchRequest(
                 query=query,
+                evaluation_type=self.evaluation_type,
                 human_selected_filters=(
                     self.retrieval_options.filters if self.retrieval_options else None
                 ),
@@ -251,7 +255,7 @@ class SearchTool(Tool):
             id=SEARCH_RESPONSE_SUMMARY_ID,
             response=SearchResponseSummary(
                 rephrased_query=query,
-                top_sections=search_pipeline.reranked_sections,
+                top_sections=search_pipeline.final_context_sections,
                 predicted_flow=search_pipeline.predicted_flow,
                 predicted_search=search_pipeline.predicted_search_type,
                 final_filters=search_pipeline.search_query.filters,
@@ -274,13 +278,14 @@ class SearchTool(Tool):
             ),
         )
 
+        # if self.llm_doc_eval and not DISABLE_AGENTIC_SEARCH:
         yield ToolResponse(
             id=SECTION_RELEVANCE_LIST_ID,
             response=search_pipeline.relevant_section_indices,
         )
 
-        final_context_sections = prune_and_merge_sections(
-            sections=search_pipeline.reranked_sections,
+        final_context_sections = prune_sections(
+            sections=search_pipeline.final_context_sections,
             section_relevance_list=search_pipeline.section_relevance_list,
             prompt_config=self.prompt_config,
             llm_config=self.llm.config,
@@ -294,11 +299,6 @@ class SearchTool(Tool):
         ]
 
         yield ToolResponse(id=FINAL_CONTEXT_DOCUMENTS, response=llm_docs)
-
-        if self.llm_doc_eval and not DISABLE_AGENTIC_SEARCH:
-            yield ToolResponse(
-                id=SEARCH_EVALUATION_ID, response=search_pipeline.relevance_summaries
-            )
 
     def final_result(self, *args: ToolResponse) -> JSON_ro:
         final_docs = cast(

--- a/backend/ee/danswer/server/query_and_chat/models.py
+++ b/backend/ee/danswer/server/query_and_chat/models.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from danswer.configs.constants import DocumentSource
+from danswer.search.enums import LLMEvaluationType
 from danswer.search.enums import SearchType
 from danswer.search.models import ChunkContext
 from danswer.search.models import RetrievalDetails
@@ -21,9 +22,9 @@ class DocumentSearchRequest(ChunkContext):
     search_type: SearchType
     retrieval_options: RetrievalDetails
     recency_bias_multiplier: float = 1.0
+    evaluation_type: LLMEvaluationType
     # This is to forcibly skip (or run) the step, if None it uses the system defaults
     skip_rerank: bool | None = None
-    skip_llm_chunk_filter: bool | None = None
 
 
 class BasicCreateChatMessageRequest(ChunkContext):

--- a/backend/ee/danswer/server/query_and_chat/query_backend.py
+++ b/backend/ee/danswer/server/query_and_chat/query_backend.py
@@ -116,7 +116,7 @@ def handle_search_request(
 
     llm_indices = relevant_documents_to_indices(
         relevance_chunks=relevant_chunks,
-        inference_sections=[
+        search_docs=[
             translate_db_search_doc_to_server_search_doc(cast(SearchDoc, doc))
             for doc in deduped_docs
         ],

--- a/backend/ee/danswer/server/query_and_chat/query_backend.py
+++ b/backend/ee/danswer/server/query_and_chat/query_backend.py
@@ -81,7 +81,7 @@ def handle_search_request(
     )
     top_sections = search_pipeline.reranked_sections
     # If using surrounding context or full doc, this will be empty
-    relevant_chunks = search_pipeline.relevant_section_indices
+    relevant_chunks = search_pipeline.section_relevance
     top_docs = [
         SavedSearchDocWithContent(
             document_id=section.center_chunk.document_id,

--- a/web/src/app/chat/modal/configuration/AssistantsTab.tsx
+++ b/web/src/app/chat/modal/configuration/AssistantsTab.tsx
@@ -94,6 +94,7 @@ const AssistantCard = ({
             ))}
           </div>
         )}
+
         <div className="text-xs text-subtle">
           <span className="font-semibold">Default model:</span>{" "}
           {getDisplayNameForModel(

--- a/web/src/components/search/SearchResultsDisplay.tsx
+++ b/web/src/components/search/SearchResultsDisplay.tsx
@@ -157,9 +157,7 @@ export const SearchResultsDisplay = ({
           showAll ||
           (searchResponse &&
             searchResponse.additional_relevance &&
-            searchResponse.additional_relevance[
-              `${doc.document_id}-${doc.chunk_ind}`
-            ].relevant) ||
+            searchResponse.additional_relevance[doc.document_id].relevant) ||
           doc.is_relevant
         );
       })
@@ -248,9 +246,7 @@ export const SearchResultsDisplay = ({
           {uniqueDocuments.map((document, ind) => {
             const relevance: DocumentRelevance | null =
               searchResponse.additional_relevance
-                ? searchResponse.additional_relevance[
-                    `${document.document_id}-${document.chunk_ind}`
-                  ]
+                ? searchResponse.additional_relevance[document.document_id]
                 : null;
 
             return agenticResults ? (


### PR DESCRIPTION
Description:

This PR refactors the LLM-based relevance evaluation in the search pipeline to improve distinctions in the search evaluation flows and merging of inference sections. 

Main changes:
1. Combined objects for returning LLM relevance information: 
 - `SectionRelevancePiece`: relevance by inference section
 - `DocumentRelevance`: relevance assessments mapped from document ID
 - `RelevanceAnalysis`: unit of relevance analysis
3. New `LLMEvaluationType` enum with options: `AGENTIC`, `BASIC`, and `SKIP`. so by definition can't mess up
4. Replaced / deprecated`skip_llm_chunk_filter` with `evaluation_type` in various models and functions.
5. Update `SearchPipeline` class to use the new evaluation type and refactored related methods.
6. Modified the pipeline + `SearchTool` to use new evaluation type + related changes
8. Refactored merging of inference sections to occur as an `@property` in Search Pipeline so processing in Search Tool doesn't need to worry about multiple inference sections from the same document
9. Updated various utility functions to work with the new `SectionRelevancePiece` model.

Key places for changes:
- `backend/danswer/search/enums.py`: Added `LLMEvaluationType` enum.
- `backend/danswer/search/pipeline.py`: Refactored `SearchPipeline` class to use new evaluation type.
- `backend/danswer/search/postprocessing/postprocessing.py`: Updated postprocessing to work with the new evaluation type.
- `backend/danswer/secondary_llm_flows/agentic_evaluation.py`: Modified to return `SectionRelevancePiece`.
- `backend/danswer/tools/search/search_tool.py`: Updated `SearchTool` to use the new evaluation type.
- `backend/ee/danswer/server/query_and_chat/query_backend.py`: Refactored `handle_search_request` to work with the new approach.

This refactoring provides more granular control over the LLM-based relevance evaluation process and improves the overall structure of the search pipeline.

Testing:
- [x] Ran all existing tests
- [ ] Ensure disabling of LLM evaluation flow works for search flow `DISABLE_AGENTIC`
- [x] Manually tested each search flow
   - [ ] Slackbot search flow
     - [ ] No LLM evaluation
   - [ ] Chat search tool
     - [ ] Basic LLM evaluation
   - [ ] Basic Search flow (w/wo agentic evaluation)
     - [ ] Agentic evaluation
