### PR TITLE
Added content tags to zendesk connector

### DIFF
--- a/backend/danswer/connectors/zendesk/connector.py
+++ b/backend/danswer/connectors/zendesk/connector.py
@@ -97,7 +97,7 @@ class ZendeskConnector(LoadConnector, PollConnector):
                 else:
                     raise Exception(f"Error: {response.status_code}\n{response.text}")
         except Exception as e:
-            print(f"Error fetching content tags: {str(e)}")
+            raise Exception(f"Error fetching content tags: {str(e)}")
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         # Subdomain is actually the whole URL

--- a/backend/danswer/connectors/zendesk/connector.py
+++ b/backend/danswer/connectors/zendesk/connector.py
@@ -67,7 +67,7 @@ class ZendeskConnector(LoadConnector, PollConnector):
     @retry(tries=3, delay=2, backoff=2)
     def _set_content_tags(
         self, subdomain: str, email: str, token: str, page_size: int = 30
-    ):
+    ) -> None:
         # Construct the base URL
         base_url = f"https://{subdomain}.zendesk.com/api/v2/guide/content_tags"
 

--- a/backend/danswer/connectors/zendesk/connector.py
+++ b/backend/danswer/connectors/zendesk/connector.py
@@ -27,7 +27,7 @@ def _article_to_document(article: Article, content_tags: dict[str, str]) -> Docu
     update_time = time_str_to_utc(article.updated_at)
 
     # build metadata
-    metadata = {
+    metadata: dict[str, str | list[str]] = {
         "labels": [str(label) for label in article.label_names if label],
         "content_tag_names": [
             content_tags[tag_id]
@@ -63,7 +63,7 @@ class ZendeskConnector(LoadConnector, PollConnector):
         self.zendesk_client: Zenpy | None = None
         self.content_tags: dict[str, str] = {}
 
-    def _set_content_tags(self, subdomain: str, email: str, token: str):
+    def _set_content_tags(self, subdomain: str, email: str, token: str) -> None:
         # Construct the URL
         url = f"https://{subdomain}.zendesk.com/api/v2/guide/content_tags"
 

--- a/backend/danswer/connectors/zendesk/connector.py
+++ b/backend/danswer/connectors/zendesk/connector.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import requests
 from zenpy import Zenpy  # type: ignore
 from zenpy.lib.api_objects.help_centre_objects import Article  # type: ignore
 
@@ -19,12 +20,24 @@ from danswer.connectors.models import Section
 from danswer.file_processing.html_utils import parse_html_page_basic
 
 
-def _article_to_document(article: Article) -> Document:
+def _article_to_document(article: Article, content_tags: dict[str, str]) -> Document:
     author = BasicExpertInfo(
         display_name=article.author.name, email=article.author.email
     )
     update_time = time_str_to_utc(article.updated_at)
-    labels = [str(label) for label in article.label_names]
+
+    # build metadata
+    metadata = {
+        "labels": [str(label) for label in article.label_names if label],
+        "content_tag_names": [
+            content_tags[tag_id]
+            for tag_id in article.content_tag_ids
+            if tag_id in content_tags
+        ],
+    }
+
+    # remove empty values
+    metadata = {k: v for k, v in metadata.items() if v}
 
     return Document(
         id=f"article:{article.id}",
@@ -35,7 +48,7 @@ def _article_to_document(article: Article) -> Document:
         semantic_identifier=article.title,
         doc_updated_at=update_time,
         primary_owners=[author],
-        metadata={"labels": labels} if labels else {},
+        metadata=metadata,
     )
 
 
@@ -48,6 +61,28 @@ class ZendeskConnector(LoadConnector, PollConnector):
     def __init__(self, batch_size: int = INDEX_BATCH_SIZE) -> None:
         self.batch_size = batch_size
         self.zendesk_client: Zenpy | None = None
+        self.content_tags: dict[str, str] = {}
+
+    def _set_content_tags(self, subdomain: str, email: str, token: str):
+        # Construct the URL
+        url = f"https://{subdomain}.zendesk.com/api/v2/guide/content_tags"
+
+        # Set up authentication
+        auth = (f"{email}/token", token)
+
+        try:
+            # Make the GET request
+            response = requests.get(url, auth=auth)
+
+            # Check if the request was successful
+            if response.status_code == 200:
+                content_tag_list = response.json().get("records", [])
+                for tag in content_tag_list:
+                    self.content_tags[tag["id"]] = tag["name"]
+            else:
+                raise Exception(f"Error: {response.status_code}\n{response.text}")
+        except Exception as e:
+            print(f"Error fetching content tags: {str(e)}")
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         # Subdomain is actually the whole URL
@@ -61,6 +96,11 @@ class ZendeskConnector(LoadConnector, PollConnector):
             subdomain=subdomain,
             email=credentials["zendesk_email"],
             token=credentials["zendesk_token"],
+        )
+        self._set_content_tags(
+            subdomain,
+            credentials["zendesk_email"],
+            credentials["zendesk_token"],
         )
         return None
 
@@ -92,10 +132,30 @@ class ZendeskConnector(LoadConnector, PollConnector):
             ):
                 continue
 
-            doc_batch.append(_article_to_document(article))
+            doc_batch.append(_article_to_document(article, self.content_tags))
             if len(doc_batch) >= self.batch_size:
                 yield doc_batch
                 doc_batch.clear()
 
         if doc_batch:
             yield doc_batch
+
+
+if __name__ == "__main__":
+    import os
+    import time
+
+    connector = ZendeskConnector()
+    connector.load_credentials(
+        {
+            "zendesk_subdomain": os.environ["ZENDESK_SUBDOMAIN"],
+            "zendesk_email": os.environ["ZENDESK_EMAIL"],
+            "zendesk_token": os.environ["ZENDESK_TOKEN"],
+        }
+    )
+
+    current = time.time()
+    one_day_ago = current - 24 * 60 * 60  # 1 day
+    document_batches = connector.poll_source(one_day_ago, current)
+
+    print(next(document_batches))


### PR DESCRIPTION
## Description
We cache all content_tags and then check if each document has any content_tag_ids. if it does, we get the content_tags that have a matching id from the cache and add it to the document metadata


## How Has This Been Tested?
I added a tag to the document and then searched for the tag name in the  


## Accepted Risk
We are using the requests library raw to grab the content_tags because the zenpy library does not support retrieving the content_tags



