### PR TITLE
Fix icons in personas (assistants) - AWS and Azrue were mixed up

### DIFF
--- a/web/src/lib/assistants/fetchPersonaEditorInfoSS.ts
+++ b/web/src/lib/assistants/fetchPersonaEditorInfoSS.ts
@@ -100,9 +100,9 @@ export async function fetchAssistantEditorInfoSS(
     } else if (provider.provider == "anthropic") {
       provider.icon = AnthropicIcon;
     } else if (provider.provider == "bedrock") {
-      provider.icon = AzureIcon;
-    } else if (provider.provider == "azure") {
       provider.icon = AWSIcon;
+    } else if (provider.provider == "azure") {
+      provider.icon = AzureIcon;
     } else {
       provider.icon = OpenSourceIcon;
     }


### PR DESCRIPTION
Fixes #2025

## Description
Switch the icons for AWS and Azure.

## How Has This Been Tested?
Tested the UI - icons are now correct.

## Accepted Risk
-

## Related Issue(s)
#2025 


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
