### PR TITLE
Helm refactor

### DIFF
--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -3,14 +3,15 @@ kind: Deployment
 metadata:
   name: {{ include "danswer-stack.fullname" . }}-indexing-model
   labels:
-    {{- include "danswer-stack.labels" . | nindent 4 }}
+    {{- range .Values.indexCapability.deployment.labels }}
+    {{ .key }}: {{ .value }}
+    {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.indexCapability.deployment.replicas }}
   selector:
     matchLabels:
-      {{- include "danswer-stack.selectorLabels" . | nindent 6 }}
-      {{- if .Values.indexCapability.deploymentLabels }}
-      {{- toYaml .Values.indexCapability.deploymentLabels | nindent 6 }}
+      {{- range .Values.indexCapability.deployment.labels }}
+      {{ .key }}: {{ .value }}
       {{- end }}
   template:
     metadata:
@@ -19,18 +20,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "danswer-stack.labels" . | nindent 8 }}
-        {{- with .Values.indexCapability.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- range .Values.indexCapability.podLabels }}
+        {{ .key }}: {{ .value }}
         {{- end }}
     spec:
       containers:
-      - name: indexing-model-server
-        image: danswer/danswer-model-server:latest
-        imagePullPolicy: IfNotPresent
-        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
+      - name: {{ .Values.indexCapability.name }}
+        image: {{ .Values.indexCapability.deployment.image.repository }}:{{ .Values.indexCapability.deployment.image.tag }}
+        imagePullPolicy: {{ .Values.indexCapability.deployment.image.pullPolicy }}
+        command: {{ toYaml .Values.indexCapability.deployment.command | nindent 14 }}
         ports:
-        - containerPort: 9000
+        - containerPort: {{ .Values.indexCapability.service.port }}
         envFrom:
           - configMapRef:
               name: {{ .Values.config.envConfigMapName }}
@@ -39,12 +39,12 @@ spec:
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "danswer-stack.envSecrets" . | nindent 10}}
         volumeMounts:
-        {{- range .Values.indexCapability.volumeMounts }}
+        {{- range .Values.indexCapability.deployment.volumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
         {{- end }}
       volumes:
-      {{- range .Values.indexCapability.volumes }}
+      {{- range .Values.indexCapability.deployment.volumes }}
       - name: {{ .name }}
         persistentVolumeClaim:
           claimName: {{ .persistentVolumeClaim.claimName }}

--- a/deployment/helm/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/templates/indexing-model-deployment.yaml
@@ -3,15 +3,14 @@ kind: Deployment
 metadata:
   name: {{ include "danswer-stack.fullname" . }}-indexing-model
   labels:
-    {{- range .Values.indexCapability.deployment.labels }}
-    {{ .key }}: {{ .value }}
-    {{- end }}
+    {{- include "danswer-stack.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.indexCapability.deployment.replicas }}
   selector:
     matchLabels:
-      {{- range .Values.indexCapability.deployment.labels }}
-      {{ .key }}: {{ .value }}
+      {{- include "danswer-stack.selectorLabels" . | nindent 6 }}
+      {{- if .Values.indexCapability.deployment.labels }}
+      {{- toYaml .Values.indexCapability.deployment.labels | nindent 6 }}
       {{- end }}
   template:
     metadata:
@@ -20,8 +19,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- range .Values.indexCapability.podLabels }}
-        {{ .key }}: {{ .value }}
+        {{- include "danswer-stack.labels" . | nindent 8 }}
+        {{- with .Values.indexCapability.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       containers:

--- a/deployment/helm/templates/indexing-model-pvc.yaml
+++ b/deployment/helm/templates/indexing-model-pvc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.indexCapability.indexingModelPVC.name }}
+  name: {{ .Values.indexCapability.pvc.name }}
 spec:
-  accessModes:
-    - {{ .Values.indexCapability.indexingModelPVC.accessMode | quote }}
+  accessModes: 
+    {{- toYaml .Values.indexCapability.pvc.accessModes | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.indexCapability.indexingModelPVC.storage | quote }}
+      storage: {{ .Values.indexCapability.pvc.storage }}

--- a/deployment/helm/templates/indexing-model-service.yaml
+++ b/deployment/helm/templates/indexing-model-service.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     {{- include "danswer-stack.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.indexCapability.service.type }}
   selector:
     {{- include "danswer-stack.selectorLabels" . | nindent 4 }}
-    {{- if .Values.indexCapability.deploymentLabels }}
-    {{- toYaml .Values.indexCapability.deploymentLabels | nindent 4 }}
+    {{- if .Values.indexCapability.deployment.labels }}
+    {{- toYaml .Values.indexCapability.deployment.labels | nindent 4 }}
     {{- end }}
   ports:
     - name: {{ .Values.indexCapability.service.name }}
       protocol: TCP
       port: {{ .Values.indexCapability.service.port }}
       targetPort: {{ .Values.indexCapability.service.port }}
-  type: {{ .Values.indexCapability.service.type }}

--- a/deployment/helm/templates/inference-model-deployment.yaml
+++ b/deployment/helm/templates/inference-model-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- end }}
     spec:
       containers:
-      - name: {{ .Values.inferenceCapability.service.name }}
+      - name: {{ .Values.inferenceCapability.name }}
         image: {{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag }}
         imagePullPolicy: {{ .Values.inferenceCapability.deployment.image.pullPolicy }}
         command: {{ toYaml .Values.inferenceCapability.deployment.command | nindent 14 }}

--- a/deployment/helm/templates/inference-model-deployment.yaml
+++ b/deployment/helm/templates/inference-model-deployment.yaml
@@ -3,21 +3,21 @@ kind: Deployment
 metadata:
   name: {{ include "danswer-stack.fullname" . }}-inference-model
   labels:
-    {{- range .Values.inferenceCapability.deployment.labels }}
-    {{ .key }}: {{ .value }}
-    {{- end }}
+    {{- include "danswer-stack.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.inferenceCapability.deployment.replicas }}
   selector:
     matchLabels:
-      {{- range .Values.inferenceCapability.deployment.labels }}
-      {{ .key }}: {{ .value }}
+      {{- include "danswer-stack.selectorLabels" . | nindent 6 }}
+      {{- if .Values.inferenceCapability.deployment.labels }}
+      {{- toYaml .Values.inferenceCapability.deployment.labels | nindent 6 }}
       {{- end }}
   template:
     metadata:
       labels:
-        {{- range .Values.inferenceCapability.podLabels }}
-        {{ .key }}: {{ .value }}
+        {{- include "danswer-stack.labels" . | nindent 8 }}
+        {{- with .Values.inferenceCapability.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       containers:

--- a/deployment/helm/templates/inference-model-service.yaml
+++ b/deployment/helm/templates/inference-model-service.yaml
@@ -2,14 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "danswer-stack.fullname" . }}-inference-model-service
+  labels:
+    {{- include "danswer-stack.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.inferenceCapability.service.type }}
+  selector:
+    {{- include "danswer-stack.selectorLabels" . | nindent 4 }}
+    {{- if .Values.inferenceCapability.deployment.labels }}
+    {{- toYaml .Values.inferenceCapability.deployment.labels | nindent 4 }}
+    {{- end }}
   ports:
     - port: {{ .Values.inferenceCapability.service.port }}
       targetPort: {{ .Values.inferenceCapability.service.port }}
       protocol: TCP
       name: {{ .Values.inferenceCapability.service.name }}
-  selector:
-    {{- range .Values.inferenceCapability.deployment.labels }}
-    {{ .key }}: {{ .value }}
-    {{- end }}

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "danswer-stack.fullname" . -}}
+{{- $svcPort := .Values.nginx.service.ports.http -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-ingress
+  labels:
+    {{- include "danswer-stack.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-nginx
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-nginx
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -324,7 +324,7 @@ vespa:
   podAnnotations: {}
   podLabels:
     app: vespa
-    app.kubernetes.io/instance: danswer
+    app.kubernetes.io/instance: danswer-stack
     app.kubernetes.io/name: vespa
   enabled: true
 

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -355,14 +355,15 @@ vespa:
   tolerations: []
   affinity: {}
 
-persistence:
-  vespa:
-    enabled: true
-    existingClaim: ""
-    storageClassName: ""
-    accessModes:
-      - ReadWriteOnce
-    size: 5Gi
+  volumeClaimTemplates:
+   - metadata:
+       name: vespa-storage
+     spec:
+       accessModes:
+         - ReadWriteOnce
+       resources:
+         requests:
+           storage: 5Gi    
 
 auth:
   # for storing smtp, oauth, slack, and other secrets

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -7,17 +7,17 @@ nameOverride: ""
 fullnameOverride: ""
 
 inferenceCapability:
+  name: inference-model-server
   service:
     name: inference-model-server-service
     type: ClusterIP
     port: 9000
   pvc:
     name: inference-model-pvc
-    accessModes:
+    accessModes: 
       - ReadWriteOnce
     storage: 3Gi
   deployment:
-    name: inference-model-server-deployment
     replicas: 1
     labels:
       - key: app
@@ -40,27 +40,41 @@ inferenceCapability:
       value: inference-model-server
 
 indexCapability:
+  name: indexing-model-server
   service:
+    name: indexing-model-server-port
     type: ClusterIP
     port: 9000
-    name: indexing-model-server-port
-  deploymentLabels:
-    app: indexing-model-server
+  pvc:
+    name: indexing-model-pvc
+    accessModes: 
+      - ReadWriteOnce
+    storage: 3Gi
+  deployment:
+    replicas: 1
+    labels:
+      - key: app
+        value: indexing-model-server
+    image:
+      repository: danswer/danswer-model-server
+      pullPolicy: IfNotPresent
+      tag: latest
+    command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
+    port: 9000
+    volumeMounts:
+      - name: indexing-model-pvc
+        mountPath: /root/.cache
+    volumes:
+      - name: indexing-model-pvc
+        persistentVolumeClaim:
+          claimName: indexing-model-pvc
   podLabels:
-    app: indexing-model-server
+    - key: app
+      value: indexing-model-server
   indexingOnly: "True"
   podAnnotations: {}
-  volumeMounts:
-    - name: indexing-model-storage
-      mountPath: /root/.cache
-  volumes:
-    - name: indexing-model-storage
-      persistentVolumeClaim:
-        claimName: indexing-model-storage
-  indexingModelPVC:
-    name: indexing-model-storage
-    accessMode: "ReadWriteOnce"
-    storage: "3Gi"
+
+
 
 config:
   envConfigMapName: env-configmap
@@ -344,23 +358,6 @@ vespa:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
-
-#ingress:
-#  enabled: false
-#  className: ""
-#  annotations: {}
-#    # kubernetes.io/ingress.class: nginx
-#    # kubernetes.io/tls-acme: "true"
-#  hosts:
-#    - host: chart-example.local
-#      paths:
-#        - path: /
-#          pathType: ImplementationSpecific
-#  tls: []
-#  #  - secretName: chart-example-tls
-#  #    hosts:
-#  #      - chart-example.local
 
 persistence:
   vespa:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -20,8 +20,7 @@ inferenceCapability:
   deployment:
     replicas: 1
     labels:
-      - key: app
-        value: inference-model-server
+      app: inference-model-server
     image:
       repository: danswer/danswer-model-server
       tag: latest
@@ -36,8 +35,7 @@ inferenceCapability:
         persistentVolumeClaim:
           claimName: inference-model-pvc
   podLabels:
-    - key: app
-      value: inference-model-server
+    app: inference-model-server
 
 indexCapability:
   name: indexing-model-server
@@ -53,8 +51,7 @@ indexCapability:
   deployment:
     replicas: 1
     labels:
-      - key: app
-        value: indexing-model-server
+      app: indexing-model-server
     image:
       repository: danswer/danswer-model-server
       pullPolicy: IfNotPresent
@@ -69,8 +66,7 @@ indexCapability:
         persistentVolumeClaim:
           claimName: indexing-model-pvc
   podLabels:
-    - key: app
-      value: indexing-model-server
+    app: indexing-model-server
   indexingOnly: "True"
   podAnnotations: {}
 

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -102,6 +102,22 @@ nginx:
 
   existingServerBlockConfigmap: danswer-nginx-conf
 
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 webserver:
   replicaCount: 1
   image:


### PR DESCRIPTION
## Description
Refactor of the Helm charts. Mostly focusing on the index and inference model deployments and services. The changes align labels and styles with existing manifests.
Adds an optional Ingress manifest.
Fixes a bug with the vespa pod label.
Adds  volumeClaimTemplates map to vespa values so storage size can be updated.

## How Has This Been Tested?
Changes were deployed to a kubernetes cluster and the application works as intended.


## Accepted Risk
These are breaking changes for existing Helm deployments. Changes to selector labels are not allowed on existing resources. The index and inference model deployments need to be deleted before upgrading via Helm.


## Related Issue(s)
Not applicable


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
