### PR TITLE
Fix secondary index attempts showing up as the primary index status +…

### DIFF
--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -93,11 +93,11 @@ def _should_create_new_indexing(
     if connector.refresh_freq is None:
         return False
 
-    # Only one scheduled job per connector at a time
-    # Can schedule another one if the current one is already running however
-    # Because the currently running one will not be until the latest time
-    # Note, this last index is for the given embedding model
-    if last_index.status == IndexingStatus.NOT_STARTED:
+    # Only one scheduled/obngoing job per connector at a time
+    if (
+        last_index.status == IndexingStatus.NOT_STARTED
+        or last_index.status == IndexingStatus.IN_PROGRESS
+    ):
         return False
 
     current_db_time = get_db_current_time(db_session)

--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -93,7 +93,11 @@ def _should_create_new_indexing(
     if connector.refresh_freq is None:
         return False
 
-    # Only one scheduled/obngoing job per connector at a time
+    # Only one scheduled/ongoing job per connector at a time
+    # this prevents cases where
+    # (1) the "latest" index_attempt is scheduled so we show
+    #     that in the UI despite another index_attempt being in-progress
+    # (2) multiple scheduled index_attempts at a time
     if (
         last_index.status == IndexingStatus.NOT_STARTED
         or last_index.status == IndexingStatus.IN_PROGRESS

--- a/backend/danswer/server/documents/connector.py
+++ b/backend/danswer/server/documents/connector.py
@@ -422,7 +422,9 @@ def get_connector_indexing_status(
         )
 
         latest_finished_attempt = get_latest_finished_index_attempt_for_cc_pair(
-            connector_credential_pair_id=cc_pair.id, db_session=db_session
+            connector_credential_pair_id=cc_pair.id,
+            secondary_index=secondary_index,
+            db_session=db_session,
         )
 
         indexing_statuses.append(
@@ -433,24 +435,26 @@ def get_connector_indexing_status(
                 credential=CredentialSnapshot.from_credential_db_model(credential),
                 public_doc=cc_pair.is_public,
                 owner=credential.user.email if credential.user else "",
-                last_finished_status=latest_finished_attempt.status
-                if latest_finished_attempt
-                else None,
-                last_status=latest_index_attempt.status
-                if latest_index_attempt
-                else None,
+                last_finished_status=(
+                    latest_finished_attempt.status if latest_finished_attempt else None
+                ),
+                last_status=(
+                    latest_index_attempt.status if latest_index_attempt else None
+                ),
                 last_success=cc_pair.last_successful_index_time,
                 docs_indexed=cc_pair_to_document_cnt.get(
                     (connector.id, credential.id), 0
                 ),
-                error_msg=latest_index_attempt.error_msg
-                if latest_index_attempt
-                else None,
-                latest_index_attempt=IndexAttemptSnapshot.from_index_attempt_db_model(
-                    latest_index_attempt
-                )
-                if latest_index_attempt
-                else None,
+                error_msg=(
+                    latest_index_attempt.error_msg if latest_index_attempt else None
+                ),
+                latest_index_attempt=(
+                    IndexAttemptSnapshot.from_index_attempt_db_model(
+                        latest_index_attempt
+                    )
+                    if latest_index_attempt
+                    else None
+                ),
                 deletion_attempt=get_deletion_status(
                     connector_id=connector.id,
                     credential_id=credential.id,

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -130,7 +130,7 @@ function ConnectorRow({
   ccPairsIndexingStatus,
   invisible,
 }: {
-  ccPairsIndexingStatus: any;
+  ccPairsIndexingStatus: ConnectorIndexingStatus<any, any>;
   invisible?: boolean;
 }) {
   const router = useRouter();
@@ -209,7 +209,9 @@ function ConnectorRow({
 
   return (
     <TableRow
-      className={`hover:bg-hover-light ${invisible ? "invisible h-0 !-mb-10" : "border border-border !border-b"}  w-full cursor-pointer relative`}
+      className={`hover:bg-hover-light ${
+        invisible ? "invisible h-0 !-mb-10" : "border border-border !border-b"
+      }  w-full cursor-pointer relative`}
       onClick={() =>
         router.push(`/admin/connector/${ccPairsIndexingStatus.cc_pair_id}`)
       }
@@ -354,12 +356,40 @@ export function CCPairIndexingStatusTable({
             name: "Sample File Connector",
             last_status: "success",
             connector: {
+              name: "Sample File Connector",
               source: "file",
+              input_type: "poll",
+              connector_specific_config: {
+                file_locations: ["/path/to/sample/file.txt"],
+              },
+              refresh_freq: 86400,
+              prune_freq: null,
+              indexing_start: new Date("2023-07-01T12:00:00Z"),
               disabled: false,
+              id: 1,
+              credential_ids: [],
+              time_created: "2023-07-01T12:00:00Z",
+              time_updated: "2023-07-01T12:00:00Z",
+            },
+            credential: {
+              id: 1,
+              name: "Sample Credential",
+              source: "file",
+              user_id: "1",
+              time_created: "2023-07-01T12:00:00Z",
+              time_updated: "2023-07-01T12:00:00Z",
+              credential_json: {},
+              admin_public: false,
             },
             public_doc: true,
             docs_indexed: 1000,
             last_success: "2023-07-01T12:00:00Z",
+            last_finished_status: "success",
+            latest_index_attempt: null,
+            owner: "1",
+            error_msg: "",
+            deletion_attempt: null,
+            is_deletable: true,
           }}
         />
         <div className="-mb-10" />


### PR DESCRIPTION
… scheduling while in-progress


## How Has This Been Tested?
Created a secondary index attempt with status failed. Verified that it previously would display the incorrect status and then that after the change it shows the correct status. 

Also verified that we would not schedule multiple index attempts for the secondary runs.
