### PR TITLE
enforce index attempt deduping on secondary indexing.

### DIFF
--- a/backend/danswer/background/celery/celery_app.py
+++ b/backend/danswer/background/celery/celery_app.py
@@ -103,7 +103,7 @@ def cleanup_connector_credential_pair_task(
 @build_celery_task_wrapper(name_cc_prune_task)
 @celery_app.task(soft_time_limit=JOB_TIMEOUT)
 def prune_documents_task(connector_id: int, credential_id: int) -> None:
-    """connector pruning task. For a cc pair, this task pulls all docuement IDs from the source
+    """connector pruning task. For a cc pair, this task pulls all document IDs from the source
     and compares those IDs to locally stored documents and deletes all locally stored IDs missing
     from the most recently pulled document ID list"""
     with Session(get_sqlalchemy_engine()) as db_session:

--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -76,7 +76,7 @@ def _should_create_new_indexing(
             # Once is enough. The model will never be able to swap otherwise.
             if last_index.status == IndexingStatus.SUCCESS:
                 return False
-            
+
             # No new index if the last index attempt is waiting to start
             if last_index.status == IndexingStatus.NOT_STARTED:
                 return False

--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -72,9 +72,17 @@ def _should_create_new_indexing(
     # When switching over models, always index at least once
     if model.status == IndexModelStatus.FUTURE:
         if last_index:
-            # secondary indexes should not index again after success
-            # or else the model will never be able to swap
+            # No new index if the last index attempt succeeded
+            # Once is enough. The model will never be able to swap otherwise.
             if last_index.status == IndexingStatus.SUCCESS:
+                return False
+            
+            # No new index if the last index attempt is waiting to start
+            if last_index.status == IndexingStatus.NOT_STARTED:
+                return False
+
+            # No new index if the last index attempt is running
+            if last_index.status == IndexingStatus.IN_PROGRESS:
                 return False
         else:
             if connector.id == 0:  # Ingestion API

--- a/backend/danswer/db/document_set.py
+++ b/backend/danswer/db/document_set.py
@@ -277,7 +277,7 @@ def mark_cc_pair__document_set_relationships_to_be_deleted__no_commit(
     `cc_pair_id` as not current and returns the list of all document set IDs
     affected.
 
-    NOTE: rases a `ValueError` if any of the document sets are currently syncing
+    NOTE: raises a `ValueError` if any of the document sets are currently syncing
     to avoid getting into a bad state."""
     document_set__cc_pair_relationships = db_session.scalars(
         select(DocumentSet__ConnectorCredentialPair).where(


### PR DESCRIPTION
## Description
Fixes DAN-379.

secondary indexes need dedupe checking as well. We didn't run into this bug before because all the indexing code was running inside the dispatch loop.


## How Has This Been Tested?
Switched models on main and observed job count rising unnecessarily.  Implemented fix and job count is no longer rising.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
