### PR TITLE
Add proper default temperature + overrides

### DIFF
--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -136,8 +136,6 @@ export function ChatPage({
         : undefined
   );
 
-  // LLM
-
   // Gather default temperature settings
   const search_param_temperature = searchParams.get(
     SEARCH_PARAM_NAMES.TEMPERATURE

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -143,10 +143,12 @@ export function ChatPage({
   const defaultTemperature = search_param_temperature
     ? parseFloat(search_param_temperature)
     : selectedAssistant?.tools.some(
-          (tool) => tool.in_code_tool_id === "SearchTool"
+          (tool) =>
+            tool.in_code_tool_id === "SearchTool" ||
+            tool.in_code_tool_id === "InternetSearchTool"
         )
-      ? 0.7
-      : 0;
+      ? 0
+      : 0.7;
   const llmOverrideManager = useLlmOverride(
     selectedChatSession,
     defaultTemperature

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/types";
 import useSWR, { mutate, useSWRConfig } from "swr";
 import { errorHandlingFetcher } from "./fetcher";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DateRangePickerValue } from "@tremor/react";
 import { SourceMetadata } from "./search/interfaces";
 import { destructureValue } from "./llm/utils";
@@ -143,7 +143,8 @@ export interface LlmOverrideManager {
 }
 
 export function useLlmOverride(
-  currentChatSession?: ChatSession
+  currentChatSession?: ChatSession,
+  defaultTemperature?: number
 ): LlmOverrideManager {
   const [llmOverride, setLlmOverride] = useState<LlmOverride>(
     currentChatSession && currentChatSession.current_alternate_model
@@ -167,7 +168,13 @@ export function useLlmOverride(
     );
   };
 
-  const [temperature, setTemperature] = useState<number | null>(null);
+  const [temperature, setTemperature] = useState<number | null>(
+    defaultTemperature != undefined ? defaultTemperature : 0
+  );
+
+  useEffect(() => {
+    setTemperature(defaultTemperature !== undefined ? defaultTemperature : 0);
+  }, [defaultTemperature]);
 
   return {
     updateModelOverrideForChatSession,


### PR DESCRIPTION
## Description
Adds improved default temperatures to search

Upon visiting a new assistant, we now decide a "default" temperature which users can modify in the chat input bar.
- If user has set search param for temperature, we adopt that as the default
- Else, if assistant has search tool - default to 0
- Else, default to 0.7


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
