### PR TITLE
Don't persist error perennially

### DIFF
--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -697,6 +697,8 @@ def stream_chat_message_objects(
 
         # Don't leak the API key
         error_msg = str(e)
+        logger.exception("error i")
+        logger.exception(e)
         if llm.config.api_key and llm.config.api_key.lower() in error_msg.lower():
             error_msg = (
                 f"LLM failed to respond. Invalid API "

--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -697,8 +697,6 @@ def stream_chat_message_objects(
 
         # Don't leak the API key
         error_msg = str(e)
-        logger.exception("error i")
-        logger.exception(e)
         if llm.config.api_key and llm.config.api_key.lower() in error_msg.lower():
             error_msg = (
                 f"LLM failed to respond. Invalid API "

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -266,7 +266,6 @@ export function ChatPage({
 
       const newMessageMap = processRawChatHistory(chatSession.messages);
       const newMessageHistory = buildLatestMessageChain(newMessageMap);
-      // if the last message is an error, don't overwrite it
 
       // Update message history except for edge where where
       // last message is an error and we're on a new chat.

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -115,6 +115,7 @@ export function ChatPage({
   const chatSessionIdRef = useRef<number | null>(existingChatSessionId);
 
   // Only updates on message load (ie. rename / switching chat session)
+  // Useful for determining which session has been loaded (i.e. still on `new, empty session` or `previous session`)
   const loadedIdSessionRef = useRef<number | null>(existingChatSessionId);
 
   // Assistants
@@ -267,11 +268,13 @@ export function ChatPage({
       const newMessageHistory = buildLatestMessageChain(newMessageMap);
       // if the last message is an error, don't overwrite it
 
+      // Update message history except for edge where where
+      // last message is an error and we're on a new chat.
+      // This corresponds to a "renaming" of chat, which occurs after first message
+      // stream
       if (
-        !(
-          messageHistory[messageHistory.length - 1]?.type === "error" &&
-          loadedSessionId == null
-        )
+        messageHistory[messageHistory.length - 1]?.type !== "error" ||
+        loadedSessionId != null
       ) {
         setCompleteMessageDetail({
           sessionId: chatSession.chat_session_id,

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -195,7 +195,6 @@ export function ChatPage({
   // this is triggered every time the user switches which chat
   // session they are using
   useEffect(() => {
-    console.log("CALLLING");
     const priorChatSessionId = chatSessionIdRef.current;
     const loadedSessionId = loadedIdSessionRef.current;
     chatSessionIdRef.current = existingChatSessionId;

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -267,8 +267,7 @@ export function ChatPage({
       const newMessageMap = processRawChatHistory(chatSession.messages);
       const newMessageHistory = buildLatestMessageChain(newMessageMap);
       // if the last message is an error, don't overwrite it
-      console.log(priorChatSessionId);
-      console.log(existingChatSessionId);
+
       if (
         !(
           messageHistory[messageHistory.length - 1]?.type === "error" &&
@@ -672,8 +671,6 @@ export function ChatPage({
     } else {
       currChatSessionId = chatSessionIdRef.current as number;
     }
-    console.log("UPDATING TO ");
-    console.log(currChatSessionId);
     chatSessionIdRef.current = currChatSessionId;
 
     const messageToResend = messageHistory.find(

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -260,18 +260,16 @@ export function ChatPage({
       const newMessageMap = processRawChatHistory(chatSession.messages);
       const newMessageHistory = buildLatestMessageChain(newMessageMap);
       // if the last message is an error, don't overwrite it
-      if (messageHistory[messageHistory.length - 1]?.type !== "error") {
-        setCompleteMessageDetail({
-          sessionId: chatSession.chat_session_id,
-          messageMap: newMessageMap,
-        });
+      setCompleteMessageDetail({
+        sessionId: chatSession.chat_session_id,
+        messageMap: newMessageMap,
+      });
 
-        const latestMessageId =
-          newMessageHistory[newMessageHistory.length - 1]?.messageId;
-        setSelectedMessageForDocDisplay(
-          latestMessageId !== undefined ? latestMessageId : null
-        );
-      }
+      const latestMessageId =
+        newMessageHistory[newMessageHistory.length - 1]?.messageId;
+      setSelectedMessageForDocDisplay(
+        latestMessageId !== undefined ? latestMessageId : null
+      );
 
       setChatSessionSharedStatus(chatSession.shared_status);
 

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -114,7 +114,7 @@ export function ChatPage({
 
   const chatSessionIdRef = useRef<number | null>(existingChatSessionId);
 
-  // Only updates on message load (ie. rename / switching chat session)
+  // Only updates on session load (ie. rename / switching chat session)
   // Useful for determining which session has been loaded (i.e. still on `new, empty session` or `previous session`)
   const loadedIdSessionRef = useRef<number | null>(existingChatSessionId);
 


### PR DESCRIPTION
## Description
- Removes check for "error message in last index" before updating message history

This makes the entire error handling process much smoother as the chat message history doesn't break like it used to 
- Now uses a new ref that tracks the actual state of the chat messages + session loading to determine when to erase the previous errors
## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
