### PR TITLE
Improve code block formatting

### DIFF
--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -1283,7 +1283,7 @@ export function ChatPage({
                       )}
 
                       <div
-                        className={`h-full bg-white w-full relative flex-auto transition-margin duration-300 overflow-x-auto mobile:pb-12 desktop:pb-[100px]`}
+                        className={`h-full w-full relative flex-auto transition-margin duration-300 overflow-x-auto mobile:pb-12 desktop:pb-[100px]`}
                         {...getRootProps()}
                       >
                         {/* <input {...getInputProps()} /> */}

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -1283,7 +1283,7 @@ export function ChatPage({
                       )}
 
                       <div
-                        className={`h-full w-full relative flex-auto transition-margin duration-300 overflow-x-auto mobile:pb-12 desktop:pb-[140px]`}
+                        className={`h-full bg-white w-full relative flex-auto transition-margin duration-300 overflow-x-auto mobile:pb-12 desktop:pb-[100px]`}
                         {...getRootProps()}
                       >
                         {/* <input {...getInputProps()} /> */}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -143,13 +143,13 @@ body {
 
 /* Base styles for code blocks */
 .prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  background-color: black;
-  font-size: small;
+  background-color: theme("colors.code-bg");
+  font-size: theme("fontSize.code-sm");
 }
 
 pre[class*="language-"],
 code[class*="language-"] {
-  color: #e0e0e0;
+  color: theme("colors.code-text");
   background: white;
 }
 
@@ -158,7 +158,7 @@ code[class*="language-"] {
 .code-line .token.prolog,
 .code-line .token.doctype,
 .code-line .token.cdata {
-  color: #608b4e;
+  color: theme("colors.token-comment");
 }
 
 .code-line .token.punctuation,
@@ -167,7 +167,7 @@ code[class*="language-"] {
 .code-line .token.url,
 .code-line .language-css .token.string,
 .code-line .style .token.string {
-  color: #d4d4d4;
+  color: theme("colors.token-punctuation");
 }
 
 .code-line .token.property,
@@ -178,7 +178,7 @@ code[class*="language-"] {
 .code-line .token.symbol,
 .code-line .token.deleted,
 .code-line .token.tag .token.punctuation {
-  color: #569cd6;
+  color: theme("colors.token-property");
 }
 
 .code-line .token.selector,
@@ -189,32 +189,32 @@ code[class*="language-"] {
 .code-line .token.inserted,
 .code-line .token.attr-value,
 .code-line .token.attr-value .token.punctuation {
-  color: #ce9178;
+  color: theme("colors.token-selector");
 }
 
 .code-line .token.atrule,
 .code-line .token.keyword {
-  color: #c586c0;
+  color: theme("colors.token-atrule");
 }
 
 .code-line .token.function,
 .code-line .token.class-name {
-  color: #dcdcaa;
+  color: theme("colors.token-function");
 }
 
 .code-line .token.regex,
 .code-line .token.important,
 .code-line .token.variable {
-  color: #9cdcfe;
+  color: theme("colors.token-regex");
 }
 
 .code-line .token.important,
 .code-line .token.bold {
-  font-weight: bold;
+  font-weight: theme("fontWeight.token-bold");
 }
 
 .code-line .token.italic {
-  font-style: italic;
+  font-style: theme("fontStyle.token-italic");
 }
 
 .code-line .token.entity {
@@ -222,5 +222,5 @@ code[class*="language-"] {
 }
 
 .code-line .token.attr-name {
-  color: #9cdcfe;
+  color: theme("colors.token-attr-name");
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -140,3 +140,125 @@
 body {
   overscroll-behavior-y: none;
 }
+
+/* font for code blocks */
+.code-line {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+}
+.pre {
+  background-color: black;
+}
+
+.prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  background-color: black;
+  font-size: small;
+}
+
+.token.selector,
+.token.important,
+.token.atrule,
+.token.keyword,
+.token.builtin {
+  color: white;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background-color: white;
+}
+/* Base styles */
+
+/* Base styles for code blocks */
+pre[class*="language-"],
+code[class*="language-"] {
+  color: #e0e0e0;
+  background: white;
+}
+
+/* Token styles */
+.code-line .token.comment,
+.code-line .token.prolog,
+.code-line .token.doctype,
+.code-line .token.cdata {
+  color: #608b4e;
+}
+
+.code-line .token.punctuation {
+  color: #d4d4d4;
+}
+
+.code-line .token.property,
+.code-line .token.tag,
+.code-line .token.boolean,
+.code-line .token.number,
+.code-line .token.constant,
+.code-line .token.symbol,
+.code-line .token.deleted {
+  color: #569cd6;
+}
+
+.code-line .token.selector,
+.code-line .token.attr-name,
+.code-line .token.string,
+.code-line .token.char,
+.code-line .token.builtin,
+.code-line .token.inserted {
+  color: #ce9178;
+}
+
+.code-line .token.operator,
+.code-line .token.entity,
+.code-line .token.url,
+.code-line .language-css .token.string,
+.code-line .style .token.string {
+  color: #d4d4d4;
+}
+
+.code-line .token.atrule,
+.code-line .token.attr-value,
+.code-line .token.keyword {
+  color: #c586c0;
+}
+
+.code-line .token.function,
+.code-line .token.class-name {
+  color: #dcdcaa;
+}
+
+.code-line .token.regex,
+.code-line .token.important,
+.code-line .token.variable {
+  color: #9cdcfe;
+}
+
+.code-line .token.important,
+.code-line .token.bold {
+  font-weight: bold;
+}
+
+.code-line .token.italic {
+  font-style: italic;
+}
+
+.code-line .token.entity {
+  cursor: help;
+}
+
+/* Specific overrides for the sample HTML structure */
+.code-line .token.tag {
+  color: #569cd6;
+}
+
+.code-line .token.tag .token.punctuation {
+  color: #808080;
+}
+
+.code-line .token.attr-name {
+  color: #9cdcfe;
+}
+
+.code-line .token.attr-value,
+.code-line .token.attr-value .token.punctuation {
+  color: #ce9178;
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -141,35 +141,12 @@ body {
   overscroll-behavior-y: none;
 }
 
-/* font for code blocks */
-.code-line {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-    "Liberation Mono", monospace;
-}
-.pre {
-  background-color: black;
-}
-
+/* Base styles for code blocks */
 .prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   background-color: black;
   font-size: small;
 }
 
-.token.selector,
-.token.important,
-.token.atrule,
-.token.keyword,
-.token.builtin {
-  color: white;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-  background-color: white;
-}
-/* Base styles */
-
-/* Base styles for code blocks */
 pre[class*="language-"],
 code[class*="language-"] {
   color: #e0e0e0;
@@ -184,7 +161,12 @@ code[class*="language-"] {
   color: #608b4e;
 }
 
-.code-line .token.punctuation {
+.code-line .token.punctuation,
+.code-line .token.operator,
+.code-line .token.entity,
+.code-line .token.url,
+.code-line .language-css .token.string,
+.code-line .style .token.string {
   color: #d4d4d4;
 }
 
@@ -194,7 +176,8 @@ code[class*="language-"] {
 .code-line .token.number,
 .code-line .token.constant,
 .code-line .token.symbol,
-.code-line .token.deleted {
+.code-line .token.deleted,
+.code-line .token.tag .token.punctuation {
   color: #569cd6;
 }
 
@@ -203,20 +186,13 @@ code[class*="language-"] {
 .code-line .token.string,
 .code-line .token.char,
 .code-line .token.builtin,
-.code-line .token.inserted {
+.code-line .token.inserted,
+.code-line .token.attr-value,
+.code-line .token.attr-value .token.punctuation {
   color: #ce9178;
 }
 
-.code-line .token.operator,
-.code-line .token.entity,
-.code-line .token.url,
-.code-line .language-css .token.string,
-.code-line .style .token.string {
-  color: #d4d4d4;
-}
-
 .code-line .token.atrule,
-.code-line .token.attr-value,
 .code-line .token.keyword {
   color: #c586c0;
 }
@@ -245,20 +221,6 @@ code[class*="language-"] {
   cursor: help;
 }
 
-/* Specific overrides for the sample HTML structure */
-.code-line .token.tag {
-  color: #569cd6;
-}
-
-.code-line .token.tag .token.punctuation {
-  color: #808080;
-}
-
 .code-line .token.attr-name {
   color: #9cdcfe;
-}
-
-.code-line .token.attr-value,
-.code-line .token.attr-value .token.punctuation {
-  color: #ce9178;
 }

--- a/web/tailwind-themes/tailwind.config.js
+++ b/web/tailwind-themes/tailwind.config.js
@@ -67,8 +67,19 @@ module.exports = {
         "searchbar-max": "750px",
       },
       colors: {
-        // background
+        // code styling
+        "code-bg": "black", // black
+        "code-text": "#e0e0e0", // light gray
+        "token-comment": "#608b4e", // green
+        "token-punctuation": "#d4d4d4", // light gray
+        "token-property": "#569cd6", // blue
+        "token-selector": "#e07b53", // more vibrant orange
+        "token-atrule": "#d18ad8", // more vibrant purple
+        "token-function": "#f0e68c", // more vibrant light yellow
+        "token-regex": "#9cdcfe", // light blue
+        "token-attr-name": "#9cdcfe", // light blue
 
+        // background
         "background-search": "#ffffff", // white
         input: "#f5f5f5",
 
@@ -232,10 +243,17 @@ module.exports = {
         "tremor-full": "9999px",
       },
       fontSize: {
+        "code-sm": "small",
         "tremor-label": ["0.75rem"],
         "tremor-default": ["0.875rem", { lineHeight: "1.25rem" }],
         "tremor-title": ["1.125rem", { lineHeight: "1.75rem" }],
         "tremor-metric": ["1.875rem", { lineHeight: "2.25rem" }],
+      },
+      fontWeight: {
+        "token-bold": "bold",
+      },
+      fontStyle: {
+        "token-italic": "italic",
       },
     },
   },


### PR DESCRIPTION
## Description
Improves code formatting and fixes math for chat input bar padding.

We can modify as needed later, now that we have isolated the relevant class names.

## Before
<img width="584" alt="Screenshot 2024-08-08 at 9 40 50 AM" src="https://github.com/user-attachments/assets/7b467ee5-0e24-4d39-92fc-438c5d38af78">

## After
<img width="602" alt="Screenshot 2024-08-08 at 9 42 48 AM" src="https://github.com/user-attachments/assets/d447b3dc-78bf-4d1a-a071-94ffcfb59acc">


## Additional fix for padding on chat input bar 

<img width="418" alt="Screenshot 2024-08-08 at 9 45 52 AM" src="https://github.com/user-attachments/assets/5bd302fe-e3ce-4434-a983-70a14c7f06da">
