### PR TITLE
quote processing for lengthy intros

### DIFF
--- a/backend/danswer/llm/answering/stream_processing/quotes_processing.py
+++ b/backend/danswer/llm/answering/stream_processing/quotes_processing.py
@@ -234,11 +234,9 @@ def process_model_tokens(
             if m:
                 found_answer_start = True
 
-                # Prevent heavy cases of hallucinations where model is not even providing a json until later
-                if is_json_prompt and len(model_output) > 70:
+                # Log cases where LLM begins with a long pre-amble
+                if is_json_prompt and len(model_output) > 40:
                     logger.warning("LLM did not produce json as prompted")
-                    found_answer_end = True
-                    continue
 
                 remaining = model_output[m.end() :]
                 if len(remaining) > 0:

--- a/backend/danswer/llm/answering/stream_processing/quotes_processing.py
+++ b/backend/danswer/llm/answering/stream_processing/quotes_processing.py
@@ -234,9 +234,11 @@ def process_model_tokens(
             if m:
                 found_answer_start = True
 
-                # Log cases where LLM begins with a long pre-amble
-                if is_json_prompt and len(model_output) > 40:
+                # Prevent heavy cases of hallucinations where model is not even providing a json until later
+                if is_json_prompt and len(model_output) > 70:
                     logger.warning("LLM did not produce json as prompted")
+                    found_answer_end = True
+                    continue
 
                 remaining = model_output[m.end() :]
                 if len(remaining) > 0:

--- a/backend/danswer/llm/answering/stream_processing/quotes_processing.py
+++ b/backend/danswer/llm/answering/stream_processing/quotes_processing.py
@@ -234,7 +234,8 @@ def process_model_tokens(
             if m:
                 found_answer_start = True
 
-                # Prevent heavy cases of hallucinations where model is not even providing a json until later
+                # Prevent heavy cases of hallucinations where model is never providing a JSON
+                # We want to quickly update the user - not stream forever
                 if is_json_prompt and len(model_output) > 70:
                     logger.warning("LLM did not produce json as prompted")
                     found_answer_end = True

--- a/backend/danswer/llm/answering/stream_processing/quotes_processing.py
+++ b/backend/danswer/llm/answering/stream_processing/quotes_processing.py
@@ -235,7 +235,7 @@ def process_model_tokens(
                 found_answer_start = True
 
                 # Prevent heavy cases of hallucinations where model is not even providing a json until later
-                if is_json_prompt and len(model_output) > 40:
+                if is_json_prompt and len(model_output) > 70:
                     logger.warning("LLM did not produce json as prompted")
                     found_answer_end = True
                     continue

--- a/backend/tests/unit/danswer/llm/answering/stream_processing/test_quote_processing.py
+++ b/backend/tests/unit/danswer/llm/answering/stream_processing/test_quote_processing.py
@@ -313,8 +313,6 @@ def test_lengthy_prefixed_json_with_quotes() -> None:
             for q in o.quotes:
                 assert q.quote == "Document"
                 actual_count += 1
-    print(actual_answer)
-    print("ANSWER BE")
     assert "This is a simple answer." == actual_answer
     assert 1 == actual_count
 

--- a/backend/tests/unit/danswer/llm/answering/stream_processing/test_quote_processing.py
+++ b/backend/tests/unit/danswer/llm/answering/stream_processing/test_quote_processing.py
@@ -283,6 +283,42 @@ def test_json_answer_split_tokens() -> None:
     assert expected_answer == actual
 
 
+def test_lengthy_prefixed_json_with_quotes() -> None:
+    tokens = [
+        "This is my response in json\n\n",
+        "```",
+        "json",
+        "\n",
+        "{",
+        '"answer": "This is a simple ',
+        "answer.",
+        '",\n"',
+        'quotes": ["Document"]',
+        "\n}",
+        "\n",
+        "```",
+    ]
+
+    gen = process_model_tokens(tokens=iter(tokens), context_docs=mock_docs)
+
+    actual_answer = ""
+    actual_count = 0
+    for o in gen:
+        if isinstance(o, DanswerAnswerPiece):
+            if o.answer_piece:
+                actual_answer += o.answer_piece
+            continue
+
+        if isinstance(o, DanswerQuotes):
+            for q in o.quotes:
+                assert q.quote == "Document"
+                actual_count += 1
+    print(actual_answer)
+    print("ANSWER BE")
+    assert "This is a simple answer." == actual_answer
+    assert 1 == actual_count
+
+
 def test_prefixed_json_with_quotes() -> None:
     tokens = [
         "```",


### PR DESCRIPTION
## Description
- Fixes occasional break in quote processing for search 
- Adds test case

Issue: 
- LLM responds with lengthy pre-amble to search queries `this is my json response \n\n..` and unnecessarily hits character limit

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
