### PR TITLE
Remove unnecessary LLM settings

### DIFF
--- a/backend/danswer/llm/chat_llm.py
+++ b/backend/danswer/llm/chat_llm.py
@@ -187,11 +187,6 @@ class DefaultMultiLLM(LLM):
     """Uses Litellm library to allow easy configuration to use a multitude of LLMs
     See https://python.langchain.com/docs/integrations/chat/litellm"""
 
-    DEFAULT_MODEL_PARAMS: dict[str, Any] = {
-        "frequency_penalty": 0,
-        "presence_penalty": 0,
-    }
-
     def __init__(
         self,
         api_key: str | None,
@@ -224,9 +219,7 @@ class DefaultMultiLLM(LLM):
             for k, v in custom_config.items():
                 os.environ[k] = v
 
-        model_kwargs = (
-            DefaultMultiLLM.DEFAULT_MODEL_PARAMS if model_provider == "openai" else {}
-        )
+        model_kwargs: dict[str, Any] = {}
         if extra_headers:
             model_kwargs.update({"extra_headers": extra_headers})
 


### PR DESCRIPTION
These settings are just the default and may throw off other LLM providers accessed via an OpenAI compatible API.