### PR TITLE
Fix formatting for non-langauge-demarcated code blocks

### DIFF
--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -154,10 +154,17 @@ export const AIMessage = ({
       return content;
     }
 
-    const codeBlockRegex = /```[\s\S]*?```|```[\s\S]*?$/g;
+    const codeBlockRegex = /```(\w*)\n[\s\S]*?```|```[\s\S]*?$/g;
     const matches = content.match(codeBlockRegex);
 
     if (matches) {
+      content = matches.reduce((acc, match) => {
+        if (!match.match(/```\w+/)) {
+          return acc.replace(match, match.replace("```", "```plaintext"));
+        }
+        return acc;
+      }, content);
+
       const lastMatch = matches[matches.length - 1];
       if (!lastMatch.endsWith("```")) {
         return content;
@@ -166,7 +173,6 @@ export const AIMessage = ({
 
     return content + (!isComplete && !toolCallGenerating ? " [*]() " : "");
   };
-
   const finalContent = processContent(content as string);
 
   const { isHovering, trackedElementRef, hoverElementRef } = useMouseTracking();
@@ -400,7 +406,6 @@ export const AIMessage = ({
                                     );
                                   }
                                 },
-
                                 code: (props) => (
                                   <CodeBlock
                                     className="w-full"


### PR DESCRIPTION
## Description
Add `plaintext` language demarcation to code blocks without any language demarcation

<img width="614" alt="Screenshot 2024-08-14 at 1 44 52 PM" src="https://github.com/user-attachments/assets/5d3af991-6ede-4ef0-8705-6764cb90ff44">


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
