### PR TITLE
Add handling for poorly formatting model names

### DIFF
--- a/backend/danswer/llm/utils.py
+++ b/backend/danswer/llm/utils.py
@@ -275,9 +275,11 @@ def get_llm_max_tokens(
         return GEN_AI_MAX_TOKENS
 
     try:
-        model_obj = model_map.get(f"{model_provider}/{model_name}")
-        if not model_obj:
-            model_obj = model_map[model_name]
+        model_obj = (
+            model_map.get(f"{model_provider}/{model_name}")
+            or model_map.get(model_name)
+            or model_map[model_name.split("/")[1]]
+        )
 
         if "max_input_tokens" in model_obj:
             return model_obj["max_input_tokens"]


### PR DESCRIPTION
## Description
The LLM configuration passed to `get_llm_max_tokens` can be poorly formatted (e.g. `bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0`) which handicaps the token limit estimation process. This simply adds an extra case to attempt to account for this kind of configuration error (and become compatible with https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json#L3324)


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
