### PR TITLE
Untoggle sidebar fully on untoggling

### DIFF
--- a/web/src/app/assistants/SidebarWrapper.tsx
+++ b/web/src/app/assistants/SidebarWrapper.tsx
@@ -42,8 +42,18 @@ export default function SidebarWrapper<T extends object>({
   size = "sm",
 }: SidebarWrapperProps<T>) {
   const [toggledSidebar, setToggledSidebar] = useState(initiallyToggled);
-
   const [showDocSidebar, setShowDocSidebar] = useState(false); // State to track if sidebar is open
+  // Used to maintain a "time out" for history sidebar so our existing refs can have time to process change
+  const [untoggled, setUntoggled] = useState(false);
+
+  const explicitlyUntoggle = () => {
+    setShowDocSidebar(false);
+
+    setUntoggled(true);
+    setTimeout(() => {
+      setUntoggled(false);
+    }, 200);
+  };
 
   const toggleSidebar = () => {
     Cookies.set(
@@ -103,7 +113,7 @@ export default function SidebarWrapper<T extends object>({
             duration-300
             ease-in-out
             ${
-              showDocSidebar || toggledSidebar
+              !untoggled && (showDocSidebar || toggledSidebar)
                 ? "opacity-100 w-[250px] translate-x-0"
                 : "opacity-0 w-[200px] pointer-events-none -translate-x-10"
             }`}
@@ -111,6 +121,7 @@ export default function SidebarWrapper<T extends object>({
         <div className="w-full relative">
           <HistorySidebar
             page={page}
+            explicitlyUntoggle={explicitlyUntoggle}
             ref={innerSidebarElementRef}
             toggleSidebar={toggleSidebar}
             toggled={toggledSidebar}

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -1202,6 +1202,17 @@ export function ChatPage({
 
   const [showDocSidebar, setShowDocSidebar] = useState(false); // State to track if sidebar is open
 
+  // Used to maintain a "time out" for history sidebar so our existing refs can have time to process change
+  const [untoggled, setUntoggled] = useState(false);
+
+  const explicitlyUntoggle = () => {
+    setShowDocSidebar(false);
+
+    setUntoggled(true);
+    setTimeout(() => {
+      setUntoggled(false);
+    }, 200);
+  };
   const toggleSidebar = () => {
     Cookies.set(
       SIDEBAR_TOGGLED_COOKIE_NAME,
@@ -1393,13 +1404,14 @@ export function ChatPage({
                 duration-300
                 ease-in-out
                 ${
-                  showDocSidebar || toggledSidebar
+                  !untoggled && (showDocSidebar || toggledSidebar)
                     ? "opacity-100 w-[250px] translate-x-0"
                     : "opacity-0 w-[200px] pointer-events-none -translate-x-10"
                 }`}
             >
               <div className="w-full relative">
                 <HistorySidebar
+                  explicitlyUntoggle={explicitlyUntoggle}
                   stopGenerating={stopGeneration}
                   reset={() => setMessage("")}
                   page="chat"

--- a/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
+++ b/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
@@ -41,7 +41,7 @@ interface HistorySidebarProps {
   showShareModal?: (chatSession: ChatSession) => void;
   showDeleteModal?: (chatSession: ChatSession) => void;
   stopGenerating?: () => void;
-  explicitlyUntoggle?: () => void;
+  explicitlyUntoggle: () => void;
 }
 
 export const HistorySidebar = forwardRef<HTMLDivElement, HistorySidebarProps>(
@@ -52,9 +52,9 @@ export const HistorySidebar = forwardRef<HTMLDivElement, HistorySidebarProps>(
       page,
       existingChats,
       currentChatSession,
-      explicitlyUntoggle = () => null,
       folders,
       openedFolders,
+      explicitlyUntoggle,
       toggleSidebar,
       removeToggle,
       stopGenerating = () => null,

--- a/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
+++ b/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
@@ -41,6 +41,7 @@ interface HistorySidebarProps {
   showShareModal?: (chatSession: ChatSession) => void;
   showDeleteModal?: (chatSession: ChatSession) => void;
   stopGenerating?: () => void;
+  explicitlyUntoggle?: () => void;
 }
 
 export const HistorySidebar = forwardRef<HTMLDivElement, HistorySidebarProps>(
@@ -51,6 +52,7 @@ export const HistorySidebar = forwardRef<HTMLDivElement, HistorySidebarProps>(
       page,
       existingChats,
       currentChatSession,
+      explicitlyUntoggle = () => null,
       folders,
       openedFolders,
       toggleSidebar,
@@ -114,6 +116,7 @@ export const HistorySidebar = forwardRef<HTMLDivElement, HistorySidebarProps>(
             toggled={toggled}
             page={page}
             toggleSidebar={toggleSidebar}
+            explicitlyUntoggle={explicitlyUntoggle}
           />
           {page == "chat" && (
             <div className="mx-3 mt-4 gap-y-1 flex-col flex gap-x-1.5 items-center items-center">

--- a/web/src/app/chat/shared_chat_search/FixedLogo.tsx
+++ b/web/src/app/chat/shared_chat_search/FixedLogo.tsx
@@ -19,7 +19,7 @@ export default function FixedLogo({
   return (
     <>
       <div
-        onClick={toggleSidebar}
+        // onClick={toggleSidebar}
         className="fixed  cursor-pointer flex z-40 left-2.5 top-2"
       >
         <div className="max-w-[200px] mobile:hidden flex items-center gap-x-1 my-auto">

--- a/web/src/app/chat/shared_chat_search/FixedLogo.tsx
+++ b/web/src/app/chat/shared_chat_search/FixedLogo.tsx
@@ -19,7 +19,7 @@ export default function FixedLogo({
   return (
     <>
       <div
-        // onClick={toggleSidebar}
+        onClick={toggleSidebar}
         className="fixed  cursor-pointer flex z-40 left-2.5 top-2"
       >
         <div className="max-w-[200px] mobile:hidden flex items-center gap-x-1 my-auto">

--- a/web/src/components/chat_search/Header.tsx
+++ b/web/src/components/chat_search/Header.tsx
@@ -73,7 +73,6 @@ export default function FunctionalHeader({
           toggleSidebar={toggleSidebar}
           handleNewChat={handleNewChat}
         />
-
         <div
           style={{ transition: "width 0.30s ease-out" }}
           className={`

--- a/web/src/components/header/LogoType.tsx
+++ b/web/src/components/header/LogoType.tsx
@@ -21,6 +21,7 @@ export default function LogoType({
   toggled,
   showArrow,
   assistantId,
+  explicitlyUntoggle = () => null,
 }: {
   hideOnMobile?: boolean;
   toggleSidebar?: () => void;
@@ -29,6 +30,7 @@ export default function LogoType({
   toggled?: boolean;
   showArrow?: boolean;
   assistantId?: number;
+  explicitlyUntoggle?: () => void;
 }) {
   const combinedSettings = useContext(SettingsContext);
   const enterpriseSettings = combinedSettings?.enterpriseSettings;
@@ -91,12 +93,20 @@ export default function LogoType({
           </Link>
         </Tooltip>
       )}
-      {showArrow && (
+      {showArrow && toggleSidebar && (
         <Tooltip
           delayDuration={0}
           content={toggled ? `Unpin sidebar` : "Pin sidebar"}
         >
-          <button className="mr-3 my-auto ml-auto" onClick={toggleSidebar}>
+          <button
+            className="mr-3 my-auto ml-auto"
+            onClick={() => {
+              toggleSidebar();
+              if (toggled) {
+                explicitlyUntoggle();
+              }
+            }}
+          >
             {!toggled && !combinedSettings?.isMobile ? (
               <RightToLineIcon />
             ) : (

--- a/web/src/components/search/SearchSection.tsx
+++ b/web/src/components/search/SearchSection.tsx
@@ -511,6 +511,8 @@ export const SearchSection = ({
   };
   const [firstSearch, setFirstSearch] = useState(true);
   const [searchState, setSearchState] = useState<searchState>("input");
+
+  // Used to maintain a "time out" for history sidebar so our existing refs can have time to process change
   const [untoggled, setUntoggled] = useState(false);
 
   const explicitlyUntoggle = () => {

--- a/web/src/components/search/SearchSection.tsx
+++ b/web/src/components/search/SearchSection.tsx
@@ -511,6 +511,16 @@ export const SearchSection = ({
   };
   const [firstSearch, setFirstSearch] = useState(true);
   const [searchState, setSearchState] = useState<searchState>("input");
+  const [untoggled, setUntoggled] = useState(false);
+
+  const explicitlyUntoggle = () => {
+    setShowDocSidebar(false);
+
+    setUntoggled(true);
+    setTimeout(() => {
+      setUntoggled(false);
+    }, 200);
+  };
 
   useSidebarVisibility({
     toggledSidebar,
@@ -600,7 +610,7 @@ export const SearchSection = ({
             duration-300 
             ease-in-out
             ${
-              showDocSidebar || toggledSidebar
+              !untoggled && (showDocSidebar || toggledSidebar)
                 ? "opacity-100 w-[250px] translate-x-0"
                 : "opacity-0 w-[200px] pointer-events-none -translate-x-10"
             }
@@ -608,6 +618,7 @@ export const SearchSection = ({
         >
           <div className="w-full relative">
             <HistorySidebar
+              explicitlyUntoggle={explicitlyUntoggle}
               reset={() => setQuery("")}
               page="search"
               ref={innerSidebarElementRef}


### PR DESCRIPTION
## Description
Explicitly closes sidebar on manually clicking `unpin`

https://github.com/user-attachments/assets/66adb6c4-b4b6-4f82-9e73-9fda1c4ad807


Separate thought: noticing a lot of shared logic for history sidebar in the 3 places it is used (search chat, "personal settings")- have added to my task list some time to group the shared logic


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
