### PR TITLE
Add granularity to filter widths

### DIFF
--- a/web/src/components/search/filtering/FilterDropdown.tsx
+++ b/web/src/components/search/filtering/FilterDropdown.tsx
@@ -13,6 +13,8 @@ export function FilterDropdown({
   icon,
   defaultDisplay,
   width = "w-64",
+  dropdownWidth,
+  optionClassName,
 }: {
   options: Option[];
   selected: string[];
@@ -20,6 +22,8 @@ export function FilterDropdown({
   icon: JSX.Element;
   defaultDisplay: string | JSX.Element;
   width?: string;
+  dropdownWidth?: string;
+  optionClassName?: string;
 }) {
   return (
     <div>
@@ -27,16 +31,16 @@ export function FilterDropdown({
         dropdown={
           <div
             className={`
-          border 
-          border-border 
-          rounded-lg 
-          bg-background
-          flex 
-          flex-col 
-          ${width}
-          max-h-96 
-          overflow-y-auto 
-          overscroll-contain`}
+              border 
+              border-border 
+              rounded-lg 
+              bg-background
+              flex 
+              flex-col 
+              ${dropdownWidth}
+              max-h-96 
+              overflow-y-auto 
+              overscroll-contain`}
           >
             {options.map((option, ind) => {
               const isSelected = selected.includes(option.key);
@@ -44,12 +48,14 @@ export function FilterDropdown({
                 <div
                   key={option.key}
                   className={`
+                    ${optionClassName}
                     flex
-                    px-3 
-                    text-sm 
-                    py-2.5 
-                    select-none 
-                    cursor-pointer 
+                    px-3
+                    text-sm
+                    py-2.5
+                    select-none
+                    cursor-pointer
+                    w-fit
                     text-emphasis
                     hover:bg-hover-light
                     ${
@@ -76,17 +82,17 @@ export function FilterDropdown({
       >
         <div
           className={`
-        flex 
-        ${width}
-        text-sm 
-        px-3
-        py-1.5 
-        rounded-lg 
-        border 
-        gap-x-2
-        border-border
-        cursor-pointer 
-        hover:bg-hover-light`}
+            flex
+            ${width}
+            text-sm
+            px-3
+            py-1.5
+            rounded-lg 
+            border 
+            gap-x-2
+            border-border
+            cursor-pointer 
+            hover:bg-hover-light`}
         >
           <div className="flex-none my-auto">{icon}</div>
           {selected.length === 0 ? (

--- a/web/src/components/search/filtering/FilterDropdown.tsx
+++ b/web/src/components/search/filtering/FilterDropdown.tsx
@@ -37,7 +37,7 @@ export function FilterDropdown({
               bg-background
               flex 
               flex-col 
-              ${dropdownWidth}
+              ${dropdownWidth || width}
               max-h-96 
               overflow-y-auto 
               overscroll-contain`}

--- a/web/src/components/search/filtering/Filters.tsx
+++ b/web/src/components/search/filtering/Filters.tsx
@@ -447,6 +447,8 @@ export function HorizontalSourceSelector({
             icon={<FiMap size={16} />}
             defaultDisplay="Sources"
             width="w-fit max-w-24 ellipsis truncate"
+            dropdownWidth="max-w-36 min-w-0 w-fit"
+            optionClassName="truncate break-all ellipsis"
           />
         )}
 
@@ -465,7 +467,9 @@ export function HorizontalSourceSelector({
             handleSelect={(option) => handleDocumentSetSelect(option.key)}
             icon={<FiBook size={16} />}
             defaultDisplay="Sets"
-            width="w-fit max-w-24 ellipsis"
+            width="w-fit max-w-24 ellipsis truncate"
+            dropdownWidth="max-w-36 min-w-0 w-fit"
+            optionClassName="truncate break-all ellipsis"
           />
         )}
 
@@ -495,7 +499,9 @@ export function HorizontalSourceSelector({
             }}
             icon={<FiTag size={16} />}
             defaultDisplay="Tags"
-            width="w-fit max-w-24 ellipsis"
+            width="w-fit max-w-24 ellipsis truncate"
+            dropdownWidth="max-w-80 min-w-0 w-fit"
+            optionClassName="truncate break-all ellipsis"
           />
         )}
       </div>

--- a/web/src/components/search/filtering/Filters.tsx
+++ b/web/src/components/search/filtering/Filters.tsx
@@ -447,7 +447,7 @@ export function HorizontalSourceSelector({
             icon={<FiMap size={16} />}
             defaultDisplay="Sources"
             width="w-fit max-w-24 ellipsis truncate"
-            dropdownWidth="max-w-36 min-w-0 w-fit"
+            dropdownWidth="max-w-36 w-fit"
             optionClassName="truncate break-all ellipsis"
           />
         )}
@@ -468,7 +468,7 @@ export function HorizontalSourceSelector({
             icon={<FiBook size={16} />}
             defaultDisplay="Sets"
             width="w-fit max-w-24 ellipsis truncate"
-            dropdownWidth="max-w-36 min-w-0 w-fit"
+            dropdownWidth="max-w-36 w-fit"
             optionClassName="truncate break-all ellipsis"
           />
         )}
@@ -500,7 +500,7 @@ export function HorizontalSourceSelector({
             icon={<FiTag size={16} />}
             defaultDisplay="Tags"
             width="w-fit max-w-24 ellipsis truncate"
-            dropdownWidth="max-w-80 min-w-0 w-fit"
+            dropdownWidth="max-w-80 w-fit"
             optionClassName="truncate break-all ellipsis"
           />
         )}


### PR DESCRIPTION
## Description
Must be able to customize dropdown's widths/classnames in terms of 
- Overarching width
- Dropdown elements' widths (as a group_
- And individual dropdown element's classnames

<img width="675" alt="Screenshot 2024-08-20 at 1 34 31 PM" src="https://github.com/user-attachments/assets/2c168cf0-7b26-44e6-a764-bc6cd4bbc82d">

<img width="698" alt="Screenshot 2024-08-20 at 1 34 39 PM" src="https://github.com/user-attachments/assets/a6d72308-c300-4f8c-b0ea-b074c5db923e">

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
