### PR TITLE
normalize emails on bulk invite, normalize/lowercase emails on invite…

### DIFF
--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -8,6 +8,7 @@ from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import status
 from pydantic import BaseModel
+from pydantic import validate_email
 from sqlalchemy import Column
 from sqlalchemy import desc
 from sqlalchemy import select
@@ -159,12 +160,18 @@ def bulk_invite_users(
     emails: list[str] = Body(..., embed=True),
     current_user: User | None = Depends(current_admin_user),
 ) -> int:
+    """emails are string validated. If any email fails validation, no emails are
+    invited and an exception is raised."""
     if current_user is None:
         raise HTTPException(
             status_code=400, detail="Auth is disabled, cannot invite users"
         )
 
-    all_emails = list(set(emails) | set(get_invited_users()))
+    normalized_emails = []
+    for email in emails:
+        email_info = validate_email(email)  # can raise EmailNotValidError
+        normalized_emails.append(email_info.normalized)  # type: ignore
+    all_emails = list(set(normalized_emails) | set(get_invited_users()))
     return write_invited_users(all_emails)
 
 

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -2,13 +2,13 @@ import re
 from datetime import datetime
 from datetime import timezone
 
+from email_validator import validate_email
 from fastapi import APIRouter
 from fastapi import Body
 from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import status
 from pydantic import BaseModel
-from pydantic import validate_email
 from sqlalchemy import Column
 from sqlalchemy import desc
 from sqlalchemy import select


### PR DESCRIPTION
… matching

## Description
Fixes DAN-432.  I did end up normalizing emails when inserting via bulk invite as the email_validator docs strongly suggest to follow this pattern.

## How Has This Been Tested?
Ran bulk invite, ran tests against upper and lowercase signup.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
