### PR TITLE
fix message param to use query instead of rephrased query

### DIFF
--- a/backend/ee/danswer/server/query_and_chat/chat_backend.py
+++ b/backend/ee/danswer/server/query_and_chat/chat_backend.py
@@ -226,7 +226,7 @@ def handle_send_message_simple_with_history(
     full_chat_msg_info = CreateChatMessageRequest(
         chat_session_id=chat_session.id,
         parent_message_id=chat_message.id,
-        message=rephrased_query,
+        message=query,
         file_descriptors=[],
         prompt_id=req.prompt_id,
         search_doc_ids=None,


### PR DESCRIPTION
## Description
Fixes DAN-445. message passing was using rephrased query instead of the original query.


## How Has This Been Tested?
Observed raw queries to the LLM before and after the change


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
