### PR TITLE
prevent usage of combinedSettings if endpoints fail (which none of th…

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -49,6 +49,22 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const combinedSettings = await getCombinedSettings({});
+  // Handling if combinedSettings is null
+  if (!combinedSettings) {
+    // Here you could redirect the user, show an error, or provide default settings
+    return (
+      <html lang="en">
+        <Head>
+          <title>Settings Unavailable</title>
+        </Head>
+        <body>
+          <div className="error">
+            Settings could not be loaded. Please try again later.
+          </div>
+        </body>
+      </html>
+    );
+  }
 
   return (
     <html lang="en">


### PR DESCRIPTION
## Description
Partial fix for DAN-456

Fail fast in the UI when settings endpoint doesn't work (it should always work and things are very bad (TM) when it doesn't).


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
