### PR TITLE
Allow graceful 404s when fetching enterprise settings

### DIFF
--- a/web/src/components/settings/lib.ts
+++ b/web/src/components/settings/lib.ts
@@ -61,7 +61,7 @@ export async function fetchSettingsSS(): Promise<CombinedSettings | null> {
     let enterpriseSettings: EnterpriseSettings | null = null;
     if (tasks.length > 1) {
       if (!results[1].ok) {
-        if (results[1].status !== 403) {
+        if (results[1].status !== 403 && results[1].status !== 404) {
           throw new Error(
             `fetchEnterpriseSettingsSS failed: status=${results[1].status} body=${await results[1].text()}`
           );


### PR DESCRIPTION
## Description
Currently, if we load any page as a non-EE user, we will get the blank "settings could not be fetched" page- we should allow 404s from non EE users, as they will not have access to the enterprise edition endpoints


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
