### PR TITLE
Logotype from toggle -> redirect

### DIFF
--- a/web/src/app/assistants/SidebarWrapper.tsx
+++ b/web/src/app/assistants/SidebarWrapper.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { HistorySidebar } from "@/app/chat/sessionSidebar/HistorySidebar";
-
 import { ChatSession } from "@/app/chat/interfaces";
 import { Folder } from "@/app/chat/folders/interfaces";
 import { User } from "@/lib/types";

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -2028,7 +2028,7 @@ export function ChatPage({
               )}
             </div>
           </div>
-          <FixedLogo toggleSidebar={toggleSidebar} />
+          <FixedLogo />
         </div>
       </div>
       <DocumentSidebar

--- a/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
+++ b/web/src/app/chat/sessionSidebar/HistorySidebar.tsx
@@ -1,19 +1,11 @@
 "use client";
 
 import { FiEdit, FiFolderPlus } from "react-icons/fi";
-import {
-  ForwardedRef,
-  forwardRef,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { ForwardedRef, forwardRef, useContext, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ChatSession } from "../interfaces";
-
 import { NEXT_PUBLIC_NEW_CHAT_DIRECTS_TO_SAME_PERSONA } from "@/lib/constants";
-
 import { Folder } from "../folders/interfaces";
 import { createFolder } from "../folders/FolderManagement";
 import { usePopup } from "@/components/admin/connectors/Popup";

--- a/web/src/app/chat/shared_chat_search/FixedLogo.tsx
+++ b/web/src/app/chat/shared_chat_search/FixedLogo.tsx
@@ -4,23 +4,22 @@ import { HeaderTitle } from "@/components/header/HeaderTitle";
 import { Logo } from "@/components/Logo";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
 import { NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED } from "@/lib/constants";
+import Link from "next/link";
 import { useContext } from "react";
 import { FiSidebar } from "react-icons/fi";
 
-export default function FixedLogo({
-  toggleSidebar = () => null,
-}: {
-  toggleSidebar?: () => void;
-}) {
+export default function FixedLogo() {
   const combinedSettings = useContext(SettingsContext);
   const settings = combinedSettings?.settings;
   const enterpriseSettings = combinedSettings?.enterpriseSettings;
 
   return (
     <>
-      <div
-        onClick={toggleSidebar}
-        className="fixed  cursor-pointer flex z-40 left-2.5 top-2"
+      <Link
+        href={
+          settings && settings.default_page === "chat" ? "/chat" : "/search"
+        }
+        className="fixed cursor-pointer flex z-40 left-2.5 top-2"
       >
         <div className="max-w-[200px] mobile:hidden flex items-center gap-x-1 my-auto">
           <div className="flex-none my-auto">
@@ -39,7 +38,7 @@ export default function FixedLogo({
             )}
           </div>
         </div>
-      </div>
+      </Link>
       <div className="mobile:hidden fixed left-2.5 bottom-4">
         <FiSidebar />
       </div>


### PR DESCRIPTION
## Description
Instead of logotype toggling the sidebar, now redirects to default page


https://github.com/user-attachments/assets/c0553b3e-054a-4e13-8ac6-3a5b493ec847



## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
