### PR TITLE
feature: send signup URL to the invited users through email

### DIFF
--- a/backend/danswer/auth/invited_users.py
+++ b/backend/danswer/auth/invited_users.py
@@ -31,18 +31,18 @@ def write_invited_users(emails: list[str]) -> int:
 
 def send_user_email_invite(user_email: str, current_user: User) -> None:
     msg = MIMEMultipart()
-    msg["Subject"] = "You're invited to join a workspace @ Arnold AI!"
+    msg["Subject"] = "You're invited to join a workspace @ Danswer!"
     msg["To"] = user_email
     msg["From"] = current_user.email
     link = f"{WEB_DOMAIN}/auth/signup"
     text = "\n".join(
         [
             "Hi!,",
-            "You have been invited to join my workspace at Arnold AI.",
+            "You have been invited to join my workspace at Danswer.",
             f"You can register your account here and join the Arnold AI workspace: {link}",
         ]
     )
-    # TODO: send the name of the workspace based on the whitelabelling in the frontend\
+    # TODO: send the name of the workspace based on the whitelabelling in the frontend
     body = MIMEText(text, "plain")
     msg.attach(body)
 

--- a/backend/danswer/auth/invited_users.py
+++ b/backend/danswer/auth/invited_users.py
@@ -1,6 +1,15 @@
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from typing import cast
 
+from danswer.configs.app_configs import SMTP_PASS
+from danswer.configs.app_configs import SMTP_PORT
+from danswer.configs.app_configs import SMTP_SERVER
+from danswer.configs.app_configs import SMTP_USER
+from danswer.configs.app_configs import WEB_DOMAIN
 from danswer.configs.constants import KV_USER_STORE_KEY
+from danswer.db.models import User
 from danswer.dynamic_configs.factory import get_dynamic_config_store
 from danswer.dynamic_configs.interface import ConfigNotFoundError
 from danswer.dynamic_configs.interface import JSON_ro
@@ -18,3 +27,28 @@ def write_invited_users(emails: list[str]) -> int:
     store = get_dynamic_config_store()
     store.store(KV_USER_STORE_KEY, cast(JSON_ro, emails))
     return len(emails)
+
+
+def send_user_email_invite(user_email: str, current_user: User) -> None:
+    msg = MIMEMultipart()
+    msg["Subject"] = "You're invited to join a workspace @ Arnold AI!"
+    msg["To"] = user_email
+    msg["From"] = current_user.email
+    link = f"{WEB_DOMAIN}/auth/signup"
+    text = "\n".join(
+        [
+            "Hi!,",
+            "You have been invited to join my workspace at Arnold AI.",
+            f"You can register your account here and join the Arnold AI workspace: {link}",
+        ]
+    )
+    # TODO: send the name of the workspace based on the whitelabelling in the frontend\
+    body = MIMEText(text, "plain")
+    msg.attach(body)
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as s:
+        s.starttls()
+        # If credentials fails with gmail, check (You need an app password, not just the basic email password)
+        # https://support.google.com/accounts/answer/185833?sjid=8512343437447396151-NA
+        s.login(SMTP_USER, SMTP_PASS)
+        s.send_message(msg)

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -16,6 +16,7 @@ from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from danswer.auth.invited_users import get_invited_users
+from danswer.auth.invited_users import send_user_email_invite
 from danswer.auth.invited_users import write_invited_users
 from danswer.auth.noauth_user import fetch_no_auth_user
 from danswer.auth.noauth_user import set_no_auth_user_preferences
@@ -168,8 +169,11 @@ def bulk_invite_users(
 
     normalized_emails = []
     for email in emails:
-        email_info = validate_email(email)  # can raise EmailNotValidError
-        normalized_emails.append(email_info.normalized)  # type: ignore
+        email_info = validate_email(email)
+        logger.info(f"sent email to {email_info} + {email}")
+        send_user_email_invite(email, current_user)
+        logger.info(f"sent email to {email_info} + {email} + {email_info.email}")
+        normalized_emails.append(email_info.normalized)
     all_emails = list(set(normalized_emails) | set(get_invited_users()))
     return write_invited_users(all_emails)
 


### PR DESCRIPTION
## Description
Send signup URL through email to the invited users. Since currently there is no way for the users to know / be notified that they have been invited - thus, this act as a notification for those invited users that they can now register and join a workspace in Danswer

## How Has This Been Tested?
Passed the pre-commit tests and also tested out locally through docker compose
![Untitled](https://github.com/user-attachments/assets/52a433c2-90a2-4c5e-bfb9-ae20bc0156fb)

## Future Improvement/s
- modification of the email body as a feature in the frontend. This can be added as part of the whitelabelling feature where the users can customize the email body being send through invite.
- replace the body with the workspace name and the name of the user. This can be implemented if additional user information will be added in the future.

## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
