### PR TITLE
Fix freezing

### DIFF
--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -212,7 +212,12 @@ CONFLUENCE_CONNECTOR_SKIP_LABEL_INDEXING = (
 
 # Attachments exceeding this size will not be retrieved (in bytes)
 CONFLUENCE_CONNECTOR_ATTACHMENT_SIZE_THRESHOLD = int(
-    os.environ.get("CONFLUENCE_CONNECTOR_ATTACHMENT_SIZE_THRESHOLD", 50 * 1024 * 1024)
+    os.environ.get("CONFLUENCE_CONNECTOR_ATTACHMENT_SIZE_THRESHOLD", 10 * 1024 * 1024)
+)
+# Attachments with more chars than this will not be indexed. This is to prevent extremely
+# large files from freezing indexing. 200,000 is ~100 google doc pages.
+CONFLUENCE_CONNECTOR_ATTACHMENT_CHAR_COUNT_THRESHOLD = int(
+    os.environ.get("CONFLUENCE_CONNECTOR_ATTACHMENT_CHAR_COUNT_THRESHOLD", 200_000)
 )
 
 JIRA_CONNECTOR_LABELS_TO_SKIP = [

--- a/backend/tests/daily/connectors/confluence/test_confluence_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_basic.py
@@ -1,0 +1,42 @@
+import os
+import time
+
+import pytest
+
+from danswer.connectors.confluence.connector import ConfluenceConnector
+
+
+@pytest.fixture
+def confluence_connector() -> ConfluenceConnector:
+    connector = ConfluenceConnector(os.environ["CONFLUENCE_TEST_SPACE_URL"])
+    connector.load_credentials(
+        {
+            "confluence_username": os.environ["CONFLUENCE_USER_NAME"],
+            "confluence_access_token": os.environ["CONFLUENCE_ACCESS_TOKEN"],
+        }
+    )
+    return connector
+
+
+def test_confluence_connector_basic(confluence_connector: ConfluenceConnector) -> None:
+    doc_batch_generator = confluence_connector.poll_source(0, time.time())
+
+    doc_batch = next(doc_batch_generator)
+    with pytest.raises(StopIteration):
+        next(doc_batch_generator)
+
+    assert len(doc_batch) == 1
+
+    doc = doc_batch[0]
+    assert doc.semantic_identifier == "DailyConnectorTestSpace Home"
+    assert doc.metadata["labels"] == ["testlabel"]
+    assert doc.primary_owners
+    assert doc.primary_owners[0].email == "chris@danswer.ai"
+    assert len(doc.sections) == 1
+
+    section = doc.sections[0]
+    assert section.text == "test123small"
+    assert (
+        section.link
+        == "https://danswerai.atlassian.net/wiki/spaces/DailyConne/overview"
+    )


### PR DESCRIPTION
Large files (e.g. 10MB log files) can cause indexing to freeze. Adding a cap to the # of chars a confluence attachment can have to be considered.

Also added a test (which in the future can automatically run at an interval) to test the basics of the confluence connector.