### PR TITLE
Lowercase slack channels automatically

### DIFF
--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -468,7 +468,6 @@ export default function AddConnector({
             >
               {(formikProps) => {
                 setFormValues(formikProps.values);
-                console.log(formikProps.values);
                 handleFormStatusChange(
                   formikProps.isValid && isFormSubmittable(formikProps.values)
                 );

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -167,6 +167,28 @@ export default function AddConnector({
     } = formValues;
     const { pruneFreq, indexingStart, refreshFreq } = advancedSettings;
 
+    // Apply transforms from connectors.ts configuration
+    const transformedConnectorSpecificConfig = Object.entries(
+      connector_specific_config
+    ).reduce(
+      (acc, [key, value]) => {
+        const matchingConfigValue = configuration.values.find(
+          (configValue) => configValue.name === key
+        );
+        if (
+          matchingConfigValue &&
+          "transform" in matchingConfigValue &&
+          matchingConfigValue.transform
+        ) {
+          acc[key] = matchingConfigValue.transform(value as string[]);
+        } else {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {} as Record<string, any>
+    );
+
     const AdvancedConfig: AdvancedConfigFinal = {
       pruneFreq: advancedSettings.pruneFreq * 60 * 60 * 24,
       indexingStart: convertStringToDateTime(indexingStart),
@@ -211,7 +233,7 @@ export default function AddConnector({
 
     const { message, isSuccess, response } = await submitConnector<any>(
       {
-        connector_specific_config: connector_specific_config,
+        connector_specific_config: transformedConnectorSpecificConfig,
         input_type: connector == "web" ? "load_state" : "poll", // single case
         name: name,
         source: connector,

--- a/web/src/lib/connectors/connectors.ts
+++ b/web/src/lib/connectors/connectors.ts
@@ -33,6 +33,7 @@ export interface SelectOption extends Option {
 export interface ListOption extends Option {
   type: "list";
   default?: string[];
+  transform?: (values: string[]) => string[];
 }
 
 export interface TextOption extends Option {
@@ -363,6 +364,8 @@ Hint: Use the singular form of the object name (e.g., 'Opportunity' instead of '
         name: "channels",
         description: `Specify 0 or more channels to index. For example, specifying the channel "support" will cause us to only index all content within the "#support" channel. If no channels are specified, all channels in your workspace will be indexed.`,
         optional: true,
+        // Slack channels can only be lowercase
+        transform: (values) => values.map((value) => value.toLowerCase()),
       },
       {
         type: "checkbox",


### PR DESCRIPTION
Prevents people from accidentally using uppercase in their specified slack channels -> indexing nothing