### PR TITLE
Add option to have persona for dm

### DIFF
--- a/backend/danswer/danswerbot/slack/config.py
+++ b/backend/danswer/danswerbot/slack/config.py
@@ -12,8 +12,10 @@ VALID_SLACK_FILTERS = [
 
 
 def get_slack_bot_config_for_channel(
-    channel_name: str | None, db_session: Session
+    channel_name: str | None, db_session: Session, is_dm=False,
 ) -> SlackBotConfig | None:
+    if is_dm:
+        channel_name = "dm"
     if not channel_name:
         return None
 

--- a/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
@@ -254,7 +254,7 @@ def handle_followup_button(
             client=client.web_client, channel_id=channel_id
         )
         slack_bot_config = get_slack_bot_config_for_channel(
-            channel_name=channel_name, db_session=db_session
+            channel_name=channel_name, db_session=db_session, is_dm=is_dm
         )
         if slack_bot_config:
             tag_names = slack_bot_config.channel_config.get("follow_up_tags")

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -183,7 +183,7 @@ def handle_message(
         respond_tag_only = channel_conf.get("respond_tag_only") or False
         respond_member_group_list = channel_conf.get("respond_member_group_list", None)
 
-    if respond_tag_only and not bypass_filters:
+    if respond_tag_only and not bypass_filters and not is_bot_dm:
         logger.info(
             "Skipping message since the channel is configured such that "
             "DanswerBot only responds to tags"

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -137,14 +137,14 @@ def prefilter_requests(req: SocketModeRequest, client: SocketModeClient) -> bool
                 return False
 
         if event.get("bot_profile"):
-            channel_name, _ = get_channel_name_from_id(
+            channel_name, is_dm = get_channel_name_from_id(
                 client=client.web_client, channel_id=channel
             )
 
             engine = get_sqlalchemy_engine()
             with Session(engine) as db_session:
                 slack_bot_config = get_slack_bot_config_for_channel(
-                    channel_name=channel_name, db_session=db_session
+                    channel_name=channel_name, db_session=db_session, is_dm=is_dm,
                 )
             if not slack_bot_config or not slack_bot_config.channel_config.get(
                 "respond_to_bots"
@@ -331,7 +331,7 @@ def process_message(
     engine = get_sqlalchemy_engine()
     with Session(engine) as db_session:
         slack_bot_config = get_slack_bot_config_for_channel(
-            channel_name=channel_name, db_session=db_session
+            channel_name=channel_name, db_session=db_session, is_dm=is_dm,
         )
 
         # Be careful about this default, don't want to accidentally spam every channel


### PR DESCRIPTION
## Description
Provide a way, to have slack configurations for Slack dm. This is done by adding channel configuration for a channel named `dm`


## How Has This Been Tested?
I ran it locally


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
