### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,18 +105,6 @@ pip install -r danswer/backend/requirements/dev.txt
 pip install -r danswer/backend/requirements/model_server.txt
 ```
 
-Now ensure the current directory is the top level of the checked out danswer repository.
-Next, install pre-commit hooks to follow the quality checks run on all Pull Requests.
-```bash
-pip install pre-commit
-pre-commit install
-```
-
-macOS will likely require you to remove some quarantine attributes on some of the hooks for them to execute properly.
-```
-sudo xattr -r -d com.apple.quarantine ~/.cache/pre-commit
-```
-
 Install [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for the frontend.
 Once the above is done, navigate to `danswer/web` run:
 ```bash
@@ -199,9 +187,20 @@ Note: if you need finer logging, add the additional environment variable `LOG_LE
 For the backend, you'll need to setup pre-commit hooks (black / reorder-python-imports).
 First, install pre-commit (if you don't have it already) following the instructions
 [here](https://pre-commit.com/#installation).
+
+On macOS, from the danswer directory you can simply install pre-commit with the following command.
+```bash
+pip install pre-commit
+```
+
 Then, from the `danswer/backend` directory, run:
 ```bash
 pre-commit install
+```
+
+macOS will likely require you to remove some quarantine attributes on some of the hooks for them to execute properly.
+```
+sudo xattr -r -d com.apple.quarantine ~/.cache/pre-commit
 ```
 
 Additionally, we use `mypy` for static type checking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ If using a lower version, modifications will have to be made to the code.
 If using a higher version, the version of Tensorflow we use may not be available for your platform.
 
 On macOS, ensure Homebrew is already set up. (https://brew.sh/)
+
+Then install python 3.11.
 ```bash
 brew install python@3.11
 ```
@@ -133,6 +135,11 @@ playwright install
 
 
 #### Dependent Docker Containers
+You will need Docker installed to run these containers.
+
+On macOS, you will need to install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and 
+ensure it is running before continuing with the following docker commands.
+
 First navigate to `danswer/deployment/docker_compose`, then start up Vespa and Postgres with:
 ```bash
 docker compose -f docker-compose.dev.yml -p danswer-stack up -d index relational_db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,22 @@ development purposes but also feel free to just use the containers and update wi
 
 
 ### Local Set Up
-It is recommended to use Python version 3.11
+It is recommended to use Python version 3.11.
 
 If using a lower version, modifications will have to be made to the code.
 If using a higher version, the version of Tensorflow we use may not be available for your platform.
 
+On macOS, ensure Homebrew is already set up. (https://brew.sh/)
+```bash
+brew install python@3.11
+```
+
+Add python 3.11 to your path: add the following line to ~/.zshrc
+```
+export PATH="$(brew --prefix)/opt/python@3.11/libexec/bin:$PATH"
+```
+
+You will need to open a new terminal for the path change above to take effect.
 
 #### Installing Requirements
 Currently, we use pip and recommend creating a virtual environment.
@@ -90,6 +101,18 @@ Install the required python dependencies:
 pip install -r danswer/backend/requirements/default.txt
 pip install -r danswer/backend/requirements/dev.txt
 pip install -r danswer/backend/requirements/model_server.txt
+```
+
+Now ensure the current directory is the top level of the checked out danswer repository.
+Next, install pre-commit hooks to follow the quality checks run on all Pull Requests.
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+macOS will likely require you to remove some quarantine attributes on some of the hooks for them to execute properly.
+```
+sudo xattr -r -d com.apple.quarantine ~/.cache/pre-commit
 ```
 
 Install [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for the frontend.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,11 @@ pip install -r danswer/backend/requirements/dev.txt
 pip install -r danswer/backend/requirements/model_server.txt
 ```
 
+If developing Enterprise Edition features, also install those requirements.
+```bash
+pip install -r danswer/backend/requirements/ee.txt
+```
+
 Install [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for the frontend.
 Once the above is done, navigate to `danswer/web` run:
 ```bash

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -12,7 +12,7 @@ distributed==2023.8.1
 fastapi==0.109.2
 fastapi-users==12.1.3
 fastapi-users-db-sqlalchemy==5.0.0
-filelock==3.12.0
+filelock==3.15.4
 google-api-python-client==2.86.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0


### PR DESCRIPTION
## Description
update contributing docs.

Also a requirements upgrade to filelock ... pinning the version previously at 3.12.0 is a direct conflict with virtualenv requirements.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
