### PR TITLE
Add user dropdown seed-able list

### DIFF
--- a/backend/ee/danswer/server/enterprise_settings/models.py
+++ b/backend/ee/danswer/server/enterprise_settings/models.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from pydantic import BaseModel
+from pydantic import Field
 
 
 class NavigationItem(BaseModel):
@@ -19,7 +20,7 @@ class EnterpriseSettings(BaseModel):
     use_custom_logotype: bool = False
 
     # custom navigation
-    custom_nav_items: List[NavigationItem] = []
+    custom_nav_items: List[NavigationItem] = Field(default_factory=list)
 
     # custom Chat components
     two_lines_for_chat_header: bool | None = None

--- a/backend/ee/danswer/server/enterprise_settings/models.py
+++ b/backend/ee/danswer/server/enterprise_settings/models.py
@@ -1,4 +1,13 @@
+from typing import List
+
 from pydantic import BaseModel
+from pydantic import Field
+
+
+class NavigationItem(BaseModel):
+    link: str
+    icon: str
+    title: str
 
 
 class EnterpriseSettings(BaseModel):
@@ -10,6 +19,9 @@ class EnterpriseSettings(BaseModel):
     use_custom_logo: bool = False
     use_custom_logotype: bool = False
 
+    # custom navigation
+    custom_nav_items: List[NavigationItem] = []
+
     # custom Chat components
     two_lines_for_chat_header: bool | None = None
     custom_lower_disclaimer_content: str | None = None
@@ -19,6 +31,16 @@ class EnterpriseSettings(BaseModel):
 
     def check_validity(self) -> None:
         return
+
+
+class EnterpriseSettingsModification(EnterpriseSettings):
+    """
+    This class extends EnterpriseSettings to allow for modifications.
+    It inherits all fields from EnterpriseSettings but excludes custom_nav_items
+    from being modified directly through this class.
+    """
+
+    custom_nav_items: List[NavigationItem] = Field(default=[], exclude=True)
 
 
 class AnalyticsScriptUpload(BaseModel):

--- a/backend/ee/danswer/server/enterprise_settings/models.py
+++ b/backend/ee/danswer/server/enterprise_settings/models.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from pydantic import BaseModel
-from pydantic import Field
 
 
 class NavigationItem(BaseModel):
@@ -31,16 +30,6 @@ class EnterpriseSettings(BaseModel):
 
     def check_validity(self) -> None:
         return
-
-
-class EnterpriseSettingsModification(EnterpriseSettings):
-    """
-    This class extends EnterpriseSettings to allow for modifications.
-    It inherits all fields from EnterpriseSettings but excludes custom_nav_items
-    from being modified directly through this class.
-    """
-
-    custom_nav_items: List[NavigationItem] = Field(default=[], exclude=True)
 
 
 class AnalyticsScriptUpload(BaseModel):

--- a/backend/ee/danswer/server/seeding.py
+++ b/backend/ee/danswer/server/seeding.py
@@ -39,7 +39,6 @@ class SeedConfiguration(BaseModel):
 
 def _parse_env() -> SeedConfiguration | None:
     seed_config_str = os.getenv(_SEED_CONFIG_ENV_VAR_NAME)
-    print(seed_config_str)
     if not seed_config_str:
         return None
     seed_config = SeedConfiguration.parse_raw(seed_config_str)

--- a/backend/ee/danswer/server/seeding.py
+++ b/backend/ee/danswer/server/seeding.py
@@ -39,6 +39,7 @@ class SeedConfiguration(BaseModel):
 
 def _parse_env() -> SeedConfiguration | None:
     seed_config_str = os.getenv(_SEED_CONFIG_ENV_VAR_NAME)
+    print(seed_config_str)
     if not seed_config_str:
         return None
     seed_config = SeedConfiguration.parse_raw(seed_config_str)

--- a/web/src/app/admin/settings/interfaces.ts
+++ b/web/src/app/admin/settings/interfaces.ts
@@ -15,10 +15,19 @@ export interface Notification {
   first_shown: string;
 }
 
+export interface NavigationItem {
+  link: string;
+  icon: string;
+  title: string;
+}
+
 export interface EnterpriseSettings {
   application_name: string | null;
   use_custom_logo: boolean;
   use_custom_logotype: boolean;
+
+  // custom navigation
+  custom_nav_items: NavigationItem[];
 
   // custom Chat components
   custom_lower_disclaimer_content: string | null;

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -99,8 +99,6 @@ import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
 
 import { SEARCH_TOOL_NAME } from "./tools/constants";
 import { useUser } from "@/components/user/UserProvider";
-import { Stop } from "@phosphor-icons/react";
-import DynamicFaIcon from "@/components/icons/DynamicFaIcon";
 
 const TEMP_USER_MESSAGE_ID = -1;
 const TEMP_ASSISTANT_MESSAGE_ID = -2;
@@ -1602,7 +1600,6 @@ export function ChatPage({
           }}
         />
       )}
-      <DynamicFaIcon name="FaQuestion" />
 
       {settingsToggled && (
         <SetDefaultModelModal

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -100,6 +100,7 @@ import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
 import { SEARCH_TOOL_NAME } from "./tools/constants";
 import { useUser } from "@/components/user/UserProvider";
 import { Stop } from "@phosphor-icons/react";
+import DynamicFaIcon from "@/components/icons/DynamicFaIcon";
 
 const TEMP_USER_MESSAGE_ID = -1;
 const TEMP_ASSISTANT_MESSAGE_ID = -2;
@@ -1601,6 +1602,7 @@ export function ChatPage({
           }}
         />
       )}
+      <DynamicFaIcon name="FaQuestion" />
 
       {settingsToggled && (
         <SetDefaultModelModal

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -64,10 +64,7 @@ import { SettingsContext } from "@/components/settings/SettingsProvider";
 import GeneratingImageDisplay from "../tools/GeneratingImageDisplay";
 import RegenerateOption from "../RegenerateOption";
 import { LlmOverride } from "@/lib/hooks";
-import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
-import { EmphasizedClickable } from "@/components/BasicClickable";
 import { ContinueGenerating } from "./ContinueMessage";
-import DynamicFaIcon from "@/components/icons/DynamicFaIcon";
 
 const TOOLS_WITH_CUSTOM_HANDLING = [
   SEARCH_TOOL_NAME,
@@ -743,7 +740,6 @@ export const HumanMessage = ({
         <div className="xl:ml-8">
           <div className="flex flex-col mr-4">
             <FileDisplay alignBubble files={files || []} />
-            <DynamicFaIcon name="Dog" />
 
             <div className="flex justify-end">
               <div className="w-full ml-8 flex w-full w-[800px] break-words">

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -67,6 +67,7 @@ import { LlmOverride } from "@/lib/hooks";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
 import { EmphasizedClickable } from "@/components/BasicClickable";
 import { ContinueGenerating } from "./ContinueMessage";
+import DynamicFaIcon from "@/components/icons/DynamicFaIcon";
 
 const TOOLS_WITH_CUSTOM_HANDLING = [
   SEARCH_TOOL_NAME,
@@ -742,6 +743,8 @@ export const HumanMessage = ({
         <div className="xl:ml-8">
           <div className="flex flex-col mr-4">
             <FileDisplay alignBubble files={files || []} />
+            <DynamicFaIcon name="Dog" />
+
             <div className="flex justify-end">
               <div className="w-full ml-8 flex w-full w-[800px] break-words">
                 {isEditing ? (

--- a/web/src/app/ee/admin/whitelabeling/WhitelabelingForm.tsx
+++ b/web/src/app/ee/admin/whitelabeling/WhitelabelingForm.tsx
@@ -64,6 +64,7 @@ export function WhitelabelingForm() {
           custom_popup_content: enterpriseSettings?.custom_popup_content || "",
           custom_lower_disclaimer_content:
             enterpriseSettings?.custom_lower_disclaimer_content || "",
+          custom_nav_items: enterpriseSettings?.custom_nav_items || [],
         }}
         validationSchema={Yup.object().shape({
           application_name: Yup.string().nullable(),

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -31,7 +31,6 @@ const DropdownOption: React.FC<DropdownOptionProps> = ({
   icon,
   label,
 }) => {
-  console.log(href);
   const content = (
     <div className="flex py-3 px-4 cursor-pointer rounded hover:bg-hover-light">
       {icon}

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -143,7 +143,7 @@ export function UserDropdown({
                 icon={
                   <DynamicFaIcon
                     name={item.icon}
-                    className="h-5 w-5 my-auto mr-2"
+                    className="h-4 w-4 my-auto mr-2"
                   />
                 }
                 label={item.title}

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useContext } from "react";
+import { useState, useRef, useContext, useEffect } from "react";
 import { FiLogOut } from "react-icons/fi";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -15,6 +15,8 @@ import {
   UsersIcon,
 } from "./icons/icons";
 import { pageType } from "@/app/chat/sessionSidebar/types";
+import { NavigationItem } from "@/app/admin/settings/interfaces";
+import DynamicFaIcon, { preloadIcons } from "./icons/DynamicFaIcon";
 
 interface DropdownOptionProps {
   href?: string;
@@ -29,6 +31,7 @@ const DropdownOption: React.FC<DropdownOptionProps> = ({
   icon,
   label,
 }) => {
+  console.log(href);
   const content = (
     <div className="flex py-3 px-4 cursor-pointer rounded hover:bg-hover-light">
       {icon}
@@ -55,6 +58,14 @@ export function UserDropdown({
   const router = useRouter();
 
   const combinedSettings = useContext(SettingsContext);
+  const customNavItems: NavigationItem[] =
+    combinedSettings?.enterpriseSettings?.custom_nav_items || [];
+
+  useEffect(() => {
+    const iconNames = customNavItems.map((item) => item.icon);
+    preloadIcons(iconNames);
+  }, [customNavItems]);
+
   if (!combinedSettings) {
     return null;
   }
@@ -126,6 +137,19 @@ export function UserDropdown({
                 overscroll-contain
               `}
           >
+            {customNavItems.map((item) => (
+              <DropdownOption
+                href={item.link}
+                icon={
+                  <DynamicFaIcon
+                    name={item.icon}
+                    className="h-5 w-5 my-auto mr-2"
+                  />
+                }
+                label={item.title}
+              />
+            ))}
+
             {showAdminPanel ? (
               <DropdownOption
                 href="/admin/indexing/status"

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -166,9 +166,12 @@ export function UserDropdown({
               )
             )}
 
-            {showLogout && (showCuratorPanel || showAdminPanel) && (
-              <div className="border-t border-border my-1" />
-            )}
+            {showLogout &&
+              (showCuratorPanel ||
+                showAdminPanel ||
+                customNavItems.length > 0) && (
+                <div className="border-t border-border my-1" />
+              )}
 
             {showLogout && (
               <DropdownOption

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -137,8 +137,9 @@ export function UserDropdown({
                 overscroll-contain
               `}
           >
-            {customNavItems.map((item) => (
+            {customNavItems.map((item, i) => (
               <DropdownOption
+                key={i}
                 href={item.link}
                 icon={
                   <DynamicFaIcon

--- a/web/src/components/admin/connectors/AdminSidebar.tsx
+++ b/web/src/components/admin/connectors/AdminSidebar.tsx
@@ -74,8 +74,8 @@ export function AdminSidebar({ collections }: { collections: Collection[] }) {
         </div>
         <div className="flex w-full justify-center">
           <Link href={"/chat"}>
-            <button className="text-sm block w-52 py-2.5 flex px-2 text-left bg-background-200 hover:bg-background-200/80 cursor-pointer rounded">
-              <BackIcon size={20} />
+            <button className="text-sm flex items-center block w-52 py-2.5 flex px-2 text-left bg-background-200 hover:bg-background-200/80 cursor-pointer rounded">
+              <BackIcon className="my-auto" size={18} />
               <p className="ml-1 break-words line-clamp-2 ellipsis leading-none">
                 Back to{" "}
                 {combinedSettings.enterpriseSettings?.application_name ||

--- a/web/src/components/icons/DynamicFaIcon.tsx
+++ b/web/src/components/icons/DynamicFaIcon.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { IconBaseProps, IconType } from "react-icons";
+import { FaQuestion } from "react-icons/fa";
+
+interface DynamicIconProps extends IconBaseProps {
+  name: string;
+}
+
+// Renders a FontAwesome icon dynamically based on the provided name
+const DynamicFaIcon: React.FC<DynamicIconProps> = ({ name, ...props }) => {
+  const IconComponent = getPreloadedIcon(name);
+  return IconComponent ? (
+    <IconComponent className="h-5 w-5" {...props} />
+  ) : (
+    <FaQuestion className="h-5 w-5" {...props} />
+  );
+};
+
+// Cache for storing preloaded icons
+const iconCache: Record<string, IconType> = {};
+
+// Preloads icons asynchronously and stores them in the cache
+export async function preloadIcons(iconNames: string[]): Promise<void> {
+  const promises = iconNames.map(async (name) => {
+    try {
+      const iconModule = await import("react-icons/fa");
+      const iconName =
+        `Fa${name.charAt(0).toUpperCase() + name.slice(1)}` as keyof typeof iconModule;
+      iconCache[name] = (iconModule[iconName] as IconType) || FaQuestion;
+    } catch (error) {
+      console.error(`Failed to load icon: ${name}`, error);
+      iconCache[name] = FaQuestion;
+    }
+  });
+
+  await Promise.all(promises);
+}
+
+// Retrieves a preloaded icon from the cache
+export function getPreloadedIcon(name: string): IconType | undefined {
+  return iconCache[name] || FaQuestion;
+}
+
+export default DynamicFaIcon;

--- a/web/src/components/icons/DynamicFaIcon.tsx
+++ b/web/src/components/icons/DynamicFaIcon.tsx
@@ -10,9 +10,9 @@ interface DynamicIconProps extends IconBaseProps {
 const DynamicFaIcon: React.FC<DynamicIconProps> = ({ name, ...props }) => {
   const IconComponent = getPreloadedIcon(name);
   return IconComponent ? (
-    <IconComponent className="h-5 w-5" {...props} />
+    <IconComponent className="h-4 w-4" {...props} />
   ) : (
-    <FaQuestion className="h-5 w-5" {...props} />
+    <FaQuestion className="h-4 w-4" {...props} />
   );
 };
 


### PR DESCRIPTION
## Description
Allow people to configure user dropdown custom links / icons / titles

A couple of perfectly valid possible approaches (for the icon side specifically)
 - User uploads image during seeding -> render image
 - User specifies name from predefined list -> render from map
 - (went with this one) User specific name from FaIcon/react https://fontawesome.com/icons/react and we dynamically load, cache, and render the specific icon 

Sample environment variable: `ENV_SEED_CONFIGURATION='{"enterprise_settings": {"custom_nav_items": [{"title": "Documentation", "link": "https://docs.example.com", "icon": "Book"}, {"title": "Support", "link": "https://support.example.com", "icon": "phone"}]}}'`


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
