### PR TITLE
Add user when they interact outside of UI (e.g. Slack bot)

### DIFF
--- a/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
+++ b/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f7e58d357687"
-down_revision = "bceb1e139447"
+down_revision = "ba98eba0f66a"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
+++ b/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
@@ -1,0 +1,26 @@
+"""add has_web column to user
+
+Revision ID: f7e58d357687
+Revises: bceb1e139447
+Create Date: 2024-09-07 20:20:54.522620
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f7e58d357687"
+down_revision = "bceb1e139447"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column("has_web_login", sa.Boolean(), nullable=False, server_default="true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "has_web_login")

--- a/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
+++ b/backend/alembic/versions/f7e58d357687_add_has_web_column_to_user.py
@@ -1,4 +1,4 @@
-"""add has_web column to user
+"""add has_web_login column to user
 
 Revision ID: f7e58d357687
 Revises: bceb1e139447

--- a/backend/danswer/auth/schemas.py
+++ b/backend/danswer/auth/schemas.py
@@ -1,6 +1,5 @@
 import uuid
 from enum import Enum
-from typing import Optional
 
 from fastapi_users import schemas
 
@@ -34,9 +33,9 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
 
 class UserCreate(schemas.BaseUserCreate):
     role: UserRole = UserRole.BASIC
-    has_web_login: Optional[bool] = True
+    has_web_login: bool | None = True
 
 
 class UserUpdate(schemas.BaseUserUpdate):
     role: UserRole
-    has_web_login: Optional[bool] = True
+    has_web_login: bool | None = True

--- a/backend/danswer/auth/schemas.py
+++ b/backend/danswer/auth/schemas.py
@@ -1,5 +1,6 @@
 import uuid
 from enum import Enum
+from typing import Optional
 
 from fastapi_users import schemas
 
@@ -33,7 +34,9 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
 
 class UserCreate(schemas.BaseUserCreate):
     role: UserRole = UserRole.BASIC
+    has_web_login: Optional[bool] = True
 
 
 class UserUpdate(schemas.BaseUserUpdate):
     role: UserRole
+    has_web_login: Optional[bool] = True

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -202,7 +202,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         except exceptions.UserAlreadyExists:
             user = await self.get_by_email(user_create.email)
             # Handle case where user has used product outside of web and is now creating an account through web
-            if not user.has_web_login and user_create.has_web_login:
+            if (
+                not user.has_web_login
+                and hasattr(user_create, "has_web_login")
+                and user_create.has_web_login
+            ):
                 user_update = UserUpdate(
                     password=user_create.password,
                     has_web_login=user_create.has_web_login,

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -188,7 +188,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user_create: schemas.UC | UserCreate,
         safe: bool = False,
         request: Optional[Request] = None,
-    ) -> models.UP:
+    ) -> User:
         verify_email_is_invited(user_create.email)
         verify_email_domain(user_create.email)
         if hasattr(user_create, "role"):
@@ -314,7 +314,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
     async def authenticate(
         self, credentials: OAuth2PasswordRequestForm
-    ) -> Optional[models.UP]:
+    ) -> Optional[User]:
         user = await super().authenticate(credentials)
         if user is None:
             try:

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -209,7 +209,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             ):
                 user_update = UserUpdate(
                     password=user_create.password,
-                    has_web_login=user_create.has_web_login,
+                    has_web_login=True,
                     role=user_create.role,
                     is_verified=user_create.is_verified,
                 )

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -16,7 +16,9 @@ from fastapi import HTTPException
 from fastapi import Request
 from fastapi import Response
 from fastapi import status
+from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager
+from fastapi_users import exceptions
 from fastapi_users import FastAPIUsers
 from fastapi_users import models
 from fastapi_users import schemas
@@ -27,12 +29,14 @@ from fastapi_users.authentication import Strategy
 from fastapi_users.authentication.strategy.db import AccessTokenDatabase
 from fastapi_users.authentication.strategy.db import DatabaseStrategy
 from fastapi_users.openapi import OpenAPIResponseType
+from fastapi_users.password import PasswordHelper
 from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
 from sqlalchemy.orm import Session
 
 from danswer.auth.invited_users import get_invited_users
 from danswer.auth.schemas import UserCreate
 from danswer.auth.schemas import UserRole
+from danswer.auth.schemas import UserUpdate
 from danswer.configs.app_configs import AUTH_TYPE
 from danswer.configs.app_configs import DISABLE_AUTH
 from danswer.configs.app_configs import EMAIL_FROM
@@ -193,7 +197,42 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 user_create.role = UserRole.ADMIN
             else:
                 user_create.role = UserRole.BASIC
-        return await super().create(user_create, safe=safe, request=request)  # type: ignore
+        user = None
+        try:
+            user = await super().create(user_create, safe=safe, request=request)  # type: ignore
+        except exceptions.UserAlreadyExists:
+            user = await self.get_by_email(user_create.email)
+            # Handle case where user has used product outside of web and is now creating an account through web
+            if not user.has_web_login and user_create.has_web_login:
+                user_update = UserUpdate(
+                    password=user_create.password,
+                    has_web_login=user_create.has_web_login,
+                    role=user_create.role,
+                    is_verified=user_create.is_verified,
+                )
+                user = await self.update(user_update, user)
+            else:
+                raise exceptions.UserAlreadyExists()
+        return user
+
+    async def create_non_web_user(self, email: str) -> User:
+        """
+        Creates a non-web user. Used when a user interacts with Slack bot
+        or other non-web interactions.
+        :raises UserAlreadyExists: A user already exists with the same e-mail.
+        :return: A new user if newly created
+        """
+        fastapi_users_pw_helper = PasswordHelper()
+        password = fastapi_users_pw_helper.generate()
+        hashed_pass = fastapi_users_pw_helper.hash(password)
+        return await self.create(
+            UserCreate(
+                email=email,
+                password=hashed_pass,
+                role=UserRole.BASIC,
+                has_web_login=False,
+            )
+        )
 
     async def oauth_callback(
         self: "BaseUserManager[models.UOAP, models.ID]",
@@ -234,6 +273,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         if user.oidc_expiry and not TRACK_EXTERNAL_IDP_EXPIRY:
             await self.user_db.update(user, update_dict={"oidc_expiry": None})
 
+        # Handle case where user has used product outside of web and is now creating an account through web
+        if not user.has_web_login:
+            await self.user_db.update(
+                user,
+                update_dict={
+                    "is_verified": is_verified_by_default,
+                    "has_web_login": True,
+                },
+            )
+            user.is_verified = is_verified_by_default
+            user.has_web_login = True
         return user
 
     async def on_after_register(
@@ -261,6 +311,22 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         )
 
         send_user_verification_email(user.email, token)
+
+    async def authenticate(
+        self, credentials: OAuth2PasswordRequestForm
+    ) -> Optional[models.UP]:
+        user = await super().authenticate(credentials)
+        if user is None:
+            try:
+                user = await self.get_by_email(credentials.username)
+                if not user.has_web_login:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="NO_WEB_LOGIN_AND_HAS_NO_PASSWORD",
+                    )
+            except exceptions.UserNotExists:
+                pass
+        return user
 
 
 async def get_user_manager(

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -29,7 +29,6 @@ from fastapi_users.authentication import Strategy
 from fastapi_users.authentication.strategy.db import AccessTokenDatabase
 from fastapi_users.authentication.strategy.db import DatabaseStrategy
 from fastapi_users.openapi import OpenAPIResponseType
-from fastapi_users.password import PasswordHelper
 from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
 from sqlalchemy.orm import Session
 
@@ -214,25 +213,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             else:
                 raise exceptions.UserAlreadyExists()
         return user
-
-    async def create_non_web_user(self, email: str) -> User:
-        """
-        Creates a non-web user. Used when a user interacts with Slack bot
-        or other non-web interactions.
-        :raises UserAlreadyExists: A user already exists with the same e-mail.
-        :return: A new user if newly created
-        """
-        fastapi_users_pw_helper = PasswordHelper()
-        password = fastapi_users_pw_helper.generate()
-        hashed_pass = fastapi_users_pw_helper.hash(password)
-        return await self.create(
-            UserCreate(
-                email=email,
-                password=hashed_pass,
-                role=UserRole.BASIC,
-                has_web_login=False,
-            )
-        )
 
     async def oauth_callback(
         self: "BaseUserManager[models.UOAP, models.ID]",

--- a/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_buttons.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from danswer.configs.constants import MessageType
 from danswer.configs.constants import SearchFeedbackType
 from danswer.configs.danswerbot_configs import DANSWER_FOLLOWUP_EMOJI
+from danswer.connectors.slack.utils import expert_info_from_slack_id
 from danswer.connectors.slack.utils import make_slack_api_rate_limited
 from danswer.danswerbot.slack.blocks import build_follow_up_resolved_blocks
 from danswer.danswerbot.slack.blocks import get_document_feedback_blocks
@@ -87,6 +88,8 @@ def handle_generate_answer_button(
     message_ts = req.payload["message"]["ts"]
     thread_ts = req.payload["container"]["thread_ts"]
     user_id = req.payload["user"]["id"]
+    expert_info = expert_info_from_slack_id(user_id, client.web_client, user_cache={})
+    email = expert_info.email if expert_info else None
 
     if not thread_ts:
         raise ValueError("Missing thread_ts in the payload")
@@ -125,6 +128,7 @@ def handle_generate_answer_button(
                 msg_to_respond=cast(str, message_ts or thread_ts),
                 thread_to_respond=cast(str, thread_ts or message_ts),
                 sender=user_id or None,
+                email=email or None,
                 bypass_filters=True,
                 is_bot_msg=False,
                 is_bot_dm=False,

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -55,7 +55,7 @@ def send_msg_ack_to_user(details: SlackMessageInfo, client: WebClient) -> None:
     )
 
 
-def add_user_if_not_exists(sender: str, client: WebClient) -> User | None:
+def add_user_if_not_exists(sender: str | None, client: WebClient) -> User | None:
     slack_user_info = expert_info_from_slack_id(sender, client, user_cache={})
     if slack_user_info and slack_user_info.email:
         return asyncio.run(add_user_in_db_if_not_exists(slack_user_info.email))

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -1,13 +1,11 @@
-import asyncio
-import contextlib
 import datetime
 
-from fastapi_users import exceptions
+from fastapi_users.password import PasswordHelper
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from sqlalchemy.orm import Session
 
-from danswer.auth.users import get_user_manager
+from danswer.auth.schemas import UserRole
 from danswer.configs.danswerbot_configs import DANSWER_BOT_FEEDBACK_REMINDER
 from danswer.configs.danswerbot_configs import DANSWER_REACT_EMOJI
 from danswer.connectors.slack.utils import expert_info_from_slack_id
@@ -24,11 +22,10 @@ from danswer.danswerbot.slack.utils import fetch_user_ids_from_groups
 from danswer.danswerbot.slack.utils import respond_in_thread
 from danswer.danswerbot.slack.utils import slack_usage_report
 from danswer.danswerbot.slack.utils import update_emote_react
-from danswer.db.auth import get_user_db
-from danswer.db.engine import get_async_session
 from danswer.db.engine import get_sqlalchemy_engine
 from danswer.db.models import SlackBotConfig
 from danswer.db.models import User
+from danswer.db.users import get_user_by_email
 from danswer.utils.logger import setup_logger
 from shared_configs.configs import SLACK_CHANNEL_ID
 
@@ -55,28 +52,23 @@ def send_msg_ack_to_user(details: SlackMessageInfo, client: WebClient) -> None:
     )
 
 
-def add_user_if_not_exists(sender: str | None, client: WebClient) -> User | None:
-    slack_user_info = expert_info_from_slack_id(sender, client, user_cache={})
-    if slack_user_info and slack_user_info.email:
-        return asyncio.run(add_user_in_db_if_not_exists(slack_user_info.email))
-    return None
+def add_user_if_not_exists(email: str, db_session: Session) -> User:
+    user = get_user_by_email(email, db_session)
+    if user is not None:
+        return user
 
-
-async def add_user_in_db_if_not_exists(email: str) -> User | None:
-    get_async_session_context = contextlib.asynccontextmanager(
-        get_async_session
-    )  # type:ignore
-    get_user_db_context = contextlib.asynccontextmanager(get_user_db)
-    get_user_manager_context = contextlib.asynccontextmanager(get_user_manager)
-
-    async with get_async_session_context() as session:
-        async with get_user_db_context(session) as user_db:
-            async with get_user_manager_context(user_db) as user_manager:
-                try:
-                    return await user_manager.create_non_web_user(email)
-                except exceptions.UserAlreadyExists:
-                    pass
-    return None
+    fastapi_users_pw_helper = PasswordHelper()
+    password = fastapi_users_pw_helper.generate()
+    hashed_pass = fastapi_users_pw_helper.hash(password)
+    user = User(
+        email=email,
+        hashed_password=hashed_pass,
+        has_web_login=False,
+        role=UserRole.BASIC,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
 
 
 def schedule_feedback_reminder(
@@ -240,9 +232,13 @@ def handle_message(
     except SlackApiError as e:
         logger.error(f"Was not able to react to user message due to: {e}")
 
-    add_user_if_not_exists(message_info.sender, client)
+    slack_user_info = expert_info_from_slack_id(
+        message_info.sender, client, user_cache={}
+    )
+    user_email = slack_user_info.email if slack_user_info else None
 
     with Session(get_sqlalchemy_engine()) as db_session:
+        add_user_if_not_exists(user_email, db_session)
         # first check if we need to respond with a standard answer
         used_standard_answer = handle_standard_answers(
             message_info=message_info,

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -235,10 +235,11 @@ def handle_message(
     slack_user_info = expert_info_from_slack_id(
         message_info.sender, client, user_cache={}
     )
-    user_email = slack_user_info.email if slack_user_info else None
 
     with Session(get_sqlalchemy_engine()) as db_session:
-        add_user_if_not_exists(user_email, db_session)
+        if slack_user_info and slack_user_info.email:
+            add_user_if_not_exists(slack_user_info.email, db_session)
+
         # first check if we need to respond with a standard answer
         used_standard_answer = handle_standard_answers(
             message_info=message_info,

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -21,7 +21,7 @@ from danswer.danswerbot.slack.utils import slack_usage_report
 from danswer.danswerbot.slack.utils import update_emote_react
 from danswer.db.engine import get_sqlalchemy_engine
 from danswer.db.models import SlackBotConfig
-from danswer.db.users import add_user_if_not_exists
+from danswer.db.users import add_non_web_user_if_not_exists
 from danswer.utils.logger import setup_logger
 from shared_configs.configs import SLACK_CHANNEL_ID
 
@@ -211,7 +211,7 @@ def handle_message(
 
     with Session(get_sqlalchemy_engine()) as db_session:
         if message_info.email:
-            add_user_if_not_exists(message_info.email, db_session)
+            add_non_web_user_if_not_exists(message_info.email, db_session)
 
         # first check if we need to respond with a standard answer
         used_standard_answer = handle_standard_answers(

--- a/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
@@ -22,7 +22,6 @@ from danswer.configs.danswerbot_configs import DANSWER_BOT_USE_QUOTES
 from danswer.configs.danswerbot_configs import DANSWER_FOLLOWUP_EMOJI
 from danswer.configs.danswerbot_configs import DANSWER_REACT_EMOJI
 from danswer.configs.danswerbot_configs import ENABLE_DANSWERBOT_REFLEXION
-from danswer.connectors.slack.utils import expert_info_from_slack_id
 from danswer.danswerbot.slack.blocks import build_documents_blocks
 from danswer.danswerbot.slack.blocks import build_follow_up_block
 from danswer.danswerbot.slack.blocks import build_qa_response_blocks
@@ -103,13 +102,10 @@ def handle_regular_answer(
     is_bot_msg = message_info.is_bot_msg
     user = None
     if message_info.is_bot_dm:
-        slack_user_info = expert_info_from_slack_id(
-            message_info.sender, client, user_cache={}
-        )
-        if slack_user_info and slack_user_info.email:
+        if message_info.email:
             engine = get_sqlalchemy_engine()
             with Session(engine) as db_session:
-                user = get_user_by_email(slack_user_info.email, db_session)
+                user = get_user_by_email(message_info.email, db_session)
 
     document_set_names: list[str] | None = None
     persona = slack_bot_config.persona if slack_bot_config else None

--- a/backend/danswer/danswerbot/slack/models.py
+++ b/backend/danswer/danswerbot/slack/models.py
@@ -9,6 +9,7 @@ class SlackMessageInfo(BaseModel):
     msg_to_respond: str | None
     thread_to_respond: str | None
     sender: str | None
+    email: str | None
     bypass_filters: bool  # User has tagged @DanswerBot
     is_bot_msg: bool  # User is using /DanswerBot
     is_bot_dm: bool  # User is direct messaging to DanswerBot

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -157,6 +157,8 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     notifications: Mapped[list["Notification"]] = relationship(
         "Notification", back_populates="user"
     )
+    # Whether the user has logged in via web. False if user has only used Danswer through Slack bot
+    has_web_login: Mapped[bool] = mapped_column(Boolean, default=True)
 
 
 class InputPrompt(Base):

--- a/backend/danswer/db/users.py
+++ b/backend/danswer/db/users.py
@@ -34,7 +34,7 @@ def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
     return user
 
 
-def add_user_if_not_exists(email: str, db_session: Session) -> User:
+def add_non_web_user_if_not_exists(email: str, db_session: Session) -> User:
     user = get_user_by_email(email, db_session)
     if user is not None:
         return user

--- a/backend/danswer/db/users.py
+++ b/backend/danswer/db/users.py
@@ -1,9 +1,11 @@
 from collections.abc import Sequence
 from uuid import UUID
 
+from fastapi_users.password import PasswordHelper
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from danswer.auth.schemas import UserRole
 from danswer.db.models import User
 
 
@@ -29,4 +31,23 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
 def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
     user = db_session.query(User).filter(User.id == user_id).first()  # type: ignore
 
+    return user
+
+
+def add_user_if_not_exists(email: str, db_session: Session) -> User:
+    user = get_user_by_email(email, db_session)
+    if user is not None:
+        return user
+
+    fastapi_users_pw_helper = PasswordHelper()
+    password = fastapi_users_pw_helper.generate()
+    hashed_pass = fastapi_users_pw_helper.hash(password)
+    user = User(
+        email=email,
+        hashed_password=hashed_pass,
+        has_web_login=False,
+        role=UserRole.BASIC,
+    )
+    db_session.add(user)
+    db_session.commit()
     return user

--- a/backend/ee/danswer/server/saml.py
+++ b/backend/ee/danswer/server/saml.py
@@ -65,6 +65,7 @@ async def upsert_saml_user(email: str) -> User:
                         password=hashed_pass,
                         is_verified=True,
                         role=role,
+                        has_web_login=True,
                     )
                 )
 

--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -72,6 +72,8 @@ export function EmailPasswordForm({
             let errorMsg = "Unknown error";
             if (errorDetail === "LOGIN_BAD_CREDENTIALS") {
               errorMsg = "Invalid email or password";
+            } else if (errorDetail === "NO_WEB_LOGIN_AND_HAS_NO_PASSWORD") {
+              errorMsg = "Create an account to set a password";
             }
             setPopup({
               type: "error",


### PR DESCRIPTION
## Description
Add capability to add user when someone interacts with a Slack bot without having logged in via the UI. This invovles:
- Adding a `has_web_login` column to `user` table. This allows us to have logic where we allow a user to set their password with basic auth. Otherwise, a user would not know the placeholder password we set for them.


## How Has This Been Tested?
- [x] Create a new user with Slack only. Be able to then authenticate with web login (basic, oidc, google_oauth).
- [x] Authenticate with web first. Can continue to interact with Slack bot.

## Accepted Risk
More database calls / Slack APIs in Slack bot + login flows.


## Checklist:
- [x] All of the automated tests pass
- [x] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
