### PR TITLE
docker versions have been deprecated for a while, so fixing the annoy…

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api_server:
     image: danswer/danswer-backend:${IMAGE_TAG:-latest}

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api_server:
     image: danswer/danswer-backend:${IMAGE_TAG:-latest}

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api_server:
     image: danswer/danswer-backend:${IMAGE_TAG:-latest}

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api_server:
     image: danswer/danswer-backend:${IMAGE_TAG:-latest}

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api_server:
     image: danswer/danswer-backend:${IMAGE_TAG:-latest}


### PR DESCRIPTION
…ing warning

## Description
Fixes DAN-578.

removing deprecated docker compose version tag.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
