### PR TITLE
ephemeral behavior for redis

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -341,12 +341,9 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server
-    volumes: 
-      - cache_volume:/data
+    command: redis-server --save "" --appendonly no
 
 volumes:
-  cache_volume:
   db_volume:
   vespa_volume: # Created by the container itself
 

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -341,6 +341,8 @@ services:
     restart: always
     ports:
       - '6379:6379'
+    # docker silently mounts /data even without an explicit volume mount, which enables
+    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
 
 volumes:

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -352,13 +352,10 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server
-    volumes: 
-      - cache_volume:/data
+    command: redis-server --save "" --appendonly no
 
 
 volumes:
-  cache_volume:
   db_volume:
   vespa_volume:
   # Created by the container itself

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -352,6 +352,8 @@ services:
     restart: always
     ports:
       - '6379:6379'
+    # docker silently mounts /data even without an explicit volume mount, which enables
+    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
 
 

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -213,13 +213,10 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server
-    volumes: 
-      - cache_volume:/data
+    command: redis-server --save "" --appendonly no
 
 
 volumes:
-  cache_volume:
   db_volume:
   vespa_volume:
   # Created by the container itself

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -213,6 +213,8 @@ services:
     restart: always
     ports:
       - '6379:6379'
+    # docker silently mounts /data even without an explicit volume mount, which enables
+    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
 
 

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -230,6 +230,8 @@ services:
     restart: always
     ports:
       - '6379:6379'
+    # docker silently mounts /data even without an explicit volume mount, which enables
+    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
 
 

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -230,13 +230,10 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server
-    volumes: 
-      - cache_volume:/data
+    command: redis-server --save "" --appendonly no
 
 
 volumes:
-  cache_volume:
   db_volume:
   vespa_volume:
   # Created by the container itself

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -209,6 +209,8 @@ services:
     restart: always
     ports:
       - '6379:6379'
+    # docker silently mounts /data even without an explicit volume mount, which enables
+    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
 
 

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -209,13 +209,10 @@ services:
     restart: always
     ports:
       - '6379:6379'
-    command: redis-server
-    volumes: 
-      - cache_volume:/data
+    command: redis-server --save "" --appendonly no
 
 
 volumes:
-  cache_volume:
   db_volume:
     driver: local
     driver_opts:

--- a/deployment/kubernetes/redis-service-deployment.yaml
+++ b/deployment/kubernetes/redis-service-deployment.yaml
@@ -38,4 +38,11 @@ spec:
               name: danswer-secrets
               key: redis_password
         command: ["redis-server"]
-        args: ["--requirepass", "$(REDIS_PASSWORD)"]
+        args:
+          # save and appendonly are not strictly necessary because kubernetes doesn't mount
+          # /data silently like docker, but add the save and appendonly for consistency         
+          [
+            "--requirepass", "$(REDIS_PASSWORD)", 
+            "--save", "", 
+            "--appendonly", "no"
+          ]


### PR DESCRIPTION
## Description
Fixes DAN-579.

Turns out the default docker container behavior is somewhat persistent, despite nearly all articles on the internet stating otherwise.

## How Has This Been Tested?
Observed incorrect persistence behavior, then removed volume and forced command line and finally saw keys removed between restarts.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
