### PR TITLE
Put "Standard Answers" behind enterprise edition

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_standard_answers.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_standard_answers.py
@@ -1,6 +1,7 @@
 from slack_sdk import WebClient
 from sqlalchemy.orm import Session
 
+from danswer.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from danswer.configs.constants import MessageType
 from danswer.configs.danswerbot_configs import DANSWER_REACT_EMOJI
 from danswer.danswerbot.slack.blocks import build_standard_answer_blocks
@@ -72,6 +73,10 @@ def handle_standard_answers(
     Returns True if standard answers are found to match the user's message and therefore,
     we still need to respond to the users.
     """
+    # Standard answers are only available in enterprise edition
+    if not ENTERPRISE_EDITION_ENABLED:
+        return False
+
     # if no channel config, then no standard answers are configured
     if not slack_bot_config:
         return False

--- a/backend/danswer/danswerbot/slack/handlers/handle_standard_answers.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_standard_answers.py
@@ -1,7 +1,6 @@
 from slack_sdk import WebClient
 from sqlalchemy.orm import Session
 
-from danswer.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from danswer.configs.constants import MessageType
 from danswer.configs.danswerbot_configs import DANSWER_REACT_EMOJI
 from danswer.danswerbot.slack.blocks import build_standard_answer_blocks
@@ -73,10 +72,6 @@ def handle_standard_answers(
     Returns True if standard answers are found to match the user's message and therefore,
     we still need to respond to the users.
     """
-    # Standard answers are only available in enterprise edition
-    if not ENTERPRISE_EDITION_ENABLED:
-        return False
-
     # if no channel config, then no standard answers are configured
     if not slack_bot_config:
         return False

--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -145,15 +145,19 @@ export function ClientLayout({
                           ),
                           link: "/admin/tools",
                         },
-                        {
-                          name: (
-                            <div className="flex">
-                              <ClipboardIcon size={18} />
-                              <div className="ml-1">Standard Answers</div>
-                            </div>
-                          ),
-                          link: "/admin/standard-answer",
-                        },
+                        ...(enableEnterprise
+                          ? [
+                              {
+                                name: (
+                                  <div className="flex">
+                                    <ClipboardIcon size={18} />
+                                    <div className="ml-1">Standard Answers</div>
+                                  </div>
+                                ),
+                                link: "/admin/standard-answer",
+                              },
+                            ]
+                          : []),
                         {
                           name: (
                             <div className="flex">


### PR DESCRIPTION
## Description
Standard Answers is put behind enterprise edition in UI

## How Has This Been Tested?
Manually, by setting `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES` to false/true and seeing change in behavior in UI

## Checklist:
- [x] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
