### PR TITLE
Add link to macOS contributions doc for installing Python 3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Danswer being a fully functional app, relies on some external software, specific
 
 
 ### Local Set Up
-Be sure to use Python version 3.11.
+Be sure to use Python version 3.11. For instructions on installing Python 3.11 on macOS, refer to the [CONTRIBUTING_MACOS.md](./CONTRIBUTING_MACOS.md) readme.
 
 If using a lower version, modifications will have to be made to the code.
 If using a higher version, sometimes some libraries will not be available (i.e. we had problems with Tensorflow in the past with higher versions of python).


### PR DESCRIPTION
## Description
Small documentation change to add instructions for installing Python 3.11 and confirm that GitHub contribution workflow works.

## How Has This Been Tested?
Documentation change

## Accepted Risk
In the future, if the macOS instructions diverge, it may make sense to reconcile the two documents

## Related Issue(s)


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
