### PR TITLE
fixes a bug with deleting connectors and foreign keys

### DIFF
--- a/backend/danswer/db/index_attempt.py
+++ b/backend/danswer/db/index_attempt.py
@@ -335,6 +335,16 @@ def delete_index_attempts(
     cc_pair_id: int,
     db_session: Session,
 ) -> None:
+    # First, delete related entries in IndexAttemptErrors
+    stmt_errors = delete(IndexAttemptError).where(
+        IndexAttemptError.index_attempt_id.in_(
+            select(IndexAttempt.id).where(
+                IndexAttempt.connector_credential_pair_id == cc_pair_id
+            )
+        )
+    )
+    db_session.execute(stmt_errors)
+
     stmt = delete(IndexAttempt).where(
         IndexAttempt.connector_credential_pair_id == cc_pair_id,
     )


### PR DESCRIPTION
## Description
Fixes DAN-608. Foreign key entries need to be removed.


## How Has This Been Tested?
Ran a deletion on a connector with failed index attempts and observed FK error. Added cleanup code and deletion succeeded.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
