### PR TITLE
Add fix for logging

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,8 @@ founders@danswer.ai for more information. Please visit https://github.com/danswe
 
 # Default DANSWER_VERSION, typically overriden during builds by GitHub Actions.
 ARG DANSWER_VERSION=0.3-dev
-ENV DANSWER_VERSION=${DANSWER_VERSION}
+ENV DANSWER_VERSION=${DANSWER_VERSION} \
+    DANSWER_RUNNING_IN_DOCKER="yes"
 
 RUN echo "DANSWER_VERSION: ${DANSWER_VERSION}"
 # Install system dependencies

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ founders@danswer.ai for more information. Please visit https://github.com/danswe
 # Default DANSWER_VERSION, typically overriden during builds by GitHub Actions.
 ARG DANSWER_VERSION=0.3-dev
 ENV DANSWER_VERSION=${DANSWER_VERSION} \
-    DANSWER_RUNNING_IN_DOCKER="yes"
+    DANSWER_RUNNING_IN_DOCKER="true"
 
 RUN echo "DANSWER_VERSION: ${DANSWER_VERSION}"
 # Install system dependencies

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -8,7 +8,10 @@ visit https://github.com/danswer-ai/danswer."
 
 # Default DANSWER_VERSION, typically overriden during builds by GitHub Actions.
 ARG DANSWER_VERSION=0.3-dev
-ENV DANSWER_VERSION=${DANSWER_VERSION}
+ENV DANSWER_VERSION=${DANSWER_VERSION} \
+    DANSWER_RUNNING_IN_DOCKER="true"
+
+
 RUN echo "DANSWER_VERSION: ${DANSWER_VERSION}"
 
 COPY ./requirements/model_server.txt /tmp/requirements.txt

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -124,6 +124,24 @@ def get_standard_formatter() -> ColoredFormatter:
     )
 
 
+def is_running_in_container():
+    container_indicators = [
+        "/.dockerenv",
+        "/run/.containerenv",
+    ]
+
+    env_indicators = [
+        "KUBERNETES_SERVICE_HOST",
+        "CONTAINER_RUNTIME",
+        "DOCKER_CONTAINER",
+        "CONTAINERD_NAMESPACE",
+    ]
+
+    return any(os.path.exists(path) for path in container_indicators) or any(
+        os.environ.get(env_var) for env_var in env_indicators
+    )
+
+
 def setup_logger(
     name: str = __name__,
     log_level: int = get_log_level_from_str(),
@@ -151,7 +169,7 @@ def setup_logger(
         uvicorn_logger.addHandler(handler)
         uvicorn_logger.setLevel(log_level)
 
-    is_containerized = os.path.exists("/.dockerenv")
+    is_containerized = is_running_in_container()
     if LOG_FILE_NAME and (is_containerized or DEV_LOGGING_ENABLED):
         log_levels = ["debug", "info", "notice"]
         for level in log_levels:

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -125,21 +125,15 @@ def get_standard_formatter() -> ColoredFormatter:
 
 
 def is_running_in_container():
-    container_indicators = [
-        "/.dockerenv",
-        "/run/.containerenv",
+    # Multiple file checks for redundancy
+    local_only_files = [
+        "pyproject.toml",
+        "Dockerfile",
+        "Dockerfile.model_server",
+        "alembic.ini",
     ]
 
-    env_indicators = [
-        "KUBERNETES_SERVICE_HOST",
-        "CONTAINER_RUNTIME",
-        "DOCKER_CONTAINER",
-        "CONTAINERD_NAMESPACE",
-    ]
-
-    return any(os.path.exists(path) for path in container_indicators) or any(
-        os.environ.get(env_var) for env_var in env_indicators
-    )
+    return not any(os.path.exists(file) for file in local_only_files)
 
 
 def setup_logger(
@@ -170,6 +164,7 @@ def setup_logger(
         uvicorn_logger.setLevel(log_level)
 
     is_containerized = is_running_in_container()
+
     if LOG_FILE_NAME and (is_containerized or DEV_LOGGING_ENABLED):
         log_levels = ["debug", "info", "notice"]
         for level in log_levels:

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -124,22 +124,11 @@ def get_standard_formatter() -> ColoredFormatter:
     )
 
 
+DANSWER_DOCKER_ENV_STR = "DANSWER_RUNNING_IN_DOCKER"
+
+
 def is_running_in_container():
-    container_indicators = [
-        "/.dockerenv",
-        "/run/.containerenv",
-    ]
-
-    env_indicators = [
-        "KUBERNETES_SERVICE_HOST",
-        "CONTAINER_RUNTIME",
-        "DOCKER_CONTAINER",
-        "CONTAINERD_NAMESPACE",
-    ]
-
-    return any(os.path.exists(path) for path in container_indicators) or any(
-        os.environ.get(env_var) for env_var in env_indicators
-    )
+    return os.getenv(DANSWER_DOCKER_ENV_STR) == "true"
 
 
 def setup_logger(

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -127,10 +127,8 @@ def get_standard_formatter() -> ColoredFormatter:
 def is_running_in_container():
     # Multiple file checks for redundancy
     local_only_files = [
-        "pyproject.toml",
         "Dockerfile",
         "Dockerfile.model_server",
-        "alembic.ini",
     ]
 
     return not any(os.path.exists(file) for file in local_only_files)

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -127,7 +127,7 @@ def get_standard_formatter() -> ColoredFormatter:
 DANSWER_DOCKER_ENV_STR = "DANSWER_RUNNING_IN_DOCKER"
 
 
-def is_running_in_container():
+def is_running_in_container() -> bool:
     return os.getenv(DANSWER_DOCKER_ENV_STR) == "true"
 
 

--- a/backend/danswer/utils/logger.py
+++ b/backend/danswer/utils/logger.py
@@ -125,13 +125,21 @@ def get_standard_formatter() -> ColoredFormatter:
 
 
 def is_running_in_container():
-    # Multiple file checks for redundancy
-    local_only_files = [
-        "Dockerfile",
-        "Dockerfile.model_server",
+    container_indicators = [
+        "/.dockerenv",
+        "/run/.containerenv",
     ]
 
-    return not any(os.path.exists(file) for file in local_only_files)
+    env_indicators = [
+        "KUBERNETES_SERVICE_HOST",
+        "CONTAINER_RUNTIME",
+        "DOCKER_CONTAINER",
+        "CONTAINERD_NAMESPACE",
+    ]
+
+    return any(os.path.exists(path) for path in container_indicators) or any(
+        os.environ.get(env_var) for env_var in env_indicators
+    )
 
 
 def setup_logger(
@@ -162,7 +170,6 @@ def setup_logger(
         uvicorn_logger.setLevel(log_level)
 
     is_containerized = is_running_in_container()
-
     if LOG_FILE_NAME and (is_containerized or DEV_LOGGING_ENABLED):
         log_levels = ["debug", "info", "notice"]
         for level in log_levels:


### PR DESCRIPTION
## Description

Current method of detecting containerization by checking for `/.dockerenv` is unreliable in Kubernetes environments, particularly EKS, leading to incorrect log file paths. 

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
