### PR TITLE
Quick redirect for `/admin` for better ergo

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function Page() {
+  // Replace me when you have something better!
+  redirect("/admin/indexing/status");
+}

--- a/web/src/components/UserDropdown.tsx
+++ b/web/src/components/UserDropdown.tsx
@@ -152,14 +152,14 @@ export function UserDropdown({
 
             {showAdminPanel ? (
               <DropdownOption
-                href="/admin/indexing/status"
+                href="/admin"
                 icon={<LightSettingsIcon className="h-5 w-5 my-auto mr-2" />}
                 label="Admin Panel"
               />
             ) : (
               showCuratorPanel && (
                 <DropdownOption
-                  href="/admin/indexing/status"
+                  href="/admin"
                   icon={<LightSettingsIcon className="h-5 w-5 my-auto mr-2" />}
                   label="Curator Panel"
                 />


### PR DESCRIPTION
## Description
This PR adds a redirect from `/admin` to `/admin/indexing/status` in the web UI, which is the page linked to by the "Admin panel" button when clicking the profile badge in the top right corner.

I also took the liberty of changing the link for the "Admin panel" button to `/admin`.

## How Has This Been Tested?
Locally

## Accepted Risk
Not that I can see

## Related Issue(s)
No

## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
