### PR TITLE
Allows httpx client timeout values to be set

### DIFF
--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -204,7 +204,7 @@ class VespaIndex(DocumentIndex):
         # indexing / updates / deletes since we have to make a large volume of requests.
         with (
             concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor,
-            httpx.Client(http2=True) as http_client,
+            httpx.Client(http2=True, timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10))) as http_client,
         ):
             # Check for existing documents, existing documents need to have all of their chunks deleted
             # prior to indexing as the document size (num chunks) may have shrunk
@@ -268,7 +268,7 @@ class VespaIndex(DocumentIndex):
         # indexing / updates / deletes since we have to make a large volume of requests.
         with (
             concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor,
-            httpx.Client(http2=True) as http_client,
+            httpx.Client(http2=True, timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10))) as http_client,
         ):
             for update_batch in batch_generator(updates, batch_size):
                 future_to_document_id = {
@@ -384,7 +384,7 @@ class VespaIndex(DocumentIndex):
 
         # NOTE: using `httpx` here since `requests` doesn't support HTTP2. This is beneficial for
         # indexing / updates / deletes since we have to make a large volume of requests.
-        with httpx.Client(http2=True) as http_client:
+        with httpx.Client(http2=True, timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10))) as http_client:
             index_names = [self.index_name]
             if self.secondary_index_name:
                 index_names.append(self.secondary_index_name)

--- a/backend/danswer/tools/internet_search/internet_search_tool.py
+++ b/backend/danswer/tools/internet_search/internet_search_tool.py
@@ -1,4 +1,6 @@
 import json
+import os 
+
 from collections.abc import Generator
 from datetime import datetime
 from typing import Any
@@ -105,7 +107,7 @@ class InternetSearchTool(Tool):
             "Content-Type": "application/json",
         }
         self.num_results = num_results
-        self.client = httpx.Client()
+        self.client = httpx.Client(timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10)))
 
     @property
     def name(self) -> str:

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -1,4 +1,6 @@
 import json
+import os 
+
 from typing import Any
 from typing import Optional
 
@@ -240,7 +242,7 @@ def embed_with_litellm_proxy(
 ) -> list[Embedding]:
     headers = {} if not api_key else {"Authorization": f"Bearer {api_key}"}
 
-    with httpx.Client() as client:
+    with httpx.Client(timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10))) as client:
         response = client.post(
             api_url,
             json={
@@ -366,7 +368,7 @@ def litellm_rerank(
     query: str, docs: list[str], api_url: str, model_name: str, api_key: str | None
 ) -> list[float]:
     headers = {} if not api_key else {"Authorization": f"Bearer {api_key}"}
-    with httpx.Client() as client:
+    with httpx.Client(timeout=httpx.Timeout(os.getenv("HTTPX_TIMEOUT", 10))) as client:
         response = client.post(
             api_url,
             json={


### PR DESCRIPTION
## Description
This allows the `httpx` client timeout values to be customized.


## How Has This Been Tested?
[Indexing done after change]


## Accepted Risk
[N/A]


## Related Issue(s)
Fixes #2458 


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
