### PR TITLE
allow custom OpenAI client timeout

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -1,4 +1,6 @@
 import json
+import os 
+
 from typing import Any
 from typing import Optional
 
@@ -56,7 +58,7 @@ def _initialize_client(
     api_key: str, provider: EmbeddingProvider, model: str | None = None
 ) -> Any:
     if provider == EmbeddingProvider.OPENAI:
-        return openai.OpenAI(api_key=api_key)
+        return openai.OpenAI(api_key=api_key, timeout=httpx.Timeout(os.getenv("OPENAI_CLIENT_TIMEOUT", 10)))
     elif provider == EmbeddingProvider.COHERE:
         return CohereClient(api_key=api_key)
     elif provider == EmbeddingProvider.VOYAGE:


### PR DESCRIPTION
## Description
[This allows a custom timeout value to be set for the OpenAI Client]


## How Has This Been Tested?
[Indexing done after change using OpenAI embedding model]


## Accepted Risk
[N/A]


## Related Issue(s)
[Fixes #2456]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
