### PR TITLE
Update default assistants to all visible

### DIFF
--- a/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
+++ b/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
@@ -41,7 +41,6 @@ def upgrade() -> None:
         OR chosen_assistants = 'null'
         OR jsonb_typeof(chosen_assistants) = 'null'
         OR (jsonb_typeof(chosen_assistants) = 'string' AND chosen_assistants = '"null"')
-        OR chosen_assistants = '[-2, -1, 0]'::jsonb
     """
     )
 

--- a/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
+++ b/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
@@ -20,18 +20,28 @@ DEFAULT_ASSISTANTS = [-2, -1, 0]
 
 def upgrade() -> None:
     # Step 1: Update any NULL values to the default value
+    # This upgrades existing users without ordered assistant
+    # to have default assistants set to visible assistants which are
+    # accessible by them.
     op.execute(
         """
-        UPDATE "user"
+        UPDATE "user" u
         SET chosen_assistants = (
-            SELECT jsonb_agg(id)
-            FROM persona
-            WHERE is_visible = true
+            SELECT jsonb_agg(
+                p.id ORDER BY
+                    COALESCE(p.display_priority, 2147483647) ASC,
+                    p.id ASC
+            )
+            FROM persona p
+            LEFT JOIN persona__user pu ON p.id = pu.persona_id AND pu.user_id = u.id
+            WHERE p.is_visible = true
+            AND (p.is_public = true OR pu.user_id IS NOT NULL)
         )
         WHERE chosen_assistants IS NULL
         OR chosen_assistants = 'null'
         OR jsonb_typeof(chosen_assistants) = 'null'
         OR (jsonb_typeof(chosen_assistants) = 'string' AND chosen_assistants = '"null"')
+        OR chosen_assistants = '[-2, -1, 0]'::jsonb
     """
     )
 

--- a/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
+++ b/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
@@ -21,9 +21,13 @@ DEFAULT_ASSISTANTS = [-2, -1, 0]
 def upgrade() -> None:
     # Step 1: Update any NULL values to the default value
     op.execute(
-        f"""
+        """
         UPDATE "user"
-        SET chosen_assistants = '{DEFAULT_ASSISTANTS}'
+        SET chosen_assistants = (
+            SELECT jsonb_agg(id)
+            FROM persona
+            WHERE is_visible = true
+        )
         WHERE chosen_assistants IS NULL
         OR chosen_assistants = 'null'
         OR jsonb_typeof(chosen_assistants) = 'null'

--- a/web/src/app/assistants/mine/AssistantsList.tsx
+++ b/web/src/app/assistants/mine/AssistantsList.tsx
@@ -306,9 +306,11 @@ export function AssistantsList({
       user?.preferences?.chosen_assistants &&
       !user?.preferences?.chosen_assistants?.includes(assistant.id)
   );
+
   const allAssistantIds = assistants.map((assistant) =>
     assistant.id.toString()
   );
+
   const [deletingPersona, setDeletingPersona] = useState<Persona | null>(null);
   const [makePublicPersona, setMakePublicPersona] = useState<Persona | null>(
     null

--- a/web/src/lib/assistants/orderAssistants.ts
+++ b/web/src/lib/assistants/orderAssistants.ts
@@ -14,15 +14,20 @@ export function orderAssistantsForUser(
       ])
     );
 
-    assistants = assistants.filter((assistant) =>
+    let filteredAssistants = assistants.filter((assistant) =>
       chosenAssistantsSet.has(assistant.id)
     );
 
-    assistants.sort((a, b) => {
+    if (filteredAssistants.length == 0) {
+      return assistants;
+    }
+
+    filteredAssistants.sort((a, b) => {
       const orderA = assistantOrderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
       const orderB = assistantOrderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
       return orderA - orderB;
     });
+    return filteredAssistants;
   }
 
   return assistants;


### PR DESCRIPTION
## Description
Updates so default assistants list (from `null`) is all those which are.

It's okay if includes visible assistants which aren't accessible to user, as upon first re-ordering will refresh to be those which user has access to.

Additionally, I think it's still okay to set server default to our assistants - users can add any additional assistants in the assistant gallery on first startup (and if none are available- we'll display all visible as was the previous behavior). Alternative would be to modify how we handle chosen assistants or set the list on user creation.

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
