### PR TITLE
Non-spotfix deletion of users

### DIFF
--- a/backend/alembic/versions/1b8206b29c5d_add_user_delete_cascades.py
+++ b/backend/alembic/versions/1b8206b29c5d_add_user_delete_cascades.py
@@ -1,0 +1,123 @@
+"""add_user_delete_cascades
+
+Revision ID: 1b8206b29c5d
+Revises: 35e6853a51d5
+Create Date: 2024-09-18 11:48:59.418726
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "1b8206b29c5d"
+down_revision = "35e6853a51d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Update foreign key constraints to add ON DELETE CASCADE
+    op.drop_constraint(
+        "oauth_account_user_id_fkey", "oauth_account", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "oauth_account_user_id_fkey",
+        "oauth_account",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("credential_user_id_fkey", "credential", type_="foreignkey")
+    op.create_foreign_key(
+        "credential_user_id_fkey",
+        "credential",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("chat_session_user_id_fkey", "chat_session", type_="foreignkey")
+    op.create_foreign_key(
+        "chat_session_user_id_fkey",
+        "chat_session",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("chat_folder_user_id_fkey", "chat_folder", type_="foreignkey")
+    op.create_foreign_key(
+        "chat_folder_user_id_fkey",
+        "chat_folder",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("prompt_user_id_fkey", "prompt", type_="foreignkey")
+    op.create_foreign_key(
+        "prompt_user_id_fkey", "prompt", "user", ["user_id"], ["id"], ondelete="CASCADE"
+    )
+
+    op.drop_constraint("notification_user_id_fkey", "notification", type_="foreignkey")
+    op.create_foreign_key(
+        "notification_user_id_fkey",
+        "notification",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("inputprompt_user_id_fkey", "inputprompt", type_="foreignkey")
+    op.create_foreign_key(
+        "inputprompt_user_id_fkey",
+        "inputprompt",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    # Revert foreign key constraints to remove ON DELETE CASCADE
+    op.drop_constraint(
+        "oauth_account_user_id_fkey", "oauth_account", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "oauth_account_user_id_fkey", "oauth_account", "user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint("credential_user_id_fkey", "credential", type_="foreignkey")
+    op.create_foreign_key(
+        "credential_user_id_fkey", "credential", "user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint("chat_session_user_id_fkey", "chat_session", type_="foreignkey")
+    op.create_foreign_key(
+        "chat_session_user_id_fkey", "chat_session", "user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint("chat_folder_user_id_fkey", "chat_folder", type_="foreignkey")
+    op.create_foreign_key(
+        "chat_folder_user_id_fkey", "chat_folder", "user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint("prompt_user_id_fkey", "prompt", type_="foreignkey")
+    op.create_foreign_key("prompt_user_id_fkey", "prompt", "user", ["user_id"], ["id"])
+
+    op.drop_constraint("notification_user_id_fkey", "notification", type_="foreignkey")
+    op.create_foreign_key(
+        "notification_user_id_fkey", "notification", "user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint("inputprompt_user_id_fkey", "inputprompt", type_="foreignkey")
+    op.create_foreign_key(
+        "inputprompt_user_id_fkey", "inputprompt", "user", ["user_id"], ["id"]
+    )

--- a/backend/alembic/versions/1b8206b29c5d_add_user_delete_cascades.py
+++ b/backend/alembic/versions/1b8206b29c5d_add_user_delete_cascades.py
@@ -16,19 +16,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Update foreign key constraints to add ON DELETE CASCADE
-    op.drop_constraint(
-        "oauth_account_user_id_fkey", "oauth_account", type_="foreignkey"
-    )
-    op.create_foreign_key(
-        "oauth_account_user_id_fkey",
-        "oauth_account",
-        "user",
-        ["user_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
-
     op.drop_constraint("credential_user_id_fkey", "credential", type_="foreignkey")
     op.create_foreign_key(
         "credential_user_id_fkey",
@@ -86,14 +73,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Revert foreign key constraints to remove ON DELETE CASCADE
-    op.drop_constraint(
-        "oauth_account_user_id_fkey", "oauth_account", type_="foreignkey"
-    )
-    op.create_foreign_key(
-        "oauth_account_user_id_fkey", "oauth_account", "user", ["user_id"], ["id"]
-    )
-
     op.drop_constraint("credential_user_id_fkey", "credential", type_="foreignkey")
     op.create_foreign_key(
         "credential_user_id_fkey", "credential", "user", ["user_id"], ["id"]

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -104,7 +104,6 @@ Auth/Authz (users, permissions, access) Tables
 class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
     # even an almost empty token from keycloak will not fit the default 1024 bytes
     access_token: Mapped[str] = mapped_column(Text, nullable=False)  # type: ignore
-    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"))
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -104,11 +104,12 @@ Auth/Authz (users, permissions, access) Tables
 class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
     # even an almost empty token from keycloak will not fit the default 1024 bytes
     access_token: Mapped[str] = mapped_column(Text, nullable=False)  # type: ignore
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"))
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
     oauth_accounts: Mapped[list[OAuthAccount]] = relationship(
-        "OAuthAccount", lazy="joined"
+        "OAuthAccount", lazy="joined", cascade="all, delete-orphan"
     )
     role: Mapped[UserRole] = mapped_column(
         Enum(UserRole, native_enum=False, default=UserRole.BASIC)
@@ -170,7 +171,9 @@ class InputPrompt(Base):
     active: Mapped[bool] = mapped_column(Boolean)
     user: Mapped[User | None] = relationship("User", back_populates="input_prompts")
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
 
 
 class InputPrompt__User(Base):
@@ -214,7 +217,9 @@ class Notification(Base):
     notif_type: Mapped[NotificationType] = mapped_column(
         Enum(NotificationType, native_enum=False)
     )
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     dismissed: Mapped[bool] = mapped_column(Boolean, default=False)
     last_shown: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True))
     first_shown: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True))
@@ -249,7 +254,7 @@ class Persona__User(Base):
 
     persona_id: Mapped[int] = mapped_column(ForeignKey("persona.id"), primary_key=True)
     user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("user.id"), primary_key=True, nullable=True
+        ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, nullable=True
     )
 
 
@@ -260,7 +265,7 @@ class DocumentSet__User(Base):
         ForeignKey("document_set.id"), primary_key=True
     )
     user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("user.id"), primary_key=True, nullable=True
+        ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, nullable=True
     )
 
 
@@ -541,7 +546,9 @@ class Credential(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     credential_json: Mapped[dict[str, Any]] = mapped_column(EncryptedJson())
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     # if `true`, then all Admins will have access to the credential
     admin_public: Mapped[bool] = mapped_column(Boolean, default=True)
     time_created: Mapped[datetime.datetime] = mapped_column(
@@ -865,7 +872,9 @@ class ChatSession(Base):
     __tablename__ = "chat_session"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     persona_id: Mapped[int | None] = mapped_column(
         ForeignKey("persona.id"), nullable=True
     )
@@ -1002,7 +1011,9 @@ class ChatFolder(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     # Only null if auth is off
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     name: Mapped[str | None] = mapped_column(String, nullable=True)
     display_priority: Mapped[int] = mapped_column(Integer, nullable=True, default=0)
 
@@ -1133,7 +1144,9 @@ class DocumentSet(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True)
     description: Mapped[str] = mapped_column(String)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     # Whether changes to the document set have been propagated
     is_up_to_date: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     # If `False`, then the document set is not visible to users who are not explicitly
@@ -1177,7 +1190,9 @@ class Prompt(Base):
     __tablename__ = "prompt"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     name: Mapped[str] = mapped_column(String)
     description: Mapped[str] = mapped_column(String)
     system_prompt: Mapped[str] = mapped_column(Text)
@@ -1214,7 +1229,9 @@ class Tool(Base):
     )
 
     # user who created / owns the tool. Will be None for built-in tools.
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
 
     user: Mapped[User | None] = relationship("User", back_populates="custom_tools")
     # Relationship to Persona through the association table
@@ -1238,7 +1255,9 @@ class Persona(Base):
     __tablename__ = "persona"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     name: Mapped[str] = mapped_column(String)
     description: Mapped[str] = mapped_column(String)
     # Number of chunks to pass to the LLM for generation.
@@ -1434,7 +1453,9 @@ class SamlAccount(Base):
     __tablename__ = "saml"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), unique=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), unique=True
+    )
     encrypted_cookie: Mapped[str] = mapped_column(Text, unique=True)
     expires_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime.datetime] = mapped_column(
@@ -1453,7 +1474,7 @@ class User__UserGroup(Base):
         ForeignKey("user_group.id"), primary_key=True
     )
     user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("user.id"), primary_key=True, nullable=True
+        ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, nullable=True
     )
 
 
@@ -1701,7 +1722,9 @@ class ExternalPermission(Base):
     __tablename__ = "external_permission"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     # Email is needed because we want to keep track of users not in Danswer to simplify process
     # when the user joins
     user_email: Mapped[str] = mapped_column(String)
@@ -1730,7 +1753,9 @@ class EmailToExternalUserCache(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     external_user_id: Mapped[str] = mapped_column(String)
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
     # Email is needed because we want to keep track of users not in Danswer to simplify process
     # when the user joins
     user_email: Mapped[str] = mapped_column(String)
@@ -1754,7 +1779,7 @@ class UsageReport(Base):
 
     # if None, report was auto-generated
     requestor_user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("user.id"), nullable=True
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
     )
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -240,6 +240,9 @@ async def delete_user(
     db_session.expunge(user_to_delete)
 
     try:
+        for oauth_account in user_to_delete.oauth_accounts:
+            db_session.delete(oauth_account)
+
         db_session.query(DocumentSet__User).filter(
             DocumentSet__User.user_id == user_to_delete.id
         ).delete()

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -31,7 +31,21 @@ from danswer.configs.app_configs import VALID_EMAIL_DOMAINS
 from danswer.configs.constants import AuthType
 from danswer.db.engine import get_session
 from danswer.db.models import AccessToken
+from danswer.db.models import ChatFolder
+from danswer.db.models import ChatSession
+from danswer.db.models import Credential
+from danswer.db.models import DocumentSet
+from danswer.db.models import DocumentSet__User
+from danswer.db.models import EmailToExternalUserCache
+from danswer.db.models import ExternalPermission
+from danswer.db.models import InputPrompt
+from danswer.db.models import Notification
+from danswer.db.models import Persona
+from danswer.db.models import Persona__User
+from danswer.db.models import Prompt
+from danswer.db.models import Tool
 from danswer.db.models import User
+from danswer.db.models import User__UserGroup
 from danswer.db.users import get_user_by_email
 from danswer.db.users import list_users
 from danswer.dynamic_configs.factory import get_dynamic_config_store
@@ -237,9 +251,42 @@ async def delete_user(
     db_session.expunge(user_to_delete)
 
     try:
-        # Delete related OAuthAccounts first
-        for oauth_account in user_to_delete.oauth_accounts:
-            db_session.delete(oauth_account)
+        db_session.query(ChatFolder).filter(
+            ChatFolder.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(ChatSession).filter(
+            ChatSession.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(Credential).filter(
+            Credential.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(DocumentSet__User).filter(
+            DocumentSet__User.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(DocumentSet).filter(
+            DocumentSet.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(EmailToExternalUserCache).filter(
+            EmailToExternalUserCache.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(ExternalPermission).filter(
+            ExternalPermission.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(InputPrompt).filter(
+            InputPrompt.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(Notification).filter(
+            Notification.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).delete()
+        db_session.query(Persona__User).filter(
+            Persona__User.user_id == user_to_delete.id
+        ).delete()
+        db_session.query(Prompt).filter(Prompt.user_id == user_to_delete.id).delete()
+        db_session.query(Tool).filter(Tool.user_id == user_to_delete.id).delete()
+        db_session.query(User__UserGroup).filter(
+            User__UserGroup.user_id == user_to_delete.id
+        ).delete()
 
         db_session.delete(user_to_delete)
         db_session.commit()

--- a/web/src/components/admin/users/SignedUpUserTable.tsx
+++ b/web/src/components/admin/users/SignedUpUserTable.tsx
@@ -195,6 +195,7 @@ const DeleteUserButton = ({
           entityName={user.email}
           onClose={() => setShowDeleteModal(false)}
           onSubmit={() => trigger({ user_email: user.email, method: "DELETE" })}
+          additionalDetails="All data associated with this user will be deleted (including personas, tools and chat sessions)."
         />
       )}
 

--- a/web/src/components/modals/DeleteEntityModal.tsx
+++ b/web/src/components/modals/DeleteEntityModal.tsx
@@ -7,11 +7,13 @@ export const DeleteEntityModal = ({
   onSubmit,
   entityType,
   entityName,
+  additionalDetails,
 }: {
   entityType: string;
   entityName: string;
   onClose: () => void;
   onSubmit: () => void;
+  additionalDetails?: string;
 }) => {
   return (
     <ModalWrapper onClose={onClose}>
@@ -23,6 +25,7 @@ export const DeleteEntityModal = ({
           Click below to confirm that you want to delete{" "}
           <b>&quot;{entityName}&quot;</b>
         </p>
+        {additionalDetails && <p className="mb-4">{additionalDetails}</p>}
         <div className="flex">
           <div className="mx-auto">
             <BasicClickable onClick={onSubmit}>


### PR DESCRIPTION
## Description
This one has been sitting in the task queue for a while - existing implementation doesn't handle foreign keys for more than a spot fix (meant for users that were created / never used, but should be functional for deleting users in general now)


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
