### PR TITLE
Move code block default language creation to citation processing

### DIFF
--- a/backend/danswer/chat/process_message.py
+++ b/backend/danswer/chat/process_message.py
@@ -709,6 +709,7 @@ def stream_chat_message_objects(
                     yield FinalUsedContextDocsResponse(
                         final_context_docs=packet.response
                     )
+
                 elif packet.id == IMAGE_GENERATION_RESPONSE_ID:
                     img_generation_response = cast(
                         list[ImageGenerationResponse], packet.response

--- a/backend/danswer/llm/answering/stream_processing/citation_processing.py
+++ b/backend/danswer/llm/answering/stream_processing/citation_processing.py
@@ -85,6 +85,15 @@ def extract_citations_from_stream(
         curr_segment += token
         llm_out += token
 
+        # Handle code blocks without language tags
+        if "`" in curr_segment:
+            if curr_segment.endswith("`"):
+                continue
+            elif "```" in curr_segment:
+                piece_that_comes_after = curr_segment.split("```")[1][0]
+                if piece_that_comes_after == "\n" and in_code_block(llm_out):
+                    curr_segment = curr_segment.replace("```", "```plaintext")
+
         citation_pattern = r"\[(\d+)\]"
 
         citations_found = list(re.finditer(citation_pattern, curr_segment))

--- a/backend/tests/unit/danswer/llm/answering/stream_processing/test_citation_processing.py
+++ b/backend/tests/unit/danswer/llm/answering/stream_processing/test_citation_processing.py
@@ -351,9 +351,9 @@ def process_text(
             [],
         ),
         (
-            "Code block with citation inside",
+            "Code block with text block",
             [
-                "Here's a code block with a citation:\n",
+                "Here's a code block with a text block:\n",
                 "```\n",
                 "# This is a comment",
                 "\n",
@@ -363,7 +363,7 @@ def process_text(
                 "\n```\n",
                 "The code demonstrates variable assignment.",
             ],
-            "Here's a code block with a citation:\n"
+            "Here's a code block with a text block:\n"
             "```plaintext\n"
             "# This is a comment\n"
             "x = 10  # This assigns 10 to x\n"

--- a/backend/tests/unit/danswer/llm/answering/stream_processing/test_citation_processing.py
+++ b/backend/tests/unit/danswer/llm/answering/stream_processing/test_citation_processing.py
@@ -286,6 +286,92 @@ def process_text(
             "[[1]](https://0.com) Citation at the beginning. ",
             ["doc_0"],
         ),
+        (
+            "Code block without language specification",
+            [
+                "Here's",
+                " a code block",
+                ":\n```\nd",
+                "ef example():\n    pass\n",
+                "```\n",
+                "End of code.",
+            ],
+            "Here's a code block:\n```plaintext\ndef example():\n    pass\n```\nEnd of code.",
+            [],
+        ),
+        (
+            "Code block with language specification",
+            [
+                "Here's a Python code block:\n",
+                "```",
+                "python",
+                "\n",
+                "def greet",
+                "(name):",
+                "\n    ",
+                "print",
+                "(f'Hello, ",
+                "{name}!')",
+                "\n",
+                "greet('World')",
+                "\n```\n",
+                "This function ",
+                "greets the user.",
+            ],
+            "Here's a Python code block:\n```python\ndef greet(name):\n    "
+            "print(f'Hello, {name}!')\ngreet('World')\n```\nThis function greets the user.",
+            [],
+        ),
+        (
+            "Multiple code blocks with different languages",
+            [
+                "JavaScript example:\n",
+                "```",
+                "javascript",
+                "\n",
+                "console",
+                ".",
+                "log",
+                "('Hello, World!');",
+                "\n```\n",
+                "Python example",
+                ":\n",
+                "```",
+                "python",
+                "\n",
+                "print",
+                "('Hello, World!')",
+                "\n```\n",
+                "Both print greetings",
+                ".",
+            ],
+            "JavaScript example:\n```javascript\nconsole.log('Hello, World!');\n"
+            "```\nPython example:\n```python\nprint('Hello, World!')\n"
+            "```\nBoth print greetings.",
+            [],
+        ),
+        (
+            "Code block with citation inside",
+            [
+                "Here's a code block with a citation:\n",
+                "```\n",
+                "# This is a comment",
+                "\n",
+                "x = 10  # This assigns 10 to x\n",
+                "print",
+                "(x)  # This prints x",
+                "\n```\n",
+                "The code demonstrates variable assignment.",
+            ],
+            "Here's a code block with a citation:\n"
+            "```plaintext\n"
+            "# This is a comment\n"
+            "x = 10  # This assigns 10 to x\n"
+            "print(x)  # This prints x\n"
+            "```\n"
+            "The code demonstrates variable assignment.",
+            [],
+        ),
     ],
 )
 def test_citation_extraction(


### PR DESCRIPTION
## Description
Our existing implementation to handle code blocks without any languages is to dynamically insert a `plaintext` tag as we process the content.

This causes issues with the way React Markdown processes content, yet we still need some way of inserting a language for code blocks that were created (by the LLM) without any (so that React Markdown can process the code block accordingly. )

This adds processing at the citation processing layer to insert the plaintext marker at the lowest level possible, so React markdown is **always** fed the correct version of the data.

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
