### PR TITLE
Fix basic auth

### DIFF
--- a/web/src/lib/user.ts
+++ b/web/src/lib/user.ts
@@ -31,6 +31,7 @@ export const basicLogin = async (
     ["username", email],
     ["password", password],
   ]);
+
   const response = await fetch("/api/auth/login", {
     method: "POST",
     credentials: "include",


### PR DESCRIPTION
## Description
Basic auth was broken by recent update to class - anybody could log in with a verified email with any password.

Relevant code: https://github.com/fastapi-users/fastapi-users/blob/42ddc241b965475390e2bce887b084152ae1a2cd/fastapi_users/manager.py#L636

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
