### PR TITLE
Fix duplicate users from slack / web

### DIFF
--- a/backend/danswer/db/users.py
+++ b/backend/danswer/db/users.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from fastapi_users.password import PasswordHelper
+from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -34,7 +35,11 @@ def get_users_by_emails(
 
 
 def get_user_by_email(email: str, db_session: Session) -> User | None:
-    user = db_session.query(User).filter(User.email == email).first()  # type: ignore
+    user = (
+        db_session.query(User)
+        .filter(func.lower(User.email) == func.lower(email))
+        .first()
+    )
 
     return user
 


### PR DESCRIPTION
If a user first logs in via web, then sends a message on Slack (and their slack email is capitalized differently), then they will have two user rows associated with them.

This fixes that.