### PR TITLE
Fix: Update EmailStr instantiation for Pydantic v2 compatibility (SAML login issue #2549)

### DIFF
--- a/backend/ee/danswer/server/saml.py
+++ b/backend/ee/danswer/server/saml.py
@@ -12,7 +12,6 @@ from fastapi_users import exceptions
 from fastapi_users.password import PasswordHelper
 from onelogin.saml2.auth import OneLogin_Saml2_Auth  # type: ignore
 from pydantic import BaseModel
-from pydantic import EmailStr
 from sqlalchemy.orm import Session
 
 from danswer.auth.schemas import UserCreate
@@ -61,7 +60,7 @@ async def upsert_saml_user(email: str) -> User:
 
                 user: User = await user_manager.create(
                     UserCreate(
-                        email=EmailStr(email),
+                        email=email,
                         password=hashed_pass,
                         is_verified=True,
                         role=role,


### PR DESCRIPTION
### Summary
This PR fixes the issue related to the upgrade of Pydantic from v1 to v2, which caused a `TypeError: EmailStr() takes no arguments` when using the SAML login flow in `saml.py` for new users.

### Changes
- Updated `EmailStr(email)` to just `email` to conform to Pydantic v2's new validation mechanism.

### Issue Reference
- Closes #2549
