### PR TITLE
delete directly via selection instead of making multiple calls to get…

### DIFF
--- a/backend/danswer/background/connector_deletion.py
+++ b/backend/danswer/background/connector_deletion.py
@@ -148,7 +148,7 @@ def document_by_cc_pair_cleanup_task(
             if count == 1:
                 # count == 1 means this is the only remaining cc_pair reference to the doc
                 # delete it from vespa and the db
-                document_index.delete(doc_ids=[document_id])
+                document_index.delete_single(doc_id=document_id)
                 delete_documents_complete__no_commit(
                     db_session=db_session,
                     document_ids=[document_id],

--- a/backend/danswer/document_index/interfaces.py
+++ b/backend/danswer/document_index/interfaces.py
@@ -157,6 +157,16 @@ class Deletable(abc.ABC):
     """
 
     @abc.abstractmethod
+    def delete_single(self, doc_id: str) -> None:
+        """
+        Given a single document id, hard delete it from the document index
+
+        Parameters:
+        - doc_id: document id as specified by the connector
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def delete(self, doc_ids: list[str]) -> None:
         """
         Given a list of document ids, hard delete them from the document index


### PR DESCRIPTION
… chunk ids and delete each one

## Description
Fixes DAN-754.

## How Has This Been Tested?
Observed 2500 chunk document deletion go from 66 seconds to 3 seconds.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
