### PR TITLE
disabled llm when skip_gen_ai_answer_question set

### DIFF
--- a/backend/tests/regression/answer_quality/run_qa.py
+++ b/backend/tests/regression/answer_quality/run_qa.py
@@ -77,14 +77,15 @@ def _initialize_files(config: dict) -> tuple[str, list[dict]]:
         "number_of_questions_in_dataset": len(questions),
     }
 
-    env_vars = get_docker_container_env_vars(config["env_name"])
-    if env_vars["ENV_SEED_CONFIGURATION"]:
-        del env_vars["ENV_SEED_CONFIGURATION"]
-    if env_vars["GPG_KEY"]:
-        del env_vars["GPG_KEY"]
-    if metadata["test_config"]["llm"]["api_key"]:
-        del metadata["test_config"]["llm"]["api_key"]
-    metadata.update(env_vars)
+    if config["env_name"]:
+        env_vars = get_docker_container_env_vars(config["env_name"])
+        if env_vars["ENV_SEED_CONFIGURATION"]:
+            del env_vars["ENV_SEED_CONFIGURATION"]
+        if env_vars["GPG_KEY"]:
+            del env_vars["GPG_KEY"]
+        if metadata["test_config"]["llm"]["api_key"]:
+            del metadata["test_config"]["llm"]["api_key"]
+        metadata.update(env_vars)
     metadata_path = os.path.join(test_output_folder, METADATA_FILENAME)
     print("saving metadata to:", metadata_path)
     with open(metadata_path, "w", encoding="utf-8") as yaml_file:
@@ -95,17 +96,18 @@ def _initialize_files(config: dict) -> tuple[str, list[dict]]:
     )
     shutil.copy2(questions_file_path, copied_questions_file_path)
 
-    zipped_files_path = config["zipped_documents_file"]
-    copied_zipped_documents_path = os.path.join(
-        test_output_folder, os.path.basename(zipped_files_path)
-    )
-    shutil.copy2(zipped_files_path, copied_zipped_documents_path)
+    if config["zipped_documents_file"]:
+        zipped_files_path = config["zipped_documents_file"]
+        copied_zipped_documents_path = os.path.join(
+            test_output_folder, os.path.basename(zipped_files_path)
+        )
+        shutil.copy2(zipped_files_path, copied_zipped_documents_path)
 
-    zipped_files_folder = os.path.dirname(zipped_files_path)
-    jsonl_file_path = os.path.join(zipped_files_folder, "target_docs.jsonl")
-    if os.path.exists(jsonl_file_path):
-        copied_jsonl_path = os.path.join(test_output_folder, "target_docs.jsonl")
-        shutil.copy2(jsonl_file_path, copied_jsonl_path)
+        zipped_files_folder = os.path.dirname(zipped_files_path)
+        jsonl_file_path = os.path.join(zipped_files_folder, "target_docs.jsonl")
+        if os.path.exists(jsonl_file_path):
+            copied_jsonl_path = os.path.join(test_output_folder, "target_docs.jsonl")
+            shutil.copy2(jsonl_file_path, copied_jsonl_path)
 
     return test_output_folder, questions
 

--- a/backend/tests/unit/danswer/llm/answering/test_skip_gen_ai.py
+++ b/backend/tests/unit/danswer/llm/answering/test_skip_gen_ai.py
@@ -1,0 +1,131 @@
+from typing import Any
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from danswer.llm.answering.answer import Answer
+from danswer.one_shot_answer.answer_question import AnswerObjectIterator
+from danswer.tools.force import ForceUseTool
+from tests.regression.answer_quality.run_qa import _process_and_write_query_results
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "skip_gen_ai_answer_generation": True,
+            "question": "What is the capital of the moon?",
+        },
+        {
+            "skip_gen_ai_answer_generation": False,
+            "question": "What is the capital of the moon but twice?",
+        },
+    ],
+)
+def test_skip_gen_ai_answer_generation_flag(config: dict[str, Any]) -> None:
+    search_tool = Mock()
+    search_tool.name = "search"
+    search_tool.run = Mock()
+    search_tool.run.return_value = [Mock()]
+    mock_llm = Mock()
+    mock_llm.config = Mock()
+    mock_llm.config.model_name = "gpt-4o-mini"
+    mock_llm.stream = Mock()
+    mock_llm.stream.return_value = [Mock()]
+    answer = Answer(
+        question=config["question"],
+        answer_style_config=Mock(),
+        prompt_config=Mock(),
+        llm=mock_llm,
+        single_message_history="history",
+        tools=[search_tool],
+        force_use_tool=(
+            ForceUseTool(
+                tool_name=search_tool.name,
+                args={"query": config["question"]},
+                force_use=True,
+            )
+        ),
+        skip_explicit_tool_calling=True,
+        return_contexts=True,
+        skip_gen_ai_answer_generation=config["skip_gen_ai_answer_generation"],
+    )
+    count = 0
+    for _ in cast(AnswerObjectIterator, answer.processed_streamed_output):
+        count += 1
+    assert count == 2
+    if not config["skip_gen_ai_answer_generation"]:
+        mock_llm.stream.assert_called_once()
+    else:
+        mock_llm.stream.assert_not_called()
+
+
+##### From here down is the client side test that was not working #####
+
+
+class FinishedTestException(Exception):
+    pass
+
+
+# could not get this to work, it seems like the mock is not being used
+# tests that the main run_qa function passes the skip_gen_ai_answer_generation flag to the Answer object
+@pytest.mark.parametrize(
+    "config, questions",
+    [
+        (
+            {
+                "skip_gen_ai_answer_generation": True,
+                "output_folder": "./test_output_folder",
+                "zipped_documents_file": "./test_docs.jsonl",
+                "questions_file": "./test_questions.jsonl",
+                "commit_sha": None,
+                "launch_web_ui": False,
+                "only_retrieve_docs": True,
+                "use_cloud_gpu": False,
+                "model_server_ip": "PUT_PUBLIC_CLOUD_IP_HERE",
+                "model_server_port": "PUT_PUBLIC_CLOUD_PORT_HERE",
+                "environment_name": "",
+                "env_name": "",
+                "limit": None,
+            },
+            [{"uid": "1", "question": "What is the capital of the moon?"}],
+        ),
+        (
+            {
+                "skip_gen_ai_answer_generation": False,
+                "output_folder": "./test_output_folder",
+                "zipped_documents_file": "./test_docs.jsonl",
+                "questions_file": "./test_questions.jsonl",
+                "commit_sha": None,
+                "launch_web_ui": False,
+                "only_retrieve_docs": True,
+                "use_cloud_gpu": False,
+                "model_server_ip": "PUT_PUBLIC_CLOUD_IP_HERE",
+                "model_server_port": "PUT_PUBLIC_CLOUD_PORT_HERE",
+                "environment_name": "",
+                "env_name": "",
+                "limit": None,
+            },
+            [{"uid": "1", "question": "What is the capital of the moon but twice?"}],
+        ),
+    ],
+)
+@pytest.mark.skip(reason="not working")
+def test_run_qa_skip_gen_ai(
+    config: dict[str, Any], questions: list[dict[str, Any]], mocker
+) -> None:
+    mocker.patch(
+        "tests.regression.answer_quality.run_qa._initialize_files",
+        return_value=("test", questions),
+    )
+
+    def arg_checker(question_data: dict, config: dict, question_number: int):
+        assert question_data == questions[0]
+        raise FinishedTestException()
+
+    mocker.patch(
+        "tests.regression.answer_quality.run_qa._process_question", arg_checker
+    )
+    with pytest.raises(FinishedTestException):
+        _process_and_write_query_results(config)

--- a/backend/tests/unit/danswer/llm/answering/test_skip_gen_ai.py
+++ b/backend/tests/unit/danswer/llm/answering/test_skip_gen_ai.py
@@ -3,6 +3,7 @@ from typing import cast
 from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from danswer.llm.answering.answer import Answer
 from danswer.one_shot_answer.answer_question import AnswerObjectIterator
@@ -113,14 +114,14 @@ class FinishedTestException(Exception):
 )
 @pytest.mark.skip(reason="not working")
 def test_run_qa_skip_gen_ai(
-    config: dict[str, Any], questions: list[dict[str, Any]], mocker
+    config: dict[str, Any], questions: list[dict[str, Any]], mocker: MockerFixture
 ) -> None:
     mocker.patch(
         "tests.regression.answer_quality.run_qa._initialize_files",
         return_value=("test", questions),
     )
 
-    def arg_checker(question_data: dict, config: dict, question_number: int):
+    def arg_checker(question_data: dict, config: dict, question_number: int) -> None:
         assert question_data == questions[0]
         raise FinishedTestException()
 


### PR DESCRIPTION
## Description
the /search/answer-with-quote endpoint has long had a skip_gen_ai_answer_question flag that did not do anything; now it correctly skips only the code portions that query an LLM.


## How Has This Been Tested?
I ran my local version of the backend with `assert False` in the functions in interfaces.py that wrap all LLM invocations. Confirmed that the assertions are hit without my changes and that they are not hit with my changes. The run_qa scripts in backend/tests/regression/answer_quality completes much faster too: 65 seconds to retrieve docs for 664 questions.

Wrote a unit test for the backend's use of the `skip_gen_ai_answer_question` flag; confirmed that LLM `stream()` is called when it is off and not called when it is on.


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
