### PR TITLE
Fix file too large error

### DIFF
--- a/backend/danswer/connectors/google_drive/connector.py
+++ b/backend/danswer/connectors/google_drive/connector.py
@@ -475,7 +475,14 @@ class GoogleDriveConnector(LoadConnector, PollConnector):
                             if e.error_details
                             else e.reason
                         )
-                        if e.status_code == 403 and reason == "cannotExportFile":
+
+                        # these errors don't represent a failure in the connector, but simply files
+                        # that can't / shouldn't be indexed
+                        ERRORS_TO_CONTINUE_ON = [
+                            "cannotExportFile",
+                            "exportSizeLimitExceeded",
+                        ]
+                        if e.status_code == 403 and reason in ERRORS_TO_CONTINUE_ON:
                             logger.warning(
                                 f"Could not export file '{file['name']}' due to '{message}', skipping..."
                             )

--- a/backend/danswer/connectors/google_drive/connector.py
+++ b/backend/danswer/connectors/google_drive/connector.py
@@ -481,6 +481,7 @@ class GoogleDriveConnector(LoadConnector, PollConnector):
                         ERRORS_TO_CONTINUE_ON = [
                             "cannotExportFile",
                             "exportSizeLimitExceeded",
+                            "cannotDownloadFile",
                         ]
                         if e.status_code == 403 and reason in ERRORS_TO_CONTINUE_ON:
                             logger.warning(


### PR DESCRIPTION
Previously would fail for .doc, .ppt, or spreadsheets that are over 5MB due to an API limitation.

https://danswer.slack.com/archives/C056265VB1N/p1728895185750569