### PR TITLE
lock to avoid rare serializable errors

### DIFF
--- a/backend/danswer/db/index_attempt.py
+++ b/backend/danswer/db/index_attempt.py
@@ -105,27 +105,55 @@ def mark_attempt_in_progress(
     index_attempt: IndexAttempt,
     db_session: Session,
 ) -> None:
-    index_attempt.status = IndexingStatus.IN_PROGRESS
-    index_attempt.time_started = index_attempt.time_started or func.now()  # type: ignore
-    db_session.commit()
+    with db_session.begin_nested():
+        try:
+            attempt = db_session.execute(
+                select(IndexAttempt)
+                .where(IndexAttempt.id == index_attempt.id)
+                .with_for_update()
+            ).scalar_one()
+
+            attempt.status = IndexingStatus.IN_PROGRESS
+            attempt.time_started = index_attempt.time_started or func.now()  # type: ignore
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
 
 def mark_attempt_succeeded(
     index_attempt: IndexAttempt,
     db_session: Session,
 ) -> None:
-    index_attempt.status = IndexingStatus.SUCCESS
-    db_session.add(index_attempt)
-    db_session.commit()
+    with db_session.begin_nested():
+        try:
+            attempt = db_session.execute(
+                select(IndexAttempt)
+                .where(IndexAttempt.id == index_attempt.id)
+                .with_for_update()
+            ).scalar_one()
+
+            attempt.status = IndexingStatus.SUCCESS
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
 
 def mark_attempt_partially_succeeded(
     index_attempt: IndexAttempt,
     db_session: Session,
 ) -> None:
-    index_attempt.status = IndexingStatus.COMPLETED_WITH_ERRORS
-    db_session.add(index_attempt)
-    db_session.commit()
+    with db_session.begin_nested():
+        try:
+            attempt = db_session.execute(
+                select(IndexAttempt)
+                .where(IndexAttempt.id == index_attempt.id)
+                .with_for_update()
+            ).scalar_one()
+
+            attempt.status = IndexingStatus.COMPLETED_WITH_ERRORS
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
 
 def mark_attempt_failed(
@@ -134,11 +162,20 @@ def mark_attempt_failed(
     failure_reason: str = "Unknown",
     full_exception_trace: str | None = None,
 ) -> None:
-    index_attempt.status = IndexingStatus.FAILED
-    index_attempt.error_msg = failure_reason
-    index_attempt.full_exception_trace = full_exception_trace
-    db_session.add(index_attempt)
-    db_session.commit()
+    with db_session.begin_nested():
+        try:
+            attempt = db_session.execute(
+                select(IndexAttempt)
+                .where(IndexAttempt.id == index_attempt.id)
+                .with_for_update()
+            ).scalar_one()
+
+            attempt.status = IndexingStatus.FAILED
+            attempt.error_msg = failure_reason
+            attempt.full_exception_trace = full_exception_trace
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
 
     source = index_attempt.connector_credential_pair.connector.source
     optional_telemetry(record_type=RecordType.FAILURE, data={"connector": source})


### PR DESCRIPTION
## Description
Fixes DAN-826. Or tries to.

This error may be just the tip of the iceberg in terms of transaction failures and we will need to review the code thoroughly.

sqlalchemy.exc.OperationalError: (psycopg2.errors.SerializationFailure) could not serialize access due to read/write dependencies among transactions
DETAIL:  Reason code: Canceled on identification as a pivot, during write.
HINT:  The transaction might succeed if retried.

[SQL: UPDATE index_attempt SET status=%(status)s, error_msg=%(error_msg)s, full_exception_trace=%(full_exception_trace)s, time_updated=now() WHERE index_attempt.id = %(index_attempt_id)s]
[parameters: {'status': 'FAILED', 'error_msg': 'Rate limit exceeded.', 'full_exception_trace': 'Traceback (most recent call last):\n  File "/app/danswer/background/indexing/run_indexing.py", line 199, in _run_indexing\n    for doc_batch in conne ... (1360 characters truncated) ... fluence.py", line 3091, in raise_for_status\n    raise HTTPError(error_msg, response=response)\nrequests.exceptions.HTTPError: Rate limit exceeded.\n', 'index_attempt_id': 56885}]
(Background on this error at: https://sqlalche.me/e/20/e3q8)

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
