### PR TITLE
add slack markdown formatting

### DIFF
--- a/backend/danswer/danswerbot/slack/formatting.py
+++ b/backend/danswer/danswerbot/slack/formatting.py
@@ -1,0 +1,66 @@
+from mistune import Markdown
+from mistune import Renderer
+
+
+def format_slack_message(message: str) -> str:
+    renderer = Markdown(renderer=SlackRenderer())
+    return renderer.render(message)
+
+
+class SlackRenderer(Renderer):
+    SPECIALS = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
+
+    def escape_special(self, text):
+        for special, replacement in self.SPECIALS.items():
+            text = text.replace(special, replacement)
+        return text
+
+    def header(self, text, level, raw=None):
+        return f"*{text}*\n"
+
+    def emphasis(self, text):
+        return f"_{text}_"
+
+    def double_emphasis(self, text):
+        return f"*{text}*"
+
+    def strikethrough(self, text):
+        return f"~{text}~"
+
+    def list(self, body, ordered=True):
+        lines = body.split("\n")
+        count = 0
+        for i, line in enumerate(lines):
+            if line.startswith("li: "):
+                count += 1
+                prefix = f"{count}. " if ordered else "• "
+                lines[i] = f"{prefix}{line[4:]}"
+        return "\n".join(lines)
+
+    def list_item(self, text):
+        return f"li: {text}\n"
+
+    def link(self, link, title, content):
+        escaped_link = self.escape_special(link)
+        if content:
+            return f"<{escaped_link}|{content}>"
+        if title:
+            return f"<{escaped_link}|{title}>"
+        return f"<{escaped_link}>"
+
+    def image(self, src, title, text):
+        escaped_src = self.escape_special(src)
+        display_text = title or text
+        return f"<{escaped_src}|{display_text}>" if display_text else f"<{escaped_src}>"
+
+    def codespan(self, text):
+        return f"`{text}`"
+
+    def block_code(self, text, lang):
+        return f"```\n{text}\n```\n"
+
+    def paragraph(self, text):
+        return f"{text}\n"
+
+    def autolink(self, link, is_email):
+        return link if is_email else self.link(link, None, None)

--- a/backend/danswer/danswerbot/slack/formatting.py
+++ b/backend/danswer/danswerbot/slack/formatting.py
@@ -8,26 +8,26 @@ def format_slack_message(message: str) -> str:
 
 
 class SlackRenderer(Renderer):
-    SPECIALS = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
+    SPECIALS: dict[str, str] = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
 
-    def escape_special(self, text):
+    def escape_special(self, text: str) -> str:
         for special, replacement in self.SPECIALS.items():
             text = text.replace(special, replacement)
         return text
 
-    def header(self, text, level, raw=None):
+    def header(self, text: str, level: int, raw: str | None = None) -> str:
         return f"*{text}*\n"
 
-    def emphasis(self, text):
+    def emphasis(self, text: str) -> str:
         return f"_{text}_"
 
-    def double_emphasis(self, text):
+    def double_emphasis(self, text: str) -> str:
         return f"*{text}*"
 
-    def strikethrough(self, text):
+    def strikethrough(self, text: str) -> str:
         return f"~{text}~"
 
-    def list(self, body, ordered=True):
+    def list(self, body: str, ordered: bool = True) -> str:
         lines = body.split("\n")
         count = 0
         for i, line in enumerate(lines):
@@ -37,10 +37,10 @@ class SlackRenderer(Renderer):
                 lines[i] = f"{prefix}{line[4:]}"
         return "\n".join(lines)
 
-    def list_item(self, text):
+    def list_item(self, text: str) -> str:
         return f"li: {text}\n"
 
-    def link(self, link, title, content):
+    def link(self, link: str, title: str | None, content: str | None) -> str:
         escaped_link = self.escape_special(link)
         if content:
             return f"<{escaped_link}|{content}>"
@@ -48,19 +48,19 @@ class SlackRenderer(Renderer):
             return f"<{escaped_link}|{title}>"
         return f"<{escaped_link}>"
 
-    def image(self, src, title, text):
+    def image(self, src: str, title: str | None, text: str | None) -> str:
         escaped_src = self.escape_special(src)
         display_text = title or text
         return f"<{escaped_src}|{display_text}>" if display_text else f"<{escaped_src}>"
 
-    def codespan(self, text):
+    def codespan(self, text: str) -> str:
         return f"`{text}`"
 
-    def block_code(self, text, lang):
+    def block_code(self, text: str, lang: str | None) -> str:
         return f"```\n{text}\n```\n"
 
-    def paragraph(self, text):
+    def paragraph(self, text: str) -> str:
         return f"{text}\n"
 
-    def autolink(self, link, is_email):
+    def autolink(self, link: str, is_email: bool) -> str:
         return link if is_email else self.link(link, None, None)

--- a/backend/danswer/danswerbot/slack/formatting.py
+++ b/backend/danswer/danswerbot/slack/formatting.py
@@ -1,8 +1,8 @@
-from mistune import Markdown
-from mistune import Renderer
+from mistune import Markdown  # type: ignore
+from mistune import Renderer  # type: ignore
 
 
-def format_slack_message(message: str) -> str:
+def format_slack_message(message: str | None) -> str:
     renderer = Markdown(renderer=SlackRenderer())
     return renderer.render(message)
 

--- a/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
@@ -27,6 +27,7 @@ from danswer.danswerbot.slack.blocks import build_follow_up_block
 from danswer.danswerbot.slack.blocks import build_qa_response_blocks
 from danswer.danswerbot.slack.blocks import build_sources_blocks
 from danswer.danswerbot.slack.blocks import get_restate_blocks
+from danswer.danswerbot.slack.formatting import format_slack_message
 from danswer.danswerbot.slack.handlers.utils import send_team_member_message
 from danswer.danswerbot.slack.models import SlackMessageInfo
 from danswer.danswerbot.slack.utils import respond_in_thread
@@ -412,10 +413,11 @@ def handle_regular_answer(
 
     # If called with the DanswerBot slash command, the question is lost so we have to reshow it
     restate_question_block = get_restate_blocks(messages[-1].message, is_bot_msg)
+    formatted_answer = format_slack_message(answer.answer)
 
     answer_blocks = build_qa_response_blocks(
         message_id=answer.chat_message_id,
-        answer=answer.answer,
+        answer=formatted_answer,
         quotes=answer.quotes.quotes if answer.quotes else None,
         source_filters=retrieval_info.applied_source_filters,
         time_cutoff=retrieval_info.applied_time_cutoff,

--- a/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
@@ -413,7 +413,7 @@ def handle_regular_answer(
 
     # If called with the DanswerBot slash command, the question is lost so we have to reshow it
     restate_question_block = get_restate_blocks(messages[-1].message, is_bot_msg)
-    formatted_answer = format_slack_message(answer.answer)
+    formatted_answer = format_slack_message(answer.answer) if answer.answer else None
 
     answer_blocks = build_qa_response_blocks(
         message_id=answer.chat_message_id,

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -30,7 +30,6 @@ from danswer.configs.danswerbot_configs import (
 from danswer.connectors.slack.utils import make_slack_api_rate_limited
 from danswer.connectors.slack.utils import SlackTextCleaner
 from danswer.danswerbot.slack.constants import FeedbackVisibility
-from danswer.danswerbot.slack.formatting import format_slack_message
 from danswer.danswerbot.slack.tokens import fetch_tokens
 from danswer.db.engine import get_sqlalchemy_engine
 from danswer.db.users import get_user_by_email
@@ -166,7 +165,6 @@ def respond_in_thread(
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")
 
-    text = format_slack_message(text)
     message_ids: list[str] = []
     if not receiver_ids:
         slack_call = make_slack_api_rate_limited(client.chat_postMessage)

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -30,6 +30,7 @@ from danswer.configs.danswerbot_configs import (
 from danswer.connectors.slack.utils import make_slack_api_rate_limited
 from danswer.connectors.slack.utils import SlackTextCleaner
 from danswer.danswerbot.slack.constants import FeedbackVisibility
+from danswer.danswerbot.slack.formatting import format_slack_message
 from danswer.danswerbot.slack.tokens import fetch_tokens
 from danswer.db.engine import get_sqlalchemy_engine
 from danswer.db.users import get_user_by_email
@@ -165,6 +166,7 @@ def respond_in_thread(
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")
 
+    text = format_slack_message(text)
     message_ids: list[str] = []
     if not receiver_ids:
         slack_call = make_slack_api_rate_limited(client.chat_postMessage)

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -81,3 +81,4 @@ dropbox==11.36.2
 boto3-stubs[s3]==1.34.133
 ultimate_sitemap_parser==0.5
 stripe==10.12.0
+mistune==0.8.4


### PR DESCRIPTION
Refer to https://api.slack.com/reference/surfaces/formatting

## Description

Before
<img width="491" alt="Screenshot 2024-10-16 at 10 29 30 PM" src="https://github.com/user-attachments/assets/37c64889-9ce4-4a80-8a83-769eb3d3cd27">

After

<img width="520" alt="Screenshot 2024-10-16 at 10 29 45 PM" src="https://github.com/user-attachments/assets/2f6fd386-266b-41c9-a749-362d934afcbd">
