### PR TITLE
Cleanup connector form

### DIFF
--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -431,10 +431,8 @@ export default function AddConnector({
                   config={configuration}
                   setSelectedFiles={setSelectedFiles}
                   selectedFiles={selectedFiles}
+                  connector={connector}
                 />
-
-                <AccessTypeForm connector={connector} />
-                <AccessTypeGroupSelector />
               </Card>
             )}
 

--- a/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
@@ -19,7 +19,7 @@ export interface DynamicConnectionFormProps {
   selectedFiles: File[];
   setSelectedFiles: Dispatch<SetStateAction<File[]>>;
   values: any;
-  connector: string;
+  connector: ConfigurableSources;
 }
 
 const DynamicConnectionForm: FC<DynamicConnectionFormProps> = ({
@@ -101,7 +101,7 @@ const DynamicConnectionForm: FC<DynamicConnectionFormProps> = ({
 
       {config.values.map((field) => !field.hidden && renderField(field))}
 
-      <AccessTypeForm connector={connector as ConfigurableSources} />
+      <AccessTypeForm connector={connector} />
       <AccessTypeGroupSelector />
 
       {config.advanced_values.length > 0 && (

--- a/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
@@ -10,12 +10,16 @@ import { TextFormField } from "@/components/admin/connectors/Field";
 import ListInput from "./ConnectorInput/ListInput";
 import FileInput from "./ConnectorInput/FileInput";
 import { AdvancedOptionsToggle } from "@/components/AdvancedOptionsToggle";
+import { AccessTypeForm } from "@/components/admin/connectors/AccessTypeForm";
+import { AccessTypeGroupSelector } from "@/components/admin/connectors/AccessTypeGroupSelector";
+import { ConfigurableSources } from "@/lib/types";
 
 export interface DynamicConnectionFormProps {
   config: ConnectionConfiguration;
   selectedFiles: File[];
   setSelectedFiles: Dispatch<SetStateAction<File[]>>;
   values: any;
+  connector: string;
 }
 
 const DynamicConnectionForm: FC<DynamicConnectionFormProps> = ({
@@ -23,6 +27,7 @@ const DynamicConnectionForm: FC<DynamicConnectionFormProps> = ({
   selectedFiles,
   setSelectedFiles,
   values,
+  connector,
 }) => {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
 
@@ -95,6 +100,9 @@ const DynamicConnectionForm: FC<DynamicConnectionFormProps> = ({
       />
 
       {config.values.map((field) => !field.hidden && renderField(field))}
+
+      <AccessTypeForm connector={connector as ConfigurableSources} />
+      <AccessTypeGroupSelector />
 
       {config.advanced_values.length > 0 && (
         <>

--- a/web/src/components/admin/connectors/AccessTypeForm.tsx
+++ b/web/src/components/admin/connectors/AccessTypeForm.tsx
@@ -57,39 +57,30 @@ export function AccessTypeForm({
 
   return (
     <>
-      {isPaidEnterpriseEnabled && (
+      {isPaidEnterpriseEnabled && isAdmin && (
         <>
-          <div>
-            <div className="flex gap-x-2 items-center">
-              <label className="text-text-950 font-medium">
-                Document Access
-              </label>
-            </div>
-            <p className="text-sm text-text-500 mb-2">
-              Control who has access to the documents indexed by this connector.
-            </p>
-
-            {isAdmin && (
-              <>
-                <DefaultDropdown
-                  options={options}
-                  selected={access_type.value}
-                  onSelect={(selected) =>
-                    access_type_helpers.setValue(selected as AccessType)
-                  }
-                  includeDefault={false}
-                />
-
-                {access_type.value === "sync" && isAutoSyncSupported && (
-                  <div>
-                    <AutoSyncOptions
-                      connectorType={connector as ValidAutoSyncSources}
-                    />
-                  </div>
-                )}
-              </>
-            )}
+          <div className="flex gap-x-2 items-center">
+            <label className="text-text-950 font-medium">Document Access</label>
           </div>
+          <p className="text-sm text-text-500 mb-2">
+            Control who has access to the documents indexed by this connector.
+          </p>
+          <DefaultDropdown
+            options={options}
+            selected={access_type.value}
+            onSelect={(selected) =>
+              access_type_helpers.setValue(selected as AccessType)
+            }
+            includeDefault={false}
+          />
+
+          {access_type.value === "sync" && isAutoSyncSupported && (
+            <div>
+              <AutoSyncOptions
+                connectorType={connector as ValidAutoSyncSources}
+              />
+            </div>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
Changes:
- removed accesstypeform for curators (they can only create private)
- moved advanced options to the bottom of the page for all users

Before:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/402aafe7-fa91-4c0b-bce4-0fb6ddd5804a">


After:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/af32f7c3-e6ce-469a-9e29-459eca1dad3a">

