### PR TITLE
Account for malformed urls

### DIFF
--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -128,6 +128,9 @@ def get_internal_links(
         if not href:
             continue
 
+        # Account for malformed backslashes in URLs
+        href = href.replace("\\", "/")
+
         if should_ignore_pound and "#" in href:
             href = href.split("#")[0]
 


### PR DESCRIPTION
## Description
User running into blocking issues with urls that use \ instead of / (malformed urls - not proper url syntax).