### PR TITLE
Notion Child Block Fix

### DIFF
--- a/backend/danswer/connectors/notion/connector.py
+++ b/backend/danswer/connectors/notion/connector.py
@@ -134,9 +134,12 @@ class NotionConnector(LoadConnector, PollConnector):
                     f"This is likely due to the block not being shared "
                     f"with the Danswer integration. Exact exception:\n\n{e}"
                 )
-                return None
+
             logger.exception(f"Error fetching blocks - {res.json()}")
-            raise e
+
+            # This can occasionally happen, the reason is unknown and cannot be reproduced on our internal Notion
+            # Assuming this will not be a critical loss of data
+            return None
         return res.json()
 
     @retry(tries=3, delay=1, backoff=2)

--- a/backend/danswer/connectors/notion/connector.py
+++ b/backend/danswer/connectors/notion/connector.py
@@ -134,8 +134,10 @@ class NotionConnector(LoadConnector, PollConnector):
                     f"This is likely due to the block not being shared "
                     f"with the Danswer integration. Exact exception:\n\n{e}"
                 )
-
-            logger.exception(f"Error fetching blocks - {res.json()}")
+            else:
+                logger.exception(
+                    f"Error fetching blocks with status code {res.status_code}: {res.json()}"
+                )
 
             # This can occasionally happen, the reason is unknown and cannot be reproduced on our internal Notion
             # Assuming this will not be a critical loss of data


### PR DESCRIPTION
## Description
For reasons unknown sometimes a child block can fail to fetch with a 400, nothing we can do.


## How Has This Been Tested?
Cannot be reproduced


## Accepted Risk (provide if relevant)
Slight risk of loss of data


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
