### PR TITLE
Distinguish users in posthog

### DIFF
--- a/backend/danswer/server/manage/models.py
+++ b/backend/danswer/server/manage/models.py
@@ -57,6 +57,7 @@ class UserInfo(BaseModel):
     oidc_expiry: datetime | None = None
     current_token_created_at: datetime | None = None
     current_token_expiry_length: int | None = None
+    organization_name: str | None = None
 
     @classmethod
     def from_model(
@@ -64,6 +65,7 @@ class UserInfo(BaseModel):
         user: User,
         current_token_created_at: datetime | None = None,
         expiry_length: int | None = None,
+        organization_name: str | None = None,
     ) -> "UserInfo":
         return cls(
             id=str(user.id),
@@ -80,6 +82,7 @@ class UserInfo(BaseModel):
                     visible_assistants=user.visible_assistants,
                 )
             ),
+            organization_name=organization_name,
             # set to None if TRACK_EXTERNAL_IDP_EXPIRY is False so that we avoid cases
             # where they previously had this set + used OIDC, and now they switched to
             # basic auth are now constantly getting redirected back to the login page

--- a/backend/danswer/server/manage/users.py
+++ b/backend/danswer/server/manage/users.py
@@ -30,6 +30,7 @@ from danswer.auth.schemas import UserStatus
 from danswer.auth.users import current_admin_user
 from danswer.auth.users import current_curator_or_admin_user
 from danswer.auth.users import current_user
+from danswer.auth.users import get_tenant_id_for_email
 from danswer.auth.users import optional_user
 from danswer.configs.app_configs import AUTH_TYPE
 from danswer.configs.app_configs import ENABLE_EMAIL_INVITES
@@ -493,10 +494,13 @@ def verify_user_logged_in(
     token_created_at = (
         None if MULTI_TENANT else get_current_token_creation(user, db_session)
     )
+    organization_name = get_tenant_id_for_email(user.email)
+
     user_info = UserInfo.from_model(
         user,
         current_token_created_at=token_created_at,
         expiry_length=SESSION_EXPIRE_TIME_SECONDS,
+        organization_name=organization_name,
     )
 
     return user_info

--- a/web/src/components/user/UserProvider.tsx
+++ b/web/src/components/user/UserProvider.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import { User, UserRole } from "@/lib/types";
 import { getCurrentUser } from "@/lib/user";
+import { usePostHog } from "posthog-js/react";
 
 interface UserContextType {
   user: User | null;
@@ -23,6 +24,21 @@ export function UserProvider({
 }) {
   const [upToDateUser, setUpToDateUser] = useState<User | null>(user);
   const [isLoadingUser, setIsLoadingUser] = useState(false);
+
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (!posthog) return;
+
+    if (user?.id) {
+      posthog.identify(user.id, {
+        email: user.email,
+        organization_name: user.organization_name,
+      });
+    } else {
+      posthog.reset();
+    }
+  }, [posthog, user]);
 
   const fetchUser = async () => {
     try {

--- a/web/src/components/user/UserProvider.tsx
+++ b/web/src/components/user/UserProvider.tsx
@@ -31,10 +31,13 @@ export function UserProvider({
     if (!posthog) return;
 
     if (user?.id) {
-      posthog.identify(user.id, {
+      const identifyData: Record<string, any> = {
         email: user.email,
-        organization_name: user.organization_name,
-      });
+      };
+      if (user.organization_name) {
+        identifyData.organization_name = user.organization_name;
+      }
+      posthog.identify(user.id, identifyData);
     } else {
       posthog.reset();
     }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface User {
   current_token_created_at?: Date;
   current_token_expiry_length?: number;
   oidc_expiry?: Date;
+  organization_name: string | null;
 }
 
 export interface MinimalUserSnapshot {


### PR DESCRIPTION
## Description
Track which tenant a user / session replay belongs to (tenant id).

Eventually, this should be organization name rather than tenant id (separate PR)