### PR TITLE
Add referral source to cloud on data plane

### DIFF
--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -228,12 +228,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         safe: bool = False,
         request: Optional[Request] = None,
     ) -> User:
+        referral_source = None
+        if request:
+            referral_source = request.cookies.get("referral_source", None)
+
         tenant_id = await fetch_ee_implementation_or_noop(
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
         )(
-            email=user_create.email,
+            email=user_create.email, referral_source=referral_source,
         )
 
         async with get_async_session_with_tenant(tenant_id) as db_session:
@@ -291,6 +295,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         refresh_token: Optional[str] = None,
         request: Optional[Request] = None,
         *,
+        referral_source: Optional[str] = None,
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> models.UOAP:
@@ -299,7 +304,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "get_or_create_tenant_id",
             async_return_default_schema,
         )(
-            email=account_email,
+            email=account_email, referral_source=referral_source,
         )
 
         if not tenant_id:
@@ -711,8 +716,6 @@ def generate_state_token(
 
 
 # refer to https://github.com/fastapi-users/fastapi-users/blob/42ddc241b965475390e2bce887b084152ae1a2cd/fastapi_users/fastapi_users.py#L91
-
-
 def create_danswer_oauth_router(
     oauth_client: BaseOAuth2,
     backend: AuthenticationBackend,
@@ -762,15 +765,23 @@ def get_oauth_router(
         response_model=OAuth2AuthorizeResponse,
     )
     async def authorize(
-        request: Request, scopes: List[str] = Query(None)
+        request: Request,
+        scopes: List[str] = Query(None),
     ) -> OAuth2AuthorizeResponse:
+        cookies = request.cookies
+        referral_source = cookies.get("referral_source", None)
+
         if redirect_url is not None:
             authorize_redirect_url = redirect_url
         else:
             authorize_redirect_url = str(request.url_for(callback_route_name))
 
         next_url = request.query_params.get("next", "/")
-        state_data: Dict[str, str] = {"next_url": next_url}
+        # Include the referral_source in the state_data
+        state_data: Dict[str, str] = {
+            "next_url": next_url,
+            "referral_source": referral_source or "default_referral",
+        }
         state = generate_state_token(state_data, state_secret)
         authorization_url = await oauth_client.get_authorization_url(
             authorize_redirect_url,
@@ -829,8 +840,9 @@ def get_oauth_router(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
 
         next_url = state_data.get("next_url", "/")
+        referral_source = state_data.get("referral_source", "/")
 
-        # Authenticate user
+        # Proceed to authenticate or create the user
         try:
             user = await user_manager.oauth_callback(
                 oauth_client.name,
@@ -840,6 +852,7 @@ def get_oauth_router(
                 token.get("expires_at"),
                 token.get("refresh_token"),
                 request,
+                referral_source=referral_source,
                 associate_by_email=associate_by_email,
                 is_verified_by_default=is_verified_by_default,
             )
@@ -865,13 +878,6 @@ def get_oauth_router(
         # Copy headers and other attributes from 'response' to 'redirect_response'
         for header_name, header_value in response.headers.items():
             redirect_response.headers[header_name] = header_value
-
-        if hasattr(response, "body"):
-            redirect_response.body = response.body
-        if hasattr(response, "status_code"):
-            redirect_response.status_code = response.status_code
-        if hasattr(response, "media_type"):
-            redirect_response.media_type = response.media_type
 
         return redirect_response
 

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -228,7 +228,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         safe: bool = False,
         request: Optional[Request] = None,
     ) -> User:
-        referral_source = request.cookies.get("referral_source", None)
+        referral_source = None
+        if request is not None:
+            referral_source = request.cookies.get("referral_source", None)
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "danswer.server.tenants.provisioning",
@@ -297,7 +299,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> models.UOAP:
-        referral_source = request.state.referral_source
+        referral_source = None
+        if request:
+            referral_source = getattr(request.state, "referral_source", None)
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "danswer.server.tenants.provisioning",
@@ -841,6 +845,7 @@ def get_oauth_router(
 
         next_url = state_data.get("next_url", "/")
         referral_source = state_data.get("referral_source", None)
+
         request.state.referral_source = referral_source
 
         # Proceed to authenticate or create the user

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -294,10 +294,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         refresh_token: Optional[str] = None,
         request: Optional[Request] = None,
         *,
-        referral_source: Optional[str] = None,
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> models.UOAP:
+        referral_source = request.state.referral_source
+
         tenant_id = await fetch_ee_implementation_or_noop(
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
@@ -840,6 +841,7 @@ def get_oauth_router(
 
         next_url = state_data.get("next_url", "/")
         referral_source = state_data.get("referral_source", None)
+        request.state.referral_source = referral_source
 
         # Proceed to authenticate or create the user
         try:
@@ -851,7 +853,6 @@ def get_oauth_router(
                 token.get("expires_at"),
                 token.get("refresh_token"),
                 request,
-                referral_source=referral_source,
                 associate_by_email=associate_by_email,
                 is_verified_by_default=is_verified_by_default,
             )

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -840,7 +840,7 @@ def get_oauth_router(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
 
         next_url = state_data.get("next_url", "/")
-        referral_source = state_data.get("referral_source", "/")
+        referral_source = state_data.get("referral_source", None)
 
         # Proceed to authenticate or create the user
         try:

--- a/backend/danswer/main.py
+++ b/backend/danswer/main.py
@@ -315,7 +315,7 @@ def get_application() -> FastAPI:
             tags=["users"],
         )
 
-    if AUTH_TYPE == AuthType.GOOGLE_OAUTH or AUTH_TYPE == AuthType.CLOUD:
+    if AUTH_TYPE == AuthType.GOOGLE_OAUTH:
         oauth_client = GoogleOAuth2(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
         include_router_with_global_prefix_prepended(
             application,

--- a/backend/ee/danswer/server/tenants/models.py
+++ b/backend/ee/danswer/server/tenants/models.py
@@ -38,3 +38,4 @@ class ImpersonateRequest(BaseModel):
 class TenantCreationPayload(BaseModel):
     tenant_id: str
     email: str
+    referral_source: str | None = None

--- a/backend/ee/danswer/server/tenants/provisioning.py
+++ b/backend/ee/danswer/server/tenants/provisioning.py
@@ -41,7 +41,9 @@ from shared_configs.enums import EmbeddingProvider
 logger = logging.getLogger(__name__)
 
 
-async def get_or_create_tenant_id(email: str) -> str:
+async def get_or_create_tenant_id(
+    email: str, referral_source: str | None = None
+) -> str:
     """Get existing tenant ID for an email or create a new tenant if none exists."""
     if not MULTI_TENANT:
         return POSTGRES_DEFAULT_SCHEMA
@@ -51,7 +53,7 @@ async def get_or_create_tenant_id(email: str) -> str:
     except exceptions.UserNotExists:
         # If tenant does not exist and in Multi tenant mode, provision a new tenant
         try:
-            tenant_id = await create_tenant(email)
+            tenant_id = await create_tenant(email, referral_source)
         except Exception as e:
             logger.error(f"Tenant provisioning failed: {e}")
             raise HTTPException(status_code=500, detail="Failed to provision tenant.")
@@ -64,13 +66,13 @@ async def get_or_create_tenant_id(email: str) -> str:
     return tenant_id
 
 
-async def create_tenant(email: str) -> str:
+async def create_tenant(email: str, referral_source: str | None = None) -> str:
     tenant_id = TENANT_ID_PREFIX + str(uuid.uuid4())
     try:
         # Provision tenant on data plane
         await provision_tenant(tenant_id, email)
         # Notify control plane
-        await notify_control_plane(tenant_id, email)
+        await notify_control_plane(tenant_id, email, referral_source)
     except Exception as e:
         logger.error(f"Tenant provisioning failed: {e}")
         await rollback_tenant_provisioning(tenant_id)
@@ -117,14 +119,18 @@ async def provision_tenant(tenant_id: str, email: str) -> None:
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
-async def notify_control_plane(tenant_id: str, email: str) -> None:
+async def notify_control_plane(
+    tenant_id: str, email: str, referral_source: str | None = None
+) -> None:
     logger.info("Fetching billing information")
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
-    payload = TenantCreationPayload(tenant_id=tenant_id, email=email)
+    payload = TenantCreationPayload(
+        tenant_id=tenant_id, email=email, referral_source=referral_source
+    )
 
     async with aiohttp.ClientSession() as session:
         async with session.post(

--- a/backend/tests/integration/common_utils/managers/tenant.py
+++ b/backend/tests/integration/common_utils/managers/tenant.py
@@ -28,10 +28,12 @@ class TenantManager:
     def create(
         tenant_id: str | None = None,
         initial_admin_email: str | None = None,
+        referral_source: str | None = None,
     ) -> dict[str, str]:
         body = {
             "tenant_id": tenant_id,
             "initial_admin_email": initial_admin_email,
+            "referral_source": referral_source,
         }
 
         token = generate_auth_token()

--- a/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
+++ b/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
@@ -14,12 +14,12 @@ from tests.integration.common_utils.test_models import DATestUser
 
 def test_multi_tenant_access_control(reset_multitenant: None) -> None:
     # Create Tenant 1 and its Admin User
-    TenantManager.create("tenant_dev1", "test1@test.com")
+    TenantManager.create("tenant_dev1", "test1@test.com", "Data Plane Registration")
     test_user1: DATestUser = UserManager.create(name="test1", email="test1@test.com")
     assert UserManager.verify_role(test_user1, UserRole.ADMIN)
 
     # Create Tenant 2 and its Admin User
-    TenantManager.create("tenant_dev2", "test2@test.com")
+    TenantManager.create("tenant_dev2", "test2@test.com", "Data Plane Registration")
     test_user2: DATestUser = UserManager.create(name="test2", email="test2@test.com")
     assert UserManager.verify_role(test_user2, UserRole.ADMIN)
 

--- a/backend/tests/integration/multitenant_tests/tenants/test_tenant_creation.py
+++ b/backend/tests/integration/multitenant_tests/tenants/test_tenant_creation.py
@@ -11,7 +11,7 @@ from tests.integration.common_utils.test_models import DATestUser
 
 # Test flow from creating tenant to registering as a user
 def test_tenant_creation(reset_multitenant: None) -> None:
-    TenantManager.create("tenant_dev", "test@test.com")
+    TenantManager.create("tenant_dev", "test@test.com", "Data Plane Registration")
     test_user: DATestUser = UserManager.create(name="test", email="test@test.com")
 
     assert UserManager.verify_role(test_user, UserRole.ADMIN)

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -194,7 +194,9 @@ function ConnectorRow({
   return (
     <TableRow
       className={`hover:bg-hover-light ${
-        invisible ? "invisible !h-0 !-mb-10" : "!border !border-border"
+        invisible
+          ? "invisible !h-0 !-mb-10 !border-none"
+          : "!border !border-border"
       }  w-full cursor-pointer relative `}
       onClick={() => {
         router.push(`/admin/connector/${ccPairsIndexingStatus.cc_pair_id}`);
@@ -434,7 +436,6 @@ export function CCPairIndexingStatusTable({
           {!shouldExpand ? "Collapse All" : "Expand All"}
         </Button>
       </div>
-
       <TableBody>
         {sortedSources
           .filter(
@@ -454,14 +455,12 @@ export function CCPairIndexingStatusTable({
               return (
                 <React.Fragment key={ind}>
                   <br className="mt-4" />
-
                   <SummaryRow
                     source={source}
                     summary={groupSummaries[source]}
                     isOpen={connectorsToggled[source] || false}
                     onToggle={() => toggleSource(source)}
                   />
-
                   {connectorsToggled[source] && (
                     <>
                       <TableRow className="border border-border">

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -188,7 +188,7 @@ const AddUserButton = ({
   };
   return (
     <>
-      <Button className="w-fit" onClick={() => setModal(true)}>
+      <Button className="my-auto w-fit" onClick={() => setModal(true)}>
         <div className="flex">
           <FiPlusSquare className="my-auto mr-2" />
           Invite Users

--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -14,9 +14,11 @@ import { Spinner } from "@/components/Spinner";
 export function EmailPasswordForm({
   isSignup = false,
   shouldVerify,
+  referralSource,
 }: {
   isSignup?: boolean;
   shouldVerify?: boolean;
+  referralSource?: string;
 }) {
   const router = useRouter();
   const { popup, setPopup } = usePopup();
@@ -39,7 +41,11 @@ export function EmailPasswordForm({
           if (isSignup) {
             // login is fast, no need to show a spinner
             setIsWorking(true);
-            const response = await basicSignup(values.email, values.password);
+            const response = await basicSignup(
+              values.email,
+              values.password,
+              referralSource
+            );
 
             if (!response.ok) {
               const errorDetail = (await response.json()).detail;

--- a/web/src/app/auth/login/SignInButton.tsx
+++ b/web/src/app/auth/login/SignInButton.tsx
@@ -36,14 +36,18 @@ export function SignInButton({
     );
   }
 
+  const url = new URL(authorizeUrl);
+
+  const finalAuthorizeUrl = url.toString();
+
   if (!button) {
     throw new Error(`Unhandled authType: ${authType}`);
   }
 
   return (
     <a
-      className="mx-auto mt-6 py-3 w-72 text-text-100 bg-accent flex rounded cursor-pointer hover:bg-indigo-800"
-      href={authorizeUrl}
+      className="mx-auto mt-6 py-3 w-full text-text-100 bg-accent flex rounded cursor-pointer hover:bg-indigo-800"
+      href={finalAuthorizeUrl}
     >
       {button}
     </a>

--- a/web/src/app/auth/signup/ReferralSourceSelector.tsx
+++ b/web/src/app/auth/signup/ReferralSourceSelector.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/admin/connectors/Field";
+
+interface ReferralSourceSelectorProps {
+  defaultValue?: string;
+}
+
+const ReferralSourceSelector: React.FC<ReferralSourceSelectorProps> = ({
+  defaultValue,
+}) => {
+  const [referralSource, setReferralSource] = useState(defaultValue);
+
+  const referralOptions = [
+    { value: "search", label: "Search Engine (Google/Bing)" },
+    { value: "friend", label: "Friend/Colleague" },
+    { value: "linkedin", label: "LinkedIn" },
+    { value: "twitter", label: "Twitter" },
+    { value: "hackernews", label: "HackerNews" },
+    { value: "reddit", label: "Reddit" },
+    { value: "youtube", label: "YouTube" },
+    { value: "podcast", label: "Podcast" },
+    { value: "blog", label: "Article/Blog" },
+    { value: "ads", label: "Advertisements" },
+    { value: "other", label: "Other" },
+  ];
+
+  const handleChange = (value: string) => {
+    setReferralSource(value);
+    const cookies = require("js-cookie");
+    cookies.set("referral_source", value, {
+      expires: 365,
+      path: "/",
+      sameSite: "strict",
+    });
+  };
+
+  return (
+    <div className="w-full max-w-sm gap-y-2 flex flex-col mx-auto">
+      <Label className="text-text-950" small={false}>
+        <>
+          How did you hear about us?{" "}
+          <span className=" text-sm italic">(optional)</span>
+        </>
+      </Label>
+      <Select value={referralSource} onValueChange={handleChange}>
+        <SelectTrigger
+          id="referral-source"
+          className="w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        >
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectContent className="max-h-60 overflow-y-auto">
+          {referralOptions.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              className="py-2 px-3 hover:bg-indigo-100 cursor-pointer"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export default ReferralSourceSelector;

--- a/web/src/app/auth/signup/ReferralSourceSelector.tsx
+++ b/web/src/app/auth/signup/ReferralSourceSelector.tsx
@@ -47,8 +47,7 @@ const ReferralSourceSelector: React.FC<ReferralSourceSelectorProps> = ({
     <div className="w-full max-w-sm gap-y-2 flex flex-col mx-auto">
       <Label className="text-text-950" small={false}>
         <>
-          How did you hear about us?{" "}
-          <span className=" text-sm italic">(optional)</span>
+          How did you hear about us?
         </>
       </Label>
       <Select value={referralSource} onValueChange={handleChange}>

--- a/web/src/app/auth/signup/ReferralSourceSelector.tsx
+++ b/web/src/app/auth/signup/ReferralSourceSelector.tsx
@@ -46,9 +46,7 @@ const ReferralSourceSelector: React.FC<ReferralSourceSelectorProps> = ({
   return (
     <div className="w-full max-w-sm gap-y-2 flex flex-col mx-auto">
       <Label className="text-text-950" small={false}>
-        <>
-          How did you hear about us?
-        </>
+        How did you hear about us?
       </Label>
       <Select value={referralSource} onValueChange={handleChange}>
         <SelectTrigger

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -12,6 +12,8 @@ import Text from "@/components/ui/text";
 import Link from "next/link";
 import { SignInButton } from "../login/SignInButton";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
+import ReferralSourceSelector from "./ReferralSourceSelector";
+import { Separator } from "@/components/ui/separator";
 
 const Page = async () => {
   // catch cases where the backend is completely unreachable here
@@ -62,6 +64,13 @@ const Page = async () => {
           <h2 className="text-center text-xl text-strong font-bold">
             {cloud ? "Complete your sign up" : "Sign Up for Danswer"}
           </h2>
+          {cloud && (
+            <>
+              <div className="w-full flex flex-col items-center space-y-4 mb-4 mt-4">
+                <ReferralSourceSelector />
+              </div>
+            </>
+          )}
 
           {cloud && authUrl && (
             <div className="w-full justify-center">

--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -420,7 +420,7 @@ export function ClientLayout({
           <div className="fixed bg-background left-0 gap-x-4 mb-8 px-4 py-2 w-full items-center flex justify-end">
             <UserDropdown />
           </div>
-          <div className="pt-20 flex overflow-y-auto h-full px-4 md:px-12">
+          <div className="pt-20 flex overflow-y-auto overflow-x-hidden h-full px-4 md:px-12">
             {children}
           </div>
         </div>

--- a/web/src/lib/user.ts
+++ b/web/src/lib/user.ts
@@ -43,7 +43,11 @@ export const basicLogin = async (
   return response;
 };
 
-export const basicSignup = async (email: string, password: string) => {
+export const basicSignup = async (
+  email: string,
+  password: string,
+  referralSource?: string
+) => {
   const response = await fetch("/api/auth/register", {
     method: "POST",
     credentials: "include",
@@ -54,6 +58,7 @@ export const basicSignup = async (email: string, password: string) => {
       email,
       username: email,
       password,
+      referral_source: referralSource,
     }),
   });
   return response;

--- a/web/src/lib/userSS.ts
+++ b/web/src/lib/userSS.ts
@@ -63,7 +63,11 @@ const getOIDCAuthUrlSS = async (nextUrl: string | null): Promise<string> => {
 };
 
 const getGoogleOAuthUrlSS = async (): Promise<string> => {
-  const res = await fetch(buildUrl(`/auth/oauth/authorize`));
+  const res = await fetch(buildUrl(`/auth/oauth/authorize`), {
+    headers: {
+      cookie: processCookies(await cookies()),
+    },
+  });
   if (!res.ok) {
     throw new Error("Failed to fetch data");
   }


### PR DESCRIPTION
## Description
Add referral source for both cloud flow (create / auth callback)

- Create: pass to the user manager function request
- Oauth callback: use state param + headers (similar to next URL)

Tested with Google/basic auth with and without EE.

<img width="370" alt="Screenshot 2024-11-11 at 4 13 21 PM" src="https://github.com/user-attachments/assets/4171baeb-182c-40e1-9027-4a4362f912fc">


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
