### PR TITLE
Cleaner EE fallback for no op

### DIFF
--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -232,6 +232,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
+            is_async=True,
         )(
             email=user_create.email,
         )
@@ -298,6 +299,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
+            is_async=True,
         )(
             email=account_email,
         )
@@ -442,6 +444,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
+            is_async=True,
         )(
             email=email,
         )
@@ -505,6 +508,7 @@ class TenantAwareJWTStrategy(JWTStrategy):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
+            is_async=True,
         )(
             email=user.email,
         )

--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -232,7 +232,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
-            is_async=True,
         )(
             email=user_create.email,
         )
@@ -299,7 +298,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
-            is_async=True,
         )(
             email=account_email,
         )
@@ -444,7 +442,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
-            is_async=True,
         )(
             email=email,
         )
@@ -508,7 +505,6 @@ class TenantAwareJWTStrategy(JWTStrategy):
             "danswer.server.tenants.provisioning",
             "get_or_create_tenant_id",
             async_return_default_schema,
-            is_async=True,
         )(
             email=user.email,
         )

--- a/backend/danswer/utils/variable_functionality.py
+++ b/backend/danswer/utils/variable_functionality.py
@@ -122,7 +122,7 @@ def noop_fallback(*args: Any, **kwargs: Any) -> None:
 
 
 def fetch_ee_implementation_or_noop(
-    module: str, attribute: str, noop_return_value: Any = None
+    module: str, attribute: str, noop_return_value: Any = None, is_async: bool = False
 ) -> Any:
     """
     Fetches an EE implementation if EE is enabled, otherwise returns a no-op function.
@@ -139,6 +139,8 @@ def fetch_ee_implementation_or_noop(
         Exception: If EE is enabled but the fetch fails.
     """
     if not global_version.is_ee_version():
+        if is_async:
+            return noop_return_value
         return lambda *args, **kwargs: noop_return_value
 
     try:

--- a/backend/danswer/utils/variable_functionality.py
+++ b/backend/danswer/utils/variable_functionality.py
@@ -146,6 +146,7 @@ def fetch_ee_implementation_or_noop(
                 return await noop_return_value(*args, **kwargs)
 
             return async_noop
+
         else:
 
             def sync_noop(*args, **kwargs):

--- a/backend/danswer/utils/variable_functionality.py
+++ b/backend/danswer/utils/variable_functionality.py
@@ -142,14 +142,14 @@ def fetch_ee_implementation_or_noop(
     if not global_version.is_ee_version():
         if inspect.iscoroutinefunction(noop_return_value):
 
-            async def async_noop(*args, **kwargs):
+            async def async_noop(*args: Any, **kwargs: Any) -> Any:
                 return await noop_return_value(*args, **kwargs)
 
             return async_noop
 
         else:
 
-            def sync_noop(*args, **kwargs):
+            def sync_noop(*args: Any, **kwargs: Any) -> Any:
                 return noop_return_value
 
             return sync_noop


### PR DESCRIPTION
## Description
Should clean up the usage of async fallbacks / make this functionality clearer generally.

Tested with various tenancy-specific flows

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
