### PR TITLE
Folder clarity

### DIFF
--- a/web/src/app/chat/folders/FolderList.tsx
+++ b/web/src/app/chat/folders/FolderList.tsx
@@ -216,9 +216,7 @@ const FolderItem = ({
                 </div>
               )}
 
-              {/* Icons Section */}
               <div className="flex ml-auto my-auto">
-                {/* Edit Icon */}
                 <div
                   onClick={handleEditFolderName}
                   className={`hover:bg-black/10 p-1 -m-1 rounded ${
@@ -230,7 +228,6 @@ const FolderItem = ({
                   <FiEdit2 size={16} />
                 </div>
 
-                {/* Delete Icon and Confirm Popover */}
                 <div className="relative">
                   <Popover
                     open={showDeleteConfirm}

--- a/web/src/app/chat/folders/FolderList.tsx
+++ b/web/src/app/chat/folders/FolderList.tsx
@@ -23,16 +23,22 @@ import { useRouter } from "next/navigation";
 import { CHAT_SESSION_ID_KEY } from "@/lib/drag/constants";
 import Cookies from "js-cookie";
 import { Popover } from "@/components/popover/Popover";
+import { ChatSession } from "../interfaces";
 const FolderItem = ({
   folder,
   currentChatId,
   isInitiallyExpanded,
   initiallySelected,
+  showShareModal,
+  showDeleteModal,
 }: {
   folder: Folder;
   currentChatId?: string;
   isInitiallyExpanded: boolean;
   initiallySelected: boolean;
+
+  showShareModal: ((chatSession: ChatSession) => void) | undefined;
+  showDeleteModal: ((chatSession: ChatSession) => void) | undefined;
 }) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(isInitiallyExpanded);
   const [isEditing, setIsEditing] = useState<boolean>(initiallySelected);
@@ -161,6 +167,9 @@ const FolderItem = ({
     return a.time_created.localeCompare(b.time_created);
   });
 
+  // Determine whether to show the trash can icon
+  const showTrashIcon = (isHovering && !isEditing) || showDeleteConfirm;
+
   return (
     <div
       key={folder.folder_id}
@@ -206,55 +215,63 @@ const FolderItem = ({
                   {editedFolderName || folder.folder_name}
                 </div>
               )}
-              {isHovering && !isEditing && (
-                <div className="flex ml-auto my-auto">
-                  <div
-                    onClick={handleEditFolderName}
-                    className="hover:bg-black/10 p-1 -m-1 rounded"
-                  >
-                    <FiEdit2 size={16} />
-                  </div>
-                  <div className="relative">
-                    <Popover
-                      open={showDeleteConfirm}
-                      onOpenChange={setShowDeleteConfirm}
-                      content={
-                        <div
-                          onClick={handleDeleteClick}
-                          className="hover:bg-black/10 p-1 -m-1 rounded ml-2"
-                        >
-                          <FiTrash size={16} />
-                        </div>
-                      }
-                      popover={
-                        <div className="p-2 w-[225px] bg-background-100 rounded shadow-lg">
-                          <p className="text-sm mb-2">
-                            Are you sure you want to delete{" "}
-                            <i>{folder.folder_name}</i>? All the content inside
-                            this folder will also be deleted.
-                          </p>
-                          <div className="flex justify-end">
-                            <button
-                              onClick={confirmDelete}
-                              className="bg-red-500 hover:bg-red-600 text-white px-2 py-1 rounded text-xs mr-2"
-                            >
-                              Yes
-                            </button>
-                            <button
-                              onClick={cancelDelete}
-                              className="bg-gray-300 hover:bg-gray-200 px-2 py-1 rounded text-xs"
-                            >
-                              No
-                            </button>
-                          </div>
-                        </div>
-                      }
-                      side="top"
-                      align="center"
-                    />
-                  </div>
+
+              {/* Icons Section */}
+              <div className="flex ml-auto my-auto">
+                {/* Edit Icon */}
+                <div
+                  onClick={handleEditFolderName}
+                  className={`hover:bg-black/10 p-1 -m-1 rounded ${
+                    isHovering && !isEditing
+                      ? ""
+                      : "opacity-0 pointer-events-none"
+                  }`}
+                >
+                  <FiEdit2 size={16} />
                 </div>
-              )}
+
+                {/* Delete Icon and Confirm Popover */}
+                <div className="relative">
+                  <Popover
+                    open={showDeleteConfirm}
+                    onOpenChange={setShowDeleteConfirm}
+                    content={
+                      <div
+                        onClick={handleDeleteClick}
+                        className={`hover:bg-black/10 p-1 -m-1 rounded ml-2 ${
+                          showTrashIcon ? "" : "opacity-0 pointer-events-none"
+                        }`}
+                      >
+                        <FiTrash size={16} />
+                      </div>
+                    }
+                    popover={
+                      <div className="p-2 w-[225px] bg-background-100 rounded shadow-lg">
+                        <p className="text-sm mb-2">
+                          Are you sure you want to delete folder{" "}
+                          <i>{folder.folder_name}</i>?
+                        </p>
+                        <div className="flex justify-end">
+                          <button
+                            onClick={confirmDelete}
+                            className="bg-red-500 hover:bg-red-600 text-white px-2 py-1 rounded text-xs mr-2"
+                          >
+                            Yes
+                          </button>
+                          <button
+                            onClick={cancelDelete}
+                            className="bg-gray-300 hover:bg-gray-200 px-2 py-1 rounded text-xs"
+                          >
+                            No
+                          </button>
+                        </div>
+                      </div>
+                    }
+                    side="top"
+                    align="center"
+                  />
+                </div>
+              </div>
 
               {isEditing && (
                 <div className="flex ml-auto my-auto">
@@ -276,6 +293,8 @@ const FolderItem = ({
           </div>
         </div>
       </BasicSelectable>
+
+      {/* Expanded Folder Content */}
       {isExpanded && folders && (
         <div className={"ml-2 pl-2 border-l border-border"}>
           {folders.map((chatSession) => (
@@ -284,6 +303,8 @@ const FolderItem = ({
               chatSession={chatSession}
               isSelected={chatSession.id === currentChatId}
               skipGradient={isDragOver}
+              showShareModal={showShareModal}
+              showDeleteModal={showDeleteModal}
             />
           ))}
         </div>
@@ -297,11 +318,15 @@ export const FolderList = ({
   currentChatId,
   openedFolders,
   newFolderId,
+  showShareModal,
+  showDeleteModal,
 }: {
   folders: Folder[];
   currentChatId?: string;
   openedFolders?: { [key: number]: boolean };
   newFolderId: number | null;
+  showShareModal: ((chatSession: ChatSession) => void) | undefined;
+  showDeleteModal: ((chatSession: ChatSession) => void) | undefined;
 }) => {
   if (folders.length === 0) {
     return null;
@@ -318,6 +343,8 @@ export const FolderList = ({
           isInitiallyExpanded={
             openedFolders ? openedFolders[folder.folder_id] || false : false
           }
+          showShareModal={showShareModal}
+          showDeleteModal={showDeleteModal}
         />
       ))}
       {folders.length == 1 && folders[0].chat_sessions.length == 0 && (

--- a/web/src/app/chat/sessionSidebar/ChatSessionDisplay.tsx
+++ b/web/src/app/chat/sessionSidebar/ChatSessionDisplay.tsx
@@ -191,7 +191,6 @@ export function ChatSessionDisplay({
                         </div>
                       </CustomTooltip>
                     )}
-
                     <div>
                       {search ? (
                         showDeleteModal && (

--- a/web/src/app/chat/sessionSidebar/PagesTab.tsx
+++ b/web/src/app/chat/sessionSidebar/PagesTab.tsx
@@ -74,6 +74,8 @@ export function PagesTab({
             folders={folders}
             currentChatId={currentChatId}
             openedFolders={openedFolders}
+            showShareModal={showShareModal}
+            showDeleteModal={showDeleteModal}
           />
         </div>
       )}


### PR DESCRIPTION
https://linear.app/danswer/issue/DAN-1018/folders-ui-weirdness

## Description
- Let users share / delete chats within folder
- Clearer copy (chats aren't deleted if folder is)
- Persist the delete popup for chats even if cursor is not hovering folder

https://github.com/user-attachments/assets/8c034b04-98b8-4a94-9d36-48b4e6549137



## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
