### PR TITLE
admins cant be set  as curator on backend

### DIFF
--- a/backend/ee/danswer/db/user_group.py
+++ b/backend/ee/danswer/db/user_group.py
@@ -441,8 +441,10 @@ def update_user_curator_relationship(
 
     if user.role == UserRole.ADMIN:
         raise ValueError(
-            f"User with id '{set_curator_request.user_id}' is an admin"
-            " so they cannot be set as a curator."
+            f"User '{user.email}' is an admin and therefore has all permissions "
+            "of a curator. If you'd like this user to only have curator permissions, "
+            "you must update their role to BASIC then assign them to be CURATOR in the "
+            "appropriate groups."
         )
 
     requested_user_groups = fetch_user_groups_for_user(

--- a/backend/ee/danswer/db/user_group.py
+++ b/backend/ee/danswer/db/user_group.py
@@ -411,6 +411,8 @@ def _validate_curator_status__no_commit(
             .all()
         )
 
+        # if the user is a curator in any of their groups, set their role to CURATOR
+        # otherwise, set their role to BASIC
         if curator_relationships:
             user.role = UserRole.CURATOR
         elif user.role == UserRole.CURATOR:
@@ -436,6 +438,13 @@ def update_user_curator_relationship(
     user = fetch_user_by_id(db_session, set_curator_request.user_id)
     if not user:
         raise ValueError(f"User with id '{set_curator_request.user_id}' not found")
+
+    if user.role == UserRole.ADMIN:
+        raise ValueError(
+            f"User with id '{set_curator_request.user_id}' is an admin"
+            " so they cannot be set as a curator."
+        )
+
     requested_user_groups = fetch_user_groups_for_user(
         db_session=db_session,
         user_id=set_curator_request.user_id,


### PR DESCRIPTION
## Description
admins cant be set  as curator on backend



## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
