### PR TITLE
Fix API keys for MIT users

### DIFF
--- a/backend/ee/danswer/db/saml.py
+++ b/backend/ee/danswer/db/saml.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from sqlalchemy import and_
 from sqlalchemy import func
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from danswer.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
@@ -44,7 +45,11 @@ def upsert_saml_account(
     return saml_acc.expires_at
 
 
-def get_saml_account(cookie: str, db_session: Session) -> SamlAccount | None:
+async def get_saml_account(
+    cookie: str, async_db_session: AsyncSession
+) -> SamlAccount | None:
+    """NOTE: this is async, since it's used during auth
+    (which is necessarily async due to FastAPI Users)"""
     stmt = (
         select(SamlAccount)
         .join(User, User.id == SamlAccount.user_id)  # type: ignore
@@ -56,7 +61,7 @@ def get_saml_account(cookie: str, db_session: Session) -> SamlAccount | None:
         )
     )
 
-    result = db_session.execute(stmt)
+    result = await async_db_session.execute(stmt)
     return result.scalar_one_or_none()
 
 

--- a/backend/ee/danswer/db/saml.py
+++ b/backend/ee/danswer/db/saml.py
@@ -65,6 +65,8 @@ async def get_saml_account(
     return result.scalar_one_or_none()
 
 
-def expire_saml_account(saml_account: SamlAccount, db_session: Session) -> None:
+async def expire_saml_account(
+    saml_account: SamlAccount, async_db_session: AsyncSession
+) -> None:
     saml_account.expires_at = func.now()
-    db_session.commit()
+    await async_db_session.commit()

--- a/backend/ee/danswer/server/saml.py
+++ b/backend/ee/danswer/server/saml.py
@@ -12,6 +12,7 @@ from fastapi_users import exceptions
 from fastapi_users.password import PasswordHelper
 from onelogin.saml2.auth import OneLogin_Saml2_Auth  # type: ignore
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from danswer.auth.schemas import UserCreate
@@ -170,15 +171,19 @@ async def saml_login_callback(
 
 
 @router.post("/logout")
-def saml_logout(
+async def saml_logout(
     request: Request,
-    db_session: Session = Depends(get_session),
+    async_db_session: AsyncSession = Depends(get_async_session),
 ) -> None:
     saved_cookie = extract_hashed_cookie(request)
 
     if saved_cookie:
-        saml_account = get_saml_account(cookie=saved_cookie, db_session=db_session)
+        saml_account = await get_saml_account(
+            cookie=saved_cookie, async_db_session=async_db_session
+        )
         if saml_account:
-            expire_saml_account(saml_account, db_session)
+            await expire_saml_account(
+                saml_account=saml_account, async_db_session=async_db_session
+            )
 
     return


### PR DESCRIPTION
Previously, the logic to actually check for an API key was in the EE version of `optional_user_`. This meant that for MIT users, the API keys would never work.

Additionally, in this PR I switched to use an async engine. Due to FastAPI Users, this flow must be async, and it's generally good practice to use async engines during async flows to avoid mistakenly blocking the event loop.