### PR TITLE
Fix default feedback options appearing incorrectly

### DIFF
--- a/web/src/app/chat/modal/FeedbackModal.tsx
+++ b/web/src/app/chat/modal/FeedbackModal.tsx
@@ -5,15 +5,19 @@ import { FeedbackType } from "../types";
 import { Modal } from "@/components/Modal";
 import { FilledLikeIcon } from "@/components/icons/icons";
 
-const predefinedPositiveFeedbackOptions =
-  process.env.NEXT_PUBLIC_POSITIVE_PREDEFINED_FEEDBACK_OPTIONS?.split(",") ||
-  [];
-const predefinedNegativeFeedbackOptions =
-  process.env.NEXT_PUBLIC_NEGATIVE_PREDEFINED_FEEDBACK_OPTIONS?.split(",") || [
-    "Retrieved documents were not relevant",
-    "AI misread the documents",
-    "Cited source had incorrect information",
-  ];
+const predefinedPositiveFeedbackOptions = process.env
+  .NEXT_PUBLIC_POSITIVE_PREDEFINED_FEEDBACK_OPTIONS
+  ? process.env.NEXT_PUBLIC_POSITIVE_PREDEFINED_FEEDBACK_OPTIONS.split(",")
+  : [];
+
+const predefinedNegativeFeedbackOptions = process.env
+  .NEXT_PUBLIC_NEGATIVE_PREDEFINED_FEEDBACK_OPTIONS
+  ? process.env.NEXT_PUBLIC_NEGATIVE_PREDEFINED_FEEDBACK_OPTIONS.split(",")
+  : [
+      "Retrieved documents were not relevant",
+      "AI misread the documents",
+      "Cited source had incorrect information",
+    ];
 
 interface FeedbackModalProps {
   feedbackType: FeedbackType;


### PR DESCRIPTION
## Description
If the env vars `NEXT_PUBLIC_POSITIVE_PREDEFINED_FEEDBACK_OPTIONS` and `NEXT_PUBLIC_NEGATIVE_PREDEFINED_FEEDBACK_OPTIONS` do not exist, their values are `""` by default. 

Because `""?.split(",")` evaluates to `[""]` which is truthy, this breaks the default list of negative/positive feedback options, causing an empty button to appear in the feedback modal.

My fix checks the truthiness of the variables before splitting or assigning default values, which accounts for the above case and the existing case when the var is null/undefined.

## Before
![Screenshot 2024-11-25 at 7 20 55 PM](https://github.com/user-attachments/assets/0741beea-3efb-446c-97fe-961d018ce6ce)

![Screenshot 2024-11-25 at 7 21 12 PM](https://github.com/user-attachments/assets/f4ec9afb-59c9-488c-9d7f-27373eb12097)

## After
![image](https://github.com/user-attachments/assets/be45298c-3a91-4fdb-aa32-9266499d1d56)

![image](https://github.com/user-attachments/assets/dd993436-a750-40be-b7cf-5f636c22c178)


## How Has This Been Tested?
Docker compose dev

## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
