### PR TITLE
ci: Add PR labeller job

### DIFF
--- a/.github/workflows/pr-labeller.yml
+++ b/.github/workflows/pr-labeller.yml
@@ -1,0 +1,20 @@
+name: PR Labeller
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate_pr_title:
+    runs-on: ubuntu-latest
+    steps:
+    - name: PR Conventional Commit Validation
+      uses: ytanikin/pr-conventional-commits@1.4.0
+      with:
+        task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
+        add_label: 'true'


### PR DESCRIPTION
## Description

This is a simple CI/CD job which ensures that PRs are pre-fixed with a specific "tag". Examples of tags are "feat" (for new features), "perf" (for performance improvements), etc..

Addresses: https://linear.app/danswer/issue/DAN-1908/add-pr-labelling-job.

## How Has This Been Tested?

CI/CD change; doesn't need to be tested.