### PR TITLE
fix(ui/Modal): Enable scrolling for overflowing content

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -94,7 +94,7 @@ export function Modal({
           flex-col
 
           ${heightOverride ? `h-${heightOverride}` : "max-h-[90vh]"}
-          ${hideOverflow ? "overflow-hidden" : "overflow-visible"}
+          ${hideOverflow ? "overflow-hidden" : "overflow-y-auto"}
         `}
       >
         {onOutsideClick && !hideCloseButton && (


### PR DESCRIPTION
fix(ui/Modal): Enable scrolling for overflowing content

## Description

Modals with content taller than their max-height were rendering with `overflow-visible` by default (when the `hideOverflow` prop was false), causing content at the bottom to be cut off and inaccessible. This was particularly noticeable in the "Configure a Generative AI Model" form when selecting the "Custom" provider tab, where model configuration and action buttons were hidden.

This commit changes the default behavior within `Modal.tsx` by replacing `overflow-visible` with `overflow-y-auto` for the main modal container div (when `hideOverflow` is false). This ensures a vertical scrollbar appears automatically when the content exceeds the modal's max-height, allowing users to scroll and access all elements within the modal.

## How Has This Been Tested?

1.  Ran the application locally using the development setup (`docker compose up` for backend services, `npm run dev` for the web UI).
2.  Navigated to Settings -> LLMs / Chat Models.
3.  Clicked "Add Model Provider".
4.  Selected the "Custom" provider tab.
5.  **Observed (Before Fix):** Content below the "Custom Configs" section was cut off, and no scrollbar was present on the modal body.
6.  Applied the code change in `src/components/Modal.tsx`.
7.  **Observed (After Fix):** A vertical scrollbar appeared on the modal body, allowing scrolling to view and interact with the "Model Configurations", "Default Model", "Fast Model" sections, and the "Enable" button at the bottom.
8.  Tested other modals briefly to ensure no obvious regressions (e.g., API key creation modal).

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check