### PR TITLE
fix: update OAuth callback URI encoding in Linear connector. Issue: https://github.com/onyx-dot-app/onyx/issues/4795

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
 from typing import TypeVar
+from urllib.parse import quote
 
 from dateutil.parser import parse
 
@@ -81,8 +82,10 @@ def get_metadata_keys_to_ignore() -> list[str]:
     return [IGNORE_FOR_QA]
 
 
-def get_oauth_callback_uri(base_domain: str, connector_id: str) -> str:
+def get_oauth_callback_uri(base_domain: str, connector_id: str, url_encode: bool = True) -> str:
     if CONNECTOR_LOCALHOST_OVERRIDE:
         # Used for development
         base_domain = CONNECTOR_LOCALHOST_OVERRIDE
-    return f"{base_domain.strip('/')}/connector/oauth/callback/{connector_id}"
+
+    uri = f"{base_domain.strip('/')}/connector/oauth/callback/{connector_id}"
+    return quote(uri) if url_encode else uri

--- a/backend/onyx/connectors/linear/connector.py
+++ b/backend/onyx/connectors/linear/connector.py
@@ -102,7 +102,7 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
         data = {
             "code": code,
             "redirect_uri": get_oauth_callback_uri(
-                base_domain, DocumentSource.LINEAR.value
+                base_domain, DocumentSource.LINEAR.value, url_encode=False
             ),
             "client_id": LINEAR_CLIENT_ID,
             "client_secret": LINEAR_CLIENT_SECRET,


### PR DESCRIPTION
- Add URL encoding option to get_oauth_callback_uri utility function
- Update Linear connector to use non-encoded callback URI for token exchange

## Description

Onyx fails to add Linear connector with invalid_redirect_uri error. This is because callback uri isn't URL encoded and, since Linear expects it to be exactly like it is specified in Linear application, redirect fails.

Added URL encoding when generating a redirect_uri. In addition Linear connector shouldn't use URL encoded URI for token exchanges.

## How Has This Been Tested?

We build our own version with this fix and were able to successfully add Linear connector.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
