### PR TITLE
fix: Change how replies are processed

### DIFF
--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -517,7 +517,7 @@ def _collect_documents_for_channel(
                     time.sleep(retry_after)
                     retries += 1
 
-            if cre or not replies:
+            if cre or replies is None:
                 failure_message = f"Retrieval of message and its replies failed; {channel.id=} {message.id=}"
                 if cre and cre.response:
                     failure_message = f"{failure_message}; {cre.response.status_code=}"


### PR DESCRIPTION
## Description

This PR fixes how the `replies: list[..] | None` variable is processed. Previously, a `None` *OR* an empty list would hit the if-case and yield a `ConnectorFailure`. With this PR, only the former hits the if-case.

Addresses: https://linear.app/danswer/issue/DAN-2063/add-rate-limiting-to-ms-teams-connector-apis.

## How Has This Been Tested?

Tests already written and are passing.