### PR TITLE
fix db connection assertion

### DIFF
--- a/backend/onyx/db/engine.py
+++ b/backend/onyx/db/engine.py
@@ -517,7 +517,13 @@ def get_session_with_tenant(*, tenant_id: str) -> Generator[Session, None, None]
         finally:
             # always reset the search path on exit
             if MULTI_TENANT:
+                if not dbapi_connection.is_valid:
+                    logger.warning(
+                        "dbapi_connection is None, likely the original connection expired."
+                    )
+                    return
                 cursor = dbapi_connection.cursor()
+
                 try:
                     cursor.execute('SET search_path TO "$user", public')
                 except Exception as e:


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2099/dbapi-connection-none

We've been seeing instances of db connections expiring on the cloud (at least, that seems to be a likely cause). When this happens, we hit an assert statement internal to sqlalchemy that we now handle gracefully.

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
