### PR TITLE
remove check for folder assistant before uploading

### DIFF
--- a/web/src/app/chat/my-documents/DocumentsContext.tsx
+++ b/web/src/app/chat/my-documents/DocumentsContext.tsx
@@ -387,20 +387,6 @@ export const DocumentsProvider: React.FC<DocumentsProviderProps> = ({
 
   const handleUpload = useCallback(
     async (files: File[]) => {
-      if (
-        folderDetails?.assistant_ids &&
-        folderDetails.assistant_ids.length > 0
-      ) {
-        setShowUploadWarning(true);
-      } else {
-        await performUpload(files);
-      }
-    },
-    [folderDetails]
-  );
-
-  const performUpload = useCallback(
-    async (files: File[]) => {
       try {
         const formData = new FormData();
         files.forEach((file) => {


### PR DESCRIPTION
## Description
Now we will let users to upload files eventhough the folder is related to the assistant.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
