### PR TITLE
fix bug in index swap

### DIFF
--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -119,7 +119,7 @@ def check_and_perform_index_swap(db_session: Session) -> SearchSettings | None:
     did change.
     """
     # Default CC-pair created for Ingestion API unused here
-    all_cc_pairs = get_connector_credential_pairs(db_session)
+    all_cc_pairs = get_connector_credential_pairs(db_session, include_user_files=True)
     cc_pair_count = max(len(all_cc_pairs) - 1, 0)
     secondary_search_settings = get_secondary_search_settings(db_session)
 


### PR DESCRIPTION
## Description

Fixes bug where instances with user files weren't able to swap their search settings
Thanks @415matt !

## How Has This Been Tested?

tested by matt

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug that prevented instances with user files from swapping their search settings.

<!-- End of auto-generated description by cubic. -->

