### PR TITLE
fix: handle empty doc batches

### DIFF
--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -430,7 +430,7 @@
       },
       "args": [
         "--filename",
-        "generated/openapi.json",
+        "generated/openapi.json"
       ]
     },
     {

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -1146,7 +1146,7 @@ def connector_document_extraction(
                     checkpoint = next_checkpoint
 
                 # below is all document processing task, so if no batch we can just continue
-                if document_batch is None:
+                if not document_batch:
                     continue
 
                 # Clean documents and create batch


### PR DESCRIPTION
## Description


Fixes https://linear.app/danswer/issue/DAN-2237/empty-doc-batches
Previously connectors that retrieved no documents wouldn't ever finish because docprocessing always expected batches with at least one doc. Now batches with 0 docs are not issued, allowing 0-doc attempts to complete.

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where connectors with no documents would hang instead of completing. Now, empty document batches are skipped so 0-document attempts finish as expected.

<!-- End of auto-generated description by cubic. -->

