### PR TITLE
fix: explicit api_server dependency on minio in docker compose files

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -13,6 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
+      - minio
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -13,6 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
+      - minio
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -14,6 +14,7 @@ services:
       - index
       - cache
       - inference_model_server
+      - minio
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -13,6 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
+      - minio
     restart: unless-stopped
     env_file:
       - .env

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -13,6 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
+      - minio
     restart: unless-stopped
     env_file:
       - .env

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
       - relational_db
       - index
       - cache
+      - minio
       - inference_model_server
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -12,6 +12,7 @@ services:
       - relational_db
       - index
       - cache
+      - minio
     restart: unless-stopped
     ports:
       - "8080"


### PR DESCRIPTION
## Description

Adds explicit dependency from api_server service to minio service in Docker compose files.

Fixes issue #4978 

## How Has This Been Tested?

In a [comment on issue #4978](https://github.com/onyx-dot-app/onyx/issues/4978#issuecomment-3104978972) I describe how I was able to overcome the issue with the `init-letsencrypt.sh` script not progressing. Explicitly defining in the Docker compose file the `api_server` service's dependency on the `minio` service causes the API server to be able to start, which in turn allows nginx to start, which allows the `init-letsencrypt.sh` script to progress.

The actual test was done on a GCP compute instance. The test actions were:

1. Ran the `init-letsencrypt.sh` script, experienced a hang while the script waiting for nginx to be ready.
2. Found in nginx logs that nginx was waiting for the api_server to be ready.
3. Found in the api_server logs that it was waiting for minio to be ready.
4. I edited [this depends_on list]( https://github.com/onyx-dot-app/onyx/blob/991d5e42037a8f259e33b9f5bfa24890dec5f349/deployment/docker_compose/docker-compose.prod.yml#L12) in the docker-compose.prod.yml file to include `- minio` as a dependency.
5. I re-ran the `init-letsencrypt.sh` script and it was able to progress successfully.

## Further Note

It appears that there may also be a dependency from the `background` service to the `minio` service. Is that the case and should I include that in this PR?

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an explicit dependency from the api_server service to the minio service in all Docker Compose files to ensure correct startup order and prevent initialization issues.

<!-- End of auto-generated description by cubic. -->

