### PR TITLE
fix: add library to fall back to for tokenizing

### DIFF
--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -9,6 +9,7 @@ pydantic==2.8.2
 retry==0.9.2
 safetensors==0.5.3
 sentence-transformers==4.0.2
+sentencepiece==0.2.0
 setfit==1.1.1
 torch==2.6.0
 transformers==4.49.0


### PR DESCRIPTION
## Description

We were seeing the following in the model server:

```
ValueError: Cannot instantiate this tokenizer from a slow version.
If it's based on sentencepiece, make sure you have sentencepiece installed.
```

so we're adding sentencepiece to support more tokenizers

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added sentencepiece to model server dependencies to support tokenizers that require it and prevent initialization errors.

<!-- End of auto-generated description by cubic. -->

