### PR TITLE
Remove unnecessary resources requests

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -17,6 +17,8 @@ from bs4 import BeautifulSoup
 from oauthlib.oauth2 import BackendApplicationClient
 from playwright.sync_api import BrowserContext
 from playwright.sync_api import Playwright
+from playwright.sync_api import Route
+from playwright.sync_api import Request
 from playwright.sync_api import sync_playwright
 from requests_oauthlib import OAuth2Session  # type:ignore
 from urllib3.exceptions import MaxRetryError
@@ -329,7 +331,7 @@ def start_playwright() -> Tuple[Playwright, BrowserContext]:
     return playwright, context
 
 
-def abort_unnecessary_resources(route, request):
+def abort_unnecessary_resources(route: Route, request: Request) -> None:
     if request.resource_type in ["image", "stylesheet", "font", "media", "websocket", "manifest", "other"]:
         route.abort()
     else:


### PR DESCRIPTION
## Description

This PR restricts unnecessary resources, in playwright, when scraping a web page.

## How Has This Been Tested?

I tested this by measuring the size of resources loaded by Playwright, using the page.on("response", calc_size) event. The calc_size function retrieves each response's size from the Content-Length header.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Blocked unnecessary resource types like images, stylesheets, and fonts during Playwright scraping to reduce bandwidth and speed up page loads.

- **Refactors**
  - Added a route handler to abort requests for non-essential resources.
  - Removed images from the DOM after page load to further reduce resource usage.

<!-- End of auto-generated description by cubic. -->

