### PR TITLE
fix(infra): Fixed RDS IAM Issue

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -121,14 +121,14 @@ resource "aws_iam_policy" "s3_access_policy" {
   })
 }
 
-# Create IAM role for S3 access using IRSA (optional)
-module "irsa-s3-access" {
+# Create IAM role for workload access using IRSA (S3 + RDS)
+module "irsa-workload-access" {
   count   = length(var.s3_bucket_names) == 0 ? 0 : 1
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "4.7.0"
 
   create_role                   = true
-  role_name                     = "AmazonEKSTFS3AccessRole-${module.eks.cluster_name}"
+  role_name                     = "AmazonEKSTFWorkloadAccessRole-${module.eks.cluster_name}"
   provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.s3_access_policy[0].arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.irsa_service_account_namespace}:${var.irsa_service_account_name}"]
@@ -143,12 +143,12 @@ resource "kubernetes_service_account" "s3_access" {
     name      = var.irsa_service_account_name
     namespace = var.irsa_service_account_namespace
     annotations = {
-      "eks.amazonaws.com/role-arn" = module.irsa-s3-access[0].iam_role_arn
+      "eks.amazonaws.com/role-arn" = module.irsa-workload-access[0].iam_role_arn
     }
   }
 }
 
-# Optionally grant the IRSA role permissions to connect to RDS using IAM auth
+# If RDS IAM auth is enabled, create a policy to allow the workload IRSA role to connect to RDS using IAM auth
 resource "aws_iam_policy" "rds_iam_connect_policy" {
   count       = var.enable_rds_iam_for_service_account && var.rds_db_connect_arn != null ? 1 : 0
   name        = "${module.eks.cluster_name}-rds-iam-connect-policy"
@@ -170,29 +170,10 @@ resource "aws_iam_policy" "rds_iam_connect_policy" {
   })
 }
 
-module "irsa-rds-connect" {
-  count   = var.enable_rds_iam_for_service_account && var.rds_db_connect_arn != null ? 1 : 0
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "4.7.0"
+resource "aws_iam_role_policy_attachment" "attach_rds_connect_to_workload_role" {
+  count      = var.enable_rds_iam_for_service_account && var.rds_db_connect_arn != null ? 1 : 0
+  role       = module.irsa-workload-access[0].iam_role_name
+  policy_arn = aws_iam_policy.rds_iam_connect_policy[0].arn
 
-  create_role                   = true
-  role_name                     = "AmazonEKSTFRDSConnectRole-${module.eks.cluster_name}"
-  provider_url                  = module.eks.oidc_provider
-  role_policy_arns              = [aws_iam_policy.rds_iam_connect_policy[0].arn]
-  oidc_fully_qualified_subjects = [
-    "system:serviceaccount:${var.irsa_service_account_namespace}:${var.rds_irsa_service_account_name}"
-  ]
-
-  depends_on = [module.eks]
-}
-
-resource "kubernetes_service_account" "rds_connect" {
-  count = var.enable_rds_iam_for_service_account && var.rds_db_connect_arn != null ? 1 : 0
-  metadata {
-    name      = var.rds_irsa_service_account_name
-    namespace = var.irsa_service_account_namespace
-    annotations = {
-      "eks.amazonaws.com/role-arn" = module.irsa-rds-connect[0].iam_role_arn
-    }
-  }
+  depends_on = [module.irsa-workload-access]
 }

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -11,7 +11,7 @@ output "cluster_certificate_authority_data" {
   sensitive = true
 }
 
-output "s3_access_role_arn" {
-  description = "ARN of the IAM role for S3 access"
-  value       = length(module.irsa-s3-access) > 0 ? module.irsa-s3-access[0].iam_role_arn : null
+output "workload_irsa_role_arn" {
+  description = "ARN of the IAM role for workloads (S3 + optional RDS)"
+  value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -122,8 +122,8 @@ variable "irsa_service_account_namespace" {
 
 variable "irsa_service_account_name" {
   type        = string
-  description = "Name of the IRSA-enabled Kubernetes service account for S3 access"
-  default     = "onyx-s3-access"
+  description = "Name of the IRSA-enabled Kubernetes service account for workload access (S3 + optional RDS)"
+  default     = "onyx-workload-access"
 }
 
 variable "enable_rds_iam_for_service_account" {
@@ -142,10 +142,4 @@ variable "rds_db_connect_arn" {
   type        = string
   description = "Full rds-db:connect ARN to allow (required when enable_rds_iam_for_service_account is true)"
   default     = null
-}
-
-variable "rds_irsa_service_account_name" {
-  type        = string
-  description = "Name of the IRSA-enabled Kubernetes service account for RDS IAM auth"
-  default     = "onyx-rds-access"
 }

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -52,7 +52,7 @@ module "postgres" {
   username         = var.postgres_username
   password         = var.postgres_password
   tags             = local.merged_tags
-  enable_rds_iam_auth = var.enable_rds_iam_auth
+  enable_rds_iam_auth = var.enable_iam_auth
 }
 
 module "s3" {
@@ -72,7 +72,7 @@ module "eks" {
   s3_bucket_names = [local.bucket_name]
 
   # Wire RDS IAM connection for the same IRSA service account used by apps
-  enable_rds_iam_for_service_account = var.enable_rds_iam_auth
+  enable_rds_iam_for_service_account = var.enable_iam_auth
   rds_db_username                    = var.postgres_username
   rds_db_connect_arn                 = var.rds_db_connect_arn
 

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -87,9 +87,9 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
-variable "enable_rds_iam_auth" {
+variable "enable_iam_auth" {
   type        = bool
-  description = "Enable AWS IAM authentication for the RDS Postgres instance"
+  description = "Enable AWS IAM authentication for the RDS Postgres instance and wire IRSA policies"
   default     = false
 }
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
There was an issue with the terraform setup since we tried to make 2 service accounts but the helm charts only take in one. This change unifies and cleans up the logic.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
I deployed to the internal cluster

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
