### PR TITLE
fix: ruff complaint about type comparison

### DIFF
--- a/backend/onyx/agents/agent_search/shared_graph_utils/calculations.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/calculations.py
@@ -60,12 +60,11 @@ def get_fit_scores(
 
         for i in [1, 5, 10]:
             fit_eval.fit_scores[rank_type].scores[str(i)] = (
-                # type(doc) is - is slightly faster than isinstance and no need to check for inheritence
                 sum(
                     [
                         float(doc.center_chunk.score)
                         for doc in docs[:i]
-                        if type(doc) is InferenceSection
+                        if isinstance(doc, InferenceSection)
                         and doc.center_chunk.score is not None
                     ]
                 )
@@ -86,9 +85,8 @@ def get_fit_scores(
             rank_type
         ].scores["1"]
 
-        # type(doc) is - is slightly faster than isinstance and no need to check for inheritence
         fit_eval.fit_scores[rank_type].chunk_ids = [
-            unique_chunk_id(doc) for doc in docs if type(doc) is InferenceSection
+            unique_chunk_id(doc) for doc in docs if isinstance(doc, InferenceSection)
         ]
 
     fit_eval.fit_score_lift = (


### PR DESCRIPTION
## Description

- Should be functionally identical for current system
- If a future doc class inherits InferenceSection, this check will pass (whereas `type(a) == b` will not pass if a is a subclass of b)

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced type(...) == InferenceSection with isinstance(..., InferenceSection) in get_fit_scores to resolve Ruff’s type-comparison warning and support subclasses. Behavior remains the same for current doc types.

<!-- End of auto-generated description by cubic. -->

