### PR TITLE
fix: allow jira api v3

### DIFF
--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -49,7 +49,6 @@ logger = setup_logger()
 
 ONE_HOUR = 3600
 
-JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "3"
 _JIRA_SLIM_PAGE_SIZE = 500
 _JIRA_FULL_PAGE_SIZE = 50
 
@@ -113,11 +112,11 @@ def process_jira_issue(
             )
             return None
 
-    description = (
-        issue.fields.description
-        if JIRA_API_VERSION in ("2", "3")
-        else extract_text_from_adf(issue.raw["fields"]["description"])
-    )
+    if isinstance(issue.fields.description, str):
+        description = issue.fields.description
+    else:
+        description = extract_text_from_adf(issue.raw["fields"]["description"])
+
     comments = get_comment_strs(
         issue=issue,
         comment_email_blacklist=comment_email_blacklist,

--- a/backend/onyx/connectors/jira/utils.py
+++ b/backend/onyx/connectors/jira/utils.py
@@ -18,6 +18,7 @@ logger = setup_logger()
 
 PROJECT_URL_PAT = "projects"
 JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "2"
+JIRA_CLOUD_API_VERSION = os.environ.get("JIRA_CLOUD_API_VERSION") or "3"
 
 
 def best_effort_basic_expert_info(obj: Any) -> BasicExpertInfo | None:
@@ -85,7 +86,7 @@ def build_jira_client(credentials: dict[str, Any], jira_base: str) -> JIRA:
         return JIRA(
             basic_auth=(email, api_token),
             server=jira_base,
-            options={"rest_api_version": JIRA_API_VERSION},
+            options={"rest_api_version": JIRA_CLOUD_API_VERSION},
         )
     else:
         return JIRA(
@@ -119,11 +120,10 @@ def get_comment_strs(
     comment_strs = []
     for comment in issue.fields.comment.comments:
         try:
-            body_text = (
-                comment.body
-                if JIRA_API_VERSION == "2"
-                else extract_text_from_adf(comment.raw["body"])
-            )
+            if isinstance(comment.body, str):
+                body_text = comment.body
+            else:
+                body_text = extract_text_from_adf(comment.raw["body"])
 
             if (
                 hasattr(comment, "author")

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
@@ -68,7 +68,7 @@ def mock_issue_large() -> MagicMock:
 
 @pytest.fixture
 def mock_jira_api_version() -> Generator[Any, Any, Any]:
-    with patch("onyx.connectors.jira.connector.JIRA_API_VERSION", "2"):
+    with patch("onyx.connectors.jira.utils.JIRA_CLOUD_API_VERSION", "3"):
         yield
 
 


### PR DESCRIPTION
## Description

- Jira deprecating v2 endpoints #5235 
- Updating api to v3 fixes + passes tests

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
