### PR TITLE
fix: enhance SharePoint connector error handling and content retrieval

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -225,6 +225,7 @@ def _convert_driveitem_to_document_with_permissions(
         logger.warning(f"Could not access content for '{driveitem.name}'")
         raise ValueError(f"Could not access content for '{driveitem.name}'")
 
+    content_bytes = None
     # Handle different content types
     if isinstance(content.value, bytes):
         content_bytes = content.value


### PR DESCRIPTION
## Description
This pull request improves error handling and content retrieval in the SharePoint connector, specifically in the `_convert_driveitem_to_document_with_permissions` function.
Error handling improvements:

* Changed the exception raised when a file exceeds the size threshold from `ValueError` to `RuntimeError`.

Content retrieval enhancements:

* Added a fallback mechanism to fetch file content using the `@microsoft.graph.downloadUrl` if the content type is not bytes, including robust error handling and logging if the download fails or the URL is unavailable.

## How Has This Been Tested?
Tested by creating the connector from UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves SharePoint connector reliability by tightening size-limit errors and adding a safe fallback to download file content when the Graph SDK returns non-bytes. This reduces ingestion failures in _convert_driveitem_to_document_with_permissions.

- **Bug Fixes**
  - Raise RuntimeError when file size exceeds SHAREPOINT_CONNECTOR_SIZE_THRESHOLD.
  - Fallback to @microsoft.graph.downloadUrl when content.value is not bytes, with timeout, status checks, and warning logs; return clear errors if URL is missing or the download fails.

<!-- End of auto-generated description by cubic. -->

