### PR TITLE
fix: scroll forms on invalid submit

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -91,6 +91,7 @@ import { SEARCH_TOOL_ID } from "@/app/chat/components/tools/constants";
 import TextView from "@/components/chat/TextView";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { MAX_CHARACTERS_PERSONA_DESCRIPTION } from "@/lib/constants";
+import { FormErrorFocus } from "@/components/FormErrorHelpers";
 
 function findSearchTool(tools: ToolSnapshot[]) {
   return tools.find((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID);
@@ -772,6 +773,7 @@ export function AssistantEditor({
                 />
               )}
               <Form className="w-full text-text-950 assistant-editor">
+                <FormErrorFocus />
                 {/* Refresh starter messages when name or description changes */}
                 <p className="text-base font-normal text-2xl">
                   {existingPersona ? (
@@ -1795,7 +1797,7 @@ export function AssistantEditor({
                       </Button>
                     )}
                   </div>
-                  <div className="flex gap-x-2">
+                  <div className="flex gap-x-4 items-center">
                     <Button
                       type="submit"
                       disabled={isSubmitting || isRequestSuccessful}

--- a/web/src/components/FormErrorHelpers.tsx
+++ b/web/src/components/FormErrorHelpers.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFormikContext } from "formik";
+
+// After a submit with errors, scroll + focus the first invalid field
+export function FormErrorFocus() {
+  const { submitCount, errors, isSubmitting } = useFormikContext<any>();
+  const lastHandled = useRef(0);
+
+  useEffect(() => {
+    if (isSubmitting) return;
+    if (submitCount <= 0 || submitCount === lastHandled.current) return;
+
+    const keys = Object.keys(errors || {});
+    if (keys.length === 0) return;
+
+    const timer = setTimeout(() => {
+      try {
+        let target: HTMLElement | null = null;
+
+        // 1) Try by id, then data-testid
+        for (const key of keys) {
+          target =
+            (document.getElementById(key) as HTMLElement | null) ||
+            (document.querySelector(
+              `[data-testid="${key}"]`
+            ) as HTMLElement | null);
+          if (target) break;
+        }
+
+        // 2) Fallback: first element with matching name
+        if (!target) {
+          for (const key of keys) {
+            const byName = document.getElementsByName(key);
+            if (byName && byName.length > 0) {
+              target = byName[0] as HTMLElement;
+              break;
+            }
+          }
+        }
+
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "center" });
+          if (typeof (target as any).focus === "function") {
+            (target as any).focus({ preventScroll: true });
+          }
+        }
+      } finally {
+        lastHandled.current = submitCount;
+      }
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [submitCount, errors, isSubmitting]);
+
+  return null;
+}


### PR DESCRIPTION
## Description

- When an invalid form is submitted, scroll to the error message
- Only implemented on the Assistant Creation page since this is the only one I could find that was longer than 1 page, but can implement on other long form pages when necessary

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Scroll to and focus the first invalid field after a failed submit to make errors easy to find on long forms. Added a reusable FormErrorFocus and applied it on the Assistant Creation page; other long forms can opt in later.

<!-- End of auto-generated description by cubic. -->

