### PR TITLE
Fix SharePoint Connector Timeout Issues

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -65,6 +65,7 @@ SLIM_BATCH_SIZE = 1000
 
 ASPX_EXTENSION = ".aspx"
 REQUEST_TIMEOUT = 10
+GRAPH_API_REQUEST_TIMEOUT = 30
 SHAREPOINT_DOWNLOAD_URL_REQUEST_TIMEOUT = 60
 
 
@@ -931,7 +932,10 @@ class SharepointConnector(
         params = {"$expand": "canvasLayout"}
 
         response = requests.get(
-            pages_endpoint, headers=headers, params=params, timeout=REQUEST_TIMEOUT
+            pages_endpoint,
+            headers=headers,
+            params=params,
+            timeout=GRAPH_API_REQUEST_TIMEOUT,
         )
         response.raise_for_status()
         pages_data = response.json()
@@ -940,7 +944,11 @@ class SharepointConnector(
         # Handle pagination if there are more pages
         while "@odata.nextLink" in pages_data:
             next_url = pages_data["@odata.nextLink"]
-            response = requests.get(next_url, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = requests.get(
+                next_url,
+                headers=headers,
+                timeout=GRAPH_API_REQUEST_TIMEOUT,
+            )
             response.raise_for_status()
             pages_data = response.json()
             all_pages.extend(pages_data.get("value", []))


### PR DESCRIPTION
## Description

### Problem
Fetching site pages from Microsoft Graph API often failed with 10s read timeouts, especially in `_fetch_site_pages()` when large or complex page data was returned.

### Root Cause
A single `REQUEST_TIMEOUT = 10` was used for all HTTP requests. While fine for small calls, it was too short for Graph API site pages, which can include large layouts, metadata, and web parts.

### Solution
- Added `GRAPH_API_REQUEST_TIMEOUT = 30` for Microsoft Graph API operations  
- Updated `_fetch_site_pages()` initial and pagination requests to use this longer timeout  
- Kept existing 10s timeout for smaller requests and 60s for downloads  

## How Has This Been Tested?

No additional tests needed as changes are minimal.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [x] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes frequent 10s read timeouts when fetching SharePoint site pages via Microsoft Graph. Increases reliability by using a 30s timeout for page fetches and pagination.

- **Bug Fixes**
  - Added GRAPH_API_REQUEST_TIMEOUT=30 for Graph site page requests (initial and paginated).
  - Kept 10s timeout for small calls and 60s for downloads.

<!-- End of auto-generated description by cubic. -->

