### PR TITLE
refactor: simplify sharepoint document extraction

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -212,18 +212,18 @@ def _probe_remote_size(url: str, timeout: int) -> int | None:
 
     # Fallback: Range request for first byte to read total from Content-Range
     try:
-        range_resp = requests.get(
+        with requests.get(
             url,
             headers={"Range": "bytes=0-0"},
             timeout=timeout,
             stream=True,
-        )
-        range_resp.raise_for_status()
-        cr = range_resp.headers.get("Content-Range")  # e.g., "bytes 0-0/12345"
-        if cr and "/" in cr:
-            total = cr.split("/")[-1]
-            if total.isdigit():
-                return int(total)
+        ) as range_resp:
+            range_resp.raise_for_status()
+            cr = range_resp.headers.get("Content-Range")  # e.g., "bytes 0-0/12345"
+            if cr and "/" in cr:
+                total = cr.split("/")[-1]
+                if total.isdigit():
+                    return int(total)
     except requests.RequestException:
         pass
 


### PR DESCRIPTION
## Description

- simplify order of operations and logic of sharepoint document download

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified the SharePoint download flow with reliable size checks and capped streaming, skipping oversized files early and standardizing request timeouts. This reduces download errors and prevents high memory usage when size is unknown.

- **Refactors**
  - Added helpers to get the Graph download URL, probe size via HEAD/Range, and stream with a hard cap.
  - Prefer downloadUrl streaming; fall back to SDK get_content only when needed.
  - Enforce SHAREPOINT_CONNECTOR_SIZE_THRESHOLD pre-download or during streaming; skip when exceeded with clear logs.
  - Replaced ad-hoc timeouts with REQUEST_TIMEOUT_SECONDS across requests, including site pages pagination.

<!-- End of auto-generated description by cubic. -->

