### PR TITLE
fix: IMAP - mail processing fixes

### DIFF
--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -423,7 +423,7 @@ def _sanitize_mailbox_names(mailboxes: list[str]) -> list[str]:
 
 def _parse_addrs(raw_header: str) -> list[tuple[str, str]]:
     addrs = raw_header.split(",")
-    name_addr_pairs = [parseaddr(addr=addr, strict=True) for addr in addrs if addr]
+    name_addr_pairs = [parseaddr(addr=addr) for addr in addrs if addr]
     return [(name, addr) for name, addr in name_addr_pairs if addr]
 
 

--- a/backend/onyx/connectors/imap/models.py
+++ b/backend/onyx/connectors/imap/models.py
@@ -35,10 +35,10 @@ class EmailHeaders(BaseModel):
             if not value:
                 return None
 
-            decoded_value, _encoding = email.header.decode_header(value)[0]
-
+            decoded_value, encoding = email.header.decode_header(value)[0]
             if isinstance(decoded_value, bytes):
-                return decoded_value.decode()
+                encoding = encoding or "utf-8"
+                return decoded_value.decode(encoding, errors="replace")
             elif isinstance(decoded_value, str):
                 return decoded_value
             else:


### PR DESCRIPTION
## Description

Fixes two bugs related to IMAP connector.

1. #5321 Add support for encodings other than UTF-8 in header parsing
2. #5359 The connector was using the email.utils API available only in Python >3.13

Fixes #5321, fixes #5359

## How Has This Been Tested?

Manually

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix IMAP mail processing by correctly decoding non-UTF-8 headers and using a Python 3.12-compatible address parser. Addresses #5321 (encoding) and #5359 (Python 3.13 API usage).

- **Bug Fixes**
  - Decode headers using their declared encoding; fall back to UTF-8 with replacement on errors.
  - Remove strict=True from parseaddr to avoid Python 3.13-only API and restore compatibility.

<!-- End of auto-generated description by cubic. -->

