### PR TITLE
fix: cancellation for thoughtful mode broken [DAN-2416]

### DIFF
--- a/backend/onyx/agents/agent_search/dr/process_llm_stream.py
+++ b/backend/onyx/agents/agent_search/dr/process_llm_stream.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from collections.abc import Iterator
 from typing import cast
 
@@ -42,6 +43,7 @@ def process_llm_stream(
     displayed_search_results: list[LlmDoc] | None = None,
     generate_final_answer: bool = False,
     chat_message_id: str | None = None,
+    is_connected: Callable[[], bool] | None = None,
 ) -> BasicSearchProcessedStreamResults:
     tool_call_chunk = AIMessageChunk(content="")
 
@@ -59,6 +61,10 @@ def process_llm_stream(
     # This stream will be the llm answer if no tool is chosen. When a tool is chosen,
     # the stream will contain AIMessageChunks with tool call information.
     for message in messages:
+        # Check for cancellation during streaming
+        if is_connected is not None and not is_connected():
+            logger.info("LLM stream processing cancelled due to connection loss")
+            break
 
         answer_piece = message.content
         if not isinstance(answer_piece, str):

--- a/backend/onyx/agents/agent_search/models.py
+++ b/backend/onyx/agents/agent_search/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -86,6 +87,8 @@ class GraphConfig(BaseModel):
     behavior: GraphSearchConfig
     # Only needed for agentic search
     persistence: GraphPersistence
+    # Function to check if the connection is still active (for cancellation support)
+    is_connected: Callable[[], bool] | None = None
 
     @model_validator(mode="after")
     def validate_search_tool(self) -> "GraphConfig":

--- a/backend/onyx/agents/agent_search/run_graph.py
+++ b/backend/onyx/agents/agent_search/run_graph.py
@@ -35,6 +35,11 @@ def manage_sync_streaming(
         input=graph_input,
         config={"metadata": {"config": config, "thread_id": str(message_id)}},
     ):
+        # Check for cancellation before yielding each event
+        if config.is_connected is not None and not config.is_connected():
+            logger.info("Graph streaming cancelled due to connection loss")
+            break
+
         yield cast(CustomStreamEvent, event)
 
 
@@ -47,6 +52,10 @@ def run_graph(
     for event in manage_sync_streaming(
         compiled_graph=compiled_graph, config=config, graph_input=input
     ):
+        # Check for cancellation before yielding each event
+        if config.is_connected is not None and not config.is_connected():
+            logger.info("Graph execution cancelled due to connection loss")
+            break
 
         yield cast(Packet, event["data"])
 

--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -126,6 +126,7 @@ class Answer:
             tooling=self.graph_tooling,
             persistence=self.graph_persistence,
             behavior=self.search_behavior_config,
+            is_connected=self.is_connected,
         )
 
     @property

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -173,6 +173,10 @@ class ChatRenameRequest(BaseModel):
     name: str | None = None
 
 
+class StopChatRequest(BaseModel):
+    chat_session_id: str
+
+
 class ChatSessionUpdateRequest(BaseModel):
     sharing_status: ChatSessionSharedStatus
 

--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -3,6 +3,7 @@
 import {
   buildChatUrl,
   nameChatSession,
+  stopChat,
   updateLlmOverrideForChatSession,
 } from "../services/lib";
 
@@ -252,6 +253,15 @@ export function useChatController({
 
   const stopGenerating = useCallback(() => {
     const currentSession = getCurrentSessionId();
+
+    // Call the stop-chat endpoint (fire and forget)
+    if (currentSession) {
+      stopChat(currentSession).catch((error) => {
+        console.error("Failed to call stop-chat endpoint:", error);
+        // We don't care if this fails - it's just a notification
+      });
+    }
+
     abortSession(currentSession);
 
     const lastMessage = currentMessageHistory[currentMessageHistory.length - 1];

--- a/web/src/app/chat/services/lib.tsx
+++ b/web/src/app/chat/services/lib.tsx
@@ -346,6 +346,19 @@ export async function deleteAllChatSessions() {
   return response;
 }
 
+export async function stopChat(chatSessionId: string) {
+  const response = await fetch(`/api/chat/stop-chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      chat_session_id: chatSessionId,
+    }),
+  });
+  return response;
+}
+
 export async function* simulateLLMResponse(input: string, delay: number = 30) {
   // Split the input string into tokens. This is a simple example, and in real use case, tokenization can be more complex.
   // Iterate over tokens and yield them one by one


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-2416/cancellation-experience-broken

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make cancel work reliably in Thoughtful Mode by adding end-to-end cancellation across the frontend, API, and agent graph. Streams and LLM/tool work stop immediately when the user cancels or the connection drops.

- New Features
  - Added POST /chat/stop-chat to cancel a session by chat_session_id.
  - Introduced a session-scoped cancellation event and an is_connected callback passed through GraphConfig and all LLM/graph paths.
  - Frontend calls stopChat() in stopGenerating to notify the server.

- Bug Fixes
  - Added cancellation checks before and during LLM JSON calls, streaming, tool decisions, clarifications, and graph streaming; stop emitting SSE packets when cancelled.
  - Short-circuit orchestration to END on cancel to avoid partial tool-call state.
  - Clean up session cancellation events; create an "interrupted" assistant message when a user stops after sending a prompt.

<!-- End of auto-generated description by cubic. -->

