### PR TITLE
fix(security): Remove Hard Fail from Trivy

### DIFF
--- a/.github/workflows/docker-build-push-backend-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-backend-container-on-tag.yml
@@ -163,5 +163,4 @@ jobs:
               --timeout 20m \
               --severity CRITICAL,HIGH \
               --ignorefile /tmp/.trivyignore \
-              --exit-code 1 \
               docker.io/${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}

--- a/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
@@ -155,5 +155,4 @@ jobs:
               --skip-version-check \
               --timeout 20m \
               --severity CRITICAL,HIGH \
-              --exit-code 1 \
               docker.io/${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}

--- a/.github/workflows/docker-build-push-model-server-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-model-server-container-on-tag.yml
@@ -180,5 +180,4 @@ jobs:
               --skip-version-check \
               --timeout 20m \
               --severity CRITICAL,HIGH \
-              --exit-code 1 \
               docker.io/${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}

--- a/.github/workflows/docker-build-push-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-web-container-on-tag.yml
@@ -166,5 +166,4 @@ jobs:
               --skip-version-check \
               --timeout 20m \
               --severity CRITICAL,HIGH \
-              --exit-code 1 \
               docker.io/${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
In my retry PR I added an `--exit-code 1` which is doing the correct thing of hard failing the check if there are High and Critical Vulnerabilities found in our code. 

In order to unblock the queue and get things built and uploaded, going to remove this flag for now and add it back in when we are able to properly address this and dedicate time to fixing each CVE that is identified. 

This is a combination of either adding to our trivy ignore file or properly addressing each CVE which is a non-trivial amount of work.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
