### PR TITLE
fix(federated-slack): pass in valid query

### DIFF
--- a/backend/onyx/agents/agent_search/dr/sub_agents/basic_search/dr_basic_search_2_act.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/basic_search/dr_basic_search_2_act.py
@@ -152,6 +152,7 @@ def basic_search(
                 alternate_db_session=search_db_session,
                 retrieved_sections_callback=callback_container.append,
                 skip_query_analysis=True,
+                original_query=rewritten_query,
             ),
         ):
             # get retrieved docs to send to the rest of the graph

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -293,7 +293,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         self, override_kwargs: SearchToolOverrideKwargs | None = None, **llm_kwargs: Any
     ) -> Generator[ToolResponse, None, None]:
         query = cast(str, llm_kwargs[QUERY_FIELD])
-        original_query = None
+        original_query = query
         precomputed_query_embedding = None
         precomputed_is_keyword = None
         precomputed_keywords = None
@@ -312,7 +312,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         kg_sources = None
         kg_chunk_id_zero_only = False
         if override_kwargs:
-            original_query = override_kwargs.original_query
+            original_query = override_kwargs.original_query or query
             precomputed_is_keyword = override_kwargs.precomputed_is_keyword
             precomputed_keywords = override_kwargs.precomputed_keywords
             precomputed_query_embedding = override_kwargs.precomputed_query_embedding


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes federated Slack search by always sending a valid original_query to the search tool. Defaults to the user query and uses the rewritten query when available to prevent None/empty values.

- **Bug Fixes**
  - Default original_query to query in SearchTool; fall back to query if override is missing.
  - Pass rewritten_query as original_query from DR basic search to ensure a valid query reaches retrieval and logging.

<!-- End of auto-generated description by cubic. -->

