### PR TITLE
SharePoint Connector Fix - Nested Subfolder Indexing

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -732,12 +732,13 @@ class SharepointConnector(
                         item
                         for item in driveitems
                         if item.parent_reference.path
-                        and any(
-                            path_part == site_descriptor.folder_path
-                            or path_part.startswith(site_descriptor.folder_path + "/")
-                            for path_part in item.parent_reference.path.split("root:/")[
-                                1
-                            ].split("/")
+                        and "root:/" in item.parent_reference.path
+                        and (
+                            item.parent_reference.path.split("root:/")[1]
+                            == site_descriptor.folder_path
+                            or item.parent_reference.path.split("root:/")[1].startswith(
+                                site_descriptor.folder_path + "/"
+                            )
                         )
                     ]
                     if len(driveitems) == 0:
@@ -848,14 +849,13 @@ class SharepointConnector(
                             item
                             for item in driveitems
                             if item.parent_reference.path
-                            and any(
-                                path_part == site_descriptor.folder_path
-                                or path_part.startswith(
-                                    site_descriptor.folder_path + "/"
-                                )
-                                for path_part in item.parent_reference.path.split(
-                                    "root:/"
-                                )[1].split("/")
+                            and "root:/" in item.parent_reference.path
+                            and (
+                                item.parent_reference.path.split("root:/")[1]
+                                == site_descriptor.folder_path
+                                or item.parent_reference.path.split("root:/")[
+                                    1
+                                ].startswith(site_descriptor.folder_path + "/")
                             )
                         ]
                         if len(driveitems) == 0:


### PR DESCRIPTION
## Description

### Summary

Fixed SharePoint connector bug preventing indexing of nested subfolders (e.g., `foo/bar`).
Connector worked for single folders (`foo`) but failed for nested folders (`foo/bar`) due to flawed path filtering logic.

## Root Cause

The filtering logic incorrectly split paths by "/" and checked individual segments instead of comparing complete folder paths:

```python
# BROKEN: Checked if any segment ["foo", "bar", "file.docx"] equals "foo/bar"
any(path_part == site_descriptor.folder_path for path_part in path.split("/"))
```

## Solution

Fixed to compare complete paths after `root:/`:

```python
# FIXED: Compares full path "foo/bar/file.docx" against "foo/bar"
path.split("root:/")[1] == site_descriptor.folder_path
or path.split("root:/")[1].startswith(site_descriptor.folder_path + "/")
```

## Changes Made

- Fixed filtering logic in `_get_drive_items_for_drive_name` 
- Fixed identical logic in `_fetch_driveitems`

## How Has This Been Tested?

Deployed locally and tested manually

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes SharePoint connector to correctly index nested subfolders (e.g., foo/bar) by matching the full parent path after root:/ instead of per-segment checks. Ensures documents in targeted subfolders are included without affecting single-folder behavior.

- **Bug Fixes**
  - Updated filtering in _get_drive_items_for_drive_name and _fetch_driveitems to compare the full path under root:/ and allow descendants via startswith.
  - Added a guard to require "root:/" in parent paths to avoid false matches.

<!-- End of auto-generated description by cubic. -->

