### PR TITLE
[running GitHub actions for #5404]

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -732,12 +732,13 @@ class SharepointConnector(
                         item
                         for item in driveitems
                         if item.parent_reference.path
-                        and any(
-                            path_part == site_descriptor.folder_path
-                            or path_part.startswith(site_descriptor.folder_path + "/")
-                            for path_part in item.parent_reference.path.split("root:/")[
-                                1
-                            ].split("/")
+                        and "root:/" in item.parent_reference.path
+                        and (
+                            item.parent_reference.path.split("root:/")[1]
+                            == site_descriptor.folder_path
+                            or item.parent_reference.path.split("root:/")[1].startswith(
+                                site_descriptor.folder_path + "/"
+                            )
                         )
                     ]
                     if len(driveitems) == 0:
@@ -848,14 +849,13 @@ class SharepointConnector(
                             item
                             for item in driveitems
                             if item.parent_reference.path
-                            and any(
-                                path_part == site_descriptor.folder_path
-                                or path_part.startswith(
-                                    site_descriptor.folder_path + "/"
-                                )
-                                for path_part in item.parent_reference.path.split(
-                                    "root:/"
-                                )[1].split("/")
+                            and "root:/" in item.parent_reference.path
+                            and (
+                                item.parent_reference.path.split("root:/")[1]
+                                == site_descriptor.folder_path
+                                or item.parent_reference.path.split("root:/")[
+                                    1
+                                ].startswith(site_descriptor.folder_path + "/")
                             )
                         ]
                         if len(driveitems) == 0:


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes nested subfolder indexing in the SharePoint connector by correcting path matching under a scoped folder. Ensures files in child folders are indexed when using folder_path (addresses Linear #5404).

- **Bug Fixes**
  - Verify "root:/" exists and compare the full path after it to folder_path, including children.
  - Apply the same logic in _get_drive_items_for_drive_name and _fetch_driveitems for consistency.

<!-- End of auto-generated description by cubic. -->

