### PR TITLE
feat: plumb auto sync permission attempts to celery tasks

### DIFF
--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -1,8 +1,10 @@
 import os
 import uuid
+from unittest.mock import patch
 
 import httpx
 import pytest
+from sqlalchemy import select
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import EXTERNAL_USER_EMAILS
@@ -13,6 +15,8 @@ from onyx.db.document import get_documents_by_ids
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingStatus
+from onyx.db.enums import PermissionSyncStatus
+from onyx.db.models import DocPermissionSyncAttempt
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -128,3 +132,237 @@ def test_mock_connector_initial_permission_sync(
     )
     assert updated_cc_pair_info is not None
     assert updated_cc_pair_info.last_full_permission_sync is not None
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_tracking_integration(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are properly tracked during real sync workflows."""
+
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-attempt-tracking-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.sync(
+        cc_pair=cc_pair,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.wait_for_sync(
+        cc_pair=cc_pair,
+        after=index_attempt.time_created,
+        number_of_updated_docs=1,
+        user_performing_action=admin_user,
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status in [
+            PermissionSyncStatus.SUCCESS,
+            PermissionSyncStatus.COMPLETED_WITH_ERRORS,
+            PermissionSyncStatus.FAILED,
+        ]
+        assert attempt.total_docs_synced >= 0
+        assert attempt.docs_with_permission_errors >= 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_tracking_with_mocked_failure(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are properly tracked when sync fails."""
+
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-attempt-failure-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    # Mock the permission sync to force a failure and verify attempt tracking
+    with patch(
+        "ee.onyx.background.celery.tasks.doc_permission_syncing.tasks.validate_ccpair_for_user"
+    ) as mock_validate:
+        mock_validate.side_effect = Exception("Validation failed for testing")
+
+        try:
+            CCPairManager.sync(
+                cc_pair=cc_pair,
+                user_performing_action=admin_user,
+            )
+            CCPairManager.wait_for_sync(
+                cc_pair=cc_pair,
+                after=index_attempt.time_created,
+                number_of_updated_docs=0,
+                user_performing_action=admin_user,
+            )
+        except Exception:
+            pass
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status == PermissionSyncStatus.FAILED
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_status_success(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are marked as SUCCESS when sync completes without errors."""
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-success-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.sync(
+        cc_pair=cc_pair,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.wait_for_sync(
+        cc_pair=cc_pair,
+        after=index_attempt.time_created,
+        number_of_updated_docs=1,
+        user_performing_action=admin_user,
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status == PermissionSyncStatus.SUCCESS
+        assert attempt.total_docs_synced >= 0
+        assert attempt.docs_with_permission_errors == 0


### PR DESCRIPTION
## Description

Partial completion of: https://linear.app/danswer/issue/DAN-2494/sync-permissions-database-and-backend-updates

Modify existing permission sync tasks to create/update attempt records. This just plumbs in the attempt tracking logic and adds some integration tests. 

PR Stack:
1. [feat: tables/migration for permission syncing attempts ](https://github.com/onyx-dot-app/onyx/pull/5397)
2. [feat: basic db methods to create and update permission sync attempts](https://github.com/onyx-dot-app/onyx/pull/5400) 
3. [feat: plumb auto sync permission attempts to celery tasks](https://github.com/onyx-dot-app/onyx/pull/5407) -> you are here
4. feat: read latest permission sync from the frontend


## How Has This Been Tested?

integration tests and some manual testing.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds attempt-level tracking for permission syncs (documents and external groups) and wires it into Celery tasks. Improves observability with clear statuses and progress metrics, aligning with Linear DAN-2494.

- **New Features**
  - Added PermissionSyncStatus enum and two tables: doc_permission_sync_attempt and external_group_permission_sync_attempt.
  - Implemented CRUD helpers to create, update progress, and mark attempts (in_progress, success, failed, completed_with_errors) with row locks and telemetry.
  - Integrated with connector_permission_sync_generator_task and external group sync to create attempts, track progress (docs/errors, users/groups/memberships), and set final status on success/failure.
  - Added unit tests for CRUD and integration tests to verify attempt lifecycle.

- **Migration**
  - Run Alembic migration 03d710ccf29c to add tables and indexes. No manual backfill required.

<!-- End of auto-generated description by cubic. -->

