### PR TITLE
feat: read latest permission sync from the frontend

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -617,7 +617,7 @@ def connector_permission_sync_generator_task(
 
         with get_session_with_current_tenant() as db_session:
             mark_doc_permission_sync_attempt_failed(
-                attempt_id, db_session, error_message=error_msg
+                attempt_id, db_session, error_message=str(e)
             )
 
         redis_connector.permissions.generator_clear()

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -544,9 +544,8 @@ def _perform_external_group_sync(
                     source=cc_pair.connector.source,
                 )
         except Exception as e:
-            error_msg = format_error_for_logging(e)
             mark_external_group_sync_attempt_failed(
-                attempt_id, db_session, error_message=error_msg
+                attempt_id, db_session, error_message=str(e)
             )
 
             # TODO: add some notification to the admins here

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -267,6 +267,22 @@ def get_doc_permission_sync_attempt(
     return db_session.scalars(stmt).first()
 
 
+def get_latest_doc_permission_sync_attempt_for_cc_pair(
+    db_session: Session,
+    connector_credential_pair_id: int,
+) -> DocPermissionSyncAttempt | None:
+    """Get the latest doc permission sync attempt for a connector credential pair."""
+    return db_session.execute(
+        select(DocPermissionSyncAttempt)
+        .where(
+            DocPermissionSyncAttempt.connector_credential_pair_id
+            == connector_credential_pair_id
+        )
+        .order_by(DocPermissionSyncAttempt.time_finished.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
 def get_recent_doc_permission_sync_attempts_for_cc_pair(
     cc_pair_id: int,
     limit: int,

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -37,6 +37,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus
+from onyx.db.enums import PermissionSyncStatus
 from onyx.db.index_attempt import count_index_attempt_errors_for_cc_pair
 from onyx.db.index_attempt import count_index_attempts_for_cc_pair
 from onyx.db.index_attempt import get_index_attempt_errors_for_cc_pair
@@ -45,6 +46,12 @@ from onyx.db.index_attempt import get_paginated_index_attempts_for_cc_pair_id
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import User
+from onyx.db.permission_sync_attempt import (
+    get_latest_doc_permission_sync_attempt_for_cc_pair,
+)
+from onyx.db.permission_sync_attempt import (
+    get_recent_doc_permission_sync_attempts_for_cc_pair,
+)
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_utils import get_deletion_attempt_snapshot
 from onyx.redis.redis_pool import get_redis_client
@@ -56,6 +63,7 @@ from onyx.server.documents.models import ConnectorCredentialPairMetadata
 from onyx.server.documents.models import DocumentSyncStatus
 from onyx.server.documents.models import IndexAttemptSnapshot
 from onyx.server.documents.models import PaginatedReturn
+from onyx.server.documents.models import PermissionSyncAttemptSnapshot
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -101,6 +109,48 @@ def get_cc_pair_index_attempts(
     )
 
 
+@router.get("/admin/cc-pair/{cc_pair_id}/permission-sync-attempts")
+def get_cc_pair_permission_sync_attempts(
+    cc_pair_id: int,
+    page_num: int = Query(0, ge=0),
+    page_size: int = Query(10, ge=1, le=1000),
+    user: User | None = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> PaginatedReturn[PermissionSyncAttemptSnapshot]:
+    if user:
+        user_has_access = verify_user_has_access_to_cc_pair(
+            cc_pair_id, db_session, user, get_editable=False
+        )
+        if not user_has_access:
+            raise HTTPException(
+                status_code=400, detail="CC Pair not found for current user permissions"
+            )
+
+    # Get all permission sync attempts for this cc pair
+    all_attempts = get_recent_doc_permission_sync_attempts_for_cc_pair(
+        cc_pair_id=cc_pair_id,
+        limit=1000,
+        db_session=db_session,
+    )
+
+    start_idx = page_num * page_size
+    end_idx = start_idx + page_size
+    paginated_attempts = all_attempts[start_idx:end_idx]
+    items = (
+        [
+            PermissionSyncAttemptSnapshot.from_permission_sync_attempt_db_model(attempt)
+            for attempt in paginated_attempts
+        ],
+    )
+
+    print(f"items: {items}")
+
+    return PaginatedReturn(
+        items=items,
+        total_items=len(all_attempts),
+    )
+
+
 @router.get("/admin/cc-pair/{cc_pair_id}")
 def get_cc_pair_full_info(
     cc_pair_id: int,
@@ -143,6 +193,16 @@ def get_cc_pair_full_info(
         only_finished=False,
     )
 
+    # Get latest permission sync attempt for status
+    latest_permission_sync_attempt = None
+    if cc_pair.access_type == AccessType.SYNC:
+        latest_permission_sync_attempt = (
+            get_latest_doc_permission_sync_attempt_for_cc_pair(
+                db_session=db_session,
+                connector_credential_pair_id=cc_pair_id,
+            )
+        )
+
     return CCPairFullInfo.from_models(
         cc_pair_model=cc_pair,
         number_of_index_attempts=count_index_attempts_for_cc_pair(
@@ -160,6 +220,26 @@ def get_cc_pair_full_info(
         is_editable_for_current_user=is_editable_for_current_user,
         indexing=bool(
             latest_attempt and latest_attempt.status == IndexingStatus.IN_PROGRESS
+        ),
+        last_permission_sync_attempt_status=(
+            latest_permission_sync_attempt.status
+            if latest_permission_sync_attempt
+            else None
+        ),
+        permission_syncing=bool(
+            latest_permission_sync_attempt
+            and latest_permission_sync_attempt.status
+            == PermissionSyncStatus.IN_PROGRESS
+        ),
+        last_permission_sync_attempt_finished=(
+            latest_permission_sync_attempt.time_finished
+            if latest_permission_sync_attempt
+            else None
+        ),
+        last_permission_sync_attempt_error_message=(
+            latest_permission_sync_attempt.error_message
+            if latest_permission_sync_attempt
+            else None
         ),
     )
 

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -4,7 +4,7 @@ import { BackButton } from "@/components/BackButton";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { SourceIcon } from "@/components/SourceIcon";
-import { CCPairStatus } from "@/components/Status";
+import { CCPairStatus, PermissionSyncStatus } from "@/components/Status";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import CredentialSection from "@/components/credentials/CredentialSection";
 import {
@@ -633,14 +633,31 @@ function Main({ ccPairId }: { ccPairId: number }) {
           </div>
 
           {ccPair.access_type === "sync" && (
-            <div className="w-[200px]">
-              <div className="text-sm font-medium mb-1">
-                Last Permission Synced
+            <>
+              <div className="w-[200px]">
+                <div className="text-sm font-medium mb-1">
+                  Permission Syncing
+                </div>
+                {ccPair.permission_syncing ||
+                ccPair.last_permission_sync_attempt_status ? (
+                  <PermissionSyncStatus
+                    status={ccPair.last_permission_sync_attempt_status}
+                    errorMsg={ccPair.last_permission_sync_attempt_error_message}
+                  />
+                ) : (
+                  <PermissionSyncStatus status={null} />
+                )}
               </div>
-              <div className="text-sm text-text-default">
-                {timeAgo(ccPair.last_full_permission_sync) ?? "-"}
+
+              <div className="w-[200px]">
+                <div className="text-sm font-medium mb-1">Last Synced</div>
+                <div className="text-sm text-text-default">
+                  {ccPair.last_permission_sync_attempt_finished
+                    ? timeAgo(ccPair.last_permission_sync_attempt_finished)
+                    : (timeAgo(ccPair.last_full_permission_sync) ?? "-")}
+                </div>
               </div>
-            </div>
+            </>
           )}
         </div>
       </Card>

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -17,6 +17,14 @@ export enum ConnectorCredentialPairStatus {
   INVALID = "INVALID",
 }
 
+export enum PermissionSyncStatusEnum {
+  NOT_STARTED = "not_started",
+  IN_PROGRESS = "in_progress",
+  SUCCESS = "success",
+  FAILED = "failed",
+  COMPLETED_WITH_ERRORS = "completed_with_errors",
+}
+
 /**
  * Returns true if the status is not currently active (i.e. paused or invalid), but not deleting
  */
@@ -52,6 +60,12 @@ export interface CCPairFullInfo {
   last_full_permission_sync: string | null;
   overall_indexing_speed: number | null;
   latest_checkpoint_description: string | null;
+
+  // permission sync attempt status
+  last_permission_sync_attempt_status: PermissionSyncStatusEnum | null;
+  permission_syncing: boolean;
+  last_permission_sync_attempt_finished: string | null;
+  last_permission_sync_attempt_error_message: string | null;
 }
 
 export interface PaginatedIndexAttempts {

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -2,6 +2,7 @@
 
 import { ValidStatuses } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
+import { timeAgo } from "@/lib/time";
 import {
   FiAlertTriangle,
   FiCheckCircle,
@@ -9,7 +10,10 @@ import {
   FiMinus,
   FiPauseCircle,
 } from "react-icons/fi";
-import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
+import {
+  ConnectorCredentialPairStatus,
+  PermissionSyncStatusEnum,
+} from "@/app/admin/connector/[ccPairId]/types";
 import {
   Tooltip,
   TooltipContent,
@@ -86,6 +90,79 @@ export function IndexAttemptStatus({
     badge = (
       <Badge variant="outline" icon={FiMinus}>
         None
+      </Badge>
+    );
+  }
+
+  return <div>{badge}</div>;
+}
+
+export function PermissionSyncStatus({
+  status,
+  errorMsg,
+}: {
+  status: PermissionSyncStatusEnum | null;
+  errorMsg?: string | null;
+}) {
+  let badge;
+
+  if (status === PermissionSyncStatusEnum.FAILED) {
+    const icon = (
+      <Badge variant="destructive" icon={FiAlertTriangle}>
+        Failed
+      </Badge>
+    );
+    if (errorMsg) {
+      badge = (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="cursor-pointer">{icon}</div>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-md p-3 text-left">
+              <div className="text-sm">
+                <div className="font-medium mb-2 text-red-600">
+                  Error Details:
+                </div>
+                <div className="whitespace-pre-wrap break-words leading-relaxed">
+                  {errorMsg}
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    } else {
+      badge = icon;
+    }
+  } else if (status === PermissionSyncStatusEnum.COMPLETED_WITH_ERRORS) {
+    badge = (
+      <Badge variant="secondary" icon={FiAlertTriangle}>
+        Completed with errors
+      </Badge>
+    );
+  } else if (status === PermissionSyncStatusEnum.SUCCESS) {
+    badge = (
+      <Badge variant="success" icon={FiCheckCircle}>
+        Succeeded
+      </Badge>
+    );
+  } else if (status === PermissionSyncStatusEnum.IN_PROGRESS) {
+    badge = (
+      <Badge variant="in_progress" icon={FiClock}>
+        In Progress
+      </Badge>
+    );
+  } else if (status === PermissionSyncStatusEnum.NOT_STARTED) {
+    badge = (
+      <Badge variant="not_started" icon={FiClock}>
+        Scheduled
+      </Badge>
+    );
+  } else {
+    badge = (
+      <Badge variant="secondary" icon={FiClock}>
+        Not Started
       </Badge>
     );
   }


### PR DESCRIPTION
## Description

Partial completion of: https://linear.app/danswer/issue/DAN-2494/sync-permissions-database-and-backend-updates

Modify existing permission sync tasks to create/update attempt records. This just plumbs in the attempt tracking logic and adds some integration tests. 

PR Stack:
1. [feat: tables/migration for permission syncing attempts ](https://github.com/onyx-dot-app/onyx/pull/5397)
2. [feat: basic db methods to create and update permission sync attempts](https://github.com/onyx-dot-app/onyx/pull/5400) 
3. [feat: plumb auto sync permission attempts to celery tasks](https://github.com/onyx-dot-app/onyx/pull/5407) 
4. feat: read latest permission sync from the frontend-> you are here


## How Has This Been Tested?

Manual testing so far. Need to add E2E tests. See video (kinda long....will add timestamps to view updates).

Status updates
0:00  - Not Started
1:55 - In Progress -> kicked off after indexing completed
2:35 - Completed


https://github.com/user-attachments/assets/239a0bbd-3ae2-442a-8858-cef205c1af13


I had to manually set the error state in the DB and upon hovering we see the details of the error.
<img width="964" height="341" alt="Screenshot 2025-09-12 at 5 58 19 PM" src="https://github.com/user-attachments/assets/b49617d5-d70b-456f-84c3-10b0b2646720" />


## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expose the latest permission-sync status and last sync time on the connector details page, backed by a new API and model updates. This progresses Linear DAN-2494 by wiring frontend UX to permission sync attempt data.

- New Features
  - Backend
    - Added get_latest_doc_permission_sync_attempt_for_cc_pair DB helper.
    - New GET /admin/cc-pair/{cc_pair_id}/permission-sync-attempts (paginated) returning PermissionSyncAttemptSnapshot.
    - CCPairFullInfo now includes last_permission_sync_attempt_status, permission_syncing, and last_permission_sync_attempt_finished.
  - Frontend
    - Connector page shows Permission Syncing badge and Last Synced time (with fallbacks).
    - Added PermissionSyncStatus component and PermissionSyncStatusEnum; updated types to consume new fields.

<!-- End of auto-generated description by cubic. -->

