### PR TITLE
fix: playwright flakiness

### DIFF
--- a/web/tests/e2e/chat/current_assistant.spec.ts
+++ b/web/tests/e2e/chat/current_assistant.spec.ts
@@ -89,6 +89,7 @@ test("Assistant Drag and Drop", async ({ page }, testInfo) => {
   expect(orderAfterDragUp[1]).toBe(initialOrder[0]);
 
   // Drag last assistant to second position
+  console.log("Dragging last assistant to second position");
   const assistants = page.locator('[data-testid^="assistant-["]');
   const lastIndex = (await assistants.count()) - 1;
   const lastAssistant = assistants.nth(lastIndex);


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a flaky Playwright drag-and-drop test by waiting for the assistant list to stabilize before continuing. Adds a small polling helper that verifies expected names are present and the order is consistent across consecutive checks.

<!-- End of auto-generated description by cubic. -->

