### PR TITLE
Fix Toggles

### DIFF
--- a/web/src/app/chat/components/input/ActionManagement.tsx
+++ b/web/src/app/chat/components/input/ActionManagement.tsx
@@ -268,6 +268,11 @@ function MCPToolsList({
         ? disabledToolIds.filter((id) => id !== toolId)
         : [...disabledToolIds, toolId],
     });
+
+    // If we're disabling a tool that is currently forced, remove it from forced tools
+    if (!disabled && forcedToolIds.includes(toolId)) {
+      setForcedToolIds(forcedToolIds.filter((id) => id !== toolId));
+    }
   };
 
   const toggleForcedTool = (toolId: number) => {
@@ -427,6 +432,11 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
         ? disabledToolIds.filter((id) => id !== toolId)
         : [...disabledToolIds, toolId],
     });
+
+    // If we're disabling a tool that is currently forced, remove it from forced tools
+    if (!disabled && forcedToolIds.includes(toolId)) {
+      setForcedToolIds(forcedToolIds.filter((id) => id !== toolId));
+    }
   };
 
   const toggleForcedTool = (toolId: number) => {


### PR DESCRIPTION
## Description

Unintuitive toggle behavior now fixed

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix toggle behavior so disabling a tool automatically clears it from forced tools, preventing contradictory states in MCPToolsList and ActionToggle. Users can no longer have a tool both disabled and forced; toggles now stay in sync.

<!-- End of auto-generated description by cubic. -->

