### PR TITLE
feat: pass slack thread context to llm as message_history

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -3,7 +3,7 @@ import time
 import traceback
 from collections.abc import Callable
 from collections.abc import Iterator
-from typing import cast
+from typing import cast, List
 from typing import Protocol
 
 from sqlalchemy.orm import Session
@@ -253,6 +253,7 @@ def stream_chat_message_objects(
     # a string which represents the history of a conversation. Used in cases like
     # Slack threads where the conversation cannot be represented by a chain of User/Assistant
     # messages.
+    message_history: List[PreviousMessage] | None = None,
     # NOTE: is not stored in the database at all.
     single_message_history: str | None = None,
 ) -> AnswerStream:
@@ -613,11 +614,11 @@ def stream_chat_message_objects(
         force_use_tool = _get_force_search_settings(
             new_msg_req, tools, search_tool_override_kwargs_for_user_files
         )
-
-        # TODO: unify message history with single message history
-        message_history = [
-            PreviousMessage.from_chat_message(msg, files) for msg in history_msgs
-        ]
+        if message_history is None:
+            # TODO: unify message history with single message history
+            message_history = [
+                PreviousMessage.from_chat_message(msg, files) for msg in history_msgs
+            ]
         if not search_tool_override_kwargs_for_user_files and in_memory_user_files:
             yield UserKnowledgeFilePacket(
                 user_files=[


### PR DESCRIPTION
## Description

Previously, Slack integration was using single_message_history but wasn't passing this to LLM for previous context. 
This solution just passes all thread messages as message_history so LLM can get context of the thread. 
Also we are not storing anything at onyx side so it shouldn't be issue in terms of slack


## How Has This Been Tested?

Manually

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added per-message history with token counting for Slack threads to improve context management and prevent token overflow in long conversations.

- **New Features**
  - Introduced message_history parameter in stream_chat_message_objects.
  - Slack handler builds a list of PreviousMessage with token_count using the persona’s tokenizer.
  - Passes message_history and single_message_history to chat processing, with a safe fallback when message_history is None.

<!-- End of auto-generated description by cubic. -->

