### PR TITLE
Port 80

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -261,7 +261,7 @@ services:
     environment:
       - DOMAIN=localhost
     ports:
-    # - "80:80"
+      - "80:80"
       - "${HOST_PORT:-3000}:80" # allow for localhost:3000 usage, since that is the norm
     volumes:
       - ../data/nginx:/etc/nginx/conf.d


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled the 80:80 port mapping for the nginx service in docker-compose. The app is now accessible at http://localhost:80, in addition to http://localhost:3000.

<!-- End of auto-generated description by cubic. -->

