### PR TITLE
Docker Version Check

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -46,6 +46,10 @@ services:
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
       uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    # Check env.template and copy to .env for env vars
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       - relational_db
       - index
@@ -93,6 +97,9 @@ services:
         update-ca-certificates;
       fi &&
       /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf"
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       - relational_db
       - index
@@ -148,6 +155,9 @@ services:
         # DO NOT TURN ON unless you have EXPLICIT PERMISSION from Onyx.
         - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
         - NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=4096"}
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       - api_server
     restart: unless-stopped
@@ -175,6 +185,9 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
     volumes:
       # Not necessary, this is just to reduce download time during startup
@@ -208,6 +221,9 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
     environment:
       - INDEXING_ONLY=True
@@ -226,6 +242,9 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
     # PRODUCTION: Override the defaults by passing in the environment variables
     environment:
@@ -243,6 +262,9 @@ services:
   index:
     image: vespaengine/vespa:8.526.15
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=${VESPA_SKIP_UPGRADE_CHECK:-true}
     # DEV: To expose ports, either:
@@ -267,6 +289,9 @@ services:
     depends_on:
       - api_server
       - web_server
+    env_file:
+      - path: .env
+        required: false
     environment:
       - DOMAIN=localhost
     ports:
@@ -303,6 +328,9 @@ services:
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
+    env_file:
+      - path: .env
+        required: false
 
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
@@ -313,6 +341,9 @@ services:
     # ports:
     #   - "9004:9000"
     #   - "9005:9001"
+    env_file:
+      - path: .env
+        required: false
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}


### PR DESCRIPTION
## Description

Env vars was previously not picked up correctly by containers

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ensures all containers load env vars from a .env file and adds a Docker Compose version check to prevent parsing errors with the new env_file format.

- **New Features**
  - Add env_file: .env (required: false) to all services in docker-compose.yml.
  - install.sh warns if Docker Compose is older than 2.24.0 and provides upgrade/manual-edit guidance with a continue/cancel prompt.

- **Migration**
  - Recommended: Upgrade Docker Compose to 2.24.0+.
  - Or manually change each env_file block to: env_file: .env.

<!-- End of auto-generated description by cubic. -->

