### PR TITLE
fix(projects): Schema migration downgrade

### DIFF
--- a/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
+++ b/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
@@ -286,10 +286,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Cannot restore deleted data - requires backup restoration."""
 
-    logger.error("CRITICAL: Downgrading data cleanup cannot restore deleted data!")
-    logger.error("Data restoration requires backup files or database backup.")
-
-    raise NotImplementedError(
+    logger.warning("CRITICAL: Downgrading data cleanup cannot restore deleted data!")
+    logger.warning("Data restoration requires backup files or database backup.")
+    logger.warning(
         "Downgrade of legacy data cleanup is not supported. "
         "Deleted data must be restored from backups."
     )


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
There is a breaking change with the downgrade logic of the projects. This PR aims to fix this so that people able to downgrade.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
N/A

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow downgrades past the user_file_legacy_data_cleanup migration by replacing the hard failure with warnings. This fixes the broken downgrade path; restoring deleted data still requires backups.

- **Bug Fixes**
  - Removed NotImplementedError in downgrade() and switched error logs to warnings.
  - Downgrade no longer blocks; it logs that deleted data cannot be restored.

<!-- End of auto-generated description by cubic. -->

