### PR TITLE
More prod fixes

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -104,6 +104,9 @@ services:
     command: -c 'max_connections=250'
     restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
+    env_file:
+    - path: .env
+      required: false
     volumes:
       - db_volume:/var/lib/postgresql/data
     logging:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -182,6 +182,9 @@ services:
     command: -c 'max_connections=250'
     restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - db_volume:/var/lib/postgresql/data
     logging:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -136,6 +136,9 @@ services:
     command: -c 'max_connections=250'
     restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - db_volume:/var/lib/postgresql/data
     logging:


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Load an optional .env file for the Postgres service across all production Docker Compose files to simplify configuration and avoid startup failures when env vars aren't provided externally. If .env is present, POSTGRES_* vars are read; if not, behavior remains unchanged.

<!-- End of auto-generated description by cubic. -->

