### PR TITLE
Feature/confluence cql pagination sanitize

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -919,10 +919,10 @@ class OnyxConfluence:
         response = self.post(url, data=data)
         logger.debug(f"jsonrpc response: {response}")
         if not response.get("result"):
-            logger.warning(
-                f"No jsonrpc response for space permissions for space {space_key}"
-                f"\nResponse: {response}"
+            logger.info(
+                f"No jsonrpc result for space permissions for space {space_key}; likely insufficient permissions."
             )
+            return []
 
         return response.get("result", [])
 


### PR DESCRIPTION
## Description
Confluence sometimes echoes query params passed via `params` back into  the `_links.next` URL, which can cause duplicate `expand` and  `body-format` entries to accumulate across pages. To avoid URL growth and eventual 400s, strip these from the path before issuing the request and re-apply them via the `params` argument.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sanitizes Confluence CQL pagination URLs to stop duplicated expand/body-format params that bloat URLs and cause 400s. Also handles missing space-permissions JSON-RPC results more gracefully.

- **Bug Fixes**
  - Strip duplicate expand/body-format from _links.next, rebuild a clean path, and merge existing expansions with body.atlas_doc_format.
  - Fallback to original URL if parsing fails.
  - Downgrade log to info and return [] when space permissions JSON-RPC has no result (likely insufficient permissions).

<!-- End of auto-generated description by cubic. -->

