### PR TITLE
fix: try reduce playwright flake

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   expect: {
     timeout: 15000, // 15 seconds timeout for all assertions to reduce flakiness
   },
+  retries: process.env.CI ? 2 : 0, // Retry failed tests 2 times in CI, 0 locally
+  workers: process.env.CI ? 2 : undefined, // Limit to 2 parallel workers in CI to reduce flakiness
   reporter: [
     ["list"],
     // Warning: uncommenting the html reporter may cause the chromatic-archives


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduce Playwright test flakiness in CI by enabling 2 retries and limiting parallel workers to 2. Local runs remain unchanged with 0 retries.

<!-- End of auto-generated description by cubic. -->

