### PR TITLE
fix: Comment out keystroke hijacking

### DIFF
--- a/web/src/hooks/useKeyPress.ts
+++ b/web/src/hooks/useKeyPress.ts
@@ -7,21 +7,18 @@ export function useKeyPress(
   key: string,
   enabled: boolean = true
 ) {
-  useEffect(() => {
-    if (!enabled) return;
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key !== key) return;
-
-      event.preventDefault();
-      callback();
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [callback, enabled]);
+  // useEffect(() => {
+  //   if (!enabled) return;
+  //   function handleKeyDown(event: KeyboardEvent) {
+  //     if (event.key !== key) return;
+  //     event.preventDefault();
+  //     callback();
+  //   }
+  //   document.addEventListener("keydown", handleKeyDown);
+  //   return () => {
+  //     document.removeEventListener("keydown", handleKeyDown);
+  //   };
+  // }, [callback, enabled]);
 }
 
 /**


### PR DESCRIPTION
## Description

Restores pressing enter. Previously, there was a listener which would always listen to "Enter" keystroke events and "hijack" them, essentially.

This PR comments that out for now, until a better solution is found.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stops global Enter key hijacking by disabling the global keydown listener in useKeyPress. Restores default Enter behavior (e.g., submitting forms and adding newlines in textareas) until we implement a scoped solution.

<!-- End of auto-generated description by cubic. -->

