### PR TITLE
feat: Update formik colours (action + danger) new new colour palette

### DIFF
--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -355,7 +355,6 @@ export function TextFormField({
             ring-offset-background-neutral-00
             file:text-text-inverted-05
             text-text-04
-            placeholder:text-text-02
 
             ${heightString}
             ${sizeClass.input}
@@ -499,7 +498,7 @@ export function TypedFileUploadFormField({
     <div className="w-full">
       <FieldLabel name={name} label={label} subtext={subtext} />
       {description && (
-        <div className="text-sm text-text-02 mb-2">{description}</div>
+        <div className="text-sm text-text-03 mb-2">{description}</div>
       )}
       <FileUpload
         selectedFiles={field.value ? [field.value.file] : []}
@@ -623,7 +622,7 @@ export const MarkdownFormField = ({
       <div className="border border-border-02 rounded-md">
         <div className="flex items-center justify-between px-4 py-2 bg-background-neutral-02 rounded-t-md">
           <div className="flex items-center space-x-2">
-            <FaMarkdown className="text-text-02" />
+            <FaMarkdown className="text-text-03" />
             <span className="text-sm font-semibold text-text-04">Markdown</span>
           </div>
           <button


### PR DESCRIPTION
## Description

This PR updates the existing action / danger colours for `formik` components to use the new colour scheme.

Addresses: https://linear.app/danswer/issue/DAN-2774/re-add-missing-red-error-text-for-formik.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated Formik component colors to the new palette, restoring consistent action/danger styles and neutral text across inputs. Addresses Linear DAN-2774 by re-adding red error text on validation messages.

- **Refactors**
  - Replaced error tokens with text-action-danger-05 across ErrorMessage, ManualErrorMessage, and validation feedback.
  - Updated neutral/text, border, and background tokens (text-03/04/05, border-02/03, background-neutral-00/02) for labels, placeholders, inputs, and the Markdown editor.
  - Switched validating status to status-info-05 and moved disabled tooltips to inverted tokens.
  - Cleaned hover, ring-offset, and file input styles to align with the new design system.

<!-- End of auto-generated description by cubic. -->

