### PR TITLE
fix(eml): Fixing EML to Text Function

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -500,7 +500,10 @@ def eml_to_text(file: IO[Any]) -> str:
         try:
             # Keep underlying upload handle open for downstream consumers.
             raw_file = text_file.detach()
-        except Exception:
+        except Exception as detach_error:
+            logger.warning(
+                f"Failed to detach TextIOWrapper for EML upload, using original file: {detach_error}"
+            )
             raw_file = file
         try:
             raw_file.seek(0)


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Customer has reported that .eml files hang and never get uploaded properly. 

This PR aims to fix that and allow us to parse the eml files correctly. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Generated an eml file locally and uploaded to confirm the fix works. Without the fix, I am able to reproduce the error the customer is seeing.

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes .eml uploads hanging by ensuring eml_to_text keeps the raw file handle open and rewinds it after parsing so downstream steps can read the file.

- **Bug Fixes**
  - Use try/finally to detach TextIOWrapper and preserve the underlying upload handle.
  - Reset the file pointer to 0; handle detach/seek errors safely.

<!-- End of auto-generated description by cubic. -->

