### PR TITLE
fix: show canceled status when indexing is canceled

### DIFF
--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -153,6 +153,15 @@ export function CCPairStatus({
           Indexing
         </Badge>
       );
+    } else if (
+      lastIndexAttemptStatus &&
+      lastIndexAttemptStatus === "canceled"
+    ) {
+      badge = (
+        <Badge variant="canceled" icon={FiClock}>
+          Canceled
+        </Badge>
+      );
     } else {
       badge = (
         <Badge variant="success" icon={FiCheckCircle}>


### PR DESCRIPTION
## Description

Closes https://linear.app/danswer/issue/DAN-2407/dont-show-completed-when-last-index-attempt-is-canceled

This change reflects the correct status chip when an indexing attempt is canceled.

<img width="857" height="310" alt="Screenshot 2025-10-09 at 11 06 14 AM" src="https://github.com/user-attachments/assets/fd20ac6b-9bc6-4ba9-b9d9-d925208eb377" />


## How Has This Been Tested?
manual testing. I did also add some react unit tests but leaving out for now. can add them in a follow up (create a new suite of react unit tests)

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show a “Canceled” status chip when an indexing attempt is canceled, so the UI reflects the correct state.
Adds a canceled branch in Status.tsx to render the canceled badge with FiClock.

<!-- End of auto-generated description by cubic. -->

