### PR TITLE
fix(helm): Removing duplicate exec

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -366,18 +366,12 @@ celery_shared:
   readinessProbe:
     # readinessProbe fails after 15s + 2m of inactivity
     # it's ok to see the readinessProbe fail transiently while the container starts
-    # NOTE(subash): I can't able to run the pod in the local without this line - so added it here. (justin)Please verify if it is required.
-    exec:
-      command: ["test", "-f", "/app/onyx/main.py"]
     initialDelaySeconds: 15
     periodSeconds: 5
     failureThreshold: 24
     timeoutSeconds: 3
   livenessProbe:
     # livenessProbe fails after 5m of inactivity
-    # NOTE(subash): I can't able to run the pod in the local without this line - so added it here. (justin)Please verify if it is required.
-    exec:
-      command: ["test", "-f", "/app/onyx/main.py"]
     initialDelaySeconds: 60
     periodSeconds: 60
     failureThreshold: 5


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
This is breaking for customers and we shouldn't add this for the celery_shared setup. If anything it should be targeted to just specific pods.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Removal and making it go back to what it was before

## Additional Options

- [x] [Optional] Override Linear Check
