### PR TITLE
fix: use system node version for prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     hooks:
     - id: prettier
       types_or: [html, css, javascript, ts, tsx]
+      language_version: system
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Description

I got into some weird state where I was trying to download node 24 via the prettier hook. This would fail consistently when running git commit. This change forces the pre-commit hook to use whatever version of node is installed on the host which _should_ be 22 if following [these instructions](https://github.com/onyx-dot-app/onyx/blob/bc3adcdc8951b08fe83b472fa4f543f8e2336fbe/CONTRIBUTING.md?plain=1#L125) correctly.

Error I saw:
```
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/opt/homebrew/opt/python@3.11/bin/python3.11', '-mnodeenv', '--prebuilt', '--clean-src', '/Users/nikolas/.cache/pre-commit/repoclsysoka/node_env-default')
return code: 1
stdout: (none)
stderr:
     * Install prebuilt node (24.10.0) ..
    Traceback (most recent call last):
      File "/opt/homebrew/lib/python3.11/site-packages/nodeenv.py", line 786, in install_node_wrapped
        download_node_src(node_url, src_dir, args)
      File "/opt/homebrew/lib/python3.11/site-packages/nodeenv.py", line 618, in download_node_src
        dl_contents = _download_node_file(node_url)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/lib/python3.11/site-packages/nodeenv.py", line 602, in _download_node_file
        return io.BytesIO(urlopen(node_url).read())
                          ^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/lib/python3.11/site-packages/nodeenv.py", line 652, in urlopen
        return urllib2.urlopen(req)
               ^^^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 216, in urlopen
        return opener.open(url, data, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 525, in open
        response = meth(req, response)
                   ^^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 634, in http_response
        response = self.parent.error(
                   ^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 563, in error
        return self._call_chain(*args)
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 496, in _call_chain
        result = func(*args)
                 ^^^^^^^^^^^
      File "/opt/homebrew/Cellar/python@3.11/3.11.13_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 643, in http_error_default
        raise HTTPError(req.full_url, code, msg, hdrs, fp)
    urllib.error.HTTPError: HTTP Error 404: Not Found
```

## How Has This Been Tested?
locally by commit this change

## Additional Options

[x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use the system Node version for the Prettier pre-commit hook to prevent nodeenv from trying to download Node 24 and failing commits. This aligns the hook with the host Node (expected v22) and avoids install errors.

<!-- End of auto-generated description by cubic. -->

