### PR TITLE
feat: plumb auto sync permission attempts to celery tasks

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -42,6 +42,12 @@ from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType
 from onyx.db.index_attempt import delete_index_attempts
 from onyx.db.index_attempt import get_recent_attempts_for_cc_pair
+from onyx.db.permission_sync_attempt import (
+    delete_doc_permission_sync_attempts__no_commit,
+)
+from onyx.db.permission_sync_attempt import (
+    delete_external_group_permission_sync_attempts__no_commit,
+)
 from onyx.db.search_settings import get_all_search_settings
 from onyx.db.sync_record import cleanup_sync_records
 from onyx.db.sync_record import insert_sync_record
@@ -437,6 +443,16 @@ def monitor_connector_deletion_taskset(
             # clean up the rest of the related Postgres entities
             # index attempts
             delete_index_attempts(
+                db_session=db_session,
+                cc_pair_id=cc_pair_id,
+            )
+
+            # permission sync attempts
+            delete_doc_permission_sync_attempts__no_commit(
+                db_session=db_session,
+                cc_pair_id=cc_pair_id,
+            )
+            delete_external_group_permission_sync_attempts__no_commit(
                 db_session=db_session,
                 cc_pair_id=cc_pair_id,
             )

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -30,6 +30,12 @@ from onyx.db.index_attempt import (
     delete_index_attempts,
     cancel_indexing_attempts_for_ccpair,
 )
+from onyx.db.permission_sync_attempt import (
+    delete_doc_permission_sync_attempts__no_commit,
+)
+from onyx.db.permission_sync_attempt import (
+    delete_external_group_permission_sync_attempts__no_commit,
+)
 from onyx.db.models import ConnectorCredentialPair
 from onyx.document_index.interfaces import DocumentIndex
 from onyx.utils.logger import setup_logger
@@ -90,6 +96,16 @@ def _unsafe_deletion(
 
     # Delete index attempts
     delete_index_attempts(
+        db_session=db_session,
+        cc_pair_id=cc_pair.id,
+    )
+
+    # Delete permission sync attempts
+    delete_doc_permission_sync_attempts__no_commit(
+        db_session=db_session,
+        cc_pair_id=cc_pair.id,
+    )
+    delete_external_group_permission_sync_attempts__no_commit(
         db_session=db_session,
         cc_pair_id=cc_pair.id,
     )

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -1,8 +1,12 @@
 import os
 import uuid
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import patch
 
 import httpx
 import pytest
+from sqlalchemy import select
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import EXTERNAL_USER_EMAILS
@@ -13,6 +17,8 @@ from onyx.db.document import get_documents_by_ids
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingStatus
+from onyx.db.enums import PermissionSyncStatus
+from onyx.db.models import DocPermissionSyncAttempt
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -128,3 +134,246 @@ def test_mock_connector_initial_permission_sync(
     )
     assert updated_cc_pair_info is not None
     assert updated_cc_pair_info.last_full_permission_sync is not None
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_tracking_integration(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are properly tracked during real sync workflows."""
+
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-attempt-tracking-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    before = datetime.now(timezone.utc)
+    CCPairManager.sync(
+        cc_pair=cc_pair,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.wait_for_sync(
+        cc_pair=cc_pair,
+        after=before,
+        number_of_updated_docs=1,
+        user_performing_action=admin_user,
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status in [
+            PermissionSyncStatus.SUCCESS,
+            PermissionSyncStatus.COMPLETED_WITH_ERRORS,
+            PermissionSyncStatus.FAILED,
+        ]
+        assert attempt.total_docs_synced is not None and attempt.total_docs_synced >= 0
+        assert (
+            attempt.docs_with_permission_errors is not None
+            and attempt.docs_with_permission_errors >= 0
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_tracking_with_mocked_failure(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are properly tracked when sync fails."""
+
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-attempt-failure-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    # Mock the permission sync to force a failure and verify attempt tracking
+    with patch(
+        "ee.onyx.background.celery.tasks.doc_permission_syncing.tasks.validate_ccpair_for_user"
+    ) as mock_validate:
+        mock_validate.side_effect = Exception("Validation failed for testing")
+
+        try:
+            before = datetime.now(timezone.utc)
+            CCPairManager.sync(
+                cc_pair=cc_pair,
+                user_performing_action=admin_user,
+            )
+            CCPairManager.wait_for_sync(
+                cc_pair=cc_pair,
+                after=before,
+                number_of_updated_docs=0,
+                user_performing_action=admin_user,
+            )
+        except Exception:
+            pass
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status == PermissionSyncStatus.FAILED
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission sync attempt tracking is enterprise only",
+)
+def test_permission_sync_attempt_status_success(
+    mock_server_client: httpx.Client,
+    vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+) -> None:
+    """Test that permission sync attempts are marked as SUCCESS when sync completes without errors."""
+    doc_uuid = uuid.uuid4()
+    test_doc = create_test_document(doc_id=f"test-doc-{doc_uuid}")
+
+    response = mock_server_client.post(
+        "/set-behavior",
+        json=[
+            {
+                "documents": [test_doc.model_dump(mode="json")],
+                "checkpoint": MockConnectorCheckpoint(has_more=False).model_dump(
+                    mode="json"
+                ),
+                "failures": [],
+            }
+        ],
+    )
+    assert response.status_code == 200
+
+    cc_pair = CCPairManager.create_from_scratch(
+        name=f"mock-connector-success-{uuid.uuid4()}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "mock_server_host": MOCK_CONNECTOR_SERVER_HOST,
+            "mock_server_port": MOCK_CONNECTOR_SERVER_PORT,
+        },
+        access_type=AccessType.SYNC,
+        user_performing_action=admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=admin_user,
+    )
+
+    before = datetime.now(timezone.utc)
+    CCPairManager.sync(
+        cc_pair=cc_pair,
+        user_performing_action=admin_user,
+    )
+
+    CCPairManager.wait_for_sync(
+        cc_pair=cc_pair,
+        after=before,
+        number_of_updated_docs=1,
+        user_performing_action=admin_user,
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        attempt = db_session.execute(
+            select(DocPermissionSyncAttempt).where(
+                DocPermissionSyncAttempt.connector_credential_pair_id == cc_pair.id
+            )
+        ).scalar_one()
+
+        assert attempt.status == PermissionSyncStatus.SUCCESS
+        assert attempt.total_docs_synced is not None and attempt.total_docs_synced >= 0
+        assert (
+            attempt.docs_with_permission_errors is not None
+            and attempt.docs_with_permission_errors == 0
+        )


### PR DESCRIPTION
## Description

Partial completion of: https://linear.app/danswer/issue/DAN-2494/sync-permissions-database-and-backend-updates

Modify existing permission sync tasks to create/update attempt records. This just plumbs in the attempt tracking logic and adds some integration tests. 

PR Stack:
1. [feat: tables/migration for permission syncing attempts ](https://github.com/onyx-dot-app/onyx/pull/5681)
2. [feat: basic db methods to create and update permission sync attempts](https://github.com/onyx-dot-app/onyx/pull/5682) 
3. [feat: plumb auto sync permission attempts to celery tasks](https://github.com/onyx-dot-app/onyx/pull/5686) -> you are here
4. feat: read latest permission sync from the frontend


## How Has This Been Tested?

integration tests and some manual testing.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds attempt-level tracking for permission syncs (documents and external groups) and wires it into Celery tasks. Improves observability with clear statuses and progress metrics, aligning with Linear DAN-2494.

- **New Features**
  - Added PermissionSyncStatus enum and two tables: doc_permission_sync_attempt and external_group_permission_sync_attempt.
  - Implemented CRUD helpers to create, update progress, and mark attempts (in_progress, success, failed, completed_with_errors) with row locks and telemetry.
  - Integrated with connector_permission_sync_generator_task and external group sync to create attempts, track progress (docs/errors, users/groups/memberships), and set final status on success/failure.
  - Added unit tests for CRUD and integration tests to verify attempt lifecycle.

- **Migration**
  - Run Alembic migration 03d710ccf29c to add tables and indexes. No manual backfill required.

<!-- End of auto-generated description by cubic. -->

