### PR TITLE
fix(indexing page): Improve page loading time

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -28,7 +28,6 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_SIMPLE_ANSWER_MAX_DISPLAYED_SOURCES
 from onyx.db.chunk import delete_chunk_stats_by_connector_credential_pair__no_commit
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import delete_from_kg_entities__no_commit
 from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_commit
 from onyx.db.enums import AccessType
@@ -55,7 +54,6 @@ from onyx.document_index.interfaces import DocumentMetadata
 from onyx.kg.models import KGStage
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.utils.logger import setup_logger
-from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
 logger = setup_logger()
 
@@ -304,80 +302,27 @@ def get_document_counts_for_cc_pairs(
     ]
 
 
-# For use with our thread-level parallelism utils. Note that any relationships
-# you wish to use MUST be eagerly loaded, as the session will not be available
-# after this function to allow lazy loading.
-def get_document_counts_for_cc_pairs_parallel(
-    cc_pairs: list[ConnectorCredentialPairIdentifier],
+def get_document_counts_for_all_cc_pairs(
+    db_session: Session,
 ) -> Sequence[tuple[int, int, int]]:
-    with get_session_with_current_tenant() as db_session:
-        return get_document_counts_for_cc_pairs(db_session, cc_pairs)
+    """Return (connector_id, credential_id, count) for ALL CC pairs with indexed docs.
 
-
-def _get_document_counts_for_cc_pairs_batch(
-    batch: list[tuple[int, int]],
-) -> list[tuple[int, int, int]]:
-    """Worker for parallel execution: opens its own session per batch."""
-    if not batch:
-        return []
-    with get_session_with_current_tenant() as db_session:
-        stmt = (
-            select(
-                DocumentByConnectorCredentialPair.connector_id,
-                DocumentByConnectorCredentialPair.credential_id,
-                func.count(),
-            )
-            .where(
-                and_(
-                    tuple_(
-                        DocumentByConnectorCredentialPair.connector_id,
-                        DocumentByConnectorCredentialPair.credential_id,
-                    ).in_(batch),
-                    DocumentByConnectorCredentialPair.has_been_indexed.is_(True),
-                )
-            )
-            .group_by(
-                DocumentByConnectorCredentialPair.connector_id,
-                DocumentByConnectorCredentialPair.credential_id,
-            )
-        )
-        return db_session.execute(stmt).all()  # type: ignore
-
-
-def get_document_counts_for_cc_pairs_batched_parallel(
-    cc_pairs: list[ConnectorCredentialPairIdentifier],
-    batch_size: int = 1000,
-    max_workers: int | None = None,
-) -> Sequence[tuple[int, int, int]]:
-    """Parallel variant that batches the IN-clause and runs batches concurrently.
-
-    Opens an isolated DB session per batch to avoid sharing a session across threads.
+    Executes a single grouped query so Postgres can fully leverage indexes,
+    avoiding large batched IN-lists.
     """
-    if not cc_pairs:
-        return []
-
-    cc_ids = [(x.connector_id, x.credential_id) for x in cc_pairs]
-
-    batches: list[list[tuple[int, int]]] = [
-        cc_ids[i : i + batch_size] for i in range(0, len(cc_ids), batch_size)
-    ]
-
-    funcs = [(_get_document_counts_for_cc_pairs_batch, (batch,)) for batch in batches]
-    results = run_functions_tuples_in_parallel(
-        functions_with_args=funcs, max_workers=max_workers
+    stmt = (
+        select(
+            DocumentByConnectorCredentialPair.connector_id,
+            DocumentByConnectorCredentialPair.credential_id,
+            func.count(),
+        )
+        .where(DocumentByConnectorCredentialPair.has_been_indexed.is_(True))
+        .group_by(
+            DocumentByConnectorCredentialPair.connector_id,
+            DocumentByConnectorCredentialPair.credential_id,
+        )
     )
-
-    aggregated_counts: dict[tuple[int, int], int] = {}
-    for batch_result in results:
-        if not batch_result:
-            continue
-        for connector_id, credential_id, cnt in batch_result:
-            aggregated_counts[(connector_id, credential_id)] = cnt
-
-    return [
-        (connector_id, credential_id, cnt)
-        for (connector_id, credential_id), cnt in aggregated_counts.items()
-    ]
+    return db_session.execute(stmt).all()  # type: ignore
 
 
 def get_access_info_for_document(

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -91,7 +91,7 @@ from onyx.db.credentials import create_credential
 from onyx.db.credentials import delete_service_account_credentials
 from onyx.db.credentials import fetch_credential_by_id_for_user
 from onyx.db.deletion_attempt import check_deletion_attempt_is_allowed
-from onyx.db.document import get_document_counts_for_cc_pairs_batched_parallel
+from onyx.db.document import get_document_counts_for_all_cc_pairs
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
@@ -795,15 +795,7 @@ def get_connector_indexing_status(
         list[IndexAttempt], latest_finished_index_attempts
     )
 
-    document_count_info = get_document_counts_for_cc_pairs_batched_parallel(
-        cc_pairs=[
-            ConnectorCredentialPairIdentifier(
-                connector_id=cc_pair.connector_id,
-                credential_id=cc_pair.credential_id,
-            )
-            for cc_pair in non_editable_cc_pairs + editable_cc_pairs
-        ]
-    )
+    document_count_info = get_document_counts_for_all_cc_pairs(db_session)
 
     # Create lookup dictionaries for efficient access
     cc_pair_to_document_cnt: dict[tuple[int, int], int] = {


### PR DESCRIPTION
## Description
 The main change is the removal of parallel and batched querying logic in favor of a single grouped SQL query, which reduces complexity and leverages database indexing for better performance.

## How Has This Been Tested?
Tested from UI

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced batched/parallel document count queries with a single grouped SQL query, reducing DB calls and thread overhead to speed up the indexing page. No user-visible changes, just faster load times.

- **Refactors**
  - Consolidated counts into one grouped SELECT leveraging DB indexes.
  - Added get_document_counts_for_all_cc_pairs(db_session); removed parallel/batched helpers.
  - Updated get_connector_indexing_status to use the single query via the existing session.

<!-- End of auto-generated description by cubic. -->

