### PR TITLE
fix(slack): Fix Fed Slack Gear Button Error

### DIFF
--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -6,13 +6,14 @@ import {
   ValidSources,
 } from "@/lib/types";
 import { SourceIcon } from "@/components/SourceIcon";
-import SvgSearch from "@/icons/search";
 import SvgX from "@/icons/x";
 import SvgSettings from "@/icons/settings";
 import { Label } from "@/components/ui/label";
 import { ErrorMessage } from "formik";
-import { Input } from "@/components/ui/input";
+import Text from "@/refresh-components/Text";
 import IconButton from "@/refresh-components/buttons/IconButton";
+import { Input } from "@/components/ui/input";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import {
   Dialog,
   DialogContent,
@@ -374,48 +375,41 @@ export const FederatedConnectorSelector = ({
     <div className="flex flex-col w-full space-y-2 mb-4">
       {label && <Label className="text-base font-medium">{label}</Label>}
 
-      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+      <Text mainUiMuted text03>
         Documents from selected federated connectors will be searched in
         real-time during queries.
-      </p>
+      </Text>
       <div className="relative">
-        <div
-          className={`flex items-center border border-input rounded-md border-neutral-200 dark:border-neutral-700 ${
-            allConnectorsSelected ? "bg-neutral-50 dark:bg-neutral-800" : ""
-          } focus-within:ring-1 focus-within:ring-ring focus-within:border-neutral-400 dark:focus-within:border-neutral-500 transition-colors`}
-        >
-          <SvgSearch className="absolute left-3 h-4 w-4 stroke-current text-neutral-500 dark:text-neutral-400" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
+        <InputTypeIn
+          ref={inputRef}
+          leftSearchIcon
+          placeholder={effectivePlaceholder}
+          value={searchQuery}
+          disabled={isInputDisabled}
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+            setOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (!allConnectorsSelected) {
               setOpen(true);
-            }}
-            onFocus={() => {
-              if (!allConnectorsSelected) {
-                setOpen(true);
-              }
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={effectivePlaceholder}
-            className={`h-9 w-full pl-9 pr-10 py-2 bg-transparent dark:bg-transparent text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 ${
-              allConnectorsSelected
-                ? "text-neutral-500 dark:text-neutral-400"
-                : ""
-            }`}
-            disabled={isInputDisabled}
-          />
-        </div>
+            }
+          }}
+          className={
+            allConnectorsSelected
+              ? "rounded-12 bg-background-neutral-01"
+              : "rounded-12"
+          }
+        />
 
         {open && !allConnectorsSelected && (
           <div
             ref={dropdownRef}
-            className="absolute z-50 w-full mt-1 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 shadow-md default-scrollbar max-h-[300px] overflow-auto"
+            className="absolute z-50 w-full mt-1 rounded-12 border border-border-02 bg-background-neutral-00 shadow-md default-scrollbar max-h-[300px] overflow-auto"
           >
             {filteredUnselectedConnectors.length === 0 ? (
-              <div className="py-4 text-center text-xs text-neutral-500 dark:text-neutral-400">
+              <div className="py-4 text-center text-xs text-text-03">
                 {searchQuery
                   ? "No matching federated connectors found"
                   : "No more federated connectors available"}
@@ -425,7 +419,7 @@ export const FederatedConnectorSelector = ({
                 {filteredUnselectedConnectors.map((connector) => (
                   <div
                     key={connector.id}
-                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-800 text-xs"
+                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
                     onClick={() => selectConnector(connector.id)}
                   >
                     <div className="flex items-center truncate mr-2">
@@ -460,7 +454,7 @@ export const FederatedConnectorSelector = ({
               return (
                 <div
                   key={connector.id}
-                  className="flex items-center bg-white dark:bg-neutral-800 rounded-md border border-neutral-300 dark:border-neutral-700 transition-all px-2 py-1 max-w-full group text-xs"
+                  className="flex items-center bg-background-neutral-00 rounded-12 border border-border-02 transition-all px-2 py-1 max-w-full group text-xs"
                 >
                   <div className="flex items-center overflow-hidden">
                     <div className="mr-1 flex-shrink-0">
@@ -489,7 +483,6 @@ export const FederatedConnectorSelector = ({
                       aria-label="Configure entities"
                       onClick={() => openConfigDialog(connector.id)}
                       icon={SvgSettings}
-                      className="!p-1 !rounded-full"
                     />
                     <IconButton
                       internal
@@ -498,7 +491,6 @@ export const FederatedConnectorSelector = ({
                       tooltip="Remove connector"
                       onClick={() => removeConnector(connector.id)}
                       icon={SvgX}
-                      className="!p-1 !rounded-full"
                     />
                   </div>
                 </div>
@@ -507,7 +499,7 @@ export const FederatedConnectorSelector = ({
           </div>
         </div>
       ) : (
-        <div className="mt-3 p-3 border border-dashed border-neutral-300 dark:border-neutral-700 rounded-md bg-neutral-50 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs">
+        <div className="mt-3 p-3 border border-dashed border-border-02 rounded-12 bg-background-neutral-01 text-text-03 text-xs">
           No federated connectors selected. Search and select connectors above.
         </div>
       )}
@@ -528,7 +520,7 @@ export const FederatedConnectorSelector = ({
         <ErrorMessage
           name={name}
           component="div"
-          className="text-red-500 dark:text-red-400 text-xs mt-1"
+          className="text-action-danger-05 text-xs mt-1"
         />
       )}
     </div>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Trying to fix the Gear Button that exists for the Federated Connector Selector. The current behavior before the change is that the Gear button works when we are creating the Document Set but when we create a new document set and then we try to click on the gear icon afterwards, it automatically closes the page and goes back to the main Document Sets page. 

This PR aims to fix this functionality due to the button component not having a proper type setup. 

At the same time, I am using the new components UI to ensure that the fixes represent the new UI changes the team has been working on. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Brought up my local instance and set up a new Fed Slack Connector to test this workflow. 

https://github.com/user-attachments/assets/7ba0227b-1671-47fb-ab6b-52e22fa171fd

## Additional Options

- [x] [Optional] Override Linear Check
