### PR TITLE
fix: Fix selector colour

### DIFF
--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/SelectInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/SelectInput.tsx
@@ -29,7 +29,7 @@ export default function SelectInput({
       <Field
         as="select"
         name={name}
-        className="w-full p-2 border border rounded-08 bg-transparent text-text-04 focus:ring-2 focus:ring-lighter-agent focus:border-lighter-agent focus:outline-none"
+        className="w-full p-2 border border-border-03 rounded-08 bg-transparent text-text-04 focus:ring-2 focus:ring-lighter-agent focus:border-lighter-agent focus:outline-none"
       >
         <option value="">Select an option</option>
         {options?.map((option: any) => (


### PR DESCRIPTION
## Description

Fix selector's colour.
<img width="789" height="594" alt="image" src="https://github.com/user-attachments/assets/2609614b-ab80-4be7-8db4-fbc27c8c5e12" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes low-contrast select dropdown in ConnectorInput. Uses a transparent background, text-text-04, and lighter-agent focus styles to match the theme and improve readability in dark mode.

<!-- End of auto-generated description by cubic. -->

