### PR TITLE
fix(ui): Updated Document Sets UI

### DIFF
--- a/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
+++ b/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
@@ -16,8 +16,7 @@ import {
   FederatedConnectorConfig,
 } from "@/lib/types";
 import { TextFormField } from "@/components/Field";
-import { Separator } from "@/components/ui/separator";
-import { Button } from "@/components/ui/button";
+import Button from "@/refresh-components/buttons/Button";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import { IsPublicGroupSelector } from "@/components/IsPublicGroupSelector";
 import React, { useEffect, useState } from "react";
@@ -198,7 +197,7 @@ export const DocumentSetCreationForm = ({
                 )}
               </div>
 
-              <Separator className="my-6" />
+              <div className="my-6 border-t border-border-02" />
 
               <div className="space-y-6">
                 {user?.role === UserRole.CURATOR ? (
@@ -246,7 +245,7 @@ export const DocumentSetCreationForm = ({
                 {/* Federated Connectors Section */}
                 {federatedConnectors && federatedConnectors.length > 0 && (
                   <>
-                    <Separator className="my-4" />
+                    <div className="my-4 border-t border-border-02" />
                     <FederatedConnectorSelector
                       name="federated_connectors"
                       label="Federated Connectors"
@@ -264,12 +263,12 @@ export const DocumentSetCreationForm = ({
                 )}
               </div>
 
-              <div className="flex mt-6 pt-4 border-t border-neutral-200">
+              <div className="flex mt-6 pt-4 border-t border-border-02">
                 <Button
                   type="submit"
-                  variant="submit"
                   disabled={props.isSubmitting}
-                  className="w-56 mx-auto py-1.5 h-auto text-sm"
+                  className="w-56 mx-auto"
+                  primary
                 >
                   {isUpdate ? "Update Document Set" : "Create Document Set"}
                 </Button>

--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useRef, useEffect } from "react";
 import { ConnectorStatus } from "@/lib/types";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
-import { X, Search } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { ErrorMessage } from "formik";
+import Text from "@/refresh-components/Text";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import IconButton from "@/refresh-components/buttons/IconButton";
+import SvgX from "@/icons/x";
 
 interface ConnectorMultiSelectProps {
   name: string;
@@ -115,48 +118,41 @@ export const ConnectorMultiSelect = ({
     <div className="flex flex-col w-full space-y-2 mb-4">
       {label && <Label className="text-base font-medium">{label}</Label>}
 
-      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+      <Text mainUiMuted text03>
         All documents indexed by the selected connectors will be part of this
         document set.
-      </p>
+      </Text>
       <div className="relative">
-        <div
-          className={`flex items-center border border-input rounded-md border-neutral-200 dark:border-neutral-700 ${
-            allConnectorsSelected ? "bg-neutral-50 dark:bg-neutral-800" : ""
-          } focus-within:ring-1 focus-within:ring-ring focus-within:border-neutral-400 dark:focus-within:border-neutral-500 transition-colors`}
-        >
-          <Search className="absolute left-3 h-4 w-4 text-neutral-500 dark:text-neutral-400" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
+        <InputTypeIn
+          ref={inputRef}
+          leftSearchIcon
+          placeholder={effectivePlaceholder}
+          value={searchQuery}
+          disabled={isInputDisabled}
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            if (!allConnectorsSelected) {
               setOpen(true);
-            }}
-            onFocus={() => {
-              if (!allConnectorsSelected) {
-                setOpen(true);
-              }
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={effectivePlaceholder}
-            className={`h-9 w-full pl-9 pr-10 py-2 bg-transparent dark:bg-transparent text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 ${
-              allConnectorsSelected
-                ? "text-neutral-500 dark:text-neutral-400"
-                : ""
-            }`}
-            disabled={isInputDisabled}
-          />
-        </div>
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          className={
+            allConnectorsSelected
+              ? "rounded-12 bg-background-neutral-01"
+              : "rounded-12"
+          }
+        />
 
         {open && !allConnectorsSelected && (
           <div
             ref={dropdownRef}
-            className="absolute z-50 w-full mt-1 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 shadow-md default-scrollbar max-h-[300px] overflow-auto"
+            className="absolute z-50 w-full mt-1 rounded-12 border border-border-02 bg-background-neutral-00 shadow-md default-scrollbar max-h-[300px] overflow-auto"
           >
             {filteredUnselectedConnectors.length === 0 ? (
-              <div className="py-4 text-center text-xs text-neutral-500 dark:text-neutral-400">
+              <div className="py-4 text-center text-xs text-text-03">
                 {searchQuery
                   ? "No matching connectors found"
                   : "No more connectors available"}
@@ -166,7 +162,7 @@ export const ConnectorMultiSelect = ({
                 {filteredUnselectedConnectors.map((connector) => (
                   <div
                     key={connector.cc_pair_id}
-                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-800 text-xs"
+                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
                     onClick={() => selectConnector(connector.cc_pair_id)}
                   >
                     <div className="flex items-center truncate mr-2">
@@ -192,7 +188,7 @@ export const ConnectorMultiSelect = ({
             {selectedConnectors.map((connector) => (
               <div
                 key={connector.cc_pair_id}
-                className="flex items-center bg-white dark:bg-neutral-800 rounded-md border border-neutral-300 dark:border-neutral-700 transition-all px-2 py-1 max-w-full group text-xs"
+                className="flex items-center bg-background-neutral-00 rounded-12 border border-border-02 transition-all px-2 py-1 max-w-full group text-xs"
               >
                 <div className="flex items-center overflow-hidden">
                   <div className="flex-shrink-0 text-xs">
@@ -205,19 +201,20 @@ export const ConnectorMultiSelect = ({
                     />
                   </div>
                 </div>
-                <button
-                  className="ml-1 flex-shrink-0 rounded-full w-4 h-4 flex items-center justify-center bg-neutral-100 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-600 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors group-hover:bg-neutral-200 dark:group-hover:bg-neutral-600"
-                  onClick={() => removeConnector(connector.cc_pair_id)}
+                <IconButton
+                  internal
+                  type="button"
                   aria-label="Remove connector"
-                >
-                  <X className="h-2.5 w-2.5" />
-                </button>
+                  tooltip="Remove connector"
+                  onClick={() => removeConnector(connector.cc_pair_id)}
+                  icon={SvgX}
+                />
               </div>
             ))}
           </div>
         </div>
       ) : (
-        <div className="mt-3 p-3 border border-dashed border-neutral-300 dark:border-neutral-700 rounded-md bg-neutral-50 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs">
+        <div className="mt-3 p-3 border border-dashed border-border-02 rounded-12 bg-background-neutral-01 text-text-03 text-xs">
           No connectors selected. Search and select connectors above.
         </div>
       )}
@@ -226,7 +223,7 @@ export const ConnectorMultiSelect = ({
         <ErrorMessage
           name={name}
           component="div"
-          className="text-red-500 dark:text-red-400 text-xs mt-1"
+          className="text-action-danger-05 text-xs mt-1"
         />
       )}
     </div>

--- a/web/src/components/NonSelectableConnectors.tsx
+++ b/web/src/components/NonSelectableConnectors.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { ConnectorStatus } from "@/lib/types";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { Label } from "@/components/ui/label";
-import { LockIcon } from "lucide-react";
+import Text from "@/refresh-components/Text";
+import SvgLock from "@/icons/lock";
 
 interface NonSelectableConnectorsProps {
   connectors: ConnectorStatus<any, any>[];
@@ -22,17 +23,21 @@ export const NonSelectableConnectors = ({
   return (
     <div className="mt-6 mb-4">
       <Label className="text-base font-medium mb-1">{title}</Label>
-      <p className="text-xs text-neutral-500 mb-3">{description}</p>
-      <div className="p-3 border border-dashed border-neutral-300 rounded-md bg-neutral-50">
-        <div className="text-xs font-medium text-neutral-700 mb-2 flex items-center">
-          <LockIcon className="h-3.5 w-3.5 mr-1.5 text-neutral-500" />
-          Unavailable connectors:
+      <Text mainUiMuted text03 className="mb-3">
+        {description}
+      </Text>
+      <div className="p-3 border border-dashed border-border-02 rounded-12 bg-background-neutral-01">
+        <div className="mb-2 flex items-center gap-1.5">
+          <SvgLock className="h-3.5 w-3.5 stroke-text-03" />
+          <Text figureSmallLabel text04 className="!mb-0">
+            Unavailable connectors:
+          </Text>
         </div>
         <div className="flex flex-wrap gap-1.5">
           {connectors.map((connector) => (
             <div
               key={`${connector.connector.id}-${connector.credential.id}`}
-              className="flex items-center px-2 py-1 cursor-not-allowed opacity-80 bg-white border border-neutral-300 rounded-md text-xs"
+              className="flex items-center px-2 py-1 cursor-not-allowed opacity-80 bg-background-neutral-00 border border-border-02 rounded-12 text-xs"
             >
               <div className="flex items-center max-w-[200px] text-xs">
                 <ConnectorTitle


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Updating the UI to match the new ui components. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally and checked it looked correct. 

https://github.com/user-attachments/assets/32c534da-39d8-4099-be66-e9038a881011

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update Document Sets screens to the new design system for consistent styling and a cleaner UI. No behavior changes.

- **Refactors**
  - Switched to refresh-components (Button, InputTypeIn, IconButton, Text) and SVG icons; removed lucide-react usage.
  - Replaced separators with tokenized borders; applied rounded-12, background, border, and error color tokens across dropdowns, chips, and empty states.
  - Kept connector multi-select logic the same; updated search input, dropdown, and remove-chip button to new components.
  - Refreshed “Unavailable connectors” block with new lock icon and typography.

<!-- End of auto-generated description by cubic. -->

