### PR TITLE
fix(admin): Properly show Unique User count

### DIFF
--- a/backend/ee/onyx/db/analytics.py
+++ b/backend/ee/onyx/db/analytics.py
@@ -73,6 +73,12 @@ def fetch_per_user_query_analytics(
             ChatSession.user_id,
         )
         .join(ChatSession, ChatSession.id == ChatMessage.chat_session_id)
+        # Include chats that have no explicit feedback instead of dropping them
+        .join(
+            ChatMessageFeedback,
+            ChatMessageFeedback.chat_message_id == ChatMessage.id,
+            isouter=True,
+        )
         .where(
             ChatMessage.time_sent >= start,
         )


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The Usage Statistics page would not historically showcase Unique User counts if Feedback was never given to Onyx. 

This meant that in a self hosted environment, if the customer never gave a thumbs up or thumbs down, they would never see the unique user counts in their dashboards. 

To be more concrete, the query referenced `ChatMessageFeedback` in the `SELECT`, but never joined it. SQLAlchemy therefore injected `chat_feedback` into the `FROM` clause as a cross join. If the feedback table is empty, that cross join produces zero rows, so every downstream aggregation (including the unique-user count the dashboard uses) comes back empty. If there happens to be exactly one feedback row, the numbers look “correct”; with multiple rows they’re inflated, which is why this slipped past other deployments.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
I removed and emptied the feedback table, verified that there was 0 unique users in my chart and then added the fix and then validated that I see the 1 user which is myself in my dashboard

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the Unique User count on the Usage Statistics dashboard by including chat messages without feedback. This prevents zero or inflated counts when the feedback table is empty or has multiple rows.

- **Bug Fixes**
  - Changed the analytics query to outer join ChatMessageFeedback, so chats without feedback are counted correctly.

<!-- End of auto-generated description by cubic. -->

