### PR TITLE
fix(logout): Fix logout again for new UI

### DIFF
--- a/web/src/sections/sidebar/Settings.tsx
+++ b/web/src/sections/sidebar/Settings.tsx
@@ -20,7 +20,7 @@ import SvgSettings from "@/icons/settings";
 import SvgLogOut from "@/icons/log-out";
 import SvgBell from "@/icons/bell";
 import SvgX from "@/icons/x";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import SvgUser from "@/icons/user";
 import { cn } from "@/lib/utils";
 import { useModalContext } from "@/components/context/ModalContext";
@@ -50,26 +50,32 @@ function SettingsPopover({
     errorHandlingFetcher
   );
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const showAdminPanel = (!user || isAdmin) && !removeAdminPanelLink;
   const showCuratorPanel = user && isCurator;
   const showLogout =
     user && !checkUserIsNoAuthUser(user.id) && !LOGOUT_DISABLED;
 
-  async function handleLogout() {
-    const isSuccess = await logout();
+  const handleLogout = () => {
+    logout().then((response) => {
+      if (!response?.ok) {
+        alert("Failed to logout");
+        return;
+      }
 
-    if (!isSuccess) {
-      alert("Failed to logout");
-      return;
-    }
+      const currentUrl = `${pathname}${
+        searchParams?.toString() ? `?${searchParams.toString()}` : ""
+      }`;
 
-    router.push(
-      `/auth/login?next=${encodeURIComponent(
-        window.location.pathname + window.location.search
-      )}`
-    );
-  }
+      const encodedRedirect = encodeURIComponent(currentUrl);
+
+      router.push(
+        `/auth/login?disableAutoRedirect=true&next=${encodedRedirect}`
+      );
+    });
+  };
 
   return (
     <>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
I fixed logout before the UI refresh but now it's broken again after the UI refresh. This PR aims to fix this again :(

Previous PR that fixed logout:
https://github.com/onyx-dot-app/onyx/pull/5600

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally with local SAML. 

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes logout in the new UI by redirecting to the login screen with disableAutoRedirect and preserving the current path and query in next. This prevents redirect loops and keeps the user’s place after signing back in.

- **Bug Fixes**
  - Build current URL using usePathname and useSearchParams.
  - Check logout() response; show an alert if it fails.
  - Redirect to /auth/login?disableAutoRedirect=true&next=<encoded>.

<!-- End of auto-generated description by cubic. -->

