### PR TITLE
fix(ui): Fix Assistant Image not showing up in Sidebar

### DIFF
--- a/web/src/sections/sidebar/components.tsx
+++ b/web/src/sections/sidebar/components.tsx
@@ -46,7 +46,9 @@ export function getAgentIcon(
     return SvgImage;
   const uploadedImageId = agent.uploaded_image_id;
   if (uploadedImageId) {
-    return ({ className }) => (
+    const UploadedImageIcon: React.FunctionComponent<SvgProps> = ({
+      className,
+    }) => (
       <div className={cn("w-full h-full", className)}>
         <img
           alt={agent.name}
@@ -56,10 +58,14 @@ export function getAgentIcon(
         />
       </div>
     );
+    UploadedImageIcon.displayName = "SidebarUploadedAgentIcon";
+    return UploadedImageIcon;
   }
-  return ({ className }) => (
+  const GeneratedIcon: React.FunctionComponent<SvgProps> = ({ className }) => (
     <div className={cn("w-full h-full", className)}>
       {generateIdenticon((agent.icon_shape || 0).toString(), 16)}
     </div>
   );
+  GeneratedIcon.displayName = "SidebarGeneratedAgentIcon";
+  return GeneratedIcon;
 }


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
There is an issue where the agent does not showcase the image that was set for the agent even though it uses it in the Main Chat Window. This PR aims to populate the sidebar as well in order to ensure that there is a custom icon.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
<img width="2061" height="809" alt="Screenshot 2025-10-14 at 2 06 03 PM" src="https://github.com/user-attachments/assets/2724fbd5-920f-46a0-af58-3cdac0ccb6c3" />
Reproduced locally and fixed the issue locally 

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the sidebar to show the assistant’s uploaded image, matching the main chat. Falls back to an identicon when no image is set.

- **Bug Fixes**
  - Render agent.uploaded_image_id in the sidebar using buildImgUrl.
  - Keep existing icons for General, Image, and Art assistants.
  - Add a styled fallback identicon; use cn for class handling.
  - Ensure images are lazy-loaded, rounded, and cover the icon area.

<!-- End of auto-generated description by cubic. -->

