### PR TITLE
refactor: Make colours in `AppSidebar` darker

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -623,7 +623,7 @@ function AppSidebarInner() {
               {/* Recents */}
               <SidebarSection title="Recents">
                 {isHistoryEmpty ? (
-                  <Text text01 className="px-padding-button">
+                  <Text text03 className="px-spacing-interline">
                     Try sending a message! Your chat history will appear here.
                   </Text>
                 ) : (

--- a/web/src/sections/sidebar/components.tsx
+++ b/web/src/sections/sidebar/components.tsx
@@ -27,7 +27,7 @@ export function SidebarSection({ title, children }: SidebarSectionProps) {
     <div className="flex flex-col gap-spacing-inline">
       <Text
         secondaryBody
-        text02
+        text03
         className="px-spacing-interline sticky top-[0rem] bg-background-tint-02 z-10"
       >
         {title}


### PR DESCRIPTION
## Description

Addresses: https://linear.app/danswer/issue/DAN-2844/placeholder-text-too-dark-in-darkmode.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adjusted AppSidebar text styles to improve contrast and readability in dark mode, addressing Linear DAN-2844. Section titles and the empty-state message now use a darker token.

- **Bug Fixes**
  - SidebarSection title: text02 -> text03.
  - Recents empty state: text01 -> text03; padding class updated to px-spacing-interline.

<!-- End of auto-generated description by cubic. -->

