### PR TITLE
fix(slack bot ui): update tokens dark mode

### DIFF
--- a/web/src/app/admin/bots/SlackBotUpdateForm.tsx
+++ b/web/src/app/admin/bots/SlackBotUpdateForm.tsx
@@ -3,7 +3,6 @@
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { SlackBot, ValidSources } from "@/lib/types";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { updateSlackBotField } from "@/lib/updateSlackBotField";
 import { Checkbox } from "@/app/admin/settings/SettingsForm";
@@ -12,8 +11,10 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { EditableStringFieldDisplay } from "@/components/EditableStringFieldDisplay";
 import { deleteSlackBot } from "./new/lib";
 import { GenericConfirmModal } from "@/components/modals/GenericConfirmModal";
-import { FiTrash } from "react-icons/fi";
-import { Button } from "@/components/ui/button";
+import Button from "@/refresh-components/buttons/Button";
+import SvgTrash from "@/icons/trash";
+import SvgChevronDownSmall from "@/icons/chevron-down-small";
+import { cn } from "@/lib/utils";
 
 export const ExistingSlackBotForm = ({
   existingSlackBot,
@@ -92,25 +93,21 @@ export const ExistingSlackBotForm = ({
 
         <div className="flex flex-col" ref={dropdownRef}>
           <div className="flex items-center gap-4">
-            <div className="border rounded-lg border-background-200">
-              <div
-                className="flex items-center gap-2 cursor-pointer hover:bg-background-100 p-2"
-                onClick={() => setIsExpanded(!isExpanded)}
-              >
-                {isExpanded ? (
-                  <ChevronDown size={20} />
-                ) : (
-                  <ChevronRight size={20} />
-                )}
-                <span>Update Tokens</span>
-              </div>
-            </div>
             <Button
-              variant="destructive"
+              leftIcon={({ className }) => (
+                <SvgChevronDownSmall
+                  className={cn(className, !isExpanded && "-rotate-90")}
+                />
+              )}
+              onClick={() => setIsExpanded(!isExpanded)}
+              secondary
+            >
+              Update Tokens
+            </Button>
+            <Button
+              danger
               onClick={() => setShowDeleteModal(true)}
-              icon={FiTrash}
-              tooltip="Click to delete"
-              className="border h-[42px]"
+              leftIcon={SvgTrash}
             >
               Delete
             </Button>

--- a/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
+++ b/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
@@ -16,22 +16,27 @@ import Link from "next/link";
 import { useState } from "react";
 import { deleteSlackChannelConfig, isPersonaASlackBotPersona } from "./lib";
 import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { FiPlusSquare, FiSettings } from "react-icons/fi";
+import Button from "@/refresh-components/buttons/Button";
+import SvgSettings from "@/icons/settings";
+import CreateButton from "@/refresh-components/buttons/CreateButton";
+import IconButton from "@/refresh-components/buttons/IconButton";
+import SvgTrash from "@/icons/trash";
 
 const numToDisplay = 50;
 
-export function SlackChannelConfigsTable({
-  slackBotId,
-  slackChannelConfigs,
-  refresh,
-  setPopup,
-}: {
+export interface SlackChannelConfigsTableProps {
   slackBotId: number;
   slackChannelConfigs: SlackChannelConfig[];
   refresh: () => void;
   setPopup: (popupSpec: PopupSpec | null) => void;
-}) {
+}
+
+export default function SlackChannelConfigsTable({
+  slackBotId,
+  slackChannelConfigs,
+  refresh,
+  setPopup,
+}: SlackChannelConfigsTableProps) {
   const [page, setPage] = useState(1);
 
   const defaultConfig = slackChannelConfigs.find((config) => config.is_default);
@@ -43,20 +48,17 @@ export function SlackChannelConfigsTable({
     <div className="space-y-8">
       <div className="flex justify-between items-center mb-6">
         <Button
-          variant="outline"
           onClick={() => {
             window.location.href = `/admin/bots/${slackBotId}/channels/${defaultConfig?.id}`;
           }}
+          secondary
+          leftIcon={SvgSettings}
         >
-          <FiSettings />
           Edit Default Configuration
         </Button>
-        <Link href={`/admin/bots/${slackBotId}/channels/new`}>
-          <Button variant="outline">
-            <FiPlusSquare />
-            New Channel Configuration
-          </Button>
-        </Link>
+        <CreateButton href={`/admin/bots/${slackBotId}/channels/new`} secondary>
+          New Channel Configuration
+        </CreateButton>
       </div>
 
       <div>
@@ -120,10 +122,7 @@ export function SlackChannelConfigsTable({
                         </div>
                       </TableCell>
                       <TableCell onClick={(e) => e.stopPropagation()}>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="hover:text-destructive"
+                        <IconButton
                           onClick={async (e) => {
                             e.stopPropagation();
                             const response = await deleteSlackChannelConfig(
@@ -143,9 +142,9 @@ export function SlackChannelConfigsTable({
                             }
                             refresh();
                           }}
-                        >
-                          <TrashIcon />
-                        </Button>
+                          icon={SvgTrash}
+                          internal
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -10,7 +10,7 @@ import {
   TextArrayField,
   TextFormField,
 } from "@/components/Field";
-import { Button } from "@/components/ui/button";
+import Button from "@/refresh-components/buttons/Button";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import { DocumentSetSelectable } from "@/components/documentSet/DocumentSetSelectable";
 import CollapsibleSection from "@/app/admin/assistants/CollapsibleSection";
@@ -625,7 +625,7 @@ export function SlackChannelConfigFormFields({
           </TooltipProvider>
         )}
         <Button type="submit">{isUpdate ? "Update" : "Create"}</Button>
-        <Button type="button" variant="outline" onClick={() => router.back()}>
+        <Button type="button" secondary onClick={() => router.back()}>
           Cancel
         </Button>
       </div>

--- a/web/src/app/admin/bots/[bot-id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/page.tsx
@@ -6,7 +6,7 @@ import { ErrorCallout } from "@/components/ErrorCallout";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import { usePopup } from "@/components/admin/connectors/Popup";
-import { SlackChannelConfigsTable } from "./SlackChannelConfigsTable";
+import SlackChannelConfigsTable from "./SlackChannelConfigsTable";
 import { useSlackBot, useSlackChannelConfigsByBot } from "./hooks";
 import { ExistingSlackBotForm } from "../SlackBotUpdateForm";
 import { Separator } from "@/components/ui/separator";

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -31,7 +31,7 @@ import ReactMarkdown from "react-markdown";
 import { FaMarkdown } from "react-icons/fa";
 import { useState, useCallback, useEffect, memo, useRef } from "react";
 import remarkGfm from "remark-gfm";
-import { Button } from "@/components/ui/button";
+import Button from "@/refresh-components/buttons/Button";
 import { Checkbox } from "@/components/ui/checkbox";
 
 import { transformLinkUri } from "@/lib/utils";
@@ -45,6 +45,9 @@ import {
   getFileTypeDefinitionForField,
   FILE_TYPE_DEFINITIONS,
 } from "@/lib/connectors/fileTypes";
+import Text from "@/refresh-components/texts/Text";
+import SvgPlusCircle from "@/icons/plus-circle";
+import CreateButton from "@/refresh-components/buttons/CreateButton";
 
 export function SectionHeader({
   children,
@@ -155,7 +158,7 @@ export function ToolTipDetails({
           <FiInfo size={12} />
         </TooltipTrigger>
         <TooltipContent side="top" align="center">
-          {children}
+          <Text inverted>{children}</Text>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -720,9 +723,7 @@ export const BooleanFormField = memo(function BooleanFormField({
             </FastField>
             {disabled && disabledTooltip && (
               <TooltipContent side="top" align="center">
-                <p className="bg-background-neutral-inverted-00 max-w-[200px] mb-1 text-sm rounded-lg p-1.5 text-text-inverted-05">
-                  {disabledTooltip}
-                </p>
+                <Text inverted>{disabledTooltip}</Text>
               </TooltipContent>
             )}
           </Tooltip>
@@ -838,21 +839,17 @@ export function TextArrayField<T extends Yup.AnyObject>({
                 </div>
               ))}
 
-            <Button
+            <CreateButton
               onClick={() => {
                 if (!disabled) {
                   arrayHelpers.push("");
                 }
               }}
-              className="mt-3 disabled:cursor-not-allowed"
-              variant="update"
-              size="sm"
               type="button"
-              icon={FiPlus}
               disabled={disabled}
             >
               Add New
-            </Button>
+            </CreateButton>
           </div>
         )}
       />

--- a/web/src/components/MultiSelectDropdown.tsx
+++ b/web/src/components/MultiSelectDropdown.tsx
@@ -137,8 +137,6 @@ const MultiSelectDropdown = ({
           onCreateOption={handleCreateOption}
           onInputChange={handleInputChange}
           inputValue={inputValue}
-          className="react-select-container"
-          classNamePrefix="react-select"
           menuPlacement={direction}
           styles={getReactSelectStyles()}
         />
@@ -150,8 +148,6 @@ const MultiSelectDropdown = ({
           onChange={handleChange}
           onInputChange={handleInputChange}
           inputValue={inputValue}
-          className="react-select-container"
-          classNamePrefix="react-select"
           menuPlacement={direction}
           styles={getReactSelectStyles()}
         />

--- a/web/src/components/ui/CheckField.tsx
+++ b/web/src/components/ui/CheckField.tsx
@@ -11,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import Text from "@/refresh-components/texts/Text";
 
 interface CheckFieldProps {
   name: string;
@@ -99,8 +100,8 @@ export const CheckFormField: React.FC<CheckFieldProps> = ({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{checkboxContent}</TooltipTrigger>
-        <TooltipContent className="mb-4" side="top" align="center">
-          <p>{tooltip}</p>
+        <TooltipContent side="top" align="center" sideOffset={25}>
+          <Text inverted>{tooltip}</Text>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>


### PR DESCRIPTION
## Description
Before change-
<img width="2808" height="1290" alt="image" src="https://github.com/user-attachments/assets/8ad5bae9-fce3-481e-8465-41dd41a088a7" />

<img width="1524" height="460" alt="image" src="https://github.com/user-attachments/assets/df5ccc8f-e99b-4570-b739-8d5efa0086ec" />

After change-
<img width="2808" height="1290" alt="image" src="https://github.com/user-attachments/assets/d330607f-5a61-40f6-bed8-532373cd7d2e" />

<img width="1524" height="494" alt="image" src="https://github.com/user-attachments/assets/5be29a7e-f613-4b84-b859-9496ece6254d" />


## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check
