### PR TITLE
chore(improve): evals

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -249,6 +249,17 @@ def fetch_llm_provider_view(
     return LLMProviderView.from_model(provider_model)
 
 
+def fetch_model_configuration_by_name(
+    db_session: Session, model_name: str
+) -> ModelConfiguration | None:
+    """Fetch a model configuration by its model name across all providers."""
+    return db_session.scalar(
+        select(ModelConfiguration)
+        .where(ModelConfiguration.name == model_name)
+        .options(selectinload(ModelConfiguration.llm_provider))
+    )
+
+
 def remove_embedding_provider(
     db_session: Session, provider_type: EmbeddingProvider
 ) -> None:

--- a/backend/onyx/evals/eval_cli.py
+++ b/backend/onyx/evals/eval_cli.py
@@ -43,6 +43,7 @@ def run_local(
     remote_dataset_name: str | None,
     search_permissions_email: str | None = None,
     no_send_logs: bool = False,
+    models: list[str] | None = None,
 ) -> EvalationAck:
     """
     Run evaluation with local configurations.
@@ -51,6 +52,8 @@ def run_local(
         local_data_path: Path to local JSON file
         remote_dataset_name: Name of remote Braintrust dataset
         search_permissions_email: Optional email address to impersonate for the evaluation
+        no_send_logs: Whether to send logs to Braintrust
+        models: List of model names to evaluate
 
     Returns:
         EvalationAck: The evaluation result
@@ -65,6 +68,7 @@ def run_local(
         search_permissions_email=search_permissions_email,
         dataset_name=remote_dataset_name or "blank",
         no_send_logs=no_send_logs,
+        models=models or ["gpt-4.1"],
     )
 
     if remote_dataset_name:
@@ -181,6 +185,14 @@ def main() -> None:
         default=False,
     )
 
+    parser.add_argument(
+        "--models",
+        type=str,
+        nargs="+",
+        help="List of model names to evaluate (e.g., --models gpt-4 gpt-4o)",
+        default=None,
+    )
+
     args = parser.parse_args()
 
     if args.local_data_path:
@@ -220,11 +232,15 @@ def main() -> None:
         if args.search_permissions_email:
             print(f"Using search permissions email: {args.search_permissions_email}")
 
+        if args.models:
+            print(f"Evaluating models: {', '.join(args.models)}")
+
         run_local(
             local_data_path=args.local_data_path,
             remote_dataset_name=args.remote_dataset_name,
             search_permissions_email=args.search_permissions_email,
             no_send_logs=args.no_send_logs,
+            models=args.models,
         )
 
 

--- a/backend/onyx/evals/providers/braintrust.py
+++ b/backend/onyx/evals/providers/braintrust.py
@@ -4,18 +4,21 @@ from typing import Any
 from braintrust import Eval
 from braintrust import EvalCase
 from braintrust import init_dataset
+from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import BRAINTRUST_MAX_CONCURRENCY
 from onyx.configs.app_configs import BRAINTRUST_PROJECT
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.evals.models import EvalationAck
 from onyx.evals.models import EvalConfigurationOptions
 from onyx.evals.models import EvalProvider
+from onyx.llm.override_models import LLMOverride
 
 
 class BraintrustEvalProvider(EvalProvider):
     def eval(
         self,
-        task: Callable[[dict[str, str]], str],
+        task: Callable[[dict[str, str], LLMOverride | None], str],
         configuration: EvalConfigurationOptions,
         data: list[dict[str, dict[str, str]]] | None = None,
         remote_dataset_name: str | None = None,
@@ -32,13 +35,43 @@ class BraintrustEvalProvider(EvalProvider):
         else:
             if data:
                 eval_data = [EvalCase(input=item["input"]) for item in data]
-        Eval(
-            name=BRAINTRUST_PROJECT,
-            data=eval_data,  # type: ignore[arg-type]
-            task=task,
-            scores=[],
-            metadata={**configuration.model_dump()},
-            max_concurrency=BRAINTRUST_MAX_CONCURRENCY,
-            no_send_logs=configuration.no_send_logs,
-        )
+
+        # Get the LLMs from the configuration
+        engine = get_sqlalchemy_engine()
+        with Session(engine) as db_session:
+            full_configuration = configuration.get_configuration(db_session)
+            llms = full_configuration.llms
+
+        # If no LLMs are specified, run with default
+        if not llms:
+            Eval(
+                name=BRAINTRUST_PROJECT,
+                data=eval_data,  # type: ignore[arg-type]
+                task=lambda eval_input: task(eval_input, None),
+                scores=[],
+                metadata={**configuration.model_dump()},
+                max_concurrency=BRAINTRUST_MAX_CONCURRENCY,
+                no_send_logs=configuration.no_send_logs,
+            )
+        else:
+            # Run an eval for each LLM in sequence
+            for llm in llms:
+                experiment_name = f"{llm.model_provider}_{llm.model_version}"
+                Eval(
+                    name=BRAINTRUST_PROJECT,
+                    experiment=experiment_name,
+                    data=eval_data,  # type: ignore[arg-type]
+                    task=lambda eval_input, llm_override=llm: task(
+                        eval_input, llm_override
+                    ),
+                    scores=[],
+                    metadata={
+                        **configuration.model_dump(),
+                        "model_provider": llm.model_provider,
+                        "model_version": llm.model_version,
+                    },
+                    max_concurrency=BRAINTRUST_MAX_CONCURRENCY,
+                    no_send_logs=configuration.no_send_logs,
+                )
+
         return EvalationAck(success=True)


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds multi-model evaluation support with per-model Braintrust experiments and a new CLI flag, letting us compare models in one run. Model names are resolved via the DB to build correct LLM overrides.

- **New Features**
  - Add --models to eval CLI to run multiple models in one command (defaults to gpt-4.1).
  - Resolve model names to LLMOverride via fetch_model_configuration_by_name.
  - Braintrust provider runs an experiment per model and passes llm_override into the task, with model metadata attached.
  - _get_answer and the eval pipeline now accept an optional llm_override for per-model runs.

- **Migration**
  - EvalProvider.eval task signature is now task(eval_input, llm_override=None).
  - EvalConfigurationOptions uses models: list[str]; EvalConfiguration uses llms: list[LLMOverride].

<!-- End of auto-generated description by cubic. -->

