### PR TITLE
chore: [Running GitHub actions for #5732]

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
-      {{- with .Values.api.nodeSelector }}
+      {{- $ns := .Values.api.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.api.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.api.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -33,8 +33,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_beat.nodeSelector }}
+      {{- $ns := .Values.celery_beat.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_beat.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_beat.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_docfetching.nodeSelector }}
+      {{- $ns := .Values.celery_worker_docfetching.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_docfetching.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_docfetching.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_docprocessing.nodeSelector }}
+      {{- $ns := .Values.celery_worker_docprocessing.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_docprocessing.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_docprocessing.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_heavy.nodeSelector }}
+      {{- $ns := .Values.celery_worker_heavy.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_heavy.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_heavy.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_light.nodeSelector }}
+      {{- $ns := .Values.celery_worker_light.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_light.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_light.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_monitoring.nodeSelector }}
+      {{- $ns := .Values.celery_worker_monitoring.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_monitoring.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_monitoring.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_primary.nodeSelector }}
+      {{- $ns := .Values.celery_worker_primary.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_primary.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_primary.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_user_file_processing.nodeSelector }}
+      {{- $ns := .Values.celery_worker_user_file_processing.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_user_file_processing.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_user_file_processing.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
-      {{- with .Values.celery_worker_user_files_indexing.nodeSelector }}
+      {{- $ns := .Values.celery_worker_user_files_indexing.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.celery_worker_user_files_indexing.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.celery_worker_user_files_indexing.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -30,8 +30,19 @@ spec:
       securityContext:
         {{- toYaml .Values.indexCapability.podSecurityContext | nindent 8 }}
       {{- end }}
-      {{- with .Values.indexCapability.nodeSelector }}
+      {{- $ns := .Values.indexCapability.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.indexCapability.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.indexCapability.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -27,8 +27,19 @@ spec:
       securityContext:
         {{- toYaml .Values.inferenceCapability.podSecurityContext | nindent 8 }}
       {{- end }}
-      {{- with .Values.inferenceCapability.nodeSelector }}
+      {{- $ns := .Values.inferenceCapability.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.inferenceCapability.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.inferenceCapability.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -32,8 +32,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.slackbot.podSecurityContext | nindent 8 }}
-      {{- with .Values.slackbot.nodeSelector }}
+      {{- $ns := .Values.slackbot.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.slackbot.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.slackbot.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -35,8 +35,19 @@ spec:
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.webserver.podSecurityContext | nindent 8 }}
-      {{- with .Values.webserver.nodeSelector }}
+      {{- $ns := .Values.webserver.nodeSelector | default .Values.global.nodeSelector -}}
+      {{- $tol := .Values.webserver.tolerations | default .Values.global.tolerations -}}
+      {{- $aff := .Values.webserver.affinity | default .Values.global.affinity -}}
+      {{- with $ns }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tol }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $aff }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -7,6 +7,12 @@ global:
   version: "latest"
   # Global pull policy for all Onyx component images
   pullPolicy: "IfNotPresent"
+  # Global node selector for all components
+  nodeSelector: {}
+  # Global tolerations for all components  
+  tolerations: []
+  # Global affinity for all components
+  affinity: {}
 
 postgresql:
   enabled: true
@@ -103,6 +109,8 @@ inferenceCapability:
     privileged: true
     runAsUser: 0
   nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 indexCapability:
   service:
@@ -137,6 +145,8 @@ indexCapability:
     privileged: true
     runAsUser: 0
   nodeSelector: {}
+  tolerations: []
+  affinity: {}
 config:
   envConfigMapName: env-configmap
 
@@ -349,6 +359,7 @@ api:
 
   nodeSelector: {}
   tolerations: []
+  affinity: {}
 
 
 ######################################################################
@@ -676,6 +687,8 @@ slackbot:
       cpu: "1000m"
       memory: "2000Mi"
   nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 celery_worker_docfetching:
   replicaCount: 1


### PR DESCRIPTION
Automated mirror of PR #5732 so private CI can run.

- [x] [Optional] Override Linear Check
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds global and per-component Kubernetes node scheduling controls (nodeSelector, tolerations, affinity) to the Onyx Helm chart. This makes it easy to place workloads on the right nodes across clusters.

- **New Features**
  - Added global values: global.nodeSelector, global.tolerations, global.affinity.
  - Added per-component overrides for api, webserver, all celery workers, indexCapability, inferenceCapability, and slackbot.
  - Templates use a fallback pattern: component values override global; empty values fall back to global.
  - Updated Helm README with examples and behavior notes.
  - Bumped chart version to 0.4.5.

<!-- End of auto-generated description by cubic. -->

