### PR TITLE
fix(sso): Fix Logout UI

### DIFF
--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -71,9 +71,20 @@ export default async function Page(props: PageProps) {
     return redirect(authUrl);
   }
 
+  const ssoLoginFooterContent =
+    authTypeMetadata &&
+    (authTypeMetadata.authType === "google_oauth" ||
+      authTypeMetadata.authType === "oidc" ||
+      authTypeMetadata.authType === "saml") ? (
+      <>Need access? Reach out to your IT admin to get access.</>
+    ) : undefined;
+
   return (
     <div className="flex flex-col ">
-      <AuthFlowContainer authState="login">
+      <AuthFlowContainer
+        authState="login"
+        footerContent={ssoLoginFooterContent}
+      >
         <div className="absolute top-10x w-full">
           <HealthCheckBanner />
         </div>

--- a/web/src/components/auth/AuthFlowContainer.tsx
+++ b/web/src/components/auth/AuthFlowContainer.tsx
@@ -4,9 +4,11 @@ import { OnyxIcon } from "../icons/icons";
 export default function AuthFlowContainer({
   children,
   authState,
+  footerContent,
 }: {
   children: React.ReactNode;
   authState?: "signup" | "login" | "join";
+  footerContent?: React.ReactNode;
 }) {
   return (
     <div className="p-4 flex flex-col items-center justify-center min-h-screen bg-background">
@@ -16,13 +18,17 @@ export default function AuthFlowContainer({
       </div>
       {authState === "login" && (
         <div className="text-sm mt-4 text-center w-full text-text-04 font-medium mx-auto">
-          Don&apos;t have an account?{" "}
-          <Link
-            href="/auth/signup"
-            className="text-action-link-05 underline transition-colors duration-200"
-          >
-            Create one
-          </Link>
+          {footerContent ?? (
+            <>
+              Don&apos;t have an account?{" "}
+              <Link
+                href="/auth/signup"
+                className="text-action-link-05 underline transition-colors duration-200"
+              >
+                Create one
+              </Link>
+            </>
+          )}
         </div>
       )}
       {authState === "signup" && (


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The SSO logout flow is confusing currently because we should not allow the user to create an account through for SSO based setups since SSO requires the IT Admin to provision an account for the user and they should not be able to sign up like Username/Password workflows. 

This PR aims to fix this by removing the `Create one` link and only keeping that link for the `basic` Auth type. 

For SSO based auth we now trigger a different footer that shows a helpful message instead. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Deployed the changes locally to validate and also validated that the current workflow forces the user to go through the IdP once more when they click on the `Continue with SAML/OIDC/Google SSO` button

Before:
<img width="566" height="354" alt="Screenshot 2025-10-15 at 9 23 30 PM" src="https://github.com/user-attachments/assets/0b3c93af-47b8-468d-b4c2-29477e1c1c16" />

After: 
<img width="557" height="349" alt="Screenshot 2025-10-15 at 9 23 04 PM" src="https://github.com/user-attachments/assets/64aa38ae-fbfd-41d6-b465-84427b6a412f" />

## Additional Options

- [x] [Optional] Override Linear Check
