### PR TITLE
fix(ui): Fix Invite Modal

### DIFF
--- a/web/src/components/modals/NewTenantModal.tsx
+++ b/web/src/components/modals/NewTenantModal.tsx
@@ -142,10 +142,9 @@ export default function NewTenantModal({
           <Dialog.Title className="text-xl font-semibold mb-4 flex items-center">
             {isInvite ? (
               <>
-                You have been invited to join {tenantInfo.number_of_users}
-                other teammate{tenantInfo.number_of_users === 1
-                  ? ""
-                  : "s"} of {APP_DOMAIN}.
+                You have been invited to join {tenantInfo.number_of_users} other
+                teammate{tenantInfo.number_of_users === 1 ? "" : "s"} of{" "}
+                {APP_DOMAIN}.
               </>
             ) : (
               <>
@@ -199,7 +198,7 @@ export default function NewTenantModal({
               )}
 
               <Button
-                variant="agent"
+                variant={isInvite ? "default" : "agent"}
                 onClick={handleJoinTenant}
                 className={`flex items-center justify-center ${
                   isInvite ? "flex-1" : "w-full"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently in the multi-tenant setup, we have users who are not able to accept the invite to their tenant since the modal is broken. This PR aims to fix this and ensures that they can get through the modal and accept their invite. 

Cleaned the spacing after the count as well

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this by rending this modal on a fake page and then validated that the UI is restored to what it was before. 

Before:
<img width="887" height="516" alt="Screenshot 2025-10-16 at 3 11 20 PM" src="https://github.com/user-attachments/assets/6e064f1b-1ce3-45c8-bbfe-02f71c9a0757" />

After:
<img width="448" height="260" alt="Screenshot 2025-10-16 at 3 12 25 PM" src="https://github.com/user-attachments/assets/cbf7548e-0bd6-4330-871a-a7afc395d387" />


## Additional Options

- [x] [Optional] Override Linear Check
