### PR TITLE
chore: codify ruff configuration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+# NOTE: This applies the default ruff configurations. This ensures ruff's defaults take precedence
+# over global configurations (~/.ruff.toml).


### PR DESCRIPTION
## Description

I have a global ruff config (`~/.ruff.toml`) I share across repos which has stricter rules/incompatible formatting and therefore causes pre-commit hooks to fail.

By tracking this file, ruff knows to skip that configuration and use the currently implied, default ruff config.

It's possible this breaks existing workflows if devs use this to prefer their own global config, but IMO, ideally those would be codified and shared here.

`ruff` has some nice non-default rules I would recommend enabling anyways. There's only ~10 errors to get to my recommended config, https://github.com/jmelahman/dotfiles/blob/a1a3e8abd2f746b5e24919f189d7df1d5f2d5911/.ruff.toml#L3-L19. If there's interest, I wouldn't mind knocking that out in a follow up.

If this is undesired, it's not too hard for me to workaround this by using `git update-index --skip-worktree` to avoid committing the file to main.

## How Has This Been Tested?

No-op, confirmed `ruff` still complains about existing issues

```
$ prek run ruff -a
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1
  backend/onyx/file_store/file_store.py:334:47: W291 [*] Trailing whitespace
      |
  332 |             if S3_GENERATE_LOCAL_CHECKSUM:
  333 |                 data_bytes = str(file_content).encode()
  334 |                 sha256_hash.update(data_bytes) 
      |                                               ^ W291
  335 |                 hash256 = sha256_hash.hexdigest() # get the sha256 has in hex format
  336 |             if hasattr(content, "seek"):
      |
      = help: Remove trailing whitespace

  Found 1 error.
  [*] 1 fixable with the `--fix` option.
```

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a repo-level .ruff.toml to enforce ruff’s default config and ignore any user global config (~/.ruff.toml). This prevents pre-commit failures from stricter personal rules and standardizes linting across the repo.

<!-- End of auto-generated description by cubic. -->

