### PR TITLE
fix(ui): Fix Available Methods Table

### DIFF
--- a/web/src/app/admin/actions/ActionEditor.tsx
+++ b/web/src/app/admin/actions/ActionEditor.tsx
@@ -26,6 +26,14 @@ import {
 } from "@/components/ui/tooltip";
 import { useAuthType } from "@/lib/hooks";
 import { InfoIcon } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 function parseJsonWithTrailingCommas(jsonString: string) {
   // Regular expression to remove trailing commas before } or ]
@@ -175,29 +183,31 @@ function ActionForm({
       {methodSpecs && methodSpecs.length > 0 && (
         <div className="my-4">
           <h3 className="text-base font-semibold mb-2">Available methods</h3>
-          <div className="overflow-x-auto">
-            <table className="min-w-full bg-white border border-background-200">
-              <thead>
-                <tr>
-                  <th className="px-4 py-2 border-b">Name</th>
-                  <th className="px-4 py-2 border-b">Summary</th>
-                  <th className="px-4 py-2 border-b">Method</th>
-                  <th className="px-4 py-2 border-b">Path</th>
-                </tr>
-              </thead>
-              <tbody>
-                {methodSpecs?.map((method: MethodSpec, index: number) => (
-                  <tr key={index} className="text-sm">
-                    <td className="px-4 py-2 border-b">{method.name}</td>
-                    <td className="px-4 py-2 border-b">{method.summary}</td>
-                    <td className="px-4 py-2 border-b">
-                      {method.method.toUpperCase()}
-                    </td>
-                    <td className="px-4 py-2 border-b">{method.path}</td>
-                  </tr>
+          <div className="rounded-lg border border-background-200 bg-background-50">
+            <Table className="min-w-full">
+              <TableHeader className="bg-background-neutral-00">
+                <TableRow noHover>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Summary</TableHead>
+                  <TableHead>Method</TableHead>
+                  <TableHead>Path</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {methodSpecs?.map((method: MethodSpec) => (
+                  <TableRow
+                    key={`${method.method}-${method.path}-${method.name}`}
+                  >
+                    <TableCell className="font-medium">{method.name}</TableCell>
+                    <TableCell>{method.summary}</TableCell>
+                    <TableCell className="uppercase">{method.method}</TableCell>
+                    <TableCell className="font-mono text-sm">
+                      {method.path}
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The Available Methods table was messed up after the UI refresh. This PR aims to fix this. 

## How Has This Been Tested?
Tested locally.

Before: 
<img width="1440" height="1318" alt="Screenshot 2025-10-16 at 6 18 50 PM" src="https://github.com/user-attachments/assets/24633608-03cb-4a2f-8ac9-d4dcbd00ab27" />

After: 
Light Mode:
<img width="1440" height="1462" alt="Screenshot 2025-10-16 at 6 28 24 PM" src="https://github.com/user-attachments/assets/7f1d41cf-2023-4eb6-8887-6c286462a257" />

Dark Mode:
<img width="1440" height="1496" alt="Screenshot 2025-10-16 at 6 28 50 PM" src="https://github.com/user-attachments/assets/3ca0ac61-aed2-4834-b463-747a8fe33aa7" />


[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check
