### PR TITLE
fix: Fix colours for error page

### DIFF
--- a/web/src/components/errorPages/ErrorPage.tsx
+++ b/web/src/components/errorPages/ErrorPage.tsx
@@ -1,4 +1,3 @@
-import { FiAlertCircle } from "react-icons/fi";
 import ErrorPageLayout from "./ErrorPageLayout";
 import Text from "@/refresh-components/texts/Text";
 import SvgAlertCircle from "@/icons/alert-circle";


### PR DESCRIPTION
## Description

Update the colours of the error page.

Addresses: https://linear.app/danswer/issue/DAN-2879/fix-colours-of-error-page.

## Screenshots

Before:

<img width="739" height="471" alt="image" src="https://github.com/user-attachments/assets/87c65581-dc7d-4d02-b8af-4f4247f4d1be" />

After:

<img width="707" height="416" alt="image" src="https://github.com/user-attachments/assets/54e6f57d-d8b3-4f03-ad90-bd10f76a5e60" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the error page to use design tokens and refreshed components so colors are correct and readable in light and dark modes. Addresses Linear DAN-2879.

- **Bug Fixes**
  - Switched to Text and SvgAlertCircle with inverted variants for consistent theming.
  - Replaced hard-coded color classes with tokens; ensured link colors work in both themes.

<!-- End of auto-generated description by cubic. -->

