### PR TITLE
No Bash in Background Container

### DIFF
--- a/backend/scripts/supervisord_entrypoint.sh
+++ b/backend/scripts/supervisord_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Entrypoint script for supervisord that sets environment variables
 # for controlling which celery workers to start
 


### PR DESCRIPTION
## Description

Fix deployments of Docker Compose

## How Has This Been Tested?

Haven't tested it

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch the supervisord entrypoint from /bin/bash to /bin/sh to fix Docker Compose deployments in containers without Bash. This makes the script compatible with Alpine and other minimal images.

<!-- End of auto-generated description by cubic. -->

