### PR TITLE
fix: documents in chat flow

### DIFF
--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -76,6 +76,7 @@ import { useAgentsContext } from "@/refresh-components/contexts/AgentsContext";
 import { ProjectFile, useProjectsContext } from "../projects/ProjectsContext";
 import { CategorizedFiles, UserFileStatus } from "../projects/projectsService";
 import { useAppParams } from "@/hooks/appNavigation";
+import { projectFilesToFileDescriptors } from "../services/fileUtils";
 
 const SYSTEM_MESSAGE_ID = -3;
 
@@ -546,12 +547,11 @@ export function useChatController({
       if (regenerationRequest) {
         // For regeneration: keep the existing user message, only create new assistant
         initialUserNode = regenerationRequest.parentMessage;
-        initialAssistantNode = buildEmptyMessage(
-          "assistant",
-          initialUserNode.nodeId,
-          undefined,
-          1
-        );
+        initialAssistantNode = buildEmptyMessage({
+          messageType: "assistant",
+          parentNodeId: initialUserNode.nodeId,
+          nodeIdOffset: 1,
+        });
       } else {
         // For new messages or editing: create/update user message and assistant
         const parentNodeIdForMessage = messageToResend
@@ -560,6 +560,7 @@ export function useChatController({
         const result = buildImmediateMessages(
           parentNodeIdForMessage,
           currMessage,
+          projectFilesToFileDescriptors(currentMessageFiles),
           messageToResend
         );
         initialUserNode = result.initialUserNode;
@@ -594,7 +595,7 @@ export function useChatController({
 
       let finalMessage: BackendMessage | null = null;
       let toolCall: ToolCallMetadata | null = null;
-      let files: FileDescriptor[] = [];
+      let files = projectFilesToFileDescriptors(currentMessageFiles);
       let packets: Packet[] = [];
 
       let newUserMessageId: number | null = null;

--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -42,7 +42,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
       {textFiles.length > 0 && (
         <div
           id="onyx-file"
-          className={cn("mt-2 auto mb-4", alignBubble && "ml-auto")}
+          className={cn("mt-2 auto", alignBubble && "ml-auto")}
         >
           <div className="flex flex-col gap-2">
             {textFiles.map((file) => (
@@ -55,7 +55,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
       {imageFiles.length > 0 && (
         <div
           id="onyx-image"
-          className={cn("mt-2 auto mb-4", alignBubble && "ml-auto")}
+          className={cn("mt-2 auto", alignBubble && "ml-auto")}
         >
           <div className="flex flex-col gap-2">
             {imageFiles.map((file) => (
@@ -66,7 +66,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
       )}
 
       {csvFiles.length > 0 && (
-        <div className={cn("mt-2 auto mb-4", alignBubble && "ml-auto")}>
+        <div className={cn("mt-2 auto", alignBubble && "ml-auto")}>
           <div className="flex flex-col gap-2">
             {csvFiles.map((file) => {
               return (
@@ -243,7 +243,7 @@ export default function HumanMessage({
           <div className="flex flex-col desktop:mr-4">
             <FileDisplay alignBubble files={files || []} />
 
-            <div className="flex justify-end">
+            <div className="flex justify-end mt-1">
               <div className="w-full ml-8 flex w-full w-[800px] break-words">
                 {isEditing ? (
                   <MessageEditing

--- a/web/src/app/chat/services/fileUtils.ts
+++ b/web/src/app/chat/services/fileUtils.ts
@@ -1,0 +1,18 @@
+import { FileDescriptor } from "../interfaces";
+import { ProjectFile } from "../projects/projectsService";
+
+export function projectsFileToFileDescriptor(
+  file: ProjectFile
+): FileDescriptor {
+  return {
+    id: file.file_id,
+    type: file.chat_file_type,
+    name: file.name,
+  };
+}
+
+export function projectFilesToFileDescriptors(
+  files: ProjectFile[]
+): FileDescriptor[] {
+  return files.map(projectsFileToFileDescriptor);
+}


### PR DESCRIPTION
## Description

Previously, the spacing was off:

Old:
<img width="346" height="133" alt="Screenshot 2025-10-17 at 11 17 15 AM" src="https://github.com/user-attachments/assets/b718e2ff-d7e9-468e-bbb7-087cd5c8c4da" />

New:
<img width="264" height="122" alt="Screenshot 2025-10-17 at 11 17 24 AM" src="https://github.com/user-attachments/assets/45aa8e2e-7024-4903-a5c8-59f6e3f0b804" />

Also, the file would not appear initially, then pop-in after a second. Now it appears immediately.

## How Has This Been Tested?

local

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes spacing around file attachments in chat and makes attached files render immediately when a message is sent. This removes layout jumps and the delayed “pop-in.”

- **Bug Fixes**
  - Show files instantly by passing current message files into buildImmediateMessages via projectFilesToFileDescriptors.
  - Added fileUtils to map ProjectFile to FileDescriptor.
  - Refactored buildEmptyMessage to a param object and support files; updated controller usage.
  - Tweaked HumanMessage spacing: removed extra mb-4 on file sections and added a small top margin before the message row.

<!-- End of auto-generated description by cubic. -->

