### PR TITLE
fix(bedrock): Make Region Selectable

### DIFF
--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -504,9 +504,40 @@ export function LLMProviderUpdateForm({
                       subtext={customConfigKey.description || undefined}
                     />
                   );
+                } else if (customConfigKey.key_type === "select") {
+                  const options =
+                    customConfigKey.options?.map((option) => ({
+                      name: option.label,
+                      value: option.value,
+                      description: option.description ?? undefined,
+                    })) ?? [];
+
+                  return (
+                    <div key={customConfigKey.name}>
+                      <SelectorFormField
+                        small={firstTimeConfiguration}
+                        name={`custom_config.${customConfigKey.name}`}
+                        label={customConfigKey.display_name}
+                        subtext={
+                          customConfigKey.description ? (
+                            <ReactMarkdown
+                              components={{ a: customLinkRenderer }}
+                            >
+                              {customConfigKey.description}
+                            </ReactMarkdown>
+                          ) : undefined
+                        }
+                        options={options}
+                        includeReset={!customConfigKey.is_required}
+                        defaultValue={
+                          customConfigKey.default_value || undefined
+                        }
+                      />
+                    </div>
+                  );
                 } else {
                   throw new Error(
-                    "Unreachable; there should only exist 2 options"
+                    `Unhandled custom config key type: ${customConfigKey.key_type}`
                   );
                 }
               }

--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -1,5 +1,11 @@
 import { PopupSpec } from "@/components/admin/connectors/Popup";
 
+export interface CustomConfigOption {
+  label: string;
+  value: string;
+  description?: string | null;
+}
+
 export interface CustomConfigKey {
   name: string;
   display_name: string;
@@ -8,9 +14,10 @@ export interface CustomConfigKey {
   is_secret: boolean;
   key_type: CustomConfigKeyType;
   default_value?: string;
+  options?: CustomConfigOption[] | null;
 }
 
-export type CustomConfigKeyType = "text_input" | "file_input";
+export type CustomConfigKeyType = "text_input" | "file_input" | "select";
 
 export interface ModelConfiguration {
   name: string;


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Making our AWS Bedrock configurable with a region dropdown rather than having the user input the region name to avoid errors.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Validated that model retrieval still worked and we not have a cleaner UI. 

<img width="1147" height="1337" alt="Screenshot 2025-10-17 at 2 37 10 PM" src="https://github.com/user-attachments/assets/f1a6667c-eaec-47fc-b982-3d750e6e9fe4" />


## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make AWS Bedrock region selectable via a dropdown in the admin LLM settings. This adds a new “select” config type and auto-populates valid regions (via boto3 with a safe fallback) to prevent typos and setup errors.

- **New Features**
  - Backend: Introduced select config type and options model; generated Bedrock region options from boto3 (bedrock + bedrock-runtime) with a conservative fallback list; applied to AWS_REGION_NAME.
  - Frontend: Added select field rendering in the LLM provider form; supports default value, optional reset, and option descriptions; updated types to include select.

<!-- End of auto-generated description by cubic. -->

