### PR TITLE
fix: Fix styling

### DIFF
--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -33,7 +33,8 @@ export default function Tag({
   const visibleIcons = children.slice(0, 3);
 
   return (
-    <button type="button"
+    <button
+      type="button"
       className={cn(
         "p-spacing-interline-mini rounded-08 group w-fit flex items-center gap-spacing-inline transition-all duration-200 ease-in-out",
         getVariantClasses(active),


### PR DESCRIPTION
## Description

Committed a change from Cubic which ended up breaking `prettier` linting. This change fixes it.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Prettier linting in Tag.tsx by reformatting the button opening tag to multiline. No functional or UI changes; this restores lint compliance after the Cubic commit.

<!-- End of auto-generated description by cubic. -->

