### PR TITLE
fix: prevent heartbeat timeout state pollution in validation loop

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -152,8 +152,6 @@ def validate_active_indexing_attempts(
     """
     logger.info("Validating active indexing attempts")
 
-    heartbeat_timeout_seconds = HEARTBEAT_TIMEOUT_SECONDS
-
     with get_session_with_current_tenant() as db_session:
 
         # Find all active indexing attempts
@@ -170,6 +168,9 @@ def validate_active_indexing_attempts(
 
         for attempt in active_attempts:
             lock_beat.reacquire()
+
+            # Initialize timeout for each attempt to prevent state pollution
+            heartbeat_timeout_seconds = HEARTBEAT_TIMEOUT_SECONDS
 
             # Double-check the attempt still exists and has the same status
             fresh_attempt = get_index_attempt(db_session, attempt.id)


### PR DESCRIPTION
## Description
Fixes a bug where heartbeat_timeout_seconds was initialized once at function scope, causing timeout values to leak between different indexing attempts during validation cycles.

**The Bug:**
When validating multiple active indexing attempts, the first attempt meeting the condition (total_batches > 0 AND completed_batches == 0) would modify the shared heartbeat_timeout_seconds variable from 30 minutes to 12 hours. This modified value would then persist for ALL subsequent attempts in that validation cycle.

**Impact:**
- Stalled indexing operations that should be detected and terminated within 30 minutes remained undetected for up to 12 hours
- Worker resources stayed allocated to dead/stuck processes
- Legitimate indexing operations were delayed due to resource starvation
- Users experienced "stuck" connectors that appeared working but were deadlocked

**The Fix:**
Move heartbeat_timeout_seconds initialization inside the loop (after lock_beat.reacquire()) to ensure each attempt is evaluated with its own independent timeout threshold.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reinitialize heartbeat_timeout_seconds inside the validation loop to prevent timeout value leaking between indexing attempts. This restores correct per-attempt timeouts and ensures stalled indexing is terminated within 30 minutes instead of lingering up to 12 hours.

<!-- End of auto-generated description by cubic. -->

