### PR TITLE
fix(ui): Initial Index Attempt Tooltip

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -20,7 +20,7 @@ import { getDocsProcessedPerMinute } from "@/lib/indexAttempt";
 import { InfoIcon } from "@/components/icons/icons";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
-import SvgServer from "@/icons/server";
+import SvgClock from "@/icons/clock";
 
 export interface IndexingAttemptsTableProps {
   ccPair: CCPairFullInfo;
@@ -140,7 +140,7 @@ export function IndexAttemptsTable({
                     {indexAttempt.from_beginning && (
                       <SimpleTooltip side="top" tooltip={reindexTooltip}>
                         <span className="cursor-help flex items-center">
-                          <SvgServer className="ml-2 h-3.5 w-3.5 stroke-current" />
+                          <SvgClock className="ml-2 h-3.5 w-3.5 stroke-current" />
                         </span>
                       </SimpleTooltip>
                     )}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
There is a bug with the UI with the Tooltip that is shown on initial index attempts. 

This PR aims to address that. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally. Need to clarify the Logo being used. 

Before:
<img width="882" height="216" alt="Screenshot 2025-10-19 at 3 22 20 PM" src="https://github.com/user-attachments/assets/b23e666e-60c9-4af5-9202-d7bc3112086f" />

After:
<img width="883" height="193" alt="Screenshot 2025-10-20 at 12 16 29 PM" src="https://github.com/user-attachments/assets/a5b548bc-70a8-4421-a971-bae449074bd4" />


## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the tooltip for full re-index attempts in IndexAttemptsTable. It now shows the correct state and renders consistently.

- **Bug Fixes**
  - Replaced TooltipProvider/Tooltip with SimpleTooltip to eliminate display issues.
  - Clarified tooltip text and logic for in_progress/not_started states.
  - Swapped FaBarsProgress icon for SvgServer for clearer visuals.

<!-- End of auto-generated description by cubic. -->

