### PR TITLE
feat: add new fields to usage report (#5784)

### DIFF
--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -50,6 +50,25 @@ def get_empty_chat_messages_entries__paginated(
             if message.message_type != MessageType.USER:
                 continue
 
+            # Get user email
+            user_email = chat_session.user.email if chat_session.user else None
+
+            # Get assistant name (from session persona, or alternate if specified)
+            assistant_name = None
+            if message.alternate_assistant_id:
+                # If there's an alternate assistant, we need to fetch it
+                from onyx.db.models import Persona
+
+                alternate_persona = (
+                    db_session.query(Persona)
+                    .filter(Persona.id == message.alternate_assistant_id)
+                    .first()
+                )
+                if alternate_persona:
+                    assistant_name = alternate_persona.name
+            elif chat_session.persona:
+                assistant_name = chat_session.persona.name
+
             message_skeletons.append(
                 ChatMessageSkeleton(
                     message_id=message.id,
@@ -57,6 +76,9 @@ def get_empty_chat_messages_entries__paginated(
                     user_id=str(chat_session.user_id) if chat_session.user_id else None,
                     flow_type=flow_type,
                     time_sent=message.time_sent,
+                    assistant_name=assistant_name,
+                    user_email=user_email,
+                    number_of_tokens=message.token_count,
                 )
             )
     if len(chat_sessions) == 0:

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -48,7 +48,17 @@ def generate_chat_messages_report(
         max_size=MAX_IN_MEMORY_SIZE, mode="w+"
     ) as temp_file:
         csvwriter = csv.writer(temp_file, delimiter=",")
-        csvwriter.writerow(["session_id", "user_id", "flow_type", "time_sent"])
+        csvwriter.writerow(
+            [
+                "session_id",
+                "user_id",
+                "flow_type",
+                "time_sent",
+                "assistant_name",
+                "user_email",
+                "number_of_tokens",
+            ]
+        )
         for chat_message_skeleton_batch in get_all_empty_chat_message_entries(
             db_session, period
         ):
@@ -59,6 +69,9 @@ def generate_chat_messages_report(
                         chat_message_skeleton.user_id,
                         chat_message_skeleton.flow_type,
                         chat_message_skeleton.time_sent.isoformat(),
+                        chat_message_skeleton.assistant_name,
+                        chat_message_skeleton.user_email,
+                        chat_message_skeleton.number_of_tokens,
                     ]
                 )
 

--- a/backend/ee/onyx/server/reporting/usage_export_models.py
+++ b/backend/ee/onyx/server/reporting/usage_export_models.py
@@ -16,6 +16,9 @@ class ChatMessageSkeleton(BaseModel):
     user_id: str | None
     flow_type: FlowType
     time_sent: datetime
+    assistant_name: str | None
+    user_email: str | None
+    number_of_tokens: int
 
 
 class UserSkeleton(BaseModel):


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expanded the chat messages usage export with assistant_name, user_email, and number_of_tokens to improve reporting and audits. CSV and models updated; integration tests verify the new columns and values.

- **New Features**
  - CSV now includes assistant_name, user_email, and number_of_tokens.
  - assistant_name resolves from alternate assistant or session persona; user_email comes from the session user; tokens use message.token_count.
  - ChatMessageSkeleton extended; report generation writes the new fields.

- **Migration**
  - Update any CSV parsers or dashboards to read the new columns.
  - Header order: session_id, user_id, flow_type, time_sent, assistant_name, user_email, number_of_tokens.

<!-- End of auto-generated description by cubic. -->

