### PR TITLE
db: remove duplicate chunk_stats deletion in delete_documents_complete__no_commit

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -686,11 +686,6 @@ def delete_documents_complete__no_commit(
         document_ids=document_ids,
     )
 
-    delete_chunk_stats_by_connector_credential_pair__no_commit(
-        db_session=db_session,
-        document_ids=document_ids,
-    )
-
     delete_documents_by_connector_credential_pair__no_commit(db_session, document_ids)
     delete_document_feedback_for_documents__no_commit(
         document_ids=document_ids, db_session=db_session


### PR DESCRIPTION
## Description

Summary:
`delete_documents_complete__no_commit` called `delete_chunk_stats_by_connector_credential_pair__no_commit` twice with identical params, causing 2x DELETEs and slower connector deletion.

Fix:
Remove the redundant second call.

Impact:
Speeds up connector deletion; reduces DB lock time.

Areas touched:
`backend/onyx/db/document.py`

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a duplicate call to delete_chunk_stats_by_connector_credential_pair__no_commit in delete_documents_complete__no_commit. This avoids double DELETEs, speeding up connector deletions and reducing DB lock time.

<!-- End of auto-generated description by cubic. -->

