### PR TITLE
fix: reduce spam of org info toast

### DIFF
--- a/web/src/app/admin/settings/SettingsForm.tsx
+++ b/web/src/app/admin/settings/SettingsForm.tsx
@@ -197,20 +197,24 @@ export function SettingsForm() {
   }
 
   function handleCompanyNameBlur() {
-    updateSettingField([
-      { fieldName: "company_name", newValue: companyName || null },
-    ]);
+    const originalValue = settings?.company_name || "";
+    if (companyName !== originalValue) {
+      updateSettingField([
+        { fieldName: "company_name", newValue: companyName || null },
+      ]);
+    }
   }
 
-  // NOTE: at the moment there's a small bug where if you click another admin panel page after typing
-  // the field doesn't update correctly
   function handleCompanyDescriptionBlur() {
-    updateSettingField([
-      {
-        fieldName: "company_description",
-        newValue: companyDescription || null,
-      },
-    ]);
+    const originalValue = settings?.company_description || "";
+    if (companyDescription !== originalValue) {
+      updateSettingField([
+        {
+          fieldName: "company_description",
+          newValue: companyDescription || null,
+        },
+      ]);
+    }
   }
 
   return (


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2892/bug-clicking-in-and-out-of-workspace-settings-input-bars-spams-the

## How Has This Been Tested?

tested in UI

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop spamming the “Org info updated” toast when clicking in and out of Workspace Settings inputs. Only save company_name and company_description on blur if the value changed (Linear DAN-2892).

<!-- End of auto-generated description by cubic. -->

