### PR TITLE
chore: hide search settings in the cloud

### DIFF
--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -168,12 +168,16 @@ const collections = (
               icon: CpuIconSkeleton,
               link: "/admin/configuration/llm",
             },
-            {
-              error: settings?.settings.needs_reindexing,
-              name: "Search Settings",
-              icon: SearchIcon,
-              link: "/admin/configuration/search",
-            },
+            ...(!enableCloud
+              ? [
+                  {
+                    error: settings?.settings.needs_reindexing,
+                    name: "Search Settings",
+                    icon: SearchIcon,
+                    link: "/admin/configuration/search",
+                  },
+                ]
+              : []),
             {
               name: "Document Processing",
               icon: DocumentIcon2,


### PR DESCRIPTION
## Description

Cloud users are using our API keys, this has sometimes caused them to pick some very expensive indexing options. Folks with a business need can still directly access the Search Settings page at its url, but in general we want to discourage admins from messing around there and costing tens of thousands of dollars.

## How Has This Been Tested?

Tested that self-hosted UI displays the search settings page as per usual

## Additional Options

- [x] [Optional] Override Linear Check
