### PR TITLE
fix(ui): Create Button Type

### DIFF
--- a/web/src/refresh-components/buttons/CreateButton.tsx
+++ b/web/src/refresh-components/buttons/CreateButton.tsx
@@ -7,6 +7,7 @@ export default function CreateButton({
   href,
   onClick,
   children,
+  type = "button",
   ...props
 }: ButtonProps) {
   return (
@@ -15,6 +16,7 @@ export default function CreateButton({
       onClick={onClick}
       leftIcon={SvgPlusCircle}
       href={href}
+      type={type}
       {...props}
     >
       {children || "Create"}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently when a user tries to Create an Assistant and then adds User Knowledge and then tries to click on the button, the assistant is created and then the workflow breaks since you can't update the assistant. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally and validated that this fixes the issue

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set CreateButton’s default type to "button" and forward the type prop to prevent unintended form submissions. This fixes the Assistant creation flow where clicking Create after adding User Knowledge would prematurely create the assistant and break the workflow.

<!-- End of auto-generated description by cubic. -->

