### PR TITLE
fix(ui): Fix Style for Access Restricted Page

### DIFF
--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ErrorPageLayout from "./ErrorPageLayout";
+import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 import { fetchCustomerPortal } from "@/lib/billing/utils";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
@@ -86,11 +86,11 @@ export default function AccessRestricted() {
 
   return (
     <ErrorPageLayout>
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-center gap-spacing-interline">
         <Text headingH2>Access Restricted</Text>
         <SvgLock className="stroke-status-error-05 w-[1.5rem] h-[1.5rem]" />
       </div>
-      <div className="space-y-4">
+      <div className="flex flex-col gap-spacing-paragraph">
         <Text text03>
           We regret to inform you that your access to Onyx has been temporarily
           suspended due to a lapse in your subscription.

--- a/web/src/components/errorPages/ErrorPageLayout.tsx
+++ b/web/src/components/errorPages/ErrorPageLayout.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { LogoType } from "../logo/Logo";
+import { LogoType } from "@/components/logo/Logo";
 
 interface ErrorPageLayoutProps {
   children: React.ReactNode;
@@ -7,12 +6,14 @@ interface ErrorPageLayoutProps {
 
 export default function ErrorPageLayout({ children }: ErrorPageLayoutProps) {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <div className="mb-4 flex items-center max-w-[220px]">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-spacing-headline bg-background px-spacing-paragraph py-spacing-block">
+      <div className="flex max-w-[220px] items-center justify-center">
         <LogoType size="large" />
       </div>
-      <div className="max-w-xl border border-border w-full bg-white shadow-md rounded-lg overflow-hidden">
-        <div className="p-6 sm:p-8">{children}</div>
+      <div className="w-full max-w-xl rounded-16 border bg-background-neutral-00 shadow-01">
+        <div className="flex flex-col gap-spacing-paragraph p-padding-content">
+          {children}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Our Access Restricted page was never updated with the UI Refresh changes so this PR aims to update this to make it look better. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

Before:
<img width="1322" height="916" alt="image" src="https://github.com/user-attachments/assets/313f7a7b-eb1c-4924-b997-13ce7366037c" />

After:
<img width="608" height="417" alt="Screenshot 2025-10-20 at 1 04 34 PM" src="https://github.com/user-attachments/assets/a05a67f3-bcc4-4c33-9c9c-d952662fd37c" />

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refreshes the Access Restricted page to match the UI Refresh. Uses design tokens for spacing, colors, and elevation to improve consistency and readability.

- **Refactors**
  - Replaced ad-hoc spacing with tokens (gap-spacing-*, p-padding-content).
  - Updated card styles to theme values (bg-background, bg-background-neutral-00, rounded-16, shadow-01, border).
  - Centered and simplified header/logo layout.
  - Switched imports to aliased paths for ErrorPageLayout and LogoType.

<!-- End of auto-generated description by cubic. -->

