### PR TITLE
fix: Edit background colour

### DIFF
--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -397,18 +397,16 @@ function ChatInputBarInner({
 
       <div className="w-full h-full flex flex-col shadow-01 bg-background-neutral-00 rounded-16">
         {currentMessageFiles.length > 0 && (
-          <div className="p-spacing-inline bg-background-neutral-01 rounded-t-16">
-            <div className="flex flex-wrap gap-2">
-              {currentMessageFiles.map((file) => (
-                <FileCard
-                  key={file.id}
-                  file={file}
-                  removeFile={handleRemoveMessageFile}
-                  hideProcessingState={hideProcessingState}
-                  onFileClick={handleFileClick}
-                />
-              ))}
-            </div>
+          <div className="p-spacing-inline rounded-t-16 flex flex-wrap gap-spacing-interline">
+            {currentMessageFiles.map((file) => (
+              <FileCard
+                key={file.id}
+                file={file}
+                removeFile={handleRemoveMessageFile}
+                hideProcessingState={hideProcessingState}
+                onFileClick={handleFileClick}
+              />
+            ))}
           </div>
         )}
 


### PR DESCRIPTION
## Description

Fix background colour of file-attachment section in `ChatInputBar`.

Addresses: https://linear.app/danswer/issue/DAN-2897/darkmode-file-attachment.

## Screenshots

### Before

<img width="828" height="187" alt="image" src="https://github.com/user-attachments/assets/4f91be31-77ac-46b7-8087-f74cb4e6085f" />

### After

<img width="832" height="190" alt="image" src="https://github.com/user-attachments/assets/988466a2-471f-44ff-8e63-67526e03d8da" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the file-attachment area background in ChatInputBar so it matches dark mode and blends with the input container. Addresses Linear DAN-2897.

- **Bug Fixes**
  - Removed bg-background-neutral-01 from the attachment wrapper and adjusted spacing (flex-wrap + gap-spacing-interline) for consistent layout.

<!-- End of auto-generated description by cubic. -->

