### PR TITLE
chore: disable contextual rag in the cloud

### DIFF
--- a/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
@@ -21,6 +21,7 @@ import { getDisplayNameForModel } from "@/lib/hooks";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import Button from "@/refresh-components/buttons/Button";
 import SvgPlusCircle from "@/icons/plus-circle";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 
 // Number of tokens to show cost calculation for
 const COST_CALCULATION_TOKENS = 1_000_000;
@@ -281,10 +282,15 @@ const AdvancedEmbeddingFormPage = forwardRef<
                 name="disable_rerank_for_streaming"
               />
               <BooleanFormField
-                subtext="Enable contextual RAG for all chunk sizes."
+                subtext={
+                  NEXT_PUBLIC_CLOUD_ENABLED
+                    ? "Contextual RAG disabled in Onyx Cloud"
+                    : "Enable contextual RAG for all chunk sizes."
+                }
                 optional
                 label="Contextual RAG"
                 name="enable_contextual_rag"
+                disabled={NEXT_PUBLIC_CLOUD_ENABLED}
               />
               <div>
                 <SelectorFormField


### PR DESCRIPTION
## Description

contextual rag in particular costs a ton unless you (as intended) choose a cheap model for summarization. Cloud customers who really want this can contact us and we can work something out (open source and non-cloud users are unaffected).

## How Has This Been Tested?

contextual rag still shows up normally in local deployments

## Additional Options

- [x] [Optional] Override Linear Check
