### PR TITLE
chore(docker): avoid chown-ing playwright cache

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -95,37 +95,36 @@ nltk.download('punkt_tab', quiet=True);"
 # Set up application files
 WORKDIR /app
 
-# Enterprise Version Files
-COPY ./ee /app/ee
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-# Set up application files
-COPY ./onyx /app/onyx
-COPY ./shared_configs /app/shared_configs
-COPY ./alembic /app/alembic
-COPY ./alembic_tenants /app/alembic_tenants
-COPY ./alembic.ini /app/alembic.ini
-COPY supervisord.conf /usr/etc/supervisord.conf
-COPY ./static /app/static
-
-# Escape hatch scripts
-COPY ./scripts/debugging /app/scripts/debugging
-COPY ./scripts/force_delete_connector_by_id.py /app/scripts/force_delete_connector_by_id.py
-COPY ./scripts/supervisord_entrypoint.sh /app/scripts/supervisord_entrypoint.sh
-RUN chmod +x /app/scripts/supervisord_entrypoint.sh
-
-# Put logo in assets
-COPY ./assets /app/assets
-
-ENV PYTHONPATH=/app
-
 # Create non-root user for security best practices
 RUN groupadd -g 1001 onyx && \
     useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
-    chown -R onyx:onyx /app && \
     mkdir -p /var/log/onyx && \
     chmod 755 /var/log/onyx && \
     chown onyx:onyx /var/log/onyx
+
+# Enterprise Version Files
+COPY --chown=onyx:onyx ./ee /app/ee
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Set up application files
+COPY --chown=onyx:onyx ./onyx /app/onyx
+COPY --chown=onyx:onyx ./shared_configs /app/shared_configs
+COPY --chown=onyx:onyx ./alembic /app/alembic
+COPY --chown=onyx:onyx ./alembic_tenants /app/alembic_tenants
+COPY --chown=onyx:onyx ./alembic.ini /app/alembic.ini
+COPY supervisord.conf /usr/etc/supervisord.conf
+COPY --chown=onyx:onyx ./static /app/static
+
+# Escape hatch scripts
+COPY --chown=onyx:onyx ./scripts/debugging /app/scripts/debugging
+COPY --chown=onyx:onyx ./scripts/force_delete_connector_by_id.py /app/scripts/force_delete_connector_by_id.py
+COPY --chown=onyx:onyx ./scripts/supervisord_entrypoint.sh /app/scripts/supervisord_entrypoint.sh
+RUN chmod +x /app/scripts/supervisord_entrypoint.sh
+
+# Put logo in assets
+COPY --chown=onyx:onyx ./assets /app/assets
+
+ENV PYTHONPATH=/app
 
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD


### PR DESCRIPTION
## Description

The [playwright cache](https://github.com/onyx-dot-app/onyx/blob/ff723992d189df868d29111ffeced37e60543048/backend/Dockerfile#L16) is installed inside of `/app`. At the end of the backend image build, this entire directory is `chown`'ed. Modifying these files then duplicates them in the final image along with the previous layer where they were originally installed.

This change reduces the overall size of the backend image by ~1.24GB, from 6.01GB to 4.77GB, 

```
onyxtrial2@Onyxs-MBP backend % docker images
REPOSITORY                     TAG                                  IMAGE ID       CREATED          SIZE
jamison/onyx-backend-chown     latest                               7dc13157ac10   14 minutes ago   4.77GB
jamison/onyx-backend           latest                               9d0be9dc58e7   26 minutes ago   6.01GB
``` 

Question: this obviously changes the permissions of the playwright cache to now be owned by `root`. I think this should be fine? but if not, it is possible to keep it owned by `onyx` and avoid the duplication by moving the chown (and therefore also the `onyx` user setup) to the same layer which installs playwright.

## How Has This Been Tested?

Captured by [Playwright Tests](https://github.com/onyx-dot-app/onyx/actions/runs/18666239058/job/53218129099?pr=5805)

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Avoid chown-ing the Playwright cache during the backend Docker build to prevent layer duplication. This reduces the image size by ~1.24GB (6.01GB → 4.77GB).

- **Refactors**
  - Replace recursive chown of /app with a find command that prunes /app/.cache and chowns the rest.
  - Keep non-root user setup and log directory permissions.
  - No runtime behavior changes; only the build step is updated.

<!-- End of auto-generated description by cubic. -->

