### PR TITLE
fix: switch out OnyxSparkleIcon for OnyxIcon for default assistant

### DIFF
--- a/web/src/app/admin/configuration/default-assistant/page.tsx
+++ b/web/src/app/admin/configuration/default-assistant/page.tsx
@@ -8,7 +8,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import Text from "@/refresh-components/texts/Text";
 import useSWR, { mutate } from "swr";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { OnyxSparkleIcon } from "@/components/icons/icons";
+import OnyxLogo from "@/icons/onyx-logo";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { useAgentsContext } from "@/refresh-components/contexts/AgentsContext";
 import { Switch } from "@/components/ui/switch";
@@ -312,7 +312,9 @@ export default function Page() {
     <div className="mx-auto max-w-4xl w-full">
       <AdminPageTitle
         title="Default Assistant"
-        icon={<OnyxSparkleIcon size={32} className="my-auto" />}
+        icon={
+          <OnyxLogo className="my-auto w-[1.5rem] h-[1.5rem] stroke-text-04" />
+        }
       />
       <DefaultAssistantConfig />
     </div>

--- a/web/src/icons/onyx-logo.tsx
+++ b/web/src/icons/onyx-logo.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+const OnyxLogo = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <g clipPath="url(#clip0_586_577)">
+      <path
+        d="M8 4.00001L4.5 2.50002L8 1.00002L11.5 2.50002L8 4.00001Z"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 12L11.5 13.5L8 15L4.5 13.5L8 12Z"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 8L2.5 11.5L1 8L2.5 4.50002L4 8Z"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 8.00002L13.5 4.50002L15 8.00001L13.5 11.5L12 8.00002Z"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_586_577">
+        <rect width={16} height={16} fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+export default OnyxLogo;

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -37,8 +37,8 @@ import {
   SearchIcon,
   DocumentIcon2,
   BrainIcon,
-  OnyxSparkleIcon,
 } from "@/components/icons/icons";
+import OnyxLogo from "@/icons/onyx-logo";
 import { CombinedSettings } from "@/app/admin/settings/interfaces";
 import { FiActivity, FiBarChart2 } from "react-icons/fi";
 import SidebarTab from "@/refresh-components/buttons/SidebarTab";
@@ -160,7 +160,7 @@ const collections = (
           items: [
             {
               name: "Default Assistant",
-              icon: OnyxSparkleIcon,
+              icon: OnyxLogo,
               link: "/admin/configuration/default-assistant",
             },
             {


### PR DESCRIPTION
## Description

Closes: https://linear.app/danswer/issue/DAN-2868/default-assistant-icon

Just switching the sparkle icon out in favor of the standard onyx logo.

## How Has This Been Tested?
<img width="711" height="658" alt="Screenshot 2025-10-20 at 5 12 31 PM" src="https://github.com/user-attachments/assets/e5453c2b-660e-4e03-bfbc-d68817e6d986" />


## Additional Options

Closes https://linear.app/danswer/issue/DAN-2868/default-assistant-icon

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Swapped OnyxSparkleIcon for OnyxIcon on the Default Assistant page and in the Admin Sidebar to use the standard Onyx logo. Addresses Linear DAN-2868 (Default Assistant icon).

<!-- End of auto-generated description by cubic. -->

