### PR TITLE
fix: whitelabling assistant logo

### DIFF
--- a/web/src/refresh-components/AgentIcon.tsx
+++ b/web/src/refresh-components/AgentIcon.tsx
@@ -1,12 +1,8 @@
-import React, { useContext } from "react";
+import React from "react";
 import crypto from "crypto";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import { buildImgUrl } from "@/app/chat/components/files/images/utils";
-import {
-  ArtAsistantIcon,
-  GeneralAssistantIcon,
-  OnyxIcon,
-} from "@/components/icons/icons";
+import { ArtAsistantIcon, OnyxIcon } from "@/components/icons/icons";
 import {
   Tooltip,
   TooltipContent,
@@ -15,7 +11,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import Text from "@/refresh-components/texts/Text";
-import { SettingsContext } from "@/components/settings/SettingsProvider";
+import { useSettingsContext } from "@/components/settings/SettingsProvider";
 
 function md5ToBits(str: string): number[] {
   const md5hex = crypto.createHash("md5").update(str).digest("hex");
@@ -95,7 +91,7 @@ export interface AgentIconProps {
 }
 
 export function AgentIcon({ agent, size = 24 }: AgentIconProps) {
-  const settings = useContext(SettingsContext);
+  const settings = useSettingsContext();
 
   // Check if whitelabeling is enabled for the default assistant
   const shouldUseWhitelabelLogo =
@@ -106,9 +102,9 @@ export function AgentIcon({ agent, size = 24 }: AgentIconProps) {
       <Tooltip>
         <TooltipTrigger asChild>
           <div className="text-text-04">
-            {agent.id == -3 ? (
+            {agent.id === -3 ? (
               <ArtAsistantIcon size={size} />
-            ) : agent.id == 0 ? (
+            ) : agent.id === 0 ? (
               shouldUseWhitelabelLogo ? (
                 <img
                   alt="Logo"
@@ -124,8 +120,6 @@ export function AgentIcon({ agent, size = 24 }: AgentIconProps) {
               ) : (
                 <OnyxIcon size={size} />
               )
-            ) : agent.id == -1 ? (
-              <GeneralAssistantIcon size={size} />
             ) : agent.uploaded_image_id ? (
               <img
                 alt={agent.name}


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2917/fix-whitelabel-v2

Now:
<img width="933" height="228" alt="Screenshot 2025-10-20 at 4 24 47 PM" src="https://github.com/user-attachments/assets/4b801e78-add8-48a3-bb7d-84a3f9bb5137" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the default assistant avatar to respect whitelabeling. When a custom logo is enabled, the default assistant now shows the tenant logo instead of the Onyx icon.

- **Bug Fixes**
  - For agent.id === 0, read use_custom_logo from SettingsContext and render /api/enterprise-settings/logo; all other agents keep existing icons.

<!-- End of auto-generated description by cubic. -->

