### PR TITLE
fix: don't set new default provider when deleted provider was not default

### DIFF
--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -743,7 +743,7 @@ export function LLMProviderUpdateForm({
                     }
 
                     // If the deleted provider was the default, set the first remaining provider as default
-                    if (existingLlmProvider?.is_default_provider) {
+                    if (existingLlmProvider.is_default_provider) {
                       const remainingProvidersResponse = await fetch(
                         LLM_PROVIDERS_ADMIN_URL
                       );


### PR DESCRIPTION
## Description

- previously: deleting ANY provider would always set the Default Provider to the "next non-default" one
- Now, first check if the deleting provider is default and only then set a new default

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix default provider handling when deleting a provider. Now we only assign a new default if the deleted provider was the current default, preventing unexpected default changes.

<!-- End of auto-generated description by cubic. -->

