### PR TITLE
refactor: Edit message generation ui

### DIFF
--- a/web/src/app/admin/assistants/StarterMessageList.tsx
+++ b/web/src/app/admin/assistants/StarterMessageList.tsx
@@ -7,12 +7,25 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useState } from "react";
-import { FiTrash2, FiRefreshCw } from "react-icons/fi";
+import { useMemo } from "react";
 import { StarterMessage } from "./interfaces";
-import { Button } from "@/components/ui/button";
-import { SwapIcon } from "@/components/icons/icons";
+import Button from "@/refresh-components/buttons/Button";
 import { TextFormField } from "@/components/Field";
+import SvgTrash from "@/icons/trash";
+import { cn } from "@/lib/utils";
+import SvgRefreshCw from "@/icons/refresh-cw";
+import Text from "@/refresh-components/texts/Text";
+import { MAX_STARTER_MESSAGES } from "@/lib/constants";
+import IconButton from "@/refresh-components/buttons/IconButton";
+
+export interface StarterMessagesListProps {
+  values: StarterMessage[];
+  arrayHelpers: ArrayHelpers;
+  isRefreshing: boolean;
+  debouncedRefreshPrompts: () => void;
+  autoStarterMessageEnabled: boolean;
+  setFieldValue: any;
+}
 
 export default function StarterMessagesList({
   values,
@@ -21,16 +34,7 @@ export default function StarterMessagesList({
   debouncedRefreshPrompts,
   autoStarterMessageEnabled,
   setFieldValue,
-}: {
-  values: StarterMessage[];
-  arrayHelpers: ArrayHelpers;
-  isRefreshing: boolean;
-  debouncedRefreshPrompts: () => void;
-  autoStarterMessageEnabled: boolean;
-  setFieldValue: any;
-}) {
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-
+}: StarterMessagesListProps) {
   const handleInputChange = (index: number, value: string) => {
     setFieldValue(`starter_messages.${index}.message`, value);
 
@@ -45,8 +49,13 @@ export default function StarterMessagesList({
     }
   };
 
+  const maxMessagesReached = useMemo(() => {
+    const validMessages = values.filter((message) => message.message !== "");
+    return validMessages.length >= MAX_STARTER_MESSAGES;
+  }, [values]);
+
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-spacing-interline">
       {values.map((starterMessage, index) => (
         <div key={index} className="flex items-center gap-2">
           <TextFormField
@@ -57,85 +66,60 @@ export default function StarterMessagesList({
             removeLabel
             small
           />
-          <Button
+          <IconButton
             type="button"
-            variant="ghost"
-            size="icon"
+            secondary
             onClick={() => {
               arrayHelpers.remove(index);
             }}
-            className={`text-text-400 hover:text-red-500 ${
-              index === values.length - 1 && !starterMessage.message
-                ? "opacity-50 cursor-not-allowed"
-                : ""
-            }`}
             disabled={
               (index === values.length - 1 && !starterMessage.message) ||
               (values.length === 1 && index === 0) // should never happen, but just in case
             }
-          >
-            <FiTrash2 className="h-4 w-4" />
-          </Button>
+            icon={SvgTrash}
+          />
         </div>
       ))}
 
-      <div className="flex items-center gap-2 ">
-        <TooltipProvider>
-          <Tooltip onOpenChange={setTooltipOpen} open={tooltipOpen}>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                onMouseEnter={() => setTooltipOpen(true)}
-                onMouseLeave={() => setTooltipOpen(false)}
-                onClick={() => {
-                  const shouldSubmit =
-                    values.filter((msg) => msg.message.trim() !== "").length <
-                      4 &&
-                    !isRefreshing &&
-                    autoStarterMessageEnabled;
-                  if (shouldSubmit) {
-                    debouncedRefreshPrompts();
-                  }
-                }}
-                className={`
-                  ${
-                    values.filter((msg) => msg.message.trim() !== "").length >=
-                      4 ||
-                    isRefreshing ||
-                    !autoStarterMessageEnabled
-                      ? "bg-background-800 text-text-300 cursor-not-allowed"
-                      : ""
-                  }
-                `}
-              >
-                <div className="flex text-xs items-center gap-x-2">
-                  {isRefreshing ? (
-                    <FiRefreshCw className="w-4 h-4 animate-spin text-white" />
-                  ) : (
-                    <SwapIcon className="w-4 h-4 text-white" />
-                  )}
-                  Generate
-                </div>
-              </Button>
-            </TooltipTrigger>
-            {!autoStarterMessageEnabled && (
-              <TooltipContent side="top" align="center">
-                <p className="bg-background-950 max-w-[200px] text-sm p-1.5 text-white">
-                  No LLM providers configured. Generation is not available.
-                </p>
-              </TooltipContent>
-            )}
-            {values.filter((msg) => msg.message.trim() !== "").length >= 4 && (
-              <TooltipContent side="top" align="center">
-                <p className="bg-background-950 max-w-[200px] text-sm p-1.5 text-white">
-                  Max four starter messages
-                </p>
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </TooltipProvider>
-      </div>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              onClick={() => {
+                const shouldSubmit =
+                  values.filter((msg) => msg.message.trim() !== "").length <
+                    4 &&
+                  !isRefreshing &&
+                  autoStarterMessageEnabled;
+                if (shouldSubmit) {
+                  debouncedRefreshPrompts();
+                }
+              }}
+              disabled={isRefreshing || maxMessagesReached}
+              leftIcon={({ className }) => (
+                <SvgRefreshCw
+                  className={cn(className, isRefreshing && "animate-spin")}
+                />
+              )}
+            >
+              Generate
+            </Button>
+          </TooltipTrigger>
+          {!autoStarterMessageEnabled && (
+            <TooltipContent side="top" align="center">
+              <Text inverted>
+                No LLM providers configured. Generation is not available.
+              </Text>
+            </TooltipContent>
+          )}
+          {maxMessagesReached && (
+            <TooltipContent side="top" align="center">
+              <Text inverted>Max four starter messages</Text>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -106,6 +106,7 @@ export const ALLOWED_URL_PROTOCOLS = [
 ];
 
 export const MAX_CHARACTERS_PERSONA_DESCRIPTION = 5000000;
+export const MAX_STARTER_MESSAGES = 4;
 
 //Credential form data key constants
 export const CREDENTIAL_NAME = "name";

--- a/web/src/refresh-components/buttons/IconButton.tsx
+++ b/web/src/refresh-components/buttons/IconButton.tsx
@@ -35,6 +35,13 @@ const buttonClasses = (active: boolean | undefined) =>
       ],
       disabled: ["bg-background-neutral-02"],
     },
+    danger: {
+      main: [
+        active ? "bg-action-danger-06" : "bg-action-danger-05",
+        "hover:bg-action-danger-04",
+      ],
+      disabled: ["bg-action-danger-02"],
+    },
     internal: {
       main: [
         active ? "bg-background-tint-00" : "bg-transparent",
@@ -64,6 +71,10 @@ const iconClasses = (active: boolean | undefined) =>
       ],
       disabled: ["stroke-text-01"],
     },
+    danger: {
+      main: ["stroke-text-light-05"],
+      disabled: ["stroke-text-light-05"],
+    },
     internal: {
       main: [
         active ? "!stroke-text-05" : "stroke-text-02",
@@ -84,6 +95,7 @@ export interface IconButtonProps
   secondary?: boolean;
   tertiary?: boolean;
   internal?: boolean;
+  danger?: boolean;
 
   // Button properties:
   onHover?: (isHovering: boolean) => void;
@@ -100,6 +112,7 @@ export default function IconButton({
   secondary,
   tertiary,
   internal,
+  danger,
 
   onHover,
   onClick,
@@ -117,7 +130,9 @@ export default function IconButton({
         ? "tertiary"
         : internal
           ? "internal"
-          : "primary";
+          : danger
+            ? "danger"
+            : "primary";
   const state = disabled ? "disabled" : "main";
 
   const buttonElement = (


### PR DESCRIPTION
## Description

Refactor how message generation works.

Addresses: https://linear.app/danswer/issue/DAN-2920/refactor-message-generation-ui.

## Screenshots

Message generation (light + dark):

<img width="919" height="172" alt="image" src="https://github.com/user-attachments/assets/4b2e73cb-0243-4bfa-963f-96eb27ef9854" />
<img width="945" height="354" alt="image" src="https://github.com/user-attachments/assets/e6194954-7b54-475f-be08-41b520657714" />

<img width="932" height="189" alt="image" src="https://github.com/user-attachments/assets/1f6fb697-9f97-4d3c-8c5b-4fccbff41e51" />
<img width="954" height="344" alt="image" src="https://github.com/user-attachments/assets/06826ef8-f110-46ac-bafe-c6a002946f19" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactors the starter message generation UI in Admin > Assistants to use refreshed components, improve disabled/tooltips logic, and enforce a max of 4 messages. Generate/delete actions are clearer, with a spinner while generating.

- **Refactors**
  - Switched to new Button and IconButton with SvgTrash and SvgRefreshCw (spinner on refresh).
  - Enforced MAX_STARTER_MESSAGES = 4 via constant and useMemo; disables Generate when reached or refreshing.
  - Simplified tooltips: show messages for missing LLM config and when max is reached; removed manual tooltip state.
  - Minor layout cleanup (spacing token) and removed old icons.
  - Added a danger variant to IconButton for shared use.

<!-- End of auto-generated description by cubic. -->

