### PR TITLE
fix(chat): prevent catastrophic backtracking when processing citations

### DIFF
--- a/backend/onyx/chat/stream_processing/citation_processing.py
+++ b/backend/onyx/chat/stream_processing/citation_processing.py
@@ -223,7 +223,7 @@ class CitationProcessorGraph:
 
         # '[', '[[', '[1', '[[1', '[1,', '[1, ', '[1,2', '[1, 2,', etc.
         # Also supports '[D1', '[D1, D3' type patterns
-        self.possible_citation_pattern = re.compile(r"\[+(?:\d+(?:,\s*\d+)*(?:,\s*)?)?$")
+        self.possible_citation_pattern = re.compile(r"\[+(?:(?:\d+|D\d+)(?:,\s*(?:\d+|D\d+))*(?:,\s*)?)?$")
 
         # group 1: '[[1]]', [[2]], etc.
         # group 2: '[1]', '[1, 2]', '[1,2,16]', etc.


### PR DESCRIPTION
## Description

- Replace ambiguous possible-citation regex with deterministic pattern: from: `(\[+(?:\d+,? ?)*$)`
  to:   `\[+(?:\d+(?:,\s*\d+)*(?:,\s*)?)?$`
- Limit search to suffix from last '[' to end of buffer to avoid O(n) scans per token:
  use: `last_lb = self.curr_segment.rfind("["); suffix = self.curr_segment[last_lb:] or ""`
- Preserve behavior: still holds buffer when mid-citation (e.g., "[", "[1", "[1, 2, ")
- Avoids catastrophic backtracking on long lists (e.g., [1, 2, …, 44]) and improves streaming responsiveness

## How Has This Been Tested?

- Simulated streaming with long citation tail; no stalls and citations processed when ']' arrives. For that I've used this [script](https://gist.github.com/razvanMiu/00e9ac21815cd58094aa8e9c92c38627).

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents catastrophic regex backtracking when parsing citations in chat, removing stalls on long lists. Improves streaming responsiveness while keeping citation detection accurate.

- **Bug Fixes**
  - Replaced possible-citation regex with deterministic pattern: r"\[+(?:\d+(?:,\s*\d+)*(?:,\s*)?)?$".
  - Limited search to the suffix from the last "[" instead of scanning the whole buffer per token.
  - Preserved mid-citation buffering (e.g., "[", "[1", "[1, 2, ") until the closing "]".

<!-- End of auto-generated description by cubic. -->

