### PR TITLE
fix(ui): Update Upload Image and Generate Icon buttons

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -876,6 +876,7 @@ export function AssistantEditor({
                     <div className="flex flex-col gap-2">
                       <Button
                         secondary
+                        type="button"
                         onClick={() => {
                           const fileInput = document.createElement("input");
                           fileInput.type = "file";
@@ -899,6 +900,7 @@ export function AssistantEditor({
                       {values.uploaded_image && (
                         <Button
                           secondary
+                          type="button"
                           onClick={() => {
                             setUploadedImagePreview(null);
                             setFieldValue("uploaded_image", null);
@@ -919,6 +921,7 @@ export function AssistantEditor({
                           removePersonaImage) && (
                           <Button
                             secondary
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation();
                               const newShape = generateRandomIconShape();
@@ -942,6 +945,7 @@ export function AssistantEditor({
                         !values.uploaded_image && (
                           <Button
                             secondary
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation();
                               setRemovePersonaImage(false);
@@ -959,6 +963,7 @@ export function AssistantEditor({
                         !values.uploaded_image && (
                           <Button
                             secondary
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation();
                               setRemovePersonaImage(true);


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Small bug where when creating a new Agent we wouldn't see this but with an existing Agent, if you tried to update the image or the icon it would submit the form. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally and validated that everything is working now.

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes accidental form submission when editing an existing assistant by setting the Upload Image and Generate Icon buttons to type="button". You can now upload/clear images and generate icons without triggering a save.

<!-- End of auto-generated description by cubic. -->

