### PR TITLE
fix(ui): Update spacing for the API Key page

### DIFF
--- a/web/src/app/admin/api-key/page.tsx
+++ b/web/src/app/admin/api-key/page.tsx
@@ -107,18 +107,23 @@ function Main() {
     );
   }
 
-  const newApiKeyButton = (
-    <CreateButton onClick={() => setShowCreateUpdateForm(true)}>
-      Create API Key
-    </CreateButton>
+  const introSection = (
+    <div className="flex flex-col items-start gap-spacing-paragraph">
+      <Text>{API_KEY_TEXT}</Text>
+      <CreateButton
+        className="self-start"
+        onClick={() => setShowCreateUpdateForm(true)}
+      >
+        Create API Key
+      </CreateButton>
+    </div>
   );
 
   if (apiKeys.length === 0) {
     return (
       <div>
         {popup}
-        <Text>{API_KEY_TEXT}</Text>
-        {newApiKeyButton}
+        {introSection}
 
         {showCreateUpdateForm && (
           <OnyxApiKeyForm
@@ -151,8 +156,7 @@ function Main() {
 
       {keyIsGenerating && <Spinner />}
 
-      <Text>{API_KEY_TEXT}</Text>
-      {newApiKeyButton}
+      {introSection}
 
       <Separator />
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The spacing on the default api key page looked rather odd. 

This is to fix it

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally.

Before:
<img width="732" height="192" alt="Screenshot 2025-10-21 at 10 38 54 AM" src="https://github.com/user-attachments/assets/15753941-c022-4201-966e-a3f0ca843e55" />

After:
<img width="733" height="256" alt="Screenshot 2025-10-21 at 10 38 32 AM" src="https://github.com/user-attachments/assets/06cc99ac-f652-444f-83ad-e6906b0f9ed5" />

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed spacing and alignment on the Admin > API Key page by stacking the intro text and “Create API Key” button with consistent gaps and left alignment. Reused a shared intro section for both empty and populated states to keep the layout consistent and reduce duplication.

<!-- End of auto-generated description by cubic. -->

