### PR TITLE
fix(ui): Align Default Assistant Page

### DIFF
--- a/web/src/app/admin/configuration/default-assistant/page.tsx
+++ b/web/src/app/admin/configuration/default-assistant/page.tsx
@@ -183,7 +183,9 @@ function DefaultAssistantConfig() {
 
         <div className="max-w-4xl">
           <div className="flex gap-x-2 items-center">
-            <div className="block font-medium text-sm">Instructions</div>
+            <Text mainUiBody text04 className="font-medium text-sm">
+              Instructions
+            </Text>
           </div>
           <SubLabel>
             Add instructions to tailor the behavior of the assistant.
@@ -205,9 +207,9 @@ function DefaultAssistantConfig() {
               placeholder="You are a professional email writing assistant that always uses a polite enthusiastic tone, emphasizes action items, and leaves blanks for the human to fill in when you have unknowns"
             />
             <div className="flex justify-between items-center mt-2">
-              <div className="text-sm text-gray-500">
+              <Text mainUiMuted text03 className="text-sm">
                 {systemPrompt.length} characters
-              </div>
+              </Text>
               <Button
                 onClick={handleSaveSystemPrompt}
                 disabled={savingPrompt || systemPrompt === originalPrompt}
@@ -221,7 +223,9 @@ function DefaultAssistantConfig() {
         <Separator />
 
         <div>
-          <p className="block font-medium text-sm mb-2">Actions</p>
+          <Text mainUiBody text04 className="font-medium text-sm mb-2">
+            Actions
+          </Text>
           <div className="space-y-3">
             {(availableTools || [])
               .slice()


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The Default Assistant Page is not aligned and the logo was not updated to the correct size. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally. 

Before:
<img width="1337" height="941" alt="Screenshot 2025-10-21 at 10 59 54 AM" src="https://github.com/user-attachments/assets/3c96308c-d6ad-4f0c-8d10-3b6eaec6bb75" />

After: 
<img width="1231" height="953" alt="Screenshot 2025-10-21 at 10 59 35 AM" src="https://github.com/user-attachments/assets/009ee415-6549-4a6f-9b92-d2fa33288806" />


## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aligned the Default Assistant configuration page with the admin layout and fixed the logo size for consistent visuals across admin pages.

- **Bug Fixes**
  - Left-aligned content by switching to a single max-w-4xl container with mr-auto and removing a redundant inner wrapper.
  - Set OnyxLogo to 32x32 for consistent sizing.
  - Tidied spacing and separators; no functional changes to forms or toggles.

<!-- End of auto-generated description by cubic. -->

