### PR TITLE
chore(github): flag and enable docker build caching

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -133,7 +133,8 @@ jobs:
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:test-${{ github.run_id }}
           push: true
           outputs: type=registry
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
 
   build-model-server-image:
     runs-on: blacksmith-16vcpu-ubuntu-2404-arm
@@ -161,7 +162,8 @@ jobs:
           push: true
           outputs: type=registry
           provenance: false
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
 
   build-integration-image:
     needs: prepare-build
@@ -195,7 +197,7 @@ jobs:
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-integration:test-${{ github.run_id }}
           push: true
           outputs: type=registry
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   integration-tests:
     needs:

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -130,7 +130,8 @@ jobs:
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:test-${{ github.run_id }}
           push: true
           outputs: type=registry
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
 
   build-model-server-image:
     runs-on: blacksmith-16vcpu-ubuntu-2404-arm
@@ -158,7 +159,8 @@ jobs:
           push: true
           outputs: type=registry
           provenance: false
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
 
   build-integration-image:
     needs: prepare-build
@@ -192,7 +194,8 @@ jobs:
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-integration:test-${{ github.run_id }}
           push: true
           outputs: type=registry
-          no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
 
   integration-tests-mit:
     needs:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -57,7 +57,7 @@ jobs:
           sbom: false
           push: true
           outputs: type=registry
-          # no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-backend-image:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
@@ -90,7 +90,7 @@ jobs:
           sbom: false
           push: true
           outputs: type=registry
-          # no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
@@ -123,7 +123,7 @@ jobs:
           sbom: false
           push: true
           outputs: type=registry
-          # no-cache: true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]


### PR DESCRIPTION
## Description

This re-enables docker caching for integration tests and implements a global flag `DOCKER_NO_CACHE` which can be used to disable caching by changing the variable's value from `false` (caching) to `true` (no-caching) here: https://github.com/onyx-dot-app/onyx/settings/variables/actions.

1 suspected culprit for the original caching issue (https://github.com/onyx-dot-app/onyx/pull/5594) is being addressed in https://github.com/onyx-dot-app/onyx/pull/5833 and a 2nd potential culprit might be addressed depending on that change.

## How Has This Been Tested?

Confirmed caching is enabled building an image on this presubmit, https://github.com/onyx-dot-app/onyx/actions/runs/18697255230/job/53317791169#step:7:198

Confirmed setting `DOCKER_NO_CACHE=true` disables caching here: https://github.com/onyx-dot-app/onyx/actions/runs/18698467292/job/53321776284?pr=5839

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Re-enabled Docker layer caching in CI for integration and Playwright builds to speed up runs. Added a DOCKER_NO_CACHE flag to let us turn caching off globally via a repo Actions variable.

- **Migration**
  - Default: caching is on.
  - To disable globally: Settings → Secrets and variables → Actions → Variables → set DOCKER_NO_CACHE=true.

<!-- End of auto-generated description by cubic. -->

