### PR TITLE
fix(internal search): Restore functionality

### DIFF
--- a/web/src/app/chat/components/input/ActionManagement.tsx
+++ b/web/src/app/chat/components/input/ActionManagement.tsx
@@ -30,7 +30,7 @@ import { useAgentsContext } from "@/refresh-components/contexts/AgentsContext";
 import Link from "next/link";
 import { getIconForAction } from "../../services/actionUtils";
 import { useUser } from "@/components/user/UserProvider";
-import { useFilters, useSourcePreferences } from "@/lib/hooks";
+import { FilterManager, useSourcePreferences } from "@/lib/hooks";
 import { listSourceMetadata } from "@/lib/sources";
 import {
   FiServer,
@@ -517,14 +517,15 @@ function MCPToolsList({
 
 interface ActionToggleProps {
   selectedAssistant: MinimalPersonaSnapshot;
+  filterManager: FilterManager;
   availableSources?: ValidSources[];
 }
 
 export function ActionToggle({
   selectedAssistant,
+  filterManager,
   availableSources = [],
 }: ActionToggleProps) {
-  const filterManager = useFilters();
   const { theme } = useTheme();
   const [open, setOpen] = useState(false);
   const [showSourceManagement, setShowSourceManagement] = useState(false);

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -531,6 +531,7 @@ function ChatInputBarInner({
             {selectedAssistant.tools.length > 0 && (
               <ActionToggle
                 selectedAssistant={selectedAssistant}
+                filterManager={filterManager}
                 availableSources={memoizedAvailableSources}
               />
             )}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently, when you try to do any filtering using the filters in the internal search to select specific connectors, you will still look over all connectors. 

The changes introduced in this PR here: https://github.com/onyx-dot-app/onyx/pull/5455 has the useFilters function that instantiates a `filterManager` that is never properly passed to the chat. 

Then we switched the setup to use the FilterManager here: https://github.com/onyx-dot-app/onyx/pull/5511 which I think did fix the filtering at a certain point but since then it had broken once more because of this: https://github.com/onyx-dot-app/onyx/pull/5529 and been broken ever since.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Set up local setup to test this end to end.

## Additional Options
Closes: https://linear.app/danswer/issue/DAN-2923/internal-search-filtering-doesnt-work

- [ ] [Optional] Override Linear Check
