### PR TITLE
chore(docker): avoid duplicating cached models layer

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -61,12 +61,11 @@ snapshot_download(repo_id='onyx-dot-app/information-content-model'); \
 snapshot_download('nomic-ai/nomic-embed-text-v1'); \
 snapshot_download('mixedbread-ai/mxbai-rerank-xsmall-v1'); \
 from sentence_transformers import SentenceTransformer; \
-SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);"
-
-# In case the user has volumes mounted to /app/.cache/huggingface that they've downloaded while
-# running Onyx, move the current contents of the cache folder to a temporary location to ensure 
-# it's preserved in order to combine with the user's cache contents
-RUN mv /app/.cache/huggingface /app/.cache/temp_huggingface && \
+SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);" && \
+    # In case the user has volumes mounted to /app/.cache/huggingface that they've downloaded while
+    # running Onyx, move the current contents of the cache folder to a temporary location to ensure
+    # it's preserved in order to combine with the user's cache contents
+    mv /app/.cache/huggingface /app/.cache/temp_huggingface && \
     chown -R onyx:onyx /app
 
 WORKDIR /app


### PR DESCRIPTION
## Description

This combines two layers in the model-server docker image. Similar to https://github.com/onyx-dot-app/onyx/pull/5805, having this `chown` in a separate layer meant the modified files were being duplicated in the final image.

This change reduces the total image size by ~50%, from 26.1GB to 14.8GB.

This could be improved further, but this is the smallest, least-invasive change to avoid duplicating files.

## How Has This Been Tested?

Non-functional change -- this only reduces the size of the final image.

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced the model-server Docker image size ~50% by combining cache setup and chown into a single layer to prevent rewriting cached models. Final image drops from 26.1GB to 14.8GB.

- **Refactors**
  - Merged snapshot downloads, SentenceTransformer init, cache move, and chown into one RUN.
  - Prevented duplicated files caused by chown in a separate layer.
  - No runtime behavior changes; preserves mounted /app/.cache/huggingface contents.

<!-- End of auto-generated description by cubic. -->

