### PR TITLE
fix(release): correctly set ONYX_VERSION in model-server image

### DIFF
--- a/.github/workflows/docker-build-push-model-server-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-model-server-container-on-tag.yml
@@ -88,7 +88,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}-amd64
           build-args: |
-            DANSWER_VERSION=${{ github.ref_name }}
+            ONYX_VERSION=${{ github.ref_name }}
           outputs: type=registry
           provenance: false
           cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
@@ -134,7 +134,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}-arm64
           build-args: |
-            DANSWER_VERSION=${{ github.ref_name }}
+            ONYX_VERSION=${{ github.ref_name }}
           outputs: type=registry
           provenance: false
           cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}


### PR DESCRIPTION
## Description

This variable was renamed in https://github.com/onyx-dot-app/onyx/commit/0ba77963c43c4a95f5152104664bee4c492dcdec and looks like this file was missed.

Confirmed the env variable in the latest version of the model server is unexpectedly the dev version,
```
$ docker run -it --rm onyxdotapp/onyx-model-server:latest env | grep ONYX_VERSION   
ONYX_VERSION=0.0.0-dev
```

## How Has This Been Tested?

Didn't really -- seems tame

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the model server release workflow to pass ONYX_VERSION instead of the deprecated DANSWER_VERSION build arg. This ensures tagged builds set ONYX_VERSION to the tag value, fixing containers that currently report 0.0.0-dev.

<!-- End of auto-generated description by cubic. -->

