### PR TITLE
chore(docker): remove empty echo ONYX_VERSION layers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,8 +15,6 @@ ENV ONYX_VERSION=${ONYX_VERSION} \
     DO_NOT_TRACK="true" \
     PLAYWRIGHT_BROWSERS_PATH="/app/.cache/ms-playwright"
 
-
-RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 # Install system dependencies
 # cmake needed for psycopg (postgres)
 # libpq-dev needed for psycopg (postgres)

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -12,8 +12,6 @@ ENV ONYX_VERSION=${ONYX_VERSION} \
     DANSWER_RUNNING_IN_DOCKER="true" \
     HF_HOME=/app/.cache/huggingface
 
-RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
-
 # Create non-root user for security best practices
 RUN mkdir -p /app && \
     groupadd -g 1001 onyx && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,7 +10,6 @@ founders@onyx.app for more information. Please visit https://github.com/onyx-dot
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
-RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 
 # Step 1. Install dependencies + rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Description

I think there is a non-zero chance these layers, being empty, was the cause of [these](https://github.com/onyx-dot-app/onyx/pull/5594) caching issues. My guess is they were either originally for debugging or for invalidating the subsequent layer caches during deployments which is otherwise sufficiently captured by the previous `ENV`, so I don't think they're really doing anything and better off removed if only to reduce the number of possible culprits for the caching issues.

## How Has This Been Tested?

```
$ docker build --build-arg ONYX_VERSION=v1.0.0 -f Dockerfile -t jamison/onyx-backend-version .
$ docker run -it --rm jamison/onyx-backend-version env | grep ONYX_VERSION
ONYX_VERSION=v1.0.0

$ docker build --build-arg ONYX_VERSION=v1.0.1 -f Dockerfile -t jamison/onyx-backend-version .
$ docker run -it --rm jamison/onyx-backend-version env | grep ONYX_VERSION
ONYX_VERSION=v1.0.1

```

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed no-op echo ONYX_VERSION steps from backend, model_server, and web Dockerfiles to prevent extra image layers. Improves Docker caching behavior while still setting ONYX_VERSION via ENV.

<!-- End of auto-generated description by cubic. -->

