### PR TITLE
feat(ui): Expand Uploaded files in Chat

### DIFF
--- a/web/src/app/chat/components/MessagesDisplay.tsx
+++ b/web/src/app/chat/components/MessagesDisplay.tsx
@@ -155,6 +155,7 @@ export const MessagesDisplay: React.FC<MessagesDisplayProps> = ({
                   parentMessage?.childrenNodeIds ?? emptyChildrenIds
                 }
                 onMessageSelection={onMessageSelection}
+                setPresentingDocument={setPresentingDocument}
               />
             </div>
           );

--- a/web/src/app/chat/message/MemoizedHumanMessage.tsx
+++ b/web/src/app/chat/message/MemoizedHumanMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
-import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { FileDescriptor } from "@/app/chat/interfaces";
 import HumanMessage from "./HumanMessage";
+import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 
 interface BaseMemoizedHumanMessageProps {
   content: string;
@@ -12,6 +12,7 @@ interface BaseMemoizedHumanMessageProps {
   shared?: boolean;
   stopGenerating?: () => void;
   disableSwitchingForStreaming?: boolean;
+  setPresentingDocument?: (doc: MinimalOnyxDocument | null) => void;
 }
 
 interface InternalMemoizedHumanMessageProps
@@ -33,6 +34,7 @@ const _MemoizedHumanMessage = React.memo(function _MemoizedHumanMessage({
   stopGenerating,
   disableSwitchingForStreaming,
   onEdit,
+  setPresentingDocument,
 }: InternalMemoizedHumanMessageProps) {
   return (
     <HumanMessage
@@ -45,6 +47,7 @@ const _MemoizedHumanMessage = React.memo(function _MemoizedHumanMessage({
       stopGenerating={stopGenerating}
       disableSwitchingForStreaming={disableSwitchingForStreaming}
       onEdit={onEdit}
+      setPresentingDocument={setPresentingDocument}
     />
   );
 });
@@ -59,6 +62,7 @@ export const MemoizedHumanMessage = ({
   stopGenerating,
   disableSwitchingForStreaming,
   handleEditWithMessageId,
+  setPresentingDocument,
 }: MemoizedHumanMessageProps) => {
   const onEdit = useCallback(
     (editedContent: string) => {
@@ -85,6 +89,7 @@ export const MemoizedHumanMessage = ({
       stopGenerating={stopGenerating}
       disableSwitchingForStreaming={disableSwitchingForStreaming}
       onEdit={onEdit}
+      setPresentingDocument={setPresentingDocument}
     />
   );
 };

--- a/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
@@ -206,6 +206,7 @@ export function SharedChatDisplay({
                             key={message.messageId}
                             content={message.message}
                             files={message.files}
+                            setPresentingDocument={setPresentingDocument}
                           />
                         );
                       } else if (message.type === "assistant") {


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
When uploading a file, we should be able to see it in the chat and then also expand it to see the contents of the file that was uploaded. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally and confirmed that this works
<img width="811" height="255" alt="Screenshot 2025-10-21 at 6 14 16 PM" src="https://github.com/user-attachments/assets/12170b7f-7134-4821-8be4-a93333882169" />
<img width="976" height="231" alt="Screenshot 2025-10-21 at 6 14 46 PM" src="https://github.com/user-attachments/assets/98843a7e-5dc1-4795-8eed-7c2591b6a7e1" />

## Additional Options
Closes https://linear.app/danswer/issue/DAN-2899/clicking-on-docs-in-the-chat-should-render-it

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Uploaded files in chat are now clickable and open in the document viewer, letting users read file contents directly from the conversation. Implements Linear DAN-2899.

- **New Features**
  - Trigger document viewer via setPresentingDocument when an attachment is clicked, wired through chat components.
  - Enable click-to-open for text files; images and CSV continue to render inline.

<!-- End of auto-generated description by cubic. -->

