### PR TITLE
fix: Edit height of mask

### DIFF
--- a/web/src/refresh-components/VerticalShadowScroller.tsx
+++ b/web/src/refresh-components/VerticalShadowScroller.tsx
@@ -26,7 +26,7 @@ export default function VerticalShadowScroller({
 
       {/* Mask Layer */}
       <div
-        className="absolute bottom-0 left-0 right-0 h-[3rem] z-[20] pointer-events-none"
+        className="absolute bottom-0 left-0 right-0 h-[2rem] z-[20] pointer-events-none"
         style={{
           background: disable
             ? undefined


### PR DESCRIPTION
## Description

This PR makes the mask height a bit shorter.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shortened the bottom mask in VerticalShadowScroller from 3rem to 2rem to improve content visibility near the scroll edge.

<!-- End of auto-generated description by cubic. -->

