### PR TITLE
Edit height of mask again

### DIFF
--- a/web/src/refresh-components/VerticalShadowScroller.tsx
+++ b/web/src/refresh-components/VerticalShadowScroller.tsx
@@ -21,12 +21,12 @@ export default function VerticalShadowScroller({
       <div className={cn("flex flex-col flex-1 overflow-y-scroll", className)}>
         {children}
         {/* We add some spacing after the masked scroller to make it clear that this is the *end* of the scroller. */}
-        <div className="min-h-[0.5rem]" />
+        <div className="min-h-[1rem]" />
       </div>
 
       {/* Mask Layer */}
       <div
-        className="absolute bottom-0 left-0 right-0 h-[2rem] z-[20] pointer-events-none"
+        className="absolute bottom-0 left-0 right-0 h-[3rem] z-[20] pointer-events-none"
         style={{
           background: disable
             ? undefined


### PR DESCRIPTION
## Description

Edit mask height again.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increase the bottom fade mask from 2rem to 3rem and the end spacer from 0.5rem to 1rem in VerticalShadowScroller to make the end of the scroller clearer. Improves visual polish and reduces abrupt cutoff.

<!-- End of auto-generated description by cubic. -->

