### PR TITLE
fix: allow user knowledge (file uploads) always

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -343,8 +343,10 @@ export function AssistantEditor({
 
   const [showVisibilityWarning, setShowVisibilityWarning] = useState(false);
 
+  const connectorsExist = ccPairs.length > 0;
+
   const canShowKnowledgeSource =
-    ccPairs.length > 0 &&
+    connectorsExist &&
     searchTool &&
     !(user?.role === UserRole.BASIC && documentSets.length === 0);
 
@@ -1002,7 +1004,7 @@ export function AssistantEditor({
                                     <TooltipTrigger asChild>
                                       <div
                                         className={`${
-                                          ccPairs.length === 0
+                                          !connectorsExist
                                             ? "opacity-70 cursor-not-allowed"
                                             : ""
                                         }`}
@@ -1025,19 +1027,20 @@ export function AssistantEditor({
                                                 );
                                               }}
                                               name={`enabled_tools_map.${searchTool.id}`}
-                                              disabled={ccPairs.length === 0}
+                                              disabled={!connectorsExist}
                                             />
                                           )}
                                         </FastField>
                                       </div>
                                     </TooltipTrigger>
 
-                                    {ccPairs.length === 0 && (
+                                    {!connectorsExist && (
                                       <TooltipContent side="top" align="center">
                                         <Text inverted>
-                                          To use the Knowledge Action, you need
-                                          to have at least one Connector
-                                          configured.
+                                          To use Knowledge, you need to have at
+                                          least one Connector configured. You
+                                          can still upload user files to the
+                                          agent below.
                                         </Text>
                                       </TooltipContent>
                                     )}
@@ -1050,7 +1053,8 @@ export function AssistantEditor({
                       </>
                     )}
 
-                    {searchTool && values.enabled_tools_map[searchTool.id] && (
+                    {((searchTool && values.enabled_tools_map[searchTool.id]) ||
+                      !connectorsExist) && (
                       <div>
                         {canShowKnowledgeSource && (
                           <>
@@ -1268,7 +1272,7 @@ export function AssistantEditor({
                           )}
 
                         {values.knowledge_source === "team_knowledge" &&
-                          ccPairs.length > 0 && (
+                          connectorsExist && (
                             <>
                               {canShowKnowledgeSource && (
                                 <div className="mt-4">


### PR DESCRIPTION
## Description

Enabling file uploads during agent creation regardless of the existence of connectors. 

## How Has This Been Tested?

manual testing

<img width="799" height="162" alt="Screenshot 2025-10-22 at 3 06 55 PM" src="https://github.com/user-attachments/assets/20dafc2e-1587-476d-ba9c-9b31ca8f7da0" />


## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Always enable User Knowledge (file uploads) in the Assistant Editor, even when no connectors are configured. Team/User knowledge cards now only show when connectors exist, with a clearer disabled state and tooltip.

- **New Features**
  - File upload is shown by default when no connectors exist (respects user_knowledge_enabled and default persona limits).
  - Team/User knowledge cards appear only when connectors exist and the Knowledge is enabled.

- **Refactors**
  - Simplified logic with a connectorsExist flag and set default knowledge_source to user_files when none exist.
  - Disabled the Knowledge toggle without connectors and updated the tooltip text.
  - Cleaned up rendering: Document Sets under Team Knowledge; file upload under User Knowledge or when no connectors.

<!-- End of auto-generated description by cubic. -->


Closes https://linear.app/danswer/issue/DAN-2921/knowledge-for-agents
