### PR TITLE
Render chat and project button popovers using the PopoverMenu component

### DIFF
--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -16,6 +16,7 @@ import { cn, noProp } from "@/lib/utils";
 import {
   Popover,
   PopoverContent,
+  PopoverMenu,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useAppParams, useAppRouter } from "@/hooks/appNavigation";
@@ -325,7 +326,7 @@ function ChatButtonInner({
         </div>
       </PopoverTrigger>
       <PopoverContent side="right" align="end">
-        {popoverItems}
+        <PopoverMenu>{popoverItems}</PopoverMenu>
       </PopoverContent>
     </>
   );

--- a/web/src/sections/sidebar/ProjectFolderButton.tsx
+++ b/web/src/sections/sidebar/ProjectFolderButton.tsx
@@ -12,6 +12,7 @@ import SvgEdit from "@/icons/edit";
 import {
   Popover,
   PopoverContent,
+  PopoverMenu,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import SvgTrash from "@/icons/trash";
@@ -166,7 +167,7 @@ function ProjectFolderButtonInner({ project }: ProjectFolderProps) {
                 </PopoverTrigger>
 
                 <PopoverContent side="right" align="end">
-                  {popoverItems}
+                  <PopoverMenu>{popoverItems}</PopoverMenu>
                 </PopoverContent>
               </>
             }


### PR DESCRIPTION
## Description

Render the popovers triggered by the chat and projects button to use the `PopoverMenu` component.

Addresses: https://linear.app/danswer/issue/DAN-2926/render-chat-and-projects-popover-menus-with-the-popovermenu-component.

## Screenshots

### Light

<img width="418" height="115" alt="image" src="https://github.com/user-attachments/assets/57728356-ed20-4063-ba99-cbe7bb32c9f0" />
<img width="425" height="209" alt="image" src="https://github.com/user-attachments/assets/5f695a23-64f6-4f1f-bd33-a0c6705821e1" />

### Dark

<img width="415" height="162" alt="image" src="https://github.com/user-attachments/assets/39868fb2-976b-4485-9013-e3e44d80d8b4" />
<img width="412" height="224" alt="image" src="https://github.com/user-attachments/assets/f10dbe18-f577-46bb-8d44-ed77f268a313" />