### PR TITLE
chore(docker): prefer uv for installing python system packages

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,8 @@ ENV ONYX_VERSION=${ONYX_VERSION} \
     DO_NOT_TRACK="true" \
     PLAYWRIGHT_BROWSERS_PATH="/app/.cache/ms-playwright"
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 # Install system dependencies
 # cmake needed for psycopg (postgres)
 # libpq-dev needed for psycopg (postgres)
@@ -46,22 +48,19 @@ RUN apt-get update && \
 # Remove py which is pulled in by retry, py is not needed and is a CVE
 COPY ./requirements/default.txt /tmp/requirements.txt
 COPY ./requirements/ee.txt /tmp/ee-requirements.txt
-RUN pip install --no-cache-dir --upgrade \
-        --retries 5 \
-        --timeout 30 \
+RUN uv pip install --system --no-cache-dir --upgrade \
         -r /tmp/requirements.txt \
         -r /tmp/ee-requirements.txt && \
     pip uninstall -y py && \
     playwright install chromium && \
     playwright install-deps chromium && \
-    ln -s /usr/local/bin/supervisord /usr/bin/supervisord
-
-# Cleanup for CVEs and size reduction
-# https://github.com/tornadoweb/tornado/issues/3107
-# xserver-common and xvfb included by playwright installation but not needed after
-# perl-base is part of the base Python Debian image but not needed for Onyx functionality
-# perl-base could only be removed with --allow-remove-essential
-RUN apt-get update && \
+    ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
+    # Cleanup for CVEs and size reduction
+    # https://github.com/tornadoweb/tornado/issues/3107
+    # xserver-common and xvfb included by playwright installation but not needed after
+    # perl-base is part of the base Python Debian image but not needed for Onyx functionality
+    # perl-base could only be removed with --allow-remove-essential
+    apt-get update && \
     apt-get remove -y --allow-remove-essential \
         perl-base \
         xserver-common \
@@ -71,14 +70,15 @@ RUN apt-get update && \
         libxmlsec1-dev \
         pkg-config \
         gcc && \
-    apt-get install -y libxmlsec1-openssl && \
+    # Install here to avoid some packages being cleaned up above
+    apt-get install -y \
+        libxmlsec1-openssl \
+        # Install postgresql-client for easy manual tests
+        postgresql-client && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
+    rm -rf ~/.cache/uv /tmp/*.txt && \
     rm -f /usr/local/lib/python3.11/site-packages/tornado/test/test.key
-
-# Install postgresql-client for easy manual tests
-# Install it here to avoid it being cleaned up above
-RUN apt-get update && apt-get install -y postgresql-client
 
 # Pre-downloading models for setups with limited egress
 RUN python -c "from tokenizers import Tokenizer; \

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -12,6 +12,8 @@ ENV ONYX_VERSION=${ONYX_VERSION} \
     DANSWER_RUNNING_IN_DOCKER="true" \
     HF_HOME=/app/.cache/huggingface
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 # Create non-root user for security best practices
 RUN mkdir -p /app && \
     groupadd -g 1001 onyx && \
@@ -32,19 +34,17 @@ RUN set -eux; \
         pkg-config \
         curl \
         ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
     # Install latest stable Rust (supports Cargo.lock v4)
     && curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable \
-    && rustc --version && cargo --version
+    && rustc --version && cargo --version \
+    && apt-get remove -y --allow-remove-essential perl-base \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements/model_server.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --upgrade \
-        --retries 5 \
-        --timeout 30 \
-        -r /tmp/requirements.txt
-
-RUN apt-get remove -y --allow-remove-essential perl-base && \ 
-    apt-get autoremove -y
+RUN uv pip install --system --no-cache-dir --upgrade \
+        -r /tmp/requirements.txt && \
+    rm -rf ~/.cache/uv /tmp/*.txt
 
 # Pre-downloading models for setups with limited egress
 # Download tokenizers, distilbert for the Onyx model


### PR DESCRIPTION
## Description

Prefer [uv](https://docs.astral.sh/uv/) for installing python packages in the backend docker image. Also includes some layer refactoring and additional cache purging to optimize image size.

Reduces the build time of the pip layer from ~110s to ~30s and the final image size from 4.75GB to 3.93GB

```
# Before
onyxdotapp/onyx-backend            latest                               6dcd9d8b02df   About a minute ago   4.75GB
# After
jamison/onyx-backend-uv            latest                               bf8739c5cf25   2 minutes ago        3.93GB
```

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch backend Docker builds to use uv for Python package installs, and streamline layers/cleanup to cut build time and image size. Pip layer time drops ~110s→~30s; final image size 4.75GB→3.93GB.

- **Refactors**
  - Copy uv/uvx from ghcr.io and install requirements with uv pip --system.
  - Consolidate cleanup: uninstall py, remove unused X/perl/dev packages, purge apt lists and uv cache, remove temp requirement files.
  - Install libxmlsec1-openssl and postgresql-client after cleanup; keep Playwright setup and supervisord symlink.

<!-- End of auto-generated description by cubic. -->

