### PR TITLE
chore(ripsecrets): ripsecrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,10 @@ repos:
     rev: v0.1.11
     hooks:
       - id: ripsecrets
+        args:
+        - --additional-pattern
+        - ^sk-[A-Za-z0-9_\-]{20,}$
+
 
   - repo: local
     hooks:

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -786,29 +786,6 @@ class OnyxConfluence:
                     type=user["accountType"],
                 )
         else:
-            # https://developer.atlassian.com/server/confluence/rest/v900/api-group-user/#api-rest-api-user-list-get
-            # ^ is only available on data center deployments
-            # Example response:
-            # [
-            #     {
-            #         'type': 'known',
-            #         'username': 'admin',
-            #         'userKey': '40281082950c5fe901950c61c55d0000',
-            #         'profilePicture': {
-            #             'path': '/images/icons/profilepics/default.svg',
-            #             'width': 48,
-            #             'height': 48,
-            #             'isDefault': True
-            #         },
-            #         'displayName': 'Admin Test',
-            #         '_links': {
-            #             'self': 'http://localhost:8090/rest/api/user?key=40281082950c5fe901950c61c55d0000'
-            #         },
-            #         '_expandable': {
-            #             'status': ''
-            #         }
-            #     }
-            # ]
             for user in self._paginate_url("rest/api/user/list", limit):
                 yield ConfluenceUser(
                     user_id=user["userKey"],


### PR DESCRIPTION
## Description

Jamison's idea -- I think it's a great idea

## How Has This Been Tested?

Caught OpenAI / Anthropic keys locally

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add ripsecrets to pre-commit to prevent committing secrets (including sk- tokens). Also cleaned up an outdated comment block in the Confluence connector.

- **Dependencies**
  - Added ripsecrets v0.1.11 to pre-commit.
  - Configured additional pattern: ^sk-[A-Za-z0-9_\-]{20,}$

- **Refactors**
  - Removed obsolete Confluence REST response example comment in onyx_confluence.py.

<!-- End of auto-generated description by cubic. -->

