### PR TITLE
chore(gha): keep registry cache-{to,from} for docker builds

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -94,6 +94,12 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:test-${{ github.run_id }}
           push: true
+          cache-from: |
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:cache
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache
+          cache-to: |
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:cache,mode=max
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache,mode=max
           outputs: type=registry
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
@@ -122,6 +128,8 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:test-${{ github.run_id }}
           push: true
+          cache-from: type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:cache
+          cache-to: type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:cache,mode=max
           outputs: type=registry
           provenance: false
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
@@ -151,10 +159,18 @@ jobs:
         uses: useblacksmith/setup-docker-builder@v1
 
       - name: Build and push integration test image with Docker Bake
-        env:
-          REGISTRY: ${{ env.PRIVATE_REGISTRY }}
-          TAG: test-${{ github.run_id }}
-        run: cd backend && docker buildx bake ${{ vars.DOCKER_NO_CACHE == 'true' && '--no-cache' || '' }} --push integration
+        uses: docker/bake-action@v5
+        with:
+          files: ./backend/docker-bake.hcl
+          targets: integration
+          push: true
+          set: |
+            REGISTRY=${{ env.PRIVATE_REGISTRY }}
+            TAG=test-${{ github.run_id }}
+            *.platform=linux/arm64
+            *.cache-from=type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache
+            *.cache-to=type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache,mode=max
+            ${{ vars.DOCKER_NO_CACHE == 'true' && '*.no-cache=true' || '' }}
 
   integration-tests:
     needs:

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -91,6 +91,12 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:test-${{ github.run_id }}
           push: true
+          cache-from: |
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:cache
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache
+          cache-to: |
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-backend:cache,mode=max
+            type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache,mode=max
           outputs: type=registry
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
@@ -119,6 +125,8 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:test-${{ github.run_id }}
           push: true
+          cache-from: type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:cache
+          cache-to: type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test-onyx-model-server:cache,mode=max
           outputs: type=registry
           provenance: false
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
@@ -148,10 +156,18 @@ jobs:
         uses: useblacksmith/setup-docker-builder@v1
 
       - name: Build and push integration test image with Docker Bake
-        env:
-          REGISTRY: ${{ env.PRIVATE_REGISTRY }}
-          TAG: test-${{ github.run_id }}
-        run: cd backend && docker buildx bake ${{ vars.DOCKER_NO_CACHE == 'true' && ' --no-cache' || '' }} --push integration
+        uses: docker/bake-action@v5
+        with:
+          files: ./backend/docker-bake.hcl
+          targets: integration
+          push: true
+          set: |
+            REGISTRY=${{ env.PRIVATE_REGISTRY }}
+            TAG=test-${{ github.run_id }}
+            *.platform=linux/arm64
+            *.cache-from=type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache
+            *.cache-to=type=registry,ref=${{ env.PRIVATE_REGISTRY }}/integration-test:cache,mode=max
+            ${{ vars.DOCKER_NO_CACHE == 'true' && '*.no-cache=true' || '' }}
 
   integration-tests-mit:
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     rev: v0.11.4
     hooks:
       - id: ruff
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
@@ -47,6 +48,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: terraform-fmt
+        name: terraform fmt
+        entry: terraform fmt -recursive
+        language: system
+        pass_filenames: false
+        files: \.tf$
       - id: check-lazy-imports
         name: Check lazy imports are not directly imported
         entry: python3 backend/scripts/check_lazy_imports.py

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -49,9 +49,9 @@ module "postgres" {
   subnet_ids    = local.private_subnets
   ingress_cidrs = [local.vpc_cidr_block]
 
-  username         = var.postgres_username
-  password         = var.postgres_password
-  tags             = local.merged_tags
+  username            = var.postgres_username
+  password            = var.postgres_password
+  tags                = local.merged_tags
   enable_rds_iam_auth = var.enable_iam_auth
 }
 
@@ -77,21 +77,21 @@ module "eks" {
   rds_db_connect_arn                 = var.rds_db_connect_arn
 
   # These variables must be defined in variables.tf or passed in via parent module
-  public_cluster_enabled  = var.public_cluster_enabled
-  private_cluster_enabled = var.private_cluster_enabled
+  public_cluster_enabled               = var.public_cluster_enabled
+  private_cluster_enabled              = var.private_cluster_enabled
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
 }
 
 module "waf" {
   source = "../waf"
-  
+
   name = local.name
   tags = local.merged_tags
-  
+
   # WAF configuration with sensible defaults
-  rate_limit_requests_per_5_minutes      = var.waf_rate_limit_requests_per_5_minutes
-  api_rate_limit_requests_per_5_minutes  = var.waf_api_rate_limit_requests_per_5_minutes
-  geo_restriction_countries              = var.waf_geo_restriction_countries
-  enable_logging                         = var.waf_enable_logging
-  log_retention_days                     = var.waf_log_retention_days
+  rate_limit_requests_per_5_minutes     = var.waf_rate_limit_requests_per_5_minutes
+  api_rate_limit_requests_per_5_minutes = var.waf_api_rate_limit_requests_per_5_minutes
+  geo_restriction_countries             = var.waf_geo_restriction_countries
+  enable_logging                        = var.waf_enable_logging
+  log_retention_days                    = var.waf_log_retention_days
 }

--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -44,5 +44,5 @@ resource "aws_db_instance" "this" {
   publicly_accessible    = false
   deletion_protection    = true
   storage_encrypted      = true
-  tags                   = var.tags 
+  tags                   = var.tags
 }


### PR DESCRIPTION
## Description

Blacksmith seems to suggest these are unnecessary, https://docs.blacksmith.sh/blacksmith-caching/docker-builds#overview, but I think we're still seeing excessive cache misses with just the local builder cache and I don't think this should have much impact in the case the builder cache is warm, so let's include for now.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use registry-backed Docker Buildx caching in PR integration workflows to reduce cache misses and speed up builds. Adds cache-from and cache-to for backend, model-server, and integration images in pr-integration-tests and pr-mit-integration-tests.

<!-- End of auto-generated description by cubic. -->

