### PR TITLE
fix(docker): Clean up USE_IAM_AUTH log

### DIFF
--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -75,7 +75,8 @@ MINIO_ROOT_PASSWORD=minioadmin
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_REGION_NAME=
-# USE_IAM_AUTH=
+# Set to true when using IAM authentication for Postgres connections.
+USE_IAM_AUTH=false
 
 
 ################################################################################


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
This is just a PR to clean up the warning that we see sometimes: 

```
WARN[0000] The "USE_IAM_AUTH" variable is not set. Defaulting to a blank string.
```
## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set USE_IAM_AUTH=false in the Docker Compose env template to stop the “variable is not set” warning during startup. Added a comment explaining when to enable IAM auth for Postgres.

<!-- End of auto-generated description by cubic. -->

