### PR TITLE
fix(bedrock): Sanitize creds for IAM

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -53,6 +53,30 @@ ONE_MILLION = 1_000_000
 CHUNKS_PER_DOC_ESTIMATE = 5
 
 
+def sanitize_custom_config(
+    custom_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Drop empty credential values and trim strings before use."""
+
+    if not custom_config:
+        return {}
+
+    sanitized: dict[str, Any] = {}
+    for key, value in custom_config.items():
+        if value is None:
+            continue
+        if isinstance(value, str):
+            trimmed_value = value.strip()
+            if not trimmed_value:
+                continue
+            sanitized[key] = trimmed_value
+            continue
+
+        sanitized[key] = value
+
+    return sanitized
+
+
 def litellm_exception_to_error_msg(
     e: Exception,
     llm: LLM,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Trying to fix an issue where IAM bedrock auth is not working for an EC2 instances that are using the IAM role on the EC2 instance.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally.

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sanitizes provider credentials in custom_config to prevent empty or whitespace values from overriding IAM role auth, fixing AWS Bedrock authentication on EC2. This ensures clean headers and model kwargs across providers.

- **Bug Fixes**
  - Added sanitize_custom_config to trim strings and drop None/empty values.
  - Applied sanitization in ChatLLM and LLM factory when setting env vars, headers, and model_kwargs (including Vertex AI kwargs).
  - Bedrock IAM auth now works on EC2 instances without explicit keys.

<!-- End of auto-generated description by cubic. -->

