### PR TITLE
fix(saml): Redirect to log back in page

### DIFF
--- a/web/src/app/auth/saml/callback/route.ts
+++ b/web/src/app/auth/saml/callback/route.ts
@@ -55,10 +55,15 @@ async function handleSamlCallback(
   const setCookieHeader = response.headers.get("set-cookie");
 
   if (!setCookieHeader) {
-    return NextResponse.redirect(
-      new URL("/auth/error", getDomain(request)),
-      SEE_OTHER_REDIRECT_STATUS
-    );
+    const loginUrl = new URL("/auth/login", getDomain(request));
+    loginUrl.searchParams.set("disableAutoRedirect", "true");
+
+    const nextParam = request.nextUrl.searchParams.get("next") || "/";
+    if (nextParam) {
+      loginUrl.searchParams.set("next", nextParam);
+    }
+
+    return NextResponse.redirect(loginUrl, SEE_OTHER_REDIRECT_STATUS);
   }
 
   const redirectResponse = NextResponse.redirect(


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently, if the user auth is set to SAML and your token expires, you are redirected to an Auth Error page because in theory the expired token does mean that you are no longer authorized. 

Instead we are updating it to redirect to the log back in screen so the user can attempt to log back in and if they hit an issue, it should go to the auth error page instead. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Spun up locally, faked an expiring token and then validated that I was redirected to the auth login page.

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Redirect SAML users with expired or missing tokens to the login page instead of the auth error screen. This enables re-authentication and preserves the intended destination.

- **Bug Fixes**
  - In /auth/saml/callback, when no Set-Cookie is present, redirect to /auth/login with disableAutoRedirect=true.
  - Preserve the next query param to return users to their original page after login.

<!-- End of auto-generated description by cubic. -->

