### PR TITLE
chore: add fe type check to pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 .mypy_cache
 .idea
 
+# typescript
+*.tsbuildinfo
+
 # testing
 /web/test-results/
 backend/onyx/agent_search/main/test_data.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,15 @@ repos:
         language: system
         files: ^backend/.*\.py$
         pass_filenames: false
+      - id: frontend-type-check
+        name: TypeScript type check (frontend)
+        entry: python3 web/scripts/type-check.py
+        language: system
+        files: ^web/.*\.(ts|tsx)$
+        pass_filenames: false
+        # Note: pass_filenames is false because tsc must check the entire
+        # project, but the files filter ensures this only runs when relevant
+        # files change. Using --incremental for faster subsequent checks.
 
   # We would like to have a mypy pre-commit hook, but due to the fact that
   # pre-commit runs in it's own isolated environment, we would need to install

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "lint:unused": "eslint --ext .js,.jsx,.ts,.tsx --rule 'unused-imports/no-unused-imports: error' --quiet --fix=false src/",
     "lint:fix-unused": "eslint --ext .js,.jsx,.ts,.tsx --rule 'unused-imports/no-unused-imports: error' --quiet --fix src/",
     "lint:fix-unused-vars": "eslint --ext .js,.jsx,.ts,.tsx --fix --quiet src/",
+    "type-check": "tsc --noEmit --incremental",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/web/scripts/type-check.py
+++ b/web/scripts/type-check.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Run TypeScript type checking for the web frontend.
+
+Note: TypeScript type checking requires checking the entire project
+due to type dependencies across files. We use --incremental to cache
+results and speed up subsequent checks.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    """Run TypeScript type-check in the web directory.
+
+    Args from pre-commit are ignored since tsc must check the full project,
+    but the files filter ensures this only runs when TS/TSX files change.
+    """
+    # Get the web directory (parent of scripts directory)
+    web_dir = Path(__file__).parent.parent
+
+    # Run the type-check npm script (which includes --incremental flag)
+    result = subprocess.run(
+        ["npm", "run", "type-check"],
+        cwd=web_dir,
+        check=False,
+    )
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Follow up from https://github.com/onyx-dot-app/onyx/pull/5881

Adding FE type checking to pre-commit. This only runs on changed files.

## How Has This Been Tested?

```
(.venv) nikolas@Nikolass-MacBook-Pro web % commit
Enter Commit Message: add type check to pre-commit
black....................................................................Passed
Reorder python imports...................................................Passed
autoflake................................................................Passed
ruff.....................................................................Passed
prettier.............................................(no files to check)Skipped
ripsecrets...............................................................Passed
Check lazy imports are not directly imported.........(no files to check)Skipped
TypeScript type check (frontend).....................(no files to check)Skipped
[nikg/fe/type-check/pre-commit 5fa49f277] add type check to pre-commit
 Committer: Nikolas Garza <nikolas@Nikolass-MacBook-Pro.local>
Your name and email address were configured automatically based
on your username and hostname. Please check that they are accurate.
You can suppress this message by setting them explicitly. Run the
following command and follow the instructions in your editor to edit
your configuration file:

    git config --global --edit

After doing this, you may fix the identity used for this commit with:

    git commit --amend --reset-author

 3 files changed, 31 insertions(+)
 create mode 100755 web/scripts/type-check.py
(.venv) nikolas@Nikolass-MacBook-Pro web % status
On branch nikg/fe/type-check/pre-commit
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        ../.worktree-db/
        ../deployment/docker_compose/docker-compose.worktree-dev1.yml

no changes added to commit (use "git add" and/or "git commit -a")
(.venv) nikolas@Nikolass-MacBook-Pro web % add-u 
(.venv) nikolas@Nikolass-MacBook-Pro web % commit
Enter Commit Message: tests
black................................................(no files to check)Skipped
Reorder python imports...............................(no files to check)Skipped
autoflake............................................(no files to check)Skipped
ruff.................................................(no files to check)Skipped
prettier.................................................................Failed
- hook id: prettier
- files were modified by this hook

web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx

ripsecrets...............................................................Passed
Check lazy imports are not directly imported.........(no files to check)Skipped
TypeScript type check (frontend).........................................Failed
- hook id: frontend-type-check
- exit code: 2

> qa@1.0.0-dev type-check
> tsc --noEmit

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:83:21 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

83     await user.type(defaultModelInputs[0], "gpt-4");
                       ~~~~~~~~~~~~~~~~~~~~~

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:160:21 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

160     await user.type(defaultModelInputs[0], "gpt-4");
                        ~~~~~~~~~~~~~~~~~~~~~

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:225:9 - error TS2739: Type '{ id: number; name: string; provider: string; api_key: string; api_base: string; api_version: string; default_model_name: string; fast_default_model_name: null; model_configurations: { name: string; is_visible: boolean; max_input_tokens: null; }[]; custom_config: {}; is_public: boolean; groups: never[]; deployment_n...' is missing the following properties from type 'LLMProviderView': is_default_provider, default_vision_model, is_default_vision_provider

225         existingLlmProvider={existingProvider}
            ~~~~~~~~~~~~~~~~~~~

  src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx:43:3
    43   existingLlmProvider?: LLMProviderView;
         ~~~~~~~~~~~~~~~~~~~
    The expected type comes from property 'existingLlmProvider' which is declared here on type 'IntrinsicAttributes & { onClose: () => void; existingLlmProvider?: LLMProviderView | undefined; shouldMarkAsDefault?: boolean | undefined; setPopup?: ((popup: PopupSpec) => void) | undefined; hideSuccess?: boolean | undefined; }'

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:314:21 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

314     await user.type(defaultModelInputs[0], "gpt-4");
                        ~~~~~~~~~~~~~~~~~~~~~

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:369:21 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

369     await user.type(defaultModelInputs[0], "gpt-4");
                        ~~~~~~~~~~~~~~~~~~~~~

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:422:22 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

422     await user.click(customConfigAddButton);
                         ~~~~~~~~~~~~~~~~~~~~~

src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:445:21 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

445     await user.type(defaultModelInputs[0], "@cf/meta/llama-2-7b-chat-int8");
                        ~~~~~~~~~~~~~~~~~~~~~

src/app/chat/input-prompts/InputPrompts.test.tsx:189:22 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

189     await user.clear(textareas![1]);
                         ~~~~~~~~~~~~~

src/app/chat/input-prompts/InputPrompts.test.tsx:191:7 - error TS2345: Argument of type 'HTMLElement | undefined' is not assignable to parameter of type 'Element'.
  Type 'undefined' is not assignable to type 'Element'.

191       textareas![1],
          ~~~~~~~~~~~~~


Found 9 errors in 2 files.

Errors  Files
     7  src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.test.tsx:83
     2  src/app/chat/input-prompts/InputPrompts.test.tsx:189


```

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a pre-commit hook that runs TypeScript type checking for the web app, catching type errors before commits. The hook triggers only when web TS/TSX files are staged.

- **New Features**
  - Added frontend-type-check hook to .pre-commit-config.yaml.
  - Added npm script "type-check" (tsc --noEmit).
  - Added web/scripts/type-check.py to run the check.

<!-- End of auto-generated description by cubic. -->

