### PR TITLE
fix(ui): Remove Bubble Text for non-search ui chats

### DIFF
--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -4,7 +4,6 @@ import React, { useState, memo, useMemo, useEffect } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import SvgMoreHorizontal from "@/icons/more-horizontal";
 import { useChatContext } from "@/refresh-components/contexts/ChatContext";
-import SvgBubbleText from "@/icons/bubble-text";
 import { deleteChatSession, renameChatSession } from "@/app/chat/services/lib";
 import { ChatSession } from "@/app/chat/interfaces";
 import ConfirmationModal from "@/refresh-components/modals/ConfirmationModal";
@@ -105,14 +104,12 @@ interface ChatButtonProps {
   chatSession: ChatSession;
   project?: Project;
   draggable?: boolean;
-  showSearchWorkflowIcon?: boolean;
 }
 
 function ChatButtonInner({
   chatSession,
   project,
   draggable = false,
-  showSearchWorkflowIcon = false,
 }: ChatButtonProps) {
   const route = useAppRouter();
   const params = useAppParams();
@@ -342,9 +339,6 @@ function ChatButtonInner({
     >
       <PopoverAnchor>
         <SidebarTab
-          leftIcon={
-            showSearchWorkflowIcon && !project ? SvgBubbleText : undefined
-          }
           onClick={() => route({ chatSessionId: chatSession.id })}
           active={params(SEARCH_PARAM_NAMES.CHAT_ID) === chatSession.id}
           rightChildren={rightMenu}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Following the Linear ticket and removing the bubble text icon for regular chats

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally.
<img width="243" height="462" alt="Screenshot 2025-10-23 at 1 35 05 PM" src="https://github.com/user-attachments/assets/679aa58a-4d68-4af4-a55d-78267e619770" />

## Additional Options

Closes https://linear.app/danswer/issue/DAN-2602/look-without-chat-icon

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the Bubble Text icon from regular chats in the sidebar; it now only appears for search workflow chats. Added a showSearchWorkflowIcon prop to ChatButton to control this, matching Linear DAN-2602.

<!-- End of auto-generated description by cubic. -->

