### PR TITLE
fix: make entire query history row clickable

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -59,7 +59,7 @@ function QueryHistoryTableRow({
   return (
     <TableRow
       key={chatSessionMinimal.id}
-      className="hover:bg-accent-background cursor-pointer relative"
+      className="hover:bg-accent-background cursor-pointer relative select-none"
     >
       <TableCell>
         <Text className="whitespace-normal line-clamp-5">


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added select-none to QueryHistoryTableRow so the entire row acts as a single clickable target without accidental text selection. This improves navigation by letting users click anywhere in the row.

<!-- End of auto-generated description by cubic. -->

