### PR TITLE
fix: add back empty ee dir

### DIFF
--- a/backend/scripts/make_foss_repo.sh
+++ b/backend/scripts/make_foss_repo.sh
@@ -38,6 +38,13 @@ git filter-repo \
   --path web/src/app/ee/LICENSE --invert-paths \
   --force
 
+# NOTE: not ideal, since this means every day folks with the repo
+# locally will need to hard reset if they want to pull in more stuff.
+echo "=== Recreating empty enterprise directory ==="
+mkdir -p backend/ee
+git add backend/ee
+git commit -m "Add empty enterprise directory" --allow-empty
+
 echo "=== Creating blob callback script ==="
 cat > /tmp/license_replacer.py << 'PYEOF'
 #!/usr/bin/env python3


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Recreates an empty backend/ee directory in the FOSS repo during make_foss_repo.sh to prevent path-related build/script errors after enterprise files are stripped. The script now creates and commits backend/ee immediately after filter-repo completes.

<!-- End of auto-generated description by cubic. -->

