### PR TITLE
fix: set git config early

### DIFF
--- a/.github/workflows/sync_foss.yml
+++ b/.github/workflows/sync_foss.yml
@@ -30,6 +30,11 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
+      - name: Set Git config
+        run: |
+          git config user.name "onyx-bot"
+          git config user.email "bot@onyx.app"
+
       - name: Build FOSS version
         run: bash backend/scripts/make_foss_repo.sh
 
@@ -38,7 +43,5 @@ jobs:
           FOSS_REPO_URL: git@github.com:onyx-dot-app/onyx-foss.git
         run: |
           cd /tmp/foss_repo
-          git config user.name "onyx-bot"
-          git config user.email "bot@onyx.app"
           git remote add public "$FOSS_REPO_URL"
           git push --force public main


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Configure git user.name and user.email early in sync_foss.yml and remove the duplicate config from the push step. This ensures all build and push steps have a valid identity and avoids commit/push errors.

<!-- End of auto-generated description by cubic. -->

