### PR TITLE
Configure default litellm timeout in factory

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -825,6 +825,7 @@ def stream_chat_message_objects(
                 persona=persona,
                 llm_override=(new_msg_req.llm_override or chat_session.llm_override),
                 additional_headers=litellm_additional_headers,
+                timeout=None,  # Will use default timeout logic
             )
             yield from _fast_message_stream(
                 answer,


### PR DESCRIPTION
## Description

This PR standardizes the timeout configuration for LLM calls originating from `get_llm_model_and_settings` in `factory.py`. It replicates the timeout logic found in `DefaultMultiLLM` from `chat_llm.py`, ensuring consistent behavior across the codebase.

Specifically, it:
- Configures a default timeout (with an extended timeout for reasoning models).
- Passes this timeout to Litellm via `ModelSettings.extra_args`.
- Updates `get_llm_model_and_settings_for_persona` and its caller in `process_message.py` to propagate the timeout parameter.

This change ensures that all LLM interactions using this factory function adhere to a consistent and configurable timeout policy.

## How Has This Been Tested?

- Ran `pytest` to ensure existing tests pass.
- Performed `mypy` type checks on `factory.py` and `process_message.py` to verify syntax and type correctness.
- Verified that the changes integrate correctly with existing call sites.

## Additional Options

- [ ] [Optional] Override Linear Check

---
<a href="https://cursor.com/background-agent?bcId=bc-bba8a422-81a3-44d0-9064-e94f3d1afd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bba8a422-81a3-44d0-9064-e94f3d1afd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized default Litellm timeouts in the LLM factory, with longer timeouts for reasoning models. Timeouts are now consistently applied and propagated through persona helpers and call sites.

- **New Features**
  - Apply default timeout (QA_TIMEOUT) or 10x for reasoning models in get_llm_model_and_settings.
  - Add and propagate a timeout parameter through get_llm_model_and_settings_for_persona; process_message passes None to use defaults.
  - Forward the timeout to Litellm via model_kwargs["timeout"] for consistent behavior across providers.

<!-- End of auto-generated description by cubic. -->

