### PR TITLE
fix: add __init__.py in empty ee dir

### DIFF
--- a/backend/scripts/make_foss_repo.sh
+++ b/backend/scripts/make_foss_repo.sh
@@ -42,8 +42,9 @@ git filter-repo \
 # locally will need to hard reset if they want to pull in more stuff.
 echo "=== Recreating empty enterprise directory ==="
 mkdir -p backend/ee
+touch backend/ee/__init__.py
 git add backend/ee
-git commit -m "Add empty enterprise directory" --allow-empty
+git commit -m "Add enterprise directory and __init__.py"
 
 echo "=== Creating blob callback script ==="
 cat > /tmp/license_replacer.py << 'PYEOF'


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add __init__.py to backend/ee during FOSS repo creation so the ee package is tracked and importable. This avoids Git dropping the empty directory and prevents build/test import errors.

<!-- End of auto-generated description by cubic. -->

