### PR TITLE
fix: initial screen when no LLM provider is set up

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -79,6 +79,7 @@ import {
 import ProjectChatSessionList from "@/app/chat/components/projects/ProjectChatSessionList";
 import { cn } from "@/lib/utils";
 import { Suggestions } from "@/sections/Suggestions";
+import { UnconfiguredLlmProviderText } from "@/components/chat/UnconfiguredLlmProviderText";
 
 const DEFAULT_CONTEXT_TOKENS = 120_000;
 interface ChatPageProps {
@@ -895,6 +896,11 @@ export function ChatPage({
                             setPresentingDocument={setPresentingDocument}
                           />
                         )}
+
+                        <UnconfiguredLlmProviderText
+                          showConfigureAPIKey={handleShowApiKeyModal}
+                        />
+
                         <ChatInputBar
                           deepResearchEnabled={deepResearchEnabled}
                           toggleDeepResearch={toggleDeepResearch}
@@ -903,7 +909,6 @@ export function ChatPage({
                           llmManager={llmManager}
                           removeDocs={() => setSelectedDocuments([])}
                           retrievalEnabled={retrievalEnabled}
-                          showConfigureAPIKey={handleShowApiKeyModal}
                           selectedDocuments={selectedDocuments}
                           message={message}
                           setMessage={setMessage}

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -20,7 +20,6 @@ import { getFormattedDateRangeString } from "@/lib/dateUtils";
 import { truncateString, cn } from "@/lib/utils";
 import { useUser } from "@/components/user/UserProvider";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
-import { UnconfiguredLlmProviderText } from "@/components/chat/UnconfiguredLlmProviderText";
 import { useProjectsContext } from "@/app/chat/projects/ProjectsContext";
 import { FileCard } from "@/app/chat/components/projects/ProjectContextPanel";
 import {
@@ -83,7 +82,6 @@ export function SourceChip({
 
 export interface ChatInputBarProps {
   removeDocs: () => void;
-  showConfigureAPIKey: () => void;
   selectedDocuments: OnyxDocument[];
   message: string;
   setMessage: (message: string) => void;
@@ -112,7 +110,6 @@ function ChatInputBarInner({
   removeDocs,
   toggleDocumentSidebar,
   filterManager,
-  showConfigureAPIKey,
   selectedDocuments,
   message,
   setMessage,
@@ -401,8 +398,6 @@ function ChatInputBarInner({
           </div>
         </div>
       )}
-
-      <UnconfiguredLlmProviderText showConfigureAPIKey={showConfigureAPIKey} />
 
       <div className="w-full h-full flex flex-col shadow-01 bg-background-neutral-00 rounded-16">
         {currentMessageFiles.length > 0 && (

--- a/web/src/components/chat/UnconfiguredLlmProviderText.tsx
+++ b/web/src/components/chat/UnconfiguredLlmProviderText.tsx
@@ -1,41 +1,27 @@
 import { useProviderStatus } from "./ProviderContext";
+import Text from "@/refresh-components/texts/Text";
 
 export function UnconfiguredLlmProviderText({
   showConfigureAPIKey,
-  noSources,
 }: {
   showConfigureAPIKey: () => void;
-  noSources?: boolean;
 }) {
   const { shouldShowConfigurationNeeded } = useProviderStatus();
 
   return (
     <>
-      {noSources ? (
-        <p className="text-base text-center w-full text-subtle">
-          You have not yet added any sources. Please add{" "}
-          <a
-            href="/admin/add-connector"
-            className="text-link hover:underline cursor-pointer"
+      {shouldShowConfigurationNeeded && (
+        <Text mainUiBody text05 className="text-center w-full pb-2">
+          Please note that you have not yet configured an LLM provider. You can
+          configure one{" "}
+          <button
+            onClick={showConfigureAPIKey}
+            className="text-action-link-05 hover:underline cursor-pointer"
           >
-            a source
-          </a>{" "}
-          to continue.
-        </p>
-      ) : (
-        shouldShowConfigurationNeeded && (
-          <p className="text-base text-center w-full text-subtle">
-            Please note that you have not yet configured an LLM provider. You
-            can configure one{" "}
-            <button
-              onClick={showConfigureAPIKey}
-              className="text-link hover:underline cursor-pointer"
-            >
-              here
-            </button>
-            .
-          </p>
-        )
+            here
+          </button>
+          .
+        </Text>
       )}
     </>
   );


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2934/no-llm-provider-set-up-screen-is-ugly

After:
<img width="960" height="439" alt="Screenshot 2025-10-24 at 11 24 17 AM" src="https://github.com/user-attachments/assets/4fc39df0-6514-4d93-b32a-9ebb13d7e833" />


## How Has This Been Tested?

local

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the initial “no LLM provider configured” state so it looks clean and is visible on first load, with a clear action to open the API key modal. Addresses Linear DAN-2934 (Onyx UI Refresh).

- **Bug Fixes**
  - Moved the unconfigured notice from ChatInputBar to ChatPage so it shows immediately.
  - Restyled the notice using the refresh Text component and action link.
  - Removed the unused noSources variant and the showConfigureAPIKey prop from ChatInputBar.

<!-- End of auto-generated description by cubic. -->

