### PR TITLE
feat(tracing): include tenant_id with braintrust traces

### DIFF
--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a0_clarification.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a0_clarification.py
@@ -94,6 +94,8 @@ from onyx.tools.tool_implementations.web_search.web_search_tool import (
 from onyx.utils.b64 import get_image_type
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
 
 logger = setup_logger()
 
@@ -685,7 +687,11 @@ def clarifier(
                 system_prompt_to_use = assistant_system_prompt
                 user_prompt_to_use = decision_prompt + assistant_task_prompt
 
-            @traced(name="clarifier stream and process", type="llm")
+            @traced(
+                name="clarifier stream and process",
+                type="llm",
+                metadata={"tenant_id": CURRENT_TENANT_ID_CONTEXTVAR.get()},
+            )
             def stream_and_process() -> BasicSearchProcessedStreamResults:
                 stream = graph_config.tooling.primary_llm.stream(
                     prompt=create_question_prompt(

--- a/backend/onyx/agents/agent_search/shared_graph_utils/llm.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/llm.py
@@ -21,6 +21,8 @@ from onyx.server.query_and_chat.streaming_models import MessageDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import StreamingType
 from onyx.utils.threadpool_concurrency import run_with_timeout
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
 
 SchemaType = TypeVar("SchemaType", bound=BaseModel)
 
@@ -28,7 +30,11 @@ SchemaType = TypeVar("SchemaType", bound=BaseModel)
 JSON_PATTERN = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
 
-@traced(name="stream llm", type="llm")
+@traced(
+    name="stream llm",
+    type="llm",
+    metadata={"tenant_id": CURRENT_TENANT_ID_CONTEXTVAR.get()},
+)
 def stream_llm_answer(
     llm: LLM,
     prompt: LanguageModelInput,

--- a/backend/onyx/chat/turn/fast_chat_turn.py
+++ b/backend/onyx/chat/turn/fast_chat_turn.py
@@ -34,6 +34,7 @@ from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import PacketObj
 from onyx.server.query_and_chat.streaming_models import SectionEnd
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 if TYPE_CHECKING:
     from litellm import ResponseFunctionToolCall
@@ -141,7 +142,7 @@ def _fast_chat_turn_core(
         message_id=message_id,
         research_type=research_type,
     )
-    with trace("fast_chat_turn"):
+    with trace("fast_chat_turn", metadata={"tenant_id": CURRENT_TENANT_ID_CONTEXTVAR.get()}):
         _run_agent_loop(
             messages=messages,
             dependencies=dependencies,

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -12,6 +12,7 @@ from onyx.configs.app_configs import DISABLE_GENERATIVE_AI
 from onyx.configs.app_configs import LOG_INDIVIDUAL_MODEL_TOKENS
 from onyx.configs.app_configs import LOG_ONYX_MODEL_INTERACTIONS
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 
 logger = setup_logger()
@@ -87,7 +88,11 @@ class LLM(abc.ABC):
         if LOG_ONYX_MODEL_INTERACTIONS:
             log_prompt(prompt)
 
-    @traced(name="invoke llm", type="llm")
+    @traced(
+        name="invoke llm",
+        type="llm",
+        metadata={"tenant_id": CURRENT_TENANT_ID_CONTEXTVAR.get()},
+    )
     def invoke(
         self,
         prompt: LanguageModelInput,

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -105,7 +105,7 @@ sendgrid==6.11.0
 voyageai==0.2.3
 cohere==5.6.1
 exa_py==1.15.4
-braintrust[openai-agents]==0.2.6
+braintrust[openai-agents]==0.3.5
 braintrust-langchain==0.0.4
 openai-agents==0.3.3
 langfuse==3.7.0


### PR DESCRIPTION
## Description

## How Has This Been Tested?


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tenant_id to Braintrust trace metadata across LLM calls and chat turns to enable per-tenant observability and filtering.

- **New Features**
  - Add metadata {"tenant_id": CURRENT_TENANT_ID_CONTEXTVAR.get()} to traces for: LLM invoke, LLM streaming, clarifier pipeline, and fast_chat_turn.
  - Allows grouping and querying traces by tenant in Braintrust.

- **Dependencies**
  - Upgrade braintrust[openai-agents] to 0.3.5.

<!-- End of auto-generated description by cubic. -->

