### PR TITLE
fix: input bar thickness

### DIFF
--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -506,8 +506,8 @@ function ChatInputBarInner({
           </div>
         )}
 
-        <div className="flex justify-between items-center w-full p-spacing-inline">
-          <div className="flex flex-row items-center gap-spacing-inline">
+        <div className="flex justify-between items-center w-full p-1">
+          <div className="flex flex-row items-center gap-1">
             <FilePicker
               onFileClick={handleFileClick}
               onPickRecent={(file: ProjectFile) => {


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2935/main-input-bar-height-is-off

New:

<img width="1722" height="930" alt="Screenshot 2025-10-24 at 2 52 23 PM" src="https://github.com/user-attachments/assets/9a968903-43c2-4ae9-9923-84c62d764332" />

Old:

<img width="1721" height="925" alt="Screenshot 2025-10-24 at 2 52 42 PM" src="https://github.com/user-attachments/assets/2e108d55-315b-48ca-94ac-89389a146956" />


## How Has This Been Tested?

👀 

## Additional Options

- [ ] [Optional] Override Linear Check
