### PR TITLE
fix: standardize and make user settings pretty

### DIFF
--- a/web/src/app/chat/components/modal/UserSettings.tsx
+++ b/web/src/app/chat/components/modal/UserSettings.tsx
@@ -360,7 +360,7 @@ export function UserSettings({ onClose }: UserSettingsProps) {
   };
 
   return (
-    <div className="flex flex-col gap-padding-content p-padding-content w-full">
+    <div className="flex flex-col gap-padding-content p-padding-content">
       {sections.length > 1 && (
         <nav>
           <ul className="flex space-x-2">

--- a/web/src/components/context/ModalContext.tsx
+++ b/web/src/components/context/ModalContext.tsx
@@ -60,7 +60,7 @@ export const ModalProvider: React.FC<{
           {showUserSettingsModal && (
             <CoreModal
               onClickOutside={() => setShowUserSettingsModal(false)}
-              className="w-full max-w-lg"
+              className="w-full max-w-xl mx-4"
             >
               <UserSettings onClose={() => setShowUserSettingsModal(false)} />
             </CoreModal>
@@ -76,7 +76,7 @@ export const ModalProvider: React.FC<{
         {showUserSettingsModal && (
           <CoreModal
             onClickOutside={() => setShowUserSettingsModal(false)}
-            className="w-full max-w-lg"
+            className="w-full max-w-xl mx-4"
           >
             <UserSettings onClose={() => setShowUserSettingsModal(false)} />
           </CoreModal>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

https://github.com/user-attachments/assets/95e6d23c-256f-414d-830f-e0190bee6a11
[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the User Settings modal and polished the layout for clarity and consistency. Modal width is unified, scrolling is fixed, and form fields use consistent spacing and typography.

- **UI Improvements**
  - Applied consistent modal width (w-full max-w-lg) via CoreModal.
  - Made UserSettings full-width; changed to overflow-y-auto and added side padding.
  - Switched “Name” and “Role” to h3 headings; normalized label styles and reduced password heading size.
  - Added consistent input spacing (mt-2) and right-aligned the “Change Password” button.

<!-- End of auto-generated description by cubic. -->

