### PR TITLE
feat(e2e-testing): record playwright traces for CI failures

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -12,7 +12,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_ECR }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_ECR }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-  
+
   # Test Environment Variables
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -215,15 +215,15 @@ jobs:
           while true; do
             current_time=$(date +%s)
             elapsed_time=$((current_time - start_time))
-            
+
             if [ $elapsed_time -ge $timeout ]; then
               echo "Timeout reached. Service did not become ready in 5 minutes."
               exit 1
             fi
-            
+
             # Use curl with error handling to ignore specific exit code 56
             response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "curl_error")
-            
+
             if [ "$response" = "200" ]; then
               echo "Service is ready!"
               break
@@ -232,7 +232,7 @@ jobs:
             else
               echo "Service not ready yet (HTTP status $response). Retrying in 5 seconds..."
             fi
-            
+
             sleep 5
           done
           echo "Finished waiting for service."
@@ -247,9 +247,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          # Includes test results and debug screenshots
+          # Includes test results and trace.zip files
           name: playwright-test-results-${{ github.run_id }}
-          path: ./web/test-results
+          path: ./web/test-results/
           retention-days: 30
 
       # save before stopping the containers so the logs can be captured

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -25,6 +25,11 @@ export default defineConfig({
   ],
   // Only run Playwright tests from tests/e2e directory (ignore Jest tests in src/)
   testMatch: /.*\/tests\/e2e\/.*\.spec\.ts/,
+  outputDir: "test-results",
+  use: {
+    // Capture trace on failure
+    trace: "retain-on-failure",
+  },
   projects: [
     {
       name: "admin",


### PR DESCRIPTION
## Description

This change enables recording trace files for failing playwright tests in CI.  These trace files are great for debugging failed tests. https://playwright.dev/docs/trace-viewer

## How Has This Been Tested?
ci

## Additional Options

- [x] [Optional] Override Linear Check