### PR TITLE
fix: remove default agent from sidebar

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -71,13 +71,17 @@ function buildVisibleAgents(
   pinnedAgents: MinimalPersonaSnapshot[],
   currentAgent: MinimalPersonaSnapshot | null
 ): [MinimalPersonaSnapshot[], boolean] {
-  if (!currentAgent) return [pinnedAgents, false];
+  /* NOTE: The unified agent (id = 0) is not visible in the sidebar, 
+  so we filter it out. */
+  if (!currentAgent)
+    return [pinnedAgents.filter((agent) => agent.id !== 0), false];
   const currentAgentIsPinned = pinnedAgents.some(
     (pinnedAgent) => pinnedAgent.id === currentAgent.id
   );
-  const visibleAgents = currentAgentIsPinned
-    ? pinnedAgents
-    : [...pinnedAgents, currentAgent];
+  const visibleAgents = (
+    currentAgentIsPinned ? pinnedAgents : [...pinnedAgents, currentAgent]
+  ).filter((agent) => agent.id !== 0);
+
   return [visibleAgents, currentAgentIsPinned];
 }
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2883/pinned-assistant-in-initial-setup

## How Has This Been Tested?

local

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the default (unified) assistant from the sidebar so it no longer appears or gets pinned during initial setup. Addresses Linear DAN-2883.

<!-- End of auto-generated description by cubic. -->

