### PR TITLE
feat: Update pinning behaviour

### DIFF
--- a/web/src/sections/sidebar/AgentButton.tsx
+++ b/web/src/sections/sidebar/AgentButton.tsx
@@ -12,6 +12,7 @@ import IconButton from "@/refresh-components/buttons/IconButton";
 import { getAgentIcon } from "@/sections/sidebar/utils";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import SvgX from "@/icons/x";
 
 interface SortableItemProps {
   id: number;
@@ -60,10 +61,11 @@ function AgentButtonInner({ agent }: AgentButtonProps) {
           active={params(SEARCH_PARAM_NAMES.PERSONA_ID) === String(agent.id)}
           rightChildren={
             <IconButton
-              icon={SvgPin}
+              icon={pinned ? SvgX : SvgPin}
               internal
               onClick={noProp(() => togglePinnedAgent(agent, !pinned))}
-              className={cn(!pinned && "hidden group-hover/SidebarTab:flex")}
+              className={cn("hidden group-hover/SidebarTab:flex")}
+              tooltip={pinned ? "Unpin Agent" : "Pin Agent"}
             />
           }
         >


### PR DESCRIPTION
## Description

This PR updates the rendering of the pinning / unpinning icon for Agents.

Addresses: https://linear.app/danswer/issue/DAN-2941/the-pin-icon-should-only-show-on-hover.

## Screenshots

### Agent is unpinned

<img width="259" height="112" alt="image" src="https://github.com/user-attachments/assets/8cca507a-8837-403d-9a39-4f26fb7d6e0c" />

### Agent is pinned

<img width="277" height="109" alt="image" src="https://github.com/user-attachments/assets/226cc838-4d60-4fc8-8189-5a42c0ff82e5" />