### PR TITLE
fix: failing web connector test due sync api

### DIFF
--- a/backend/tests/daily/connectors/web/test_web_connector.py
+++ b/backend/tests/daily/connectors/web/test_web_connector.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from onyx.connectors.models import Document
@@ -74,12 +76,17 @@ def test_web_connector_bot_protection() -> None:
 
 
 def test_web_connector_recursive_www_redirect() -> None:
-    # Check that onyx.app can be recursed if re-directed to www.onyx.app
-    connector = WebConnector(
-        base_url="https://onyx.app",
-        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
-    )
+    # Check that https://onyx.app can be recursed if re-directed to www.onyx.app
+    # Run in thread pool to avoid conflict with pytest-asyncio's event loop
+    def _run_connector() -> list[Document]:
+        connector = WebConnector(
+            base_url="https://onyx.app",
+            web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+        )
+        return [doc for batch in connector.load_from_state() for doc in batch]
 
-    documents = [doc for batch in connector.load_from_state() for doc in batch]
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(_run_connector)
+        documents = future.result()
 
     assert len(documents) > 1


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WebConnector redirect test by running the sync connector in a thread pool to avoid pytest-asyncio event loop conflicts. Confirms https://onyx.app correctly recurses after redirect to www.onyx.app and yields multiple documents.

<!-- End of auto-generated description by cubic. -->

