### PR TITLE
refactor: PR#4[option_1] drop is_positive column

### DIFF
--- a/backend/alembic/versions/a2b3c4d5e6f7_drop_deprecated_is_positive_column.py
+++ b/backend/alembic/versions/a2b3c4d5e6f7_drop_deprecated_is_positive_column.py
@@ -1,0 +1,41 @@
+"""drop deprecated is_positive column
+
+Revision ID: a2b3c4d5e6f7
+Revises: f3adfff20605
+Create Date: 2025-10-27 15:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a2b3c4d5e6f7"
+down_revision = "f3adfff20605"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the deprecated is_positive column
+    op.drop_column("chat_feedback", "is_positive")
+
+
+def downgrade() -> None:
+    # Re-add is_positive column
+    op.add_column(
+        "chat_feedback", sa.Column("is_positive", sa.Boolean(), nullable=True)
+    )
+
+    # Backfill from feedback enum
+    op.execute(
+        """
+        UPDATE chat_feedback
+        SET is_positive = CASE
+            WHEN feedback = 'like' THEN TRUE
+            WHEN feedback = 'dislike' THEN FALSE
+            ELSE NULL
+        END
+    """
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2326,7 +2326,7 @@ class ChatMessageFeedback(Base):
         ForeignKey("chat_message.id", ondelete="SET NULL"), nullable=True
     )
 
-    # New enum column - use this going forward
+    # Enum-based feedback (now the only feedback field)
     feedback: Mapped[ChatMessageFeedbackEnum | None] = mapped_column(
         Enum(
             ChatMessageFeedbackEnum,
@@ -2334,9 +2334,6 @@ class ChatMessageFeedback(Base):
         ),
         nullable=True,
     )
-
-    # Deprecated: kept for rollback safety, will be removed in Stage 3
-    is_positive: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     required_followup: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     feedback_text: Mapped[str | None] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Description

This completes the migration from boolean is_positive to enum-based feedback. Can be merged directly into Stage 1 (whuang/refactor-chat-feedback-enums).

NOTE: this may also be merged onto stage 2b --> #5943 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the deprecated is_positive column and completes the move to enum-based chat feedback. Simplifies the data model and removes the dual source of truth.

- **Migration**
  - Alembic migration drops chat_feedback.is_positive.
  - ChatMessageFeedback model no longer includes is_positive; feedback enum is the only field.
  - Downgrade re-adds is_positive and backfills from feedback (like → true, dislike → false, else null).

<!-- End of auto-generated description by cubic. -->

