### PR TITLE
fix(misc): Update Date Checker

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import requests
 from dateutil.parser import parse
+from dateutil.parser import ParserError
 
 from onyx.configs.app_configs import CONNECTOR_LOCALHOST_OVERRIDE
 from onyx.configs.constants import IGNORE_FOR_QA
@@ -31,22 +32,40 @@ def datetime_to_utc(dt: datetime) -> datetime:
 
 def time_str_to_utc(datetime_str: str) -> datetime:
     # Remove all timezone abbreviations in parentheses
-    datetime_str = re.sub(r"\([A-Z]+\)", "", datetime_str).strip()
+    normalized = re.sub(r"\([A-Z]+\)", "", datetime_str).strip()
 
     # Remove any remaining parentheses and their contents
-    datetime_str = re.sub(r"\(.*?\)", "", datetime_str).strip()
+    normalized = re.sub(r"\(.*?\)", "", normalized).strip()
 
-    try:
-        dt = parse(datetime_str)
-    except ValueError:
-        # Fix common format issues (e.g. "0000" => "+0000")
-        if "0000" in datetime_str:
-            datetime_str = datetime_str.replace(" 0000", " +0000")
-            dt = parse(datetime_str)
-        else:
-            raise
+    candidates: list[str] = [normalized]
 
-    return datetime_to_utc(dt)
+    # Some sources (e.g. Gmail) may prefix the value with labels like "Date:"
+    label_stripped = re.sub(
+        r"^\s*[A-Za-z][A-Za-z\s_-]*:\s*", "", normalized, count=1
+    ).strip()
+    if label_stripped and label_stripped != normalized:
+        candidates.append(label_stripped)
+
+    # Fix common format issues (e.g. "0000" => "+0000")
+    for candidate in list(candidates):
+        if " 0000" in candidate:
+            fixed = candidate.replace(" 0000", " +0000")
+            if fixed not in candidates:
+                candidates.append(fixed)
+
+    last_exception: Exception | None = None
+    for candidate in candidates:
+        try:
+            dt = parse(candidate)
+            return datetime_to_utc(dt)
+        except (ValueError, ParserError) as exc:
+            last_exception = exc
+
+    if last_exception is not None:
+        raise last_exception
+
+    # Fallback in case parsing failed without raising (should not happen)
+    raise ValueError(f"Unable to parse datetime string: {datetime_str}")
 
 
 def basic_expert_info_representation(info: BasicExpertInfo) -> str | None:

--- a/backend/tests/unit/onyx/connectors/gmail/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/gmail/test_connector.py
@@ -57,6 +57,9 @@ def test_time_str_to_utc() -> None:
         "22 Mar 2020 20:12:18 +0000 (GMT)": datetime.datetime(
             2020, 3, 22, 20, 12, 18, tzinfo=datetime.timezone.utc
         ),
+        "Date: Wed, 27 Aug 2025 11:40:00 +0200": datetime.datetime(
+            2025, 8, 27, 9, 40, 0, tzinfo=datetime.timezone.utc
+        ),
     }
     for strptime, expected_datetime in str_to_dt.items():
         assert time_str_to_utc(strptime) == expected_datetime


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
A customer is seeing an issue when it comes to normalizing the Date in their emails and sees the following errors:

```
Traceback (most recent call last):
  File "/app/onyx/background/indexing/run_docfetching.py", line 1117, in connector_document_extraction
    for document_batch, failure, next_checkpoint in connector_runner.run(
  File "/app/onyx/connectors/connector_runner.py", line 186, in run
    for document_batch in self.connector.poll_source(
  File "/app/onyx/connectors/gmail/connector.py", line 432, in poll_source
    raise e
  File "/app/onyx/connectors/gmail/connector.py", line 428, in poll_source
    yield from self._fetch_threads(start, end)
  File "/app/onyx/connectors/gmail/connector.py", line 343, in _fetch_threads
    doc = thread_to_document(full_thread, user_email)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/gmail/connector.py", line 202, in thread_to_document
    updated_at_datetime = time_str_to_utc(updated_at)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/cross_connector_utils/miscellaneous_utils.py", line 37, in time_str_to_utc
    dt = parse(datetime_str)
         ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dateutil/parser/_parser.py", line 1368, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dateutil/parser/_parser.py", line 643, in parse
    raise ParserError("Unknown string format: %s", timestr)
dateutil.parser._parser.ParserError: Unknown string format: Date: Wed, 27 Aug 2025 11:40:00 +0200
```
This PR aims to properly handle for this case. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested with unit tests

## Additional Options

- [x] [Optional] Override Linear Check
