### PR TITLE
fix(openpyxl): Workbook issue

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -89,6 +89,7 @@ _MARKITDOWN_CONVERTER: Optional["MarkItDown"] = None
 KNOWN_OPENPYXL_BUGS = [
     "Value must be either numerical or a string containing a wildcard",
     "File contains no valid workbook part",
+    "Unable to read workbook: could not read stylesheet from None",
 ]
 
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
There is another known issue with the OpenPyXL library with workbooks not being able to get parsed. 

Cleaning this up for some customers.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Pattern match

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a new OpenPyXL error pattern to our known-bugs list to catch workbook parse failures: "Unable to read workbook: could not read stylesheet from None". This improves robustness when parsing affected Excel files.

<!-- End of auto-generated description by cubic. -->

