### PR TITLE
fix: respect auth_disabled in fe middleware for local dev

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED } from "./lib/constants";
-import { getAuthDisabledSS } from "./lib/userSS";
+import { getAuthDisabledSS } from "@/lib/userSS";
 
 // Authentication cookie name (matches backend: FASTAPI_USERS_AUTH_COOKIE_NAME)
 const FASTAPI_USERS_AUTH_COOKIE_NAME = "fastapiusersauth";


### PR DESCRIPTION
## Description

This was causing redirects when developing EE features locally. 


## How Has This Been Tested?

local testing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated frontend middleware to respect the auth_disabled flag. When auth is disabled, protected routes no longer redirect in local development.

<!-- End of auto-generated description by cubic. -->

