### PR TITLE
fix: text overlap for tool responses when expanded

### DIFF
--- a/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
@@ -298,10 +298,8 @@ export default function MultiToolRenderer({
       {/* Expanded content */}
       <div
         className={cn(
-          "transition-all duration-300 ease-in-out",
-          isExpanded
-            ? "max-h-[2000px] opacity-100"
-            : "max-h-0 opacity-0 invisible"
+          "transition-all duration-300 ease-in-out overflow-hidden",
+          isExpanded ? "max-h-[2000px] opacity-100" : "max-h-0 opacity-0"
         )}
       >
         <div
@@ -371,13 +369,13 @@ export default function MultiToolRenderer({
                     {/* Dot with background to cover the line */}
                     <div
                       className="
-                        flex-shrink-0 
-                        flex 
-                        items-center 
-                        justify-center 
-                        w-5 
-                        h-5 
-                        bg-background 
+                        flex-shrink-0
+                        flex
+                        items-center
+                        justify-center
+                        w-5
+                        h-5
+                        bg-background
                         rounded-full
                       "
                     >


### PR DESCRIPTION
## Description

Closes https://linear.app/danswer/issue/DAN-2925/bug-long-reasoning-block-expands-into-the-answer

ensure long reasoning responses for tool calls were overlapping the main chat. now we will push the chat down if the tool responses are expanded

Fix: Removed invisible class so content no longer appears instantly before the container has expanded, preventing text overlap during the expand animation.

## How Has This Been Tested?

local testing

Before:
<img width="2100" height="1412" alt="image" src="https://github.com/user-attachments/assets/2ddb2fbf-0c36-47b6-b7ed-20f0247236b5" />

After: 
Disregard the numbering for the reasoning steps. that was removed
![2025-10-31 12 21 58](https://github.com/user-attachments/assets/4e9907f3-34e8-46f2-a6de-fd632d5765c3)



## Additional Options

- [ ] [Optional] Override Linear Check
