### PR TITLE
feat: Load random documents in document explorer page for empty queries

### DIFF
--- a/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
+++ b/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
@@ -363,4 +363,10 @@ schema {{ schema_name }} {
             expression: bm25(content) + (5 * bm25(title))
         }
     }
+
+    rank-profile random_ inherits default {
+        first-phase {
+            expression: random
+        }
+    }
 }

--- a/backend/onyx/server/query_and_chat/query_backend.py
+++ b/backend/onyx/server/query_and_chat/query_backend.py
@@ -71,7 +71,12 @@ def admin_search(
             status_code=400,
             detail="Cannot use admin-search when using a non-Vespa document index",
         )
-    matching_chunks = document_index.admin_retrieval(query=query, filters=final_filters)
+    if not query or query.strip() == "":
+        matching_chunks = document_index.random_retrieval(filters=final_filters)
+    else:
+        matching_chunks = document_index.admin_retrieval(
+            query=query, filters=final_filters
+        )
 
     documents = SearchDoc.from_chunks_or_sections(matching_chunks)
 


### PR DESCRIPTION
## Description
Currently when the initial search query is empty, no documents are shown. Add functionality to show a subset of random documents when the input query box is empty and provide examples of expected search results. Any filters selected for time, sources, and connector would apply to the list of documents shown. 

NOTE: The Vespa schema didn't include the random rank-profile which needed to be added in this PR for the `random_retrieval` function to work correctly. To view these changes locally, docker container and python servers need to be restarted.

## How Has This Been Tested?

https://github.com/user-attachments/assets/a630c6ce-3ff6-404a-950e-cfe137513f06

- [x] [Optional] Override Linear Check





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show random documents in the Document Explorer when the search query is empty, respecting selected filters. This improves discoverability and provides example results.

- **New Features**
  - Backend: uses random_retrieval for blank queries; else admin_retrieval.
  - Vespa: adds random_ rank-profile (first-phase: random) for random retrieval.
  - Frontend: triggers search and updates URL for empty queries; shows a loading indicator; doesn't clear results.

- **Migration**
  - Vespa schema changed; restart the Vespa Docker container and Python servers to load the new rank-profile.

<sup>Written for commit 3f146f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





