### PR TITLE
fix: remove extra /wiki from v2 url

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -63,7 +63,7 @@ _USER_EMAIL_CACHE: dict[str, str | None] = {}
 _DEFAULT_PAGINATION_LIMIT = 1000
 
 _CONFLUENCE_SPACES_API_V1 = "rest/api/space"
-_CONFLUENCE_SPACES_API_V2 = "wiki/api/v2/spaces"
+_CONFLUENCE_SPACES_API_V2 = "api/v2/spaces"
 
 
 class ConfluenceRateLimitError(Exception):


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Confluence v2 spaces API URL by removing the extra /wiki segment. Requests now hit api/v2/spaces, avoiding 404s and matching the Cloud v2 endpoint.

<!-- End of auto-generated description by cubic. -->

