### PR TITLE
fix: Better Logs for Rate Limits

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -59,7 +59,7 @@ def _unwrap_nested_exception(error: Exception) -> Exception:
     """
     visited: set[int] = set()
     current = error
-    while True:
+    for _ in range(100):
         visited.add(id(current))
         candidate: Exception | None = None
         cause = getattr(current, "__cause__", None)


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We are seeing RateLimitErrors without proper information in the UI. This PR aims to give more fidelity for the user.
```
onyx.llm.chat_llm.LLMRateLimitError: litellm.RateLimitError: RateLimitError: OpenAIException - You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.
```


## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved LiteLLM rate limit error messages by unwrapping nested exceptions and surfacing provider-specific details for clearer logs.

- **Bug Fixes**
  - Added _unwrap_nested_exception to traverse __cause__ and nested args to expose the root LiteLLM error.
  - RateLimitError now includes the model provider name and upstream message/detail when available.
  - Standardized handling across exceptions using the unwrapped core exception without changing existing mappings.

<!-- End of auto-generated description by cubic. -->

