### PR TITLE
fix(message): Process UUID properly

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -530,7 +530,7 @@ def stream_chat_message_objects(
                     continue
                 try:
                     user_file_ids.append(UUID(uid))
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, AttributeError):
                     logger.warning(
                         "Skipping invalid user_file_id from current_message_files: %s",
                         uid,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Customer is reporting that they are seeing this strange behavior.
<img width="1774" height="448" alt="image" src="https://github.com/user-attachments/assets/8d35cfce-445f-48e7-ab2c-6f5d73efbcb7" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely handle user_file_id UUIDs in chat message processing. Missing or malformed IDs are now skipped with a warning instead of causing errors, improving stability when attaching files.

<!-- End of auto-generated description by cubic. -->

