### PR TITLE
feat(azure): Adding support for Image Gen 1

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -799,6 +799,9 @@ AZURE_DALLE_API_VERSION = os.environ.get("AZURE_DALLE_API_VERSION")
 AZURE_DALLE_API_KEY = os.environ.get("AZURE_DALLE_API_KEY")
 AZURE_DALLE_API_BASE = os.environ.get("AZURE_DALLE_API_BASE")
 AZURE_DALLE_DEPLOYMENT_NAME = os.environ.get("AZURE_DALLE_DEPLOYMENT_NAME")
+AZURE_IMAGE_UNDERLYING_MODEL = os.environ.get(
+    "AZURE_IMAGE_UNDERLYING_MODEL", "dall-e-3"
+)
 
 # configurable image model
 IMAGE_MODEL_NAME = os.environ.get("IMAGE_MODEL_NAME", "gpt-image-1")

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -14,6 +14,7 @@ from onyx.configs.app_configs import AZURE_DALLE_API_BASE
 from onyx.configs.app_configs import AZURE_DALLE_API_KEY
 from onyx.configs.app_configs import AZURE_DALLE_API_VERSION
 from onyx.configs.app_configs import AZURE_DALLE_DEPLOYMENT_NAME
+from onyx.configs.app_configs import AZURE_IMAGE_UNDERLYING_MODEL
 from onyx.configs.app_configs import IMAGE_MODEL_NAME
 from onyx.configs.constants import TMP_DRALPHA_PERSONA_NAME
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
@@ -273,6 +274,11 @@ def construct_tools(
                         api_version=img_generation_llm_config.api_version,
                         additional_headers=image_generation_tool_config.additional_headers,
                         model=img_generation_llm_config.model_name,
+                        underlying_model=(
+                            IMAGE_MODEL_NAME
+                            if img_generation_llm_config.model_provider == "openai"
+                            else AZURE_IMAGE_UNDERLYING_MODEL
+                        ),
                         tool_id=db_tool_model.id,
                     )
                 ]

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -104,9 +104,16 @@ class ImageGenerationTool(Tool[None]):
         num_imgs: int = 1,
         additional_headers: dict[str, str] | None = None,
         output_format: ImageFormat = _DEFAULT_OUTPUT_FORMAT,
+        underlying_model: str | None = None,
     ) -> None:
 
-        if model == "gpt-image-1" and output_format == ImageFormat.URL:
+        self.model = model
+        self.underlying_model = underlying_model or model
+        self._is_gpt_image_model = (
+            self.model == "gpt-image-1" or self.underlying_model == "gpt-image-1"
+        )
+
+        if self._is_gpt_image_model and output_format == ImageFormat.URL:
             raise ValueError(
                 "gpt-image-1 does not support URL format. Please use BASE64 format."
             )
@@ -115,7 +122,6 @@ class ImageGenerationTool(Tool[None]):
         self.api_base = api_base
         self.api_version = api_version
 
-        self.model = model
         self.num_imgs = num_imgs
 
         self.additional_headers = additional_headers
@@ -246,12 +252,12 @@ class ImageGenerationTool(Tool[None]):
         from litellm import image_generation  # type: ignore
 
         if shape == ImageShape.LANDSCAPE:
-            if self.model == "gpt-image-1":
+            if self._is_gpt_image_model:
                 size = "1536x1024"
             else:
                 size = "1792x1024"
         elif shape == ImageShape.PORTRAIT:
-            if self.model == "gpt-image-1":
+            if self._is_gpt_image_model:
                 size = "1024x1536"
             else:
                 size = "1024x1792"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently Azure Open AI only support dalle by default but we are updating the code to support gpt-image-1 while still be backwards compatible

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally and logged to ensure that the image-1 model was being used.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure support for gpt-image-1 image generation while keeping DALL·E compatibility. Introduces an underlying model config and updates the image tool to handle gpt-image-1 constraints.

- **New Features**
  - Added AZURE_IMAGE_UNDERLYING_MODEL (default: "dall-e-3") and route Azure to use it; OpenAI continues to use IMAGE_MODEL_NAME.
  - Image tool detects gpt-image-1, blocks URL output (requires BASE64), and applies correct portrait/landscape sizes.

- **Migration**
  - Set AZURE_IMAGE_UNDERLYING_MODEL="gpt-image-1" for Azure deployments using GPT Image 1.
  - Use BASE64 output when selecting gpt-image-1.

<!-- End of auto-generated description by cubic. -->

