### PR TITLE
chore(agents): sdk clean type parsing

### DIFF
--- a/backend/onyx/agents/agent_sdk/sync_agent_stream_adapter.py
+++ b/backend/onyx/agents/agent_sdk/sync_agent_stream_adapter.py
@@ -9,6 +9,7 @@ from typing import TypeVar
 
 from agents import Agent
 from agents import RunResultStreaming
+from agents import StreamEvent
 from agents import TContext
 from agents.run import Runner
 
@@ -53,7 +54,7 @@ class SyncAgentStream(Generic[T]):
         self._context = context
         self._max_turns = max_turns
 
-        self._q: "queue.Queue[object]" = queue.Queue(maxsize=queue_maxsize)
+        self._q: "queue.Queue[StreamEvent]" = queue.Queue(maxsize=queue_maxsize)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
         self.streamed: RunResultStreaming | None = None
@@ -66,7 +67,7 @@ class SyncAgentStream(Generic[T]):
 
     # ---------- public sync API ----------
 
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self) -> Iterator[StreamEvent]:
         try:
             while True:
                 item = self._q.get()
@@ -76,7 +77,7 @@ class SyncAgentStream(Generic[T]):
                         raise self._exc
                     # Normal completion
                     return
-                yield item  # type: ignore[misc,return-value]
+                yield item
         finally:
             # Ensure we fully clean up whether we exited due to exception,
             # StopIteration, or external cancel.


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized stream event typing in the agents SDK to use StreamEvent across the sync adapter and fast chat turn. This simplifies parsing, improves type safety, and reduces runtime type checks.

- **Refactors**
  - SyncAgentStreamAdapter queue and iterator now use StreamEvent; removed type ignore in iteration.
  - fast_chat_turn processes events via ev.type and ev.item.type (run_item_stream_event, tool_call_item, message_output_item, raw_response_event).
  - Replaced isinstance checks for RawResponsesStreamEvent and ToolCallItem with structured event handling.
  - Emits MessageStart on message_output_item and continues handling output_text.delta for streaming text.

<!-- End of auto-generated description by cubic. -->

