### PR TITLE
fix: always convert strings to document sources

### DIFF
--- a/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a1_search_objects.py
+++ b/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a1_search_objects.py
@@ -14,10 +14,10 @@ from onyx.agents.agent_search.models import GraphConfig
 from onyx.agents.agent_search.shared_graph_utils.agent_prompt_ops import (
     trim_prompt_piece,
 )
-from onyx.configs.constants import DocumentSource
 from onyx.prompts.agents.dc_prompts import DC_OBJECT_NO_BASE_DATA_EXTRACTION_PROMPT
 from onyx.prompts.agents.dc_prompts import DC_OBJECT_SEPARATOR
 from onyx.prompts.agents.dc_prompts import DC_OBJECT_WITH_BASE_DATA_EXTRACTION_PROMPT
+from onyx.secondary_llm_flows.source_filter import strings_to_document_sources
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_with_timeout
 
@@ -61,10 +61,12 @@ def search_objects(
         if agent_1_independent_sources_str is None:
             raise ValueError("Agent 1 Independent Research Sources not found")
 
-        document_sources = [
-            DocumentSource(x.strip().lower())
-            for x in agent_1_independent_sources_str.split(DC_OBJECT_SEPARATOR)
-        ]
+        document_sources = strings_to_document_sources(
+            [
+                x.strip().lower()
+                for x in agent_1_independent_sources_str.split(DC_OBJECT_SEPARATOR)
+            ]
+        )
 
         agent_1_output_objective = extract_section(
             agent_1_instructions, "Output Objective:"

--- a/backend/onyx/agents/agent_search/dr/sub_agents/basic_search/dr_basic_search_2_act.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/basic_search/dr_basic_search_2_act.py
@@ -30,6 +30,7 @@ from onyx.db.connector import DocumentSource
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.prompts.dr_prompts import BASE_SEARCH_PROCESSING_PROMPT
 from onyx.prompts.dr_prompts import INTERNAL_SEARCH_PROMPTS
+from onyx.secondary_llm_flows.source_filter import strings_to_document_sources
 from onyx.server.query_and_chat.streaming_models import SearchToolDelta
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (
@@ -128,10 +129,11 @@ def basic_search(
         if re.match(date_pattern, implied_start_date):
             implied_time_filter = datetime.strptime(implied_start_date, "%Y-%m-%d")
 
-    specified_source_types: list[DocumentSource] | None = [
-        DocumentSource(source_type)
-        for source_type in search_processing.specified_source_types
-    ]
+    specified_source_types: list[DocumentSource] | None = (
+        strings_to_document_sources(search_processing.specified_source_types)
+        if search_processing.specified_source_types
+        else None
+    )
 
     if specified_source_types is not None and len(specified_source_types) == 0:
         specified_source_types = None


### PR DESCRIPTION
## Description

An attempt to fix an issue where we see `<some str>  is not a valid DocumentSource`. The error surfaces when we expect a string to be used as a document source. This is sometimes the case when inferring document sources from the user's query string. These changes ensure, we always convert strings into document sources and if we can't we ignore them.

## How Has This Been Tested?

local testing -> forced an invalid document source to be set -> submit a chat message using internal research to trigger the document inference codepaths -> the chat did not error out


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes when invalid document source strings are inferred from queries by validating and converting strings to DocumentSource, and ignoring invalid entries to keep chat/search stable.

- **Bug Fixes**
  - Use strings_to_document_sources to convert and validate source strings; invalid values are filtered out.
  - Normalize input (trim + lower) before conversion in DC search analysis and DR basic search.
  - If conversion yields no sources, set specified_source_types to None to avoid downstream errors.

<!-- End of auto-generated description by cubic. -->

