### PR TITLE
fix(web-connector): empty semantic identifiers from trailing / with PDF URLs

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -535,7 +535,8 @@ class WebConnector(LoadConnector):
                 id=initial_url,
                 sections=[TextSection(link=initial_url, text=page_text)],
                 source=DocumentSource.WEB,
-                semantic_identifier=initial_url.rstrip("/").split("/")[-1] or initial_url,
+                semantic_identifier=initial_url.rstrip("/").split("/")[-1] 
+                or initial_url,
                 metadata=metadata,
                 doc_updated_at=(
                     _get_datetime_from_last_modified_header(last_modified)


### PR DESCRIPTION
## Description

If a document URL includes a trailing slash AND it is a PDF, the current split call will always choose the last returned value which is always an empty string. For example:

```
url = "https://hello.com/test/"
url.split("/") == ['https:', '', 'hello.com', 'test', '']
(index of -1 == '')
```

Adding rstrip to filter out any trailing slashes fixes this issue. We also added an `or initial_url` as a a backup, as making `semantic_identifier` equal to an empty string results in a cascade failure (any RAG calls that attempt to pull in the affected document(s) will always fail.)

How to check in Postgres if you have any affected documents:

```
SELECT
      d.id,
      d.semantic_id,
      d.link,
      c.id as connector_id,
      c.name as connector_name,
      c.source as connector_type,
      dbcc.credential_id,
      cc.id as cc_pair_id
  FROM document d
  JOIN document_by_connector_credential_pair dbcc ON d.id = dbcc.id
  JOIN connector c ON dbcc.connector_id = c.id
  JOIN connector_credential_pair cc ON dbcc.connector_id = cc.connector_id
      AND dbcc.credential_id = cc.credential_id
  WHERE d.semantic_id IS NULL OR d.semantic_id = ''
  ORDER BY c.id, d.link;
```

## How Has This Been Tested?

Manually, with a sitemap containing links to PDFs with trailing slashes. Before this PR, we receieved an error about the semantic_identifier column being empty in Postgres. With this patch and following a connector deletion/re-add we no longer see this occur.

Stacktrace users received prior to this patch:

<details>

Traceback (most recent call last):
  File "/app/onyx/agents/agent_search/orchestration/nodes/call_tool.py", line 56, in call_tool
    for response in tool_runner.tool_responses():
  File "/app/onyx/tools/tool_runner.py", line 38, in tool_responses
    for tool_response in self.tool.run(
  File "/app/onyx/tools/tool_implementations/search/search_tool.py", line 422, in run
    yield from yield_search_responses(
  File "/app/onyx/tools/tool_implementations/search/search_tool.py", line 480, in yield_search_responses
    top_sections=get_retrieved_sections(),
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/tools/tool_implementations/search/search_tool.py", line 425, in <lambda>
    get_retrieved_sections=lambda: search_pipeline.merged_retrieved_sections,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/pipeline.py", line 354, in merged_retrieved_sections
    return _merge_sections(sections=self.retrieved_sections)
                                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/pipeline.py", line 347, in retrieved_sections
    self._retrieved_sections = self._get_sections()
                               ^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/utils/timing.py", line 31, in wrapped_func
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/pipeline.py", line 187, in _get_sections
    retrieved_chunks = self._get_chunks()
                       ^^^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/pipeline.py", line 159, in _get_chunks
    self._retrieved_chunks = retrieve_chunks(
                             ^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/retrieval/search_runner.py", line 439, in retrieve_chunks
    parallel_search_results = run_functions_tuples_in_parallel(run_queries)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/utils/threadpool_concurrency.py", line 217, in run_functions_tuples_in_parallel
    results.append((index, future.result()))
                           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/utils/timing.py", line 31, in wrapped_func
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/context/search/retrieval/search_runner.py", line 279, in doc_index_retrieval
    top_base_chunks_standard_ranking = wait_on_background(
                                       ^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/utils/threadpool_concurrency.py", line 351, in wait_on_background
    raise task.exception
  File "/app/onyx/utils/threadpool_concurrency.py", line 295, in run
    self.result = self.func(*self.args, **self.kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/document_index/vespa/index.py", line 989, in hybrid_retrieval
    return query_vespa(params)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/decorator.py", line 235, in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/retry/api.py", line 73, in retry_decorator
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/retry/api.py", line 33, in __retry_internal
    return f()
           ^^^
  File "/app/onyx/document_index/vespa/chunk_retrieval.py", line 388, in query_vespa
    inference_chunks = [_vespa_hit_to_inference_chunk(hit) for hit in filtered_hits]
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/document_index/vespa/chunk_retrieval.py", line 388, in <listcomp>
    inference_chunks = [_vespa_hit_to_inference_chunk(hit) for hit in filtered_hits]
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/document_index/vespa/chunk_retrieval.py", line 143, in _vespa_hit_to_inference_chunk
    semantic_identifier=fields[SEMANTIC_IDENTIFIER],
                        ~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'semantic_identifier'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/app/onyx/chat/process_message.py", line 1025, in stream_chat_message_objects
    for packet in answer.processed_streamed_output:
  File "/app/onyx/chat/answer.py", line 163, in processed_streamed_output
    for packet in stream:
  File "/app/onyx/agents/agent_search/run_graph.py", line 110, in run_graph
    for event in manage_sync_streaming(
  File "/app/onyx/agents/agent_search/run_graph.py", line 96, in manage_sync_streaming
    for event in compiled_graph.stream(
  File "/usr/local/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 1724, in stream
    for _ in runner.tick(
  File "/usr/local/lib/python3.11/site-packages/langgraph/pregel/runner.py", line 302, in tick
    _panic_or_proceed(
  File "/usr/local/lib/python3.11/site-packages/langgraph/pregel/runner.py", line 619, in _panic_or_proceed
    raise exc
  File "/usr/local/lib/python3.11/site-packages/langgraph/pregel/executor.py", line 83, in done
    task.result()
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langgraph/pregel/retry.py", line 40, in run_with_retry
    return task.proc.invoke(task.input, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langgraph/utils/runnable.py", line 506, in invoke
    input = step.invoke(input, config, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langgraph/utils/runnable.py", line 270, in invoke
    ret = context.run(self.func, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/agents/agent_search/orchestration/nodes/call_tool.py", line 63, in call_tool
    raise ToolCallException(
onyx.agents.agent_search.orchestration.nodes.call_tool.ToolCallException: Error during tool call for Search Tool: 'semantic_identifier'
During task with name 'call_tool' and id '8f37c1a7-324a-b2a5-5058-8a7abe33e16d'

</details>

## Additional Options

- [ ] [Optional] Override Linear Check
