### PR TITLE
feat: View permissioning information for documents in documents explorer

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -257,6 +257,7 @@ class InferenceChunk(BaseChunk):
     large_chunk_reference_ids: list[int] = Field(default_factory=list)
 
     is_federated: bool = False
+    access_control_list: list[str] | None = None
 
     @property
     def unique_id(self) -> str:
@@ -356,6 +357,7 @@ class SearchDoc(BaseModel):
     primary_owners: list[str] | None = None
     secondary_owners: list[str] | None = None
     is_internet: bool = False
+    access_control_list: list[str] | None = None
 
     @classmethod
     def from_chunks_or_sections(
@@ -389,6 +391,7 @@ class SearchDoc(BaseModel):
                 primary_owners=chunk.primary_owners,
                 secondary_owners=chunk.secondary_owners,
                 is_internet=False,
+                access_control_list=chunk.access_control_list,
             )
             for item in items
         ]
@@ -450,6 +453,7 @@ class SavedSearchDoc(SearchDoc):
             primary_owners=None,
             secondary_owners=None,
             is_internet=True,
+            access_control_list=[],
         )
 
     def __lt__(self, other: Any) -> bool:

--- a/backend/onyx/document_index/vespa/indexing_utils.py
+++ b/backend/onyx/document_index/vespa/indexing_utils.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 import httpx
 from retry import retry
 
+from onyx.configs.constants import SOURCE_TYPE
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
 )
@@ -47,7 +48,6 @@ from onyx.document_index.vespa_constants import SECTION_CONTINUATION
 from onyx.document_index.vespa_constants import SEMANTIC_IDENTIFIER
 from onyx.document_index.vespa_constants import SKIP_TITLE_EMBEDDING
 from onyx.document_index.vespa_constants import SOURCE_LINKS
-from onyx.document_index.vespa_constants import SOURCE_TYPE
 from onyx.document_index.vespa_constants import TENANT_ID
 from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import TITLE_EMBEDDING

--- a/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
+++ b/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
@@ -3,17 +3,34 @@ from datetime import timedelta
 from datetime import timezone
 
 from onyx.configs.constants import INDEX_SEPARATOR
+from onyx.configs.constants import SOURCE_TYPE
 from onyx.context.search.models import IndexFilters
 from onyx.document_index.interfaces import VespaChunkRequest
+from onyx.document_index.vespa.deletion import CONTENT_SUMMARY
 from onyx.document_index.vespa_constants import ACCESS_CONTROL_LIST
+from onyx.document_index.vespa_constants import AGGREGATED_CHUNK_BOOST_FACTOR
+from onyx.document_index.vespa_constants import BLURB
+from onyx.document_index.vespa_constants import BOOST
+from onyx.document_index.vespa_constants import CHUNK_CONTEXT
 from onyx.document_index.vespa_constants import CHUNK_ID
+from onyx.document_index.vespa_constants import CONTENT
+from onyx.document_index.vespa_constants import DOC_SUMMARY
 from onyx.document_index.vespa_constants import DOC_UPDATED_AT
 from onyx.document_index.vespa_constants import DOCUMENT_ID
 from onyx.document_index.vespa_constants import DOCUMENT_SETS
 from onyx.document_index.vespa_constants import HIDDEN
+from onyx.document_index.vespa_constants import IMAGE_FILE_NAME
+from onyx.document_index.vespa_constants import LARGE_CHUNK_REFERENCE_IDS
+from onyx.document_index.vespa_constants import METADATA
 from onyx.document_index.vespa_constants import METADATA_LIST
-from onyx.document_index.vespa_constants import SOURCE_TYPE
+from onyx.document_index.vespa_constants import METADATA_SUFFIX
+from onyx.document_index.vespa_constants import PRIMARY_OWNERS
+from onyx.document_index.vespa_constants import SECONDARY_OWNERS
+from onyx.document_index.vespa_constants import SECTION_CONTINUATION
+from onyx.document_index.vespa_constants import SEMANTIC_IDENTIFIER
+from onyx.document_index.vespa_constants import SOURCE_LINKS
 from onyx.document_index.vespa_constants import TENANT_ID
+from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import USER_PROJECT
 from onyx.kg.utils.formatting_utils import split_relationship_id
 from onyx.utils.logger import setup_logger
@@ -232,3 +249,36 @@ def build_vespa_id_based_retrieval_yql(
 
     id_based_retrieval_yql_section += ")"
     return id_based_retrieval_yql_section
+
+
+def build_yql_base(index_name: str, include_acl: bool = False) -> str:
+    yql_base = (
+        f"select "
+        f"documentid, "
+        f"{DOCUMENT_ID}, "
+        f"{CHUNK_ID}, "
+        f"{BLURB}, "
+        f"{CONTENT}, "
+        f"{SOURCE_TYPE}, "
+        f"{SOURCE_LINKS}, "
+        f"{SEMANTIC_IDENTIFIER}, "
+        f"{TITLE}, "
+        f"{SECTION_CONTINUATION}, "
+        f"{IMAGE_FILE_NAME}, "
+        f"{BOOST}, "
+        f"{AGGREGATED_CHUNK_BOOST_FACTOR}, "
+        f"{HIDDEN}, "
+        f"{DOC_UPDATED_AT}, "
+        f"{PRIMARY_OWNERS}, "
+        f"{SECONDARY_OWNERS}, "
+        f"{LARGE_CHUNK_REFERENCE_IDS}, "
+        f"{METADATA}, "
+        f"{METADATA_SUFFIX}, "
+        f"{DOC_SUMMARY}, "
+        f"{CHUNK_CONTEXT}, "
+        f"{CONTENT_SUMMARY} "
+    )
+    if include_acl:
+        yql_base += f", {ACCESS_CONTROL_LIST} "
+    yql_base += f"from {index_name} where "
+    return yql_base

--- a/backend/onyx/document_index/vespa_constants.py
+++ b/backend/onyx/document_index/vespa_constants.py
@@ -3,7 +3,6 @@ from onyx.configs.app_configs import VESPA_CONFIG_SERVER_HOST
 from onyx.configs.app_configs import VESPA_HOST
 from onyx.configs.app_configs import VESPA_PORT
 from onyx.configs.app_configs import VESPA_TENANT_PORT
-from onyx.configs.constants import SOURCE_TYPE
 
 # config server
 
@@ -74,32 +73,3 @@ IMAGE_FILE_NAME = "image_file_name"
 
 # Specific to Vespa, needed for highlighting matching keywords / section
 CONTENT_SUMMARY = "content_summary"
-
-
-YQL_BASE = (
-    f"select "
-    f"documentid, "
-    f"{DOCUMENT_ID}, "
-    f"{CHUNK_ID}, "
-    f"{BLURB}, "
-    f"{CONTENT}, "
-    f"{SOURCE_TYPE}, "
-    f"{SOURCE_LINKS}, "
-    f"{SEMANTIC_IDENTIFIER}, "
-    f"{TITLE}, "
-    f"{SECTION_CONTINUATION}, "
-    f"{IMAGE_FILE_NAME}, "
-    f"{BOOST}, "
-    f"{AGGREGATED_CHUNK_BOOST_FACTOR}, "
-    f"{HIDDEN}, "
-    f"{DOC_UPDATED_AT}, "
-    f"{PRIMARY_OWNERS}, "
-    f"{SECONDARY_OWNERS}, "
-    f"{LARGE_CHUNK_REFERENCE_IDS}, "
-    f"{METADATA}, "
-    f"{METADATA_SUFFIX}, "
-    f"{DOC_SUMMARY}, "
-    f"{CHUNK_CONTEXT}, "
-    f"{CONTENT_SUMMARY} "
-    f"from {{index_name}} where "
-)

--- a/backend/scripts/debugging/onyx_vespa.py
+++ b/backend/scripts/debugging/onyx_vespa.py
@@ -43,6 +43,7 @@ from pydantic import BaseModel
 from sqlalchemy import and_
 
 from onyx.configs.constants import INDEX_SEPARATOR
+from onyx.configs.constants import SOURCE_TYPE
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import SearchRequest
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -63,7 +64,6 @@ from onyx.document_index.vespa_constants import DOCUMENT_SETS
 from onyx.document_index.vespa_constants import HIDDEN
 from onyx.document_index.vespa_constants import METADATA_LIST
 from onyx.document_index.vespa_constants import SEARCH_ENDPOINT
-from onyx.document_index.vespa_constants import SOURCE_TYPE
 from onyx.document_index.vespa_constants import VESPA_APP_CONTAINER_URL
 from onyx.document_index.vespa_constants import VESPA_APPLICATION_ENDPOINT
 from onyx.utils.logger import setup_logger

--- a/backend/tests/unit/onyx/utils/test_vespa_query.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_query.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import INDEX_SEPARATOR
+from onyx.configs.constants import SOURCE_TYPE
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import Tag
 from onyx.document_index.vespa.shared_utils.vespa_request_builders import (
@@ -15,7 +16,6 @@ from onyx.document_index.vespa_constants import DOCUMENT_ID
 from onyx.document_index.vespa_constants import DOCUMENT_SETS
 from onyx.document_index.vespa_constants import HIDDEN
 from onyx.document_index.vespa_constants import METADATA_LIST
-from onyx.document_index.vespa_constants import SOURCE_TYPE
 from onyx.document_index.vespa_constants import TENANT_ID
 from onyx.document_index.vespa_constants import USER_PROJECT
 from shared_configs.configs import MULTI_TENANT

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -30,6 +30,8 @@ const DocumentDisplay = ({
   refresh: () => void;
   setPopup: (popupSpec: PopupSpec | null) => void;
 }) => {
+  const acl = document.access_control_list;
+  const aclStr = acl && acl.length ? acl.join(", ") : "None";
   return (
     <div
       key={document.document_id}
@@ -91,6 +93,16 @@ const DocumentDisplay = ({
           <div className="ml-1 my-auto">
             <CustomCheckbox checked={!document.hidden} />
           </div>
+        </div>
+
+        <div className="px-1 py-0.5 bg-accent-background-hovered rounded flex items-center gap-1">
+          <span>Permissions:</span>
+          <span
+            className="truncate max-w-[220px] whitespace-nowrap overflow-hidden"
+            title={aclStr}
+          >
+            {aclStr}
+          </span>
         </div>
       </div>
       {document.updated_at && (

--- a/web/src/lib/search/interfaces.ts
+++ b/web/src/lib/search/interfaces.ts
@@ -71,6 +71,7 @@ export interface OnyxDocument extends MinimalOnyxDocument {
   db_doc_id?: number;
   is_internet: boolean;
   validationState?: null | "good" | "bad";
+  access_control_list: string[] | null;
 }
 
 export interface LoadedOnyxDocument extends OnyxDocument {


### PR DESCRIPTION
## Description
Display permissioning (access control) information for documents in Document Explorer.

## How Has This Been Tested?
<img width="1472" height="761" alt="Screenshot 2025-10-30 at 12 18 49 PM" src="https://github.com/user-attachments/assets/5219738c-64da-44ac-89f3-6b5f28979db9" />

## Additional Options

- [x] [Optional] Override Linear Check


























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show document permissions in the Documents Explorer so you can quickly see who has access. The app now surfaces the ACL from Vespa and displays it per document.

- **New Features**
  - Added access_control_list to chunk and document models and selectively fetched it from Vespa.
  - Parsed ACL keys from Vespa hits and passed them through to SearchDoc.
  - Rendered “Permissions: …” in Explorer with a fallback to “None” when no ACL is present.

<sup>Written for commit b99b5ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

























