### PR TITLE
fix(vespa): Adjust node count

### DIFF
--- a/backend/ee/onyx/document_index/vespa/app_config/cloud-services.xml.jinja
+++ b/backend/ee/onyx/document_index/vespa/app_config/cloud-services.xml.jinja
@@ -18,7 +18,7 @@
             <!-- <document type="danswer_chunk" mode="index" /> -->
 {{ document_elements }}
         </documents>
-        <nodes count="45">
+        <nodes count="50">
             <resources vcpu="8.0" memory="128.0Gb" architecture="arm64" storage-type="local"
                 disk="475.0Gb" />
         </nodes>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The number of nodes is a bit close for comfort. Adjusting accordingly

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased Vespa node count from 45 to 50 to add capacity headroom and reduce risk of saturation during peak load.

<sup>Written for commit ba848367b0be223fe9be0be05ca16bd338fd35f9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

