### PR TITLE
fix: don't fail filestore cleanup

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -1,9 +1,7 @@
-import inspect
 import multiprocessing
 import os
 import time
 import traceback
-from functools import lru_cache
 from time import sleep
 
 import sentry_sdk
@@ -40,38 +38,6 @@ from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import SENTRY_DSN
 
 logger = setup_logger()
-
-
-@lru_cache(maxsize=128)
-def _can_reconstruct_exception(exc_type: type) -> bool:
-    """
-    Check if an exception type can be safely reconstructed with a single string argument.
-
-    Some exception types require specific constructor arguments beyond just a message.
-    For example:
-    - ValueError("msg") works ✓
-    - ClientError(error_response, operation_name) requires 2 args ✗
-
-    This function uses introspection to check if type(exc_type)(message) will succeed
-    by examining the constructor signature.
-
-    Args:
-        exc_type: The exception class to check
-
-    Returns:
-        True if the exception can be constructed with just a string message,
-        False if it requires additional arguments
-
-    Note:
-        Uses LRU cache to avoid repeated introspection overhead.
-    """
-    sig = inspect.signature(exc_type.__init__)
-    params = [p for p in sig.parameters.values() if p.name != "self"]
-
-    # Can reconstruct if it has 0-1 params, or multiple params with defaults
-    return len(params) <= 1 or all(
-        p.default != inspect.Parameter.empty for p in params[1:]
-    )
 
 
 def _verify_indexing_attempt(
@@ -271,29 +237,14 @@ def _docfetching_task(
             f"search_settings={search_settings_id}"
         )
 
-        # Truncate long exception messages to prevent them from overwhelming logs/storage.
-        # CONTEXT: This function runs in a spawned process. When an exception occurs,
-        # job_client.py's _initializer() captures the ENTIRE traceback (including any
-        # intermediate failed attempts) via traceback.format_exc() and sends it to the
-        # parent process for logging.
-
-        # PROBLEM: If we blindly try type(e)(str(e)[:1024]) and it fails (because the
-        # exception requires specific constructor args), Python includes BOTH the failed
-        # TypeError AND the original exception in the traceback, polluting logs.
-
-        # Only attempt reconstruction if it is safe to do so
+        # special bulletproofing ... truncate long exception messages
+        # for exception types that require more args, this will fail
+        # thus the try/except
         try:
-            if _can_reconstruct_exception(type(e)):
-                # Safe to reconstruct with truncated message
-                sanitized_e = type(e)(str(e)[:1024])
-                sanitized_e.__traceback__ = e.__traceback__
-                raise sanitized_e
-            else:
-                # Not safe to reconstruct, raise original exception
-                raise e
+            sanitized_e = type(e)(str(e)[:1024])
+            sanitized_e.__traceback__ = e.__traceback__
+            raise sanitized_e
         except Exception:
-            # If introspection or reconstruction fails for any reason,
-            # fall back to raising the original exception
             raise e
 
     logger.info(


### PR DESCRIPTION
## Description

1. Don't fail file store cleanup when the object is already gone

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented file store cleanup from failing when an S3 object is missing and reduced noisy error logs by safely truncating exception messages in docfetching tasks.

- **Bug Fixes**
  - Treat S3 NoSuchKey as a successful delete and still remove the DB record.
  - Log a warning instead of failing when the object is already gone.

- **Error Handling**
  - Truncate long exception messages (1024 chars) only when safe to reconstruct.
  - Use introspection to avoid raising new TypeErrors from exceptions that need specific args.
  - Fall back to the original exception if reconstruction isn’t safe.

<sup>Written for commit de1c64d4d02b33d414b61f7c8b2b605e8d64e6e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



