### PR TITLE
fix: dark/light coloring of manage subscription button 

### DIFF
--- a/web/src/app/ee/admin/billing/BillingInformationPage.tsx
+++ b/web/src/app/ee/admin/billing/BillingInformationPage.tsx
@@ -16,9 +16,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import Button from "@/refresh-components/buttons/Button";
-import { CreditCard, ArrowFatUp } from "@phosphor-icons/react";
+import { CreditCard } from "@phosphor-icons/react";
 import { SubscriptionSummary } from "./SubscriptionSummary";
 import { BillingAlerts } from "./BillingAlerts";
+import { ClipboardIcon } from "@/components/icons/icons";
 
 export default function BillingInformationPage() {
   const router = useRouter();
@@ -114,8 +115,11 @@ export default function BillingInformationPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Button onClick={handleManageSubscription} className="w-full">
-            <ArrowFatUp className="mr-2" size={16} />
+          <Button
+            onClick={handleManageSubscription}
+            className="w-full justify-center"
+            leftIcon={ClipboardIcon}
+          >
             Manage Subscription
           </Button>
         </CardContent>


### PR DESCRIPTION
## Description

Fixing a dark/light mode issue for the manage subscription button. Also changed to a clipboard icon (still a 3rd party icon but can switch this during migration to internal icons which is happening mid november. 

Before:
<img width="1972" height="1492" alt="image" src="https://github.com/user-attachments/assets/37b7a5bc-e4cc-464b-90dc-4609cb47444f" />


After: 
![2025-10-31 17 22 48](https://github.com/user-attachments/assets/bd4eaf11-ea97-4766-a654-8e3b70243b87)


## How Has This Been Tested?

local testing

## Additional Options

- [x] [Optional] Override Linear Check
