### PR TITLE
feat: save draft messages for each session

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -344,17 +344,26 @@ export function ChatPage({
     }, 100);
   }, [autoScrollEnabled]);
 
+  const debounceNumber = 100; // time for debouncing
+
+  // handle re-sizing of the text area
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
   const resetInputBar = useCallback(() => {
     setCurrentMessageFiles([]);
     if (endPaddingRef.current) {
       endPaddingRef.current.style.height = `95px`;
     }
+    // Reset textarea height
+    if (textAreaRef.current) {
+      textAreaRef.current.value = "";
+      textAreaRef.current.style.height = "0px";
+      textAreaRef.current.style.height = `${Math.min(
+        textAreaRef.current.scrollHeight,
+        200 // MAX_INPUT_HEIGHT from ChatInputBar
+      )}px`;
+    }
   }, [setCurrentMessageFiles]);
-
-  const debounceNumber = 100; // time for debouncing
-
-  // handle re-sizing of the text area
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   // ResizeObserver watches inputRef for height changes
   useEffect(() => {

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -351,20 +351,14 @@ function ChatInputBarInner({
     }
   }, [draftKey, textAreaRef, resizeTextarea]);
 
-  // Clear input when transitioning away from input state
+  // Effect: Clear input when transitioning away from input state
   useEffect(() => {
     if (prevChatState.current === "input" && chatState !== "input") {
       setLocalMessage("");
-      resetInputBar();
-
-      // Directly manipulate DOM to reset height (React state hasn't flushed yet)
-      if (textAreaRef.current) {
-        textAreaRef.current.value = "";
-        resizeTextarea(textAreaRef.current);
-      }
+      resetInputBar(); // Handles both parent padding and textarea height
     }
     prevChatState.current = chatState;
-  }, [chatState, textAreaRef, resetInputBar, resizeTextarea]);
+  }, [chatState, resetInputBar]);
 
   const startFilterSlash = useMemo(() => {
     if (localMessage !== undefined) {


### PR DESCRIPTION
**Problem:** When users type a message and navigate away (e.g., click on a different chat), their draft text is lost.
**Result:** Drafts persist across navigation within the same browser session.

## What Changed

### 1. Storage mechanism
- **Storage:** sessionStorage with key `chat-draft-${chatSessionId || "new"}`
- **Saves:** On every keystroke (synchronous, ~0.05ms overhead)
- **Loads:** On mount and when switching between chats
- **Clears:** When leaving "input" state (submit/regenerate)

### 2. Loading behavior
- **Priority:** URL params (`initialMessage`) always take precedence over saved drafts
- **On mount:** `useState` initializer loads `initialMessage` if present, otherwise loads saved draft
- **On chat switch:** `useEffect` watches `draftKey` changes and loads appropriate draft
- **Skip initial mount:** Uses `hasMountedRef` flag to prevent effect from running on first render
- **Textarea resize:** After loading draft on chat switch, resize textarea to match restored content

### 3. Clearing behavior
- **On submit:** Clear effect fires when `chatState` transitions from "input" → "loading"
- **Uses ref:** `draftKeyRef` instead of `draftKey` in dependencies to prevent firing on chat switches
- **Height reset:** `requestAnimationFrame` recalculates height after clearing


## Note:
**Before:**
- Chat input bar would retain message contents no matter what chat session you click to

**After:**
- Each chat session can have a message draft in sessionStorage --> this is the same behavior as ChatGPT and Claude

## Additional Options

- [x] [Optional] Override Linear Check
























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted chat input drafts per session so users don’t lose text when switching chats or navigating. Also improved input clearing and textarea sizing.

- **New Features**
  - Save/load drafts in sessionStorage keyed by chatSessionId (or "new").
  - Pass chatSessionId and resetInputBar from ChatPage to ChatInputBar for per-session drafts and proper UI reset.

- **Bug Fixes**
  - Reload the correct draft when switching chats; initial load uses URL initialMessage over saved drafts.
  - Clear saved draft right before submit; clear input and reset height when leaving input state.
  - Wrap storage access in SSR-safe helpers with try/catch to avoid errors in restricted environments.
  - Resize textarea after restoring a draft on chat switch; reset height on clear.

<sup>Written for commit 9f591fdc7a234774bfbca544a2b81c2ce4de6d84. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->























