### PR TITLE
fix: too many redirects

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -36,6 +36,9 @@ DISABLE_GENERATIVE_AI = os.environ.get("DISABLE_GENERATIVE_AI", "").lower() == "
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 
+# Controls whether anonymous user access is enabled when auth is disabled
+ANONYMOUS_USER_ENABLED = os.environ.get("ANONYMOUS_USER_ENABLED", "").lower() == "true"
+
 # If set to true, will show extra/uncommon connectors in the "Other" category
 SHOW_EXTRA_CONNECTORS = os.environ.get("SHOW_EXTRA_CONNECTORS", "").lower() == "true"
 

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -1,6 +1,7 @@
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
+from onyx.configs.app_configs import ANONYMOUS_USER_ENABLED
 from onyx.configs.constants import KV_SETTINGS_KEY
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.key_value_store.factory import get_kv_store
@@ -38,14 +39,14 @@ def load_settings() -> Settings:
             assert isinstance(value, bytes)
             anonymous_user_enabled = int(value.decode("utf-8")) == 1
         else:
-            # Default to False
-            anonymous_user_enabled = False
-            # Optionally store the default back to Redis
-            redis_client.set(OnyxRedisLocks.ANONYMOUS_USER_ENABLED, "0")
+            # Default to environment variable value, fallback to False
+            anonymous_user_enabled = ANONYMOUS_USER_ENABLED
+            # Store the default back to Redis
+            redis_client.set(OnyxRedisLocks.ANONYMOUS_USER_ENABLED, "1" if anonymous_user_enabled else "0")
     except Exception as e:
-        # Log the error and reset to default
+        # Log the error and reset to environment variable or default
         logger.error(f"Error loading anonymous user setting from Redis: {str(e)}")
-        anonymous_user_enabled = False
+        anonymous_user_enabled = ANONYMOUS_USER_ENABLED
 
     settings.anonymous_user_enabled = anonymous_user_enabled
     settings.query_history_type = ONYX_QUERY_HISTORY_TYPE


### PR DESCRIPTION
## Description

Fixes "too many redirects" error when upgrading from Onyx 2.0.3 to 2.1.2 with disabled authentication.

**Root Cause:** The `ANONYMOUS_USER_ENABLED` environment variable was never read by the backend code, causing the frontend to receive incorrect metadata (`{"anonymousUserEnabled": false}`) and redirect to `/auth/login` despite authentication being disabled.

**Changes Made:**
1. Added `ANONYMOUS_USER_ENABLED` environment variable reading in [app_configs.py](cci:7://file:///Users/marcin/Projects/_marcin/onyx/backend/onyx/configs/app_configs.py:0:0-0:0)
2. Updated [settings/store.py](cci:7://file:///Users/marcin/Projects/_marcin/onyx/backend/onyx/server/settings/store.py:0:0-0:0) to use the environment variable as default instead of hardcoded `False`
3. Fixed Redis initialization to store the environment variable value

**Impact:** Restores proper functionality for deployments using `AUTH_TYPE=disabled` with `ANONYMOUS_USER_ENABLED=true`.

## How Has This Been Tested?

1. **Environment Setup:** Kubernetes deployment with Onyx 2.1.2, `AUTH_TYPE=disabled`, `ANONYMOUS_USER_ENABLED=true`
2. **Pre-Fix Verification:** Confirmed redirect loop - endpoints returned 307 redirects to `/auth/login`
3. **Code Analysis:** Pinpointed missing environment variable handling in backend settings initialization
4. **Fix Implementation:** Added proper environment variable reading and Redis initialization
5. **Post-Fix Testing:** Verified API returns correct metadata and frontend no longer redirects
6. **Configuration Validation:** Confirmed both environment variables and Redis values are properly synchronized



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a redirect loop after upgrading to 2.1.2 when auth is disabled by correctly honoring ANONYMOUS_USER_ENABLED and syncing it with Redis. Restores anonymous access so the app no longer redirects to /auth/login.

- **Bug Fixes**
  - Read ANONYMOUS_USER_ENABLED from env in app_configs.py.
  - Use the env value as the default when Redis is empty; persist it as 1/0.
  - On Redis errors, fall back to the env value instead of hardcoded false.

<sup>Written for commit 155ae103eee3cdd68ee0c745e6777b603e9e4272. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

