### PR TITLE
chore: [Running GitHub actions for #6033]

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -36,6 +36,9 @@ DISABLE_GENERATIVE_AI = os.environ.get("DISABLE_GENERATIVE_AI", "").lower() == "
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 
+# Controls whether anonymous user access is enabled when auth is disabled
+ANONYMOUS_USER_ENABLED = os.environ.get("ANONYMOUS_USER_ENABLED", "").lower() == "true"
+
 # If set to true, will show extra/uncommon connectors in the "Other" category
 SHOW_EXTRA_CONNECTORS = os.environ.get("SHOW_EXTRA_CONNECTORS", "").lower() == "true"
 

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -1,6 +1,7 @@
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
+from onyx.configs.app_configs import ANONYMOUS_USER_ENABLED
 from onyx.configs.constants import KV_SETTINGS_KEY
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.key_value_store.factory import get_kv_store
@@ -38,14 +39,14 @@ def load_settings() -> Settings:
             assert isinstance(value, bytes)
             anonymous_user_enabled = int(value.decode("utf-8")) == 1
         else:
-            # Default to False
-            anonymous_user_enabled = False
-            # Optionally store the default back to Redis
-            redis_client.set(OnyxRedisLocks.ANONYMOUS_USER_ENABLED, "0")
+            # Default to environment variable value, fallback to False
+            anonymous_user_enabled = ANONYMOUS_USER_ENABLED
+            # Store the default back to Redis
+            redis_client.set(OnyxRedisLocks.ANONYMOUS_USER_ENABLED, "1" if anonymous_user_enabled else "0")
     except Exception as e:
-        # Log the error and reset to default
+        # Log the error and reset to environment variable or default
         logger.error(f"Error loading anonymous user setting from Redis: {str(e)}")
-        anonymous_user_enabled = False
+        anonymous_user_enabled = ANONYMOUS_USER_ENABLED
 
     settings.anonymous_user_enabled = anonymous_user_enabled
     settings.query_history_type = ONYX_QUERY_HISTORY_TYPE


### PR DESCRIPTION
Automated mirror of PR #6033 so private CI can run.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ANONYMOUS_USER_ENABLED env flag and uses it as the default when loading the anonymous user setting. Prevents redirect loops when auth is disabled and Redis has no stored value.

- **New Features**
  - Introduced ANONYMOUS_USER_ENABLED config and persisted its default to Redis when missing.

- **Bug Fixes**
  - On Redis missing/error, fall back to the env flag instead of hard-coded False.

<sup>Written for commit 155ae103eee3cdd68ee0c745e6777b603e9e4272. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

