### PR TITLE
fix: Remove dbg-red

### DIFF
--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -6,7 +6,6 @@ import { WebResultIcon } from "../WebResultIcon";
 import Text from "@/refresh-components/texts/Text";
 import { openDocument } from "@/lib/search/utils";
 import { SubQuestionDetail } from "@/app/chat/interfaces";
-import { cn } from "@/lib/utils";
 import { ValidSources } from "@/lib/types";
 import { Card } from "@/components/ui/card";
 
@@ -135,7 +134,7 @@ export function CompactDocumentCard({
     document.is_internet || document.source_type === ValidSources.Web;
 
   return (
-    <Card className="shadow-00 w-[20rem] dbg-red">
+    <Card className="shadow-00 w-[20rem]">
       <button
         onClick={() => {
           openDocument(document, updatePresentingDocument);


### PR DESCRIPTION
## Description

Remove `dbg-red` from `DocumentDisplay` card.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dbg-red class from the CompactDocumentCard to prevent unintended red debug styling in production.

<sup>Written for commit 8d61b070eee4408a3511050ca1df16fa524cea45. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

