### PR TITLE
fix: Fix signin button

### DIFF
--- a/web/src/app/auth/login/SignInButton.tsx
+++ b/web/src/app/auth/login/SignInButton.tsx
@@ -1,8 +1,8 @@
 import Button from "@/refresh-components/buttons/Button";
-import Text from "@/refresh-components/texts/Text";
 import { AuthType } from "@/lib/constants";
 import Link from "next/link";
 import { FcGoogle } from "react-icons/fc";
+import { SvgProps } from "@/icons";
 
 interface SignInButtonProps {
   authorizeUrl: string;
@@ -14,16 +14,11 @@ export default function SignInButton({
   authType,
 }: SignInButtonProps) {
   let button: React.ReactNode;
+  let icon: React.FunctionComponent<SvgProps> | undefined;
 
   if (authType === "google_oauth" || authType === "cloud") {
-    button = (
-      <div className="flex flex-row items-center justify-center w-full gap-2">
-        <FcGoogle />
-        <Text text03 mainUiAction>
-          Continue with Google
-        </Text>
-      </div>
-    );
+    button = "Continue with Google";
+    icon = FcGoogle;
   } else if (authType === "oidc") {
     button = "Continue with OIDC SSO";
   } else if (authType === "saml") {
@@ -42,6 +37,7 @@ export default function SignInButton({
       <Button
         secondary={authType === "google_oauth" || authType === "cloud"}
         className="!w-full"
+        leftIcon={icon}
       >
         {button}
       </Button>


### PR DESCRIPTION
## Description

The current signin-button does not utilize the proper `Button`'s icon prop. This PR fixes that.

Addresses: https://linear.app/danswer/issue/DAN-3042/fix-signinbuttons-usage-of-the-button.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed SignInButton to use Button’s leftIcon so the Google icon displays correctly and the button label uses plain text. Addresses Linear issue DAN-3042 by aligning with the Button API and removing the custom wrapper.

<sup>Written for commit 2a6c7d5666319231716e7e1770bd0367aec6efa7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

