### PR TITLE
fix: don't re-direct to login when auth disabled

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -12,6 +12,11 @@ export const SUB_HEADER = "h-12";
 
 export const INTERNAL_URL = process.env.INTERNAL_URL || "http://127.0.0.1:8080";
 
+// NOTE: this should ONLY be used on the server-side (including middleware).
+// The AUTH_TYPE environment variable is set in the backend and shared with Next.js
+export const SERVER_SIDE_ONLY__AUTH_TYPE = (process.env.AUTH_TYPE ||
+  "disabled") as AuthType;
+
 export const NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED =
   process.env.NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED?.toLowerCase() ===
   "true";


### PR DESCRIPTION
## Description

- Previous PR added a middleware-level "fast auth check" for cookie --> if not present, instantly re-direct to login
- This PR: when `auth=disabled`, don't check for cookie
- Difference from Nik's (closed) PR
-- Instead of making a check with the web server on every request, we import the env var (no hop on each request)

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops redirecting to /auth/login when auth is disabled. Middleware now skips auth checks based on AUTH_TYPE.

- **Bug Fixes**
  - Skip protected-route cookie checks when AUTH_TYPE is "disabled".
  - Add SERVER_SIDE_ONLY__AUTH_TYPE constant sourced from server env for middleware.

<sup>Written for commit c11a02bb0ef6e14d4684a0cc2d5921ea86b21a25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

