### PR TITLE
fix(helm): Removal of OAUTH COOKIE and addition of dbreadonly secret

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -840,12 +840,10 @@ auth:
     secretKeys:
       OAUTH_CLIENT_ID: "oauth_client_id"
       OAUTH_CLIENT_SECRET: "oauth_client_secret"
-      OAUTH_COOKIE_SECRET: "oauth_cookie_secret"
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
     values:
       oauth_client_id: ""
       oauth_client_secret: ""
-      oauth_cookie_secret: ""
   smtp:
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: false


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Some cleanup and additions to make the Helm Chart more configurable.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally in my environment

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused OAUTH_COOKIE_SECRET and adds a dbreadonly secret to configure read-only DB credentials in the Helm chart. Bumps chart version to 0.4.7.

- New Features
  - Added auth.dbreadonly secret with DB_READONLY_USER and DB_READONLY_PASSWORD; supports existingSecret and custom secretName.

- Refactors
  - Removed OAUTH_COOKIE_SECRET from auth.oauth to eliminate an unused value.

<sup>Written for commit dbf34f86a08e5d4c877271ab271b5fb5a8dda454. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

