### PR TITLE
fix(helm): Remove OAUTH Cookie secret

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -840,12 +840,10 @@ auth:
     secretKeys:
       OAUTH_CLIENT_ID: "oauth_client_id"
       OAUTH_CLIENT_SECRET: "oauth_client_secret"
-      OAUTH_COOKIE_SECRET: "oauth_cookie_secret"
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
     values:
       oauth_client_id: ""
       oauth_client_secret: ""
-      oauth_cookie_secret: ""
   smtp:
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: false


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Removing unused variable

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused OAUTH_COOKIE_SECRET from the Helm chart to simplify auth secrets and avoid confusion. Bumped chart version to 0.4.7.

<sup>Written for commit 6961ad767a8a52c6d61bc3277a129eccb62ae64b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

