### PR TITLE
Add pro user tier system with LLM model selection restrictions

### DIFF
--- a/backend/onyx/auth/schemas.py
+++ b/backend/onyx/auth/schemas.py
@@ -7,8 +7,10 @@ from fastapi_users import schemas
 class UserRole(str, Enum):
     """
     User roles
-    - Basic can't perform any admin actions
-    - Admin can perform all admin actions
+    - Basic can't perform any admin actions, and when ENABLE_PRO_USER_RESTRICTIONS is true,
+      can only use assistant default models
+    - Pro can access full LLM model selection and other pro features
+    - Admin can perform all admin actions and access all features
     - Curator can perform admin actions for
         groups they are curators of
     - Global Curator can perform admin actions
@@ -25,6 +27,7 @@ class UserRole(str, Enum):
     GLOBAL_CURATOR = "global_curator"
     SLACK_USER = "slack_user"
     EXT_PERM_USER = "ext_perm_user"
+    PRO_USER = "pro_user"
 
     def is_web_login(self) -> bool:
         return self not in [

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -192,4 +192,11 @@ INDEXING_INFORMATION_CONTENT_CLASSIFICATION_CUTOFF_LENGTH = int(
     os.environ.get("INDEXING_INFORMATION_CONTENT_CLASSIFICATION_CUTOFF_LENGTH") or 10
 )
 
+# Enable pro user restrictions on LLM model selection
+# When enabled, basic users can only use the assistant's default model
+# Pro users and admins have access to all available models
+ENABLE_PRO_USER_RESTRICTIONS = (
+    os.environ.get("ENABLE_PRO_USER_RESTRICTIONS", "").lower() == "true"
+)
+
 ENVIRONMENT = os.environ.get("ENVIRONMENT") or "not_explicitly_set"

--- a/web/src/components/admin/users/buttons/UserRoleDropdown.tsx
+++ b/web/src/components/admin/users/buttons/UserRoleDropdown.tsx
@@ -89,7 +89,10 @@ const UserRoleDropdown = ({
               // Always show the current role
               const isCurrentRole = user.role === role;
 
-              return isNotVisibleRole && !isCurrentRole ? null : (
+              // PRO_USER should always be visible for admins to assign
+              const isProUser = role === UserRole.PRO_USER;
+
+              return isNotVisibleRole && !isCurrentRole && !isProUser ? null : (
                 <SelectItem
                   key={role}
                   onClick={() => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,6 +46,7 @@ export enum UserRole {
   GLOBAL_CURATOR = "global_curator",
   EXT_PERM_USER = "ext_perm_user",
   SLACK_USER = "slack_user",
+  PRO_USER = "pro_user",
 }
 
 export const USER_ROLE_LABELS: Record<UserRole, string> = {
@@ -56,6 +57,7 @@ export const USER_ROLE_LABELS: Record<UserRole, string> = {
   [UserRole.LIMITED]: "Limited",
   [UserRole.EXT_PERM_USER]: "External Permissioned User",
   [UserRole.SLACK_USER]: "Slack User",
+  [UserRole.PRO_USER]: "Pro User",
 };
 
 export const INVALID_ROLE_HOVER_TEXT: Partial<Record<UserRole, string>> = {
@@ -66,6 +68,8 @@ export const INVALID_ROLE_HOVER_TEXT: Partial<Record<UserRole, string>> = {
   [UserRole.CURATOR]: "Curator role must be assigned in the Groups tab",
   [UserRole.SLACK_USER]:
     "This role is automatically assigned to users who only use Onyx via Slack",
+  [UserRole.PRO_USER]:
+    "Pro users have access to model selection and other pro features but no admin privileges",
 };
 
 export interface User {


### PR DESCRIPTION
## Summary

This PR introduces a pro user tier system that restricts LLM model selection for basic users when enabled via environment variable.

## Changes

- ✅ Add `ENABLE_PRO_USER_RESTRICTIONS` environment variable to control feature
- ✅ Add `PRO_USER` role to UserRole enum (backend and frontend)
- ✅ Filter LLM models for basic users to only show default model when restrictions enabled
- ✅ Grant full model access to ADMIN, PRO_USER, CURATOR, and GLOBAL_CURATOR roles
- ✅ Update UserRoleDropdown to show PRO_USER option in admin UI
- ✅ Maintain backward compatibility when feature is disabled

## Behavior

When `ENABLE_PRO_USER_RESTRICTIONS=true`:
- **Basic users**: See only 1 model option (assistant's default model)
- **Pro Users, Curators, Global Curators, Admins**: See all available models

When `ENABLE_PRO_USER_RESTRICTIONS=false` or unset:
- All users see all models (backward compatible)

## Testing

- [x] Backend model filtering logic verified
- [x] Frontend role dropdown updated
- [x] Environment variable configuration tested
- [x] Docker stack tested with basic auth enabled
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Pro user tier and an optional restriction on LLM model selection. When enabled, basic users see only the assistant’s default model; Pro and elevated roles keep full access.

- **New Features**
  - Feature gate via ENABLE_PRO_USER_RESTRICTIONS (off by default).
  - New role: PRO_USER (backend and frontend).
  - Full model access for ADMIN, PRO_USER, CURATOR, GLOBAL_CURATOR.
  - Backend filters model list to the provider’s default for basic users when enabled.
  - Admin UI: UserRoleDropdown shows PRO_USER for assignment.
  - No behavior change when the flag is disabled.

<sup>Written for commit 369160c92c52d17c5b3956299638d0dc7d021384. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

