### PR TITLE
fix(gha): waiting for vespa container (WIP)

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
-      
+
       - name: Discover test directories
         id: set-matrix
         run: |
@@ -45,7 +45,7 @@ jobs:
     needs: discover-test-dirs
     # Use larger runner with more resources for Vespa
     runs-on: [runs-on, runner=16cpu-linux-x64, "run-id=${{ github.run_id }}"]
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -85,11 +85,11 @@ jobs:
         run: |
           echo "Waiting for services to be ready..."
           sleep 30
-          
+
           # Wait for Vespa specifically
           echo "Waiting for Vespa to be ready..."
-          timeout 300 bash -c 'until curl -f -s http://localhost:8081/ApplicationStatus > /dev/null 2>&1; do echo "Vespa not ready, waiting..."; sleep 10; done' || docker logs onyx-index-1
-          
+          timeout 300 bash -c 'until curl -f -s http://localhost:8081/ApplicationStatus > /dev/null 2>&1; do echo "Vespa not ready, waiting..."; sleep 10; done' || docker ps
+
           echo "Services should be ready now"
 
       - name: Run migrations


### PR DESCRIPTION
## Description

This step currently has a 5min timeout and consistently times out.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now lists running containers with docker ps when the 5-minute Vespa readiness check times out, making timeouts easier to debug. This replaces the generic timeout message and still lets the workflow continue.

<sup>Written for commit 0372cce27a78965978d06d680ac00823484247b8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



