### PR TITLE
feat(gha): persist the mypy_cache

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -60,7 +60,7 @@ jobs:
             --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
 
       - name: Cache mypy cache
-        if: vars.DISABLE_MYPY_CACHE != 'true'
+        if: ${{ vars.DISABLE_MYPY_CACHE != 'true' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
         with:
           path: backend/.mypy_cache


### PR DESCRIPTION
## Description

This caches the [mypy_cache](https://mypy.readthedocs.io/en/stable/command_line.html#incremental-mode) between builds making the mypy invocation incremental.

This cache may be prone to corruption, so included a `DISABLE_MYPY_CACHE` flag to disable via an [Actions Variable](https://github.com/onyx-dot-app/onyx/settings/variables/actions).

Before (~3min): https://github.com/onyx-dot-app/onyx/actions/runs/19118774444/job/54634313967?pr=6079#step:12:1
After (~20s): https://github.com/onyx-dot-app/onyx/actions/runs/19118774444/job/54634734796#step:12:1 

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache MyPy results across CI runs to make type checks incremental and faster. Adds an Actions variable to disable the cache if needed.

- **New Features**
  - Cache .mypy_cache with actions/cache, using OS + source/config hashes for invalidation.
  - Opt-out via vars.DISABLE_MYPY_CACHE='true'.

<sup>Written for commit 53deb2a4f0fcc5fa0cfe291496ab760d164b447b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













