### PR TITLE
fix(gha): Dont wait for vespa server

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
-      
+
       - name: Discover test directories
         id: set-matrix
         run: |
@@ -45,7 +45,7 @@ jobs:
     needs: discover-test-dirs
     # Use larger runner with more resources for Vespa
     runs-on: [runs-on, runner=16cpu-linux-x64, "run-id=${{ github.run_id }}"]
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -80,17 +80,6 @@ jobs:
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d minio relational_db cache index
-
-      - name: Wait for services
-        run: |
-          echo "Waiting for services to be ready..."
-          sleep 30
-          
-          # Wait for Vespa specifically
-          echo "Waiting for Vespa to be ready..."
-          timeout 300 bash -c 'until curl -f -s http://localhost:8081/ApplicationStatus > /dev/null 2>&1; do echo "Vespa not ready, waiting..."; sleep 10; done' || echo "Vespa timeout - continuing anyway"
-          
-          echo "Services should be ready now"
 
       - name: Run migrations
         run: |


### PR DESCRIPTION
## Description

Right now, we seem to be waiting for 5.5 minutes for every test for the vespa server to come up which [it never does](https://github.com/onyx-dot-app/onyx/actions/runs/19119525737/job/54636705176#step:7:75) afaict,

```
Vespa timeout - continuing anyway
```

The server seems to be complaining about [the config server not being found](https://github.com/onyx-dot-app/onyx/actions/runs/19117753382/job/54631045055#step:7:106),

```
[2025-11-05 22:16:09.849] INFO    config-sentinel  sentinel.config.frt.frtconfigagent	No response / error from config server. This is normal before an application package is deployed. (key: name=cloud.config.sentinel,configId=hosts/7d764f902e81) (errcode=103, validresponse:0), trying again in 9.000000 seconds
```

The following diff seems to resolve the config server issues, but the application still seams partially initialized and I haven't personally gotten it into a healthy state locally,

```
diff --git a/deployment/docker_compose/docker-compose.yml b/deployment/docker_compose/docker-compose.yml
index 435368972..5ef7317aa 100644
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -266,8 +266,10 @@ services:
     env_file:
       - path: .env
         required: false
+    hostname: vespa
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=${VESPA_SKIP_UPGRADE_CHECK:-true}
+      - VESPA_HOSTNAME=vespa
     # DEV: To expose ports, either:
     # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
     # 2. Uncomment the ports below
```

but I am not sure that change is worth it compared to just removing the wait which seems reasonable and non-invasive in the interim.

Moreover, we may prefer to replace this with a container [healthcheck](https://docs.docker.com/reference/compose-file/services/#healthcheck) and use docker-compose's [service waiter](https://docs.docker.com/reference/cli/docker/compose/up/) (`docker-compose up -d --wait`) anyways.

## How Has This Been Tested?

Presumably captured by presubmit

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the Vespa readiness wait from the pr-external-dependency-unit-tests workflow. This avoids a 5+ minute timeout per job from a failing curl loop, speeding up CI without changing test behavior.

<sup>Written for commit 3f3fa2d9c6b96bac4edcc5c22c5649831105f746. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

