### PR TITLE
chore(gha): migrate external dependency tests to uv

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -69,9 +69,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('backend/requirements/*.txt', 'backend/pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.workflow }}-uv-${{ hashFiles('backend/requirements/*.txt', 'backend/pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-uv-
+            ${{ runner.os }}-${{ github.workflow }}-uv-
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5


### PR DESCRIPTION
## Description

The `external-dependency-unit-tests` are now very fast (about 2min faster on average),

<img width="1920" height="1080" alt="20251105_21h31m37s_grim" src="https://github.com/user-attachments/assets/1f1d6ee0-358f-4e1a-8119-632e7988d785" />


## How Has This Been Tested?

Mostly captured by presubmit

## Additional Options

- [x] Override Linear Check














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the external dependency unit test workflow to uv for Python installs. This speeds up installs with caching and reduces pip-related flakiness.

- **Refactors**
  - Use astral-sh/setup-uv and install via uv pip --system.
  - Enable uv caching (~/.cache/uv) and remove pip caching/install steps; keep Playwright setup.
  - Add runs-on/action and extras=s3-cache runner label.

<sup>Written for commit 46c9d2d7054fa31f6c53e5a7caa0461a9f04a677. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













