### PR TITLE
fix: disable PAT when AUTH_TYPE is disabled

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -396,15 +396,13 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     )
     include_router_with_global_prefix_prepended(application, long_term_logs_router)
     include_router_with_global_prefix_prepended(application, api_key_router)
-    include_router_with_global_prefix_prepended(application, pat_router)
     include_router_with_global_prefix_prepended(application, standard_oauth_router)
     include_router_with_global_prefix_prepended(application, federated_router)
     include_router_with_global_prefix_prepended(application, mcp_router)
     include_router_with_global_prefix_prepended(application, mcp_admin_router)
 
-    if AUTH_TYPE == AuthType.DISABLED:
-        # Server logs this during auth setup verification step
-        pass
+    if AUTH_TYPE != AuthType.DISABLED:
+        include_router_with_global_prefix_prepended(application, pat_router)
 
     if AUTH_TYPE == AuthType.BASIC or AUTH_TYPE == AuthType.CLOUD:
         include_auth_router_with_prefix(

--- a/web/src/app/chat/components/modal/UserSettings.tsx
+++ b/web/src/app/chat/components/modal/UserSettings.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { getDisplayNameForModel } from "@/lib/hooks";
+import { getDisplayNameForModel, useAuthType } from "@/lib/hooks";
 import { parseLlmDescriptor, structureValue } from "@/lib/llm/utils";
 import { setUserDefaultModel } from "@/lib/users/UserSettings";
 import { usePathname, useRouter } from "next/navigation";
@@ -58,6 +58,7 @@ export function UserSettings({ onClose }: UserSettingsProps) {
     updateUserThemePreference,
   } = useUser();
   const { llmProviders } = useLLMProviders();
+  const authType = useAuthType();
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
   const messageRef = useRef<HTMLDivElement>(null);
@@ -138,14 +139,14 @@ export function UserSettings({ onClose }: UserSettingsProps) {
       visibleSections.push({ id: "password", label: "Password" });
     }
 
-    // Always show tokens tab
-    visibleSections.push({ id: "tokens", label: "Access Tokens" });
+    if (authType && authType !== "disabled") {
+      visibleSections.push({ id: "tokens", label: "Access Tokens" });
+    }
 
-    // Always show Connectors tab, will be disabled if loading or no connectors
     visibleSections.push({ id: "connectors", label: "Connectors" });
 
     return visibleSections;
-  }, [showPasswordSection]);
+  }, [showPasswordSection, authType]);
 
   useEffect(() => {
     if (!sections.some((section) => section.id === activeSection)) {


### PR DESCRIPTION
- Backend: Conditionally include PAT router only when AUTH_TYPE != DISABLED
- Frontend: Hide Access Tokens tab in user settings when auth is disabled
- Fixes bug where PAT UI was shown but non-functional with AUTH_TYPE=DISABLED
- Follows same pattern as other auth-dependent routers (reset password, register)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Personal Access Tokens when AUTH_TYPE is disabled to prevent showing a non-functional tokens UI. The server now skips the PAT router and the client hides the Access Tokens tab.

- **Bug Fixes**
  - Backend: include pat_router only when AUTH_TYPE != DISABLED.
  - Frontend: hide the “Access Tokens” tab in User Settings when authType is disabled.
  - Matches the pattern used for other auth-dependent routes.

<sup>Written for commit 5b49adb0096ee3e31d9e7807b3dbdb663e35b819. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





