### PR TITLE
feat(deps): ignore linear check for dependabot

### DIFF
--- a/.github/workflows/pr-linear-check.yml
+++ b/.github/workflows/pr-linear-check.yml
@@ -11,7 +11,14 @@ jobs:
       - name: Check PR body for Linear link or override
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          # Skip check for dependabot PRs
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "PR is from dependabot. Skipping Linear check."
+            exit 0
+          fi
+
           # Looking for "https://linear.app" in the body
           if echo "$PR_BODY" | grep -qE "https://linear\.app"; then
             echo "Found a Linear link. Check passed."


### PR DESCRIPTION
## Description

This is a quite inconvenient and I don't think we're concerned about dependabot changes been tracked

## How Has This Been Tested?

Mostly captured by presubmit

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the Linear link check for Dependabot PRs to avoid blocking automated dependency updates. The workflow now exits early when the PR author is dependabot[bot].

<sup>Written for commit 3334c81215faf3087d3adf782d2a62c97e21a8f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

