### PR TITLE
chore(gha): migrate connectors-check to uv w/ caching

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -119,29 +119,40 @@ env:
 jobs:
   connectors-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=8cpu-linux-x64, "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=8cpu-linux-x64, "run-id=${{ github.run_id }}", "extras=s3-cache"]
 
     env:
       PYTHONPATH: ./backend
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # ratchet:astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Cache uv cache directory
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ github.workflow }}-uv-${{ hashFiles('backend/requirements/*.txt', 'backend/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.workflow }}-uv-
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: |
-            backend/requirements/default.txt
-            backend/requirements/dev.txt
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --retries 5 --timeout 30 -r backend/requirements/default.txt
-          pip install --retries 5 --timeout 30 -r backend/requirements/dev.txt
+          uv pip install --system \
+            -r backend/requirements/default.txt \
+            -r backend/requirements/dev.txt
           playwright install chromium
           playwright install-deps chromium
 


### PR DESCRIPTION
## Description

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the connectors-check GitHub Actions job to use uv with caching to speed Python dependency installs and improve CI reliability.

- **Refactors**
  - Added astral-sh/setup-uv with caching and switched installs to `uv pip install --system`.
  - Cached `~/.cache/uv` via actions/cache keyed to requirements and pyproject; enabled runner extras for s3-cache.
  - Removed pip caching/flags; kept Python 3.11 setup and Playwright installs.

<sup>Written for commit 2a24fb0f45935b1d126016fad91e040bd8a41423. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

