### PR TITLE
fix: don't auto include all types

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -8,6 +8,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
+    "types": [],
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled auto-inclusion of all @types packages by setting "types": [] in web/tsconfig.json. This prevents unintended type conflicts and keeps the type surface explicit.

- **Migration**
  - Add required types explicitly when needed (e.g., "types": ["node", "jest"]).

<sup>Written for commit 8da006ba77af9944183166dbfb62e4d0a6b6b4b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

