### PR TITLE
fix(icons): Update Token Rate Limits page

### DIFF
--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -4,7 +4,9 @@ import { AdminPageTitle } from "@/components/admin/Title";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import Text from "@/components/ui/text";
 import { useState } from "react";
-import { FiGlobe, FiUser, FiUsers } from "react-icons/fi";
+import SvgGlobe from "@/icons/globe";
+import SvgUser from "@/icons/user";
+import SvgUsers from "@/icons/users";
 import {
   insertGlobalTokenRateLimit,
   insertGroupTokenRateLimit,
@@ -149,15 +151,24 @@ function Main() {
         >
           <TabsList>
             <TabsTrigger value="0" className="flex items-center gap-2">
-              <FiGlobe />
+              <SvgGlobe
+                aria-hidden="true"
+                className="h-3.5 w-3.5 stroke-text-03 group-data-[state=active]:stroke-text-04 shrink-0"
+              />
               Global
             </TabsTrigger>
             <TabsTrigger value="1" className="flex items-center gap-2">
-              <FiUser />
+              <SvgUser
+                aria-hidden="true"
+                className="h-3.5 w-3.5 stroke-text-03 group-data-[state=active]:stroke-text-04 shrink-0"
+              />
               User
             </TabsTrigger>
             <TabsTrigger value="2" className="flex items-center gap-2">
-              <FiUsers />
+              <SvgUsers
+                aria-hidden="true"
+                className="h-3.5 w-3.5 stroke-text-03 group-data-[state=active]:stroke-text-04 shrink-0"
+              />
               User Groups
             </TabsTrigger>
           </TabsList>

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -35,7 +35,7 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   >
-    <Text className="group-data-[state=active]:text-text-04 text-text-03">
+    <Text className="group-data-[state=active]:text-text-04 text-text-03 inline-flex items-center gap-2">
       {children}
     </Text>
   </TabsPrimitive.Trigger>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Icons looked wonky so fixed it.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

Before:
<img width="894" height="495" alt="Screenshot 2025-11-06 at 5 30 25 PM" src="https://github.com/user-attachments/assets/ccc56a6b-3415-455f-bb7a-fe8cccabeecd" />

After:
<img width="895" height="480" alt="Screenshot 2025-11-06 at 5 30 48 PM" src="https://github.com/user-attachments/assets/bbdaf83c-17eb-4e10-8122-c00562dff353" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned and inconsistent icons on the Token Rate Limits admin page by switching to our SVG icons and tightening tab layout. Icons now render consistently and match active state colors.

- **Bug Fixes**
  - Replaced FiGlobe/FiUser/FiUsers with SvgGlobe/SvgUser/SvgUsers (aria-hidden, 14px, active-state stroke colors).
  - Updated TabsTrigger to inline-flex with gap for proper icon/text alignment while preserving active text color.

<sup>Written for commit ac01bbde14a559ca99c735d2d445c0af1322299a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

