### PR TITLE
fix: Sidebar sizing fix

### DIFF
--- a/web/src/sections/sidebar/SidebarWrapper.tsx
+++ b/web/src/sections/sidebar/SidebarWrapper.tsx
@@ -29,8 +29,12 @@ function LogoSection({ folded, setFolded }: LogoSectionProps) {
   return (
     <div
       className={cn(
+        // # Note
+        //
         // The `px-3.5` was chosen carefully to make the logo sit in the center of the folded + unfolded sidebar view.
         // If you want to modify it, you'll also have to modify the size of the sidebar (located at the bottom of this file, annotated with `@HERE`).
+        //
+        // - @raunakab
         "flex flex-row items-center py-1 gap-1 min-h-[3.5rem] px-3.5",
         folded ? "justify-start" : "justify-between"
       )}
@@ -74,6 +78,8 @@ export default function SidebarWrapper({
           "h-screen flex flex-col bg-background-tint-02 py-2 gap-4 group/SidebarWrapper transition-width duration-200 ease-in-out",
 
           // @HERE (size of sidebar)
+          //
+          // - @raunakab
           folded ? "w-[3.25rem]" : "w-[15rem]"
         )}
       >


### PR DESCRIPTION
## Description

Fix sizing for `SidebarTab` when closed. It was asymmetrical before. This PR fixes that.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes folded sidebar sizing to center the logo and remove asymmetry. Adjusts padding to px-3.5 and folded width to 3.25rem, with a note linking logo centering to the sidebar size.

<sup>Written for commit 0a7ef1da44724373fdaf28052e315f31d94bd7f3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



