### PR TITLE
feat: set service ports dynamically for git worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # editors
-.vscode
+.vscode/.env
+.vscode/launch.json
 .zed
 
 # macos

--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -107,7 +107,7 @@
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
       },
-      "args": ["model_server.main:app", "--reload", "--port", "9000"],
+      "args": ["model_server.main:app", "--reload", "--port", "${MODEL_SERVER_PORT}"],
       "presentation": {
         "group": "2"
       },
@@ -126,7 +126,7 @@
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
       },
-      "args": ["onyx.main:app", "--reload", "--port", "8080"],
+      "args": ["onyx.main:app", "--reload", "--port", "${APP_PORT}"],
       "presentation": {
         "group": "2"
       },
@@ -472,16 +472,16 @@
       }
     },
     {
-      "name": "Clear and Restart External Volumes and Containers",
+      "name": "Start Worktree Containers",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "bash",
+      "runtimeExecutable": "python3",
       "runtimeArgs": [
-        "${workspaceFolder}/backend/scripts/restart_containers.sh"
+        "${workspaceFolder}/scripts/start_containers.py"
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
-      "stopOnEntry": true,
+      "envFile": "${workspaceFolder}/.vscode/.env",
       "presentation": {
         "group": "3"
       }
@@ -579,7 +579,7 @@
       "name": "Debug React Web App in Chrome",
       "type": "chrome",
       "request": "launch",
-      "url": "http://localhost:3000",
+      "url": "http://localhost:${PORT}",
       "webRoot": "${workspaceFolder}/web"
     }
   ]

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -18,7 +18,7 @@ from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT
 # App Configs
 #####
 APP_HOST = "0.0.0.0"
-APP_PORT = 8080
+APP_PORT = int(os.environ.get("APP_PORT") or "8080")
 # API_PREFIX is used to prepend a base path for all API routes
 # generally used if using a reverse proxy which doesn't support stripping the `/api`
 # prefix from requests directed towards the API server. In these cases, set this to `/api`

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -163,8 +163,9 @@ class SlackbotHandler:
 
         # Start the Prometheus metrics server
         logger.info("Starting Prometheus metrics server")
-        start_http_server(8000)
-        logger.info("Prometheus metrics server started")
+        metrics_port = int(os.environ.get("SLACK_BOT_METRICS_PORT", "8000"))
+        start_http_server(metrics_port)
+        logger.info(f"Prometheus metrics server started on port {metrics_port}")
 
         # Start background threads
         logger.info("Starting background threads")

--- a/scripts/worktree/README.md
+++ b/scripts/worktree/README.md
@@ -1,0 +1,395 @@
+# Onyx Worktree Scripts
+
+Python scripts for managing git worktree instances with isolated Docker containers and dynamic port allocation.
+
+## Overview
+
+These scripts enable running multiple Onyx instances simultaneously using git worktrees. Each worktree gets:
+- **Isolated Docker containers** with unique names and volumes
+- **Dynamically allocated ports** to avoid conflicts
+- **Independent configuration** via `.vscode/.env`
+- **Generated VSCode launch configuration** from template
+
+## Scripts
+
+### `setup_worktree.py`
+
+**Purpose**: Initial setup script for a new worktree instance.
+
+**What it does**:
+1. Detects worktree name from the current directory path
+2. Finds available ports for all services (tries base+10, base+20, base+30...)
+3. Preserves existing environment settings (API keys, feature flags, etc.) from main repo
+4. Generates `.vscode/.env` with allocated ports and preserved settings
+5. Generates `.vscode/launch.json` from `.vscode/launch.template.jsonc`
+6. Creates a quick-start guide at `plans/worktree-quick-start.md`
+
+**Usage**:
+```bash
+cd /path/to/worktree
+python3 scripts/worktree/setup_worktree.py
+```
+
+**Example Output**:
+```
+Onyx Worktree Setup
+==================
+
+Detected worktree: dev1
+
+Finding available ports...
+✓ Next.js Web: 3010
+✓ API Server: 8090
+✓ Model Server: 9010
+✓ Slack Bot Metrics: 8010
+✓ PostgreSQL: 5442
+✓ Redis: 6389
+✓ Vespa: 8091
+✓ Vespa Tenant: 19081
+✓ MinIO API: 9014
+✓ MinIO Console: 9015
+
+Generated files:
+  ✓ .vscode/.env
+  ✓ .vscode/launch.json
+  ✓ plans/worktree-quick-start.md
+
+Container naming:
+  Prefix: onyx_dev1
+  Example: onyx_dev1_postgres
+
+Next steps:
+1. Start containers: python3 scripts/worktree/start_containers.py
+2. Open VSCode Run & Debug
+3. Launch "Run All Onyx Services"
+4. Access at http://localhost:3010
+```
+
+**Port Allocation**:
+- **Base ports**: 3000 (web), 8080 (API), 9000 (model), 5432 (postgres), etc.
+- **Increment**: 10 per attempt
+- **Max attempts**: 20
+- **Example**: If 3000 is taken, tries 3010, 3020, 3030...
+
+**Environment Settings Preserved**:
+- API keys (GEN_AI_API_KEY, OPENAI_API_KEY, etc.)
+- Feature flags (ENABLE_*, DISABLE_*)
+- Service URLs (unless port-related)
+- Authentication tokens
+- All other non-port settings
+
+**Environment Settings Regenerated**:
+- All port numbers (PORT, APP_PORT, MODEL_SERVER_PORT, etc.)
+- Service URLs that include ports (WEB_DOMAIN, INTERNAL_URL, S3_ENDPOINT_URL)
+- Container configuration (CONTAINER_PREFIX, WORKTREE_NAME)
+
+### `start_containers.py`
+
+**Purpose**: Start and manage Docker containers for the worktree instance.
+
+**What it does**:
+1. Reads configuration from `.vscode/.env`
+2. Stops any existing containers with the same prefix
+3. Starts PostgreSQL, Vespa, Redis, and MinIO containers
+4. Runs Alembic migrations
+5. Waits for services to be ready
+
+**Usage**:
+```bash
+# The script automatically loads .vscode/.env
+cd /path/to/worktree
+python3 scripts/worktree/start_containers.py
+```
+
+**Note**: The script automatically loads `.vscode/.env` and validates the configuration. You do NOT need to manually `source .vscode/.env`.
+
+**Or from VSCode**:
+- Open Run & Debug panel (Cmd+Shift+D)
+- Select "Start Worktree Containers"
+- Click Start
+
+**Example Output**:
+```
+Stopping existing containers...
+Starting PostgreSQL container...
+Starting Vespa container...
+Starting Redis container...
+Starting MinIO container...
+Waiting for PostgreSQL to be ready...
+Running Alembic migration...
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> abc123, initial schema
+
+Containers started successfully!
+```
+
+**Container Names**:
+- Format: `{CONTAINER_PREFIX}_{service}`
+- Example for worktree "dev1":
+  - `onyx_dev1_postgres`
+  - `onyx_dev1_redis`
+  - `onyx_dev1_vespa`
+  - `onyx_dev1_minio`
+
+**Volume Names**:
+- Format: `{CONTAINER_PREFIX}_{service}_data`
+- Example for worktree "dev1":
+  - `onyx_dev1_postgres_data`
+  - `onyx_dev1_redis_data`
+  - `onyx_dev1_vespa_data`
+  - `onyx_dev1_minio_data`
+
+## Workflow
+
+### First-Time Setup
+
+```bash
+# 1. Create worktree
+cd ~/onyx
+git worktree add ~/onyx-worktrees/dev1 -b feature/my-feature
+
+# 2. Navigate to worktree
+cd ~/onyx-worktrees/dev1
+
+# 3. Run setup script
+python3 scripts/worktree/setup_worktree.py
+
+# 4. Start containers
+python3 scripts/worktree/start_containers.py
+
+# 5. Open in VSCode
+code .
+
+# 6. Launch services
+# Run & Debug → "Run All Onyx Services" → Start
+```
+
+### Daily Development
+
+```bash
+# Start containers (if stopped)
+cd ~/onyx-worktrees/dev1
+python3 scripts/worktree/start_containers.py
+
+# Launch services from VSCode
+# Run & Debug → "Run All Onyx Services"
+```
+
+### Switching Between Worktrees
+
+Each worktree runs independently with its own ports and containers:
+
+```bash
+# Main instance
+cd ~/onyx
+# Uses: localhost:3000, containers: onyx_postgres, onyx_redis, etc.
+
+# dev1 worktree
+cd ~/onyx-worktrees/dev1
+python3 scripts/worktree/start_containers.py
+# Uses: localhost:3010, containers: onyx_dev1_postgres, onyx_dev1_redis, etc.
+
+# dev2 worktree
+cd ~/onyx-worktrees/dev2
+python3 scripts/worktree/start_containers.py
+# Uses: localhost:3020, containers: onyx_dev2_postgres, onyx_dev2_redis, etc.
+```
+
+## Configuration Files
+
+### `.vscode/.env`
+
+Generated by `setup_worktree.py`, contains all environment variables:
+
+```bash
+# Worktree Configuration
+WORKTREE_NAME=dev1
+CONTAINER_PREFIX=onyx_dev1
+
+# Application Ports
+PORT=3010
+APP_PORT=8090
+MODEL_SERVER_PORT=9010
+
+# Infrastructure Ports
+POSTGRES_PORT=5442
+REDIS_PORT=6389
+VESPA_PORT=8091
+VESPA_TENANT_PORT=19081
+MINIO_PORT=9014
+MINIO_CONSOLE_PORT=9015
+
+# Service URLs
+WEB_DOMAIN=http://localhost:3010
+INTERNAL_URL=http://localhost:8090
+
+# Preserved settings from main repo
+GEN_AI_API_KEY=sk-proj-...
+OPENAI_API_KEY=sk-proj-...
+# ... other settings ...
+```
+
+### `.vscode/launch.template.jsonc`
+
+Template file used to generate `.vscode/launch.json`. Contains placeholders:
+- `${PORT}` - Web server port
+- `${APP_PORT}` - API server port
+- `${MODEL_SERVER_PORT}` - Model server port
+
+**Do not edit** `.vscode/launch.json` directly - changes will be overwritten when you re-run `setup_worktree.py`.
+
+## Container Management
+
+### View Running Containers
+
+```bash
+# All containers for this worktree
+docker ps | grep dev1
+
+# Specific container
+docker ps | grep dev1_postgres
+```
+
+### Stop Containers
+
+```bash
+# Stop all worktree containers
+docker stop onyx_dev1_postgres onyx_dev1_redis onyx_dev1_vespa onyx_dev1_minio
+
+# Stop specific container
+docker stop onyx_dev1_postgres
+```
+
+### Restart Containers
+
+```bash
+python3 scripts/worktree/start_containers.py
+```
+
+### View Logs
+
+```bash
+# View logs
+docker logs onyx_dev1_postgres
+
+# Follow logs
+docker logs -f onyx_dev1_postgres
+```
+
+### Clean Up Data
+
+```bash
+# Remove all volumes (⚠️ deletes all data!)
+docker volume rm onyx_dev1_postgres_data onyx_dev1_redis_data onyx_dev1_vespa_data onyx_dev1_minio_data
+
+# Remove specific volume
+docker volume rm onyx_dev1_postgres_data
+```
+
+## Troubleshooting
+
+### Port Already in Use
+
+**Symptom**: Error binding to port
+
+**Solution**:
+```bash
+# Check what's using the port
+lsof -i :3010
+
+# Kill the process or re-run setup to allocate new ports
+python3 scripts/worktree/setup_worktree.py
+```
+
+### Container Fails to Start
+
+**Symptom**: Container immediately exits
+
+**Solution**:
+```bash
+# Check container logs
+docker logs onyx_dev1_postgres
+
+# Remove and recreate
+docker rm onyx_dev1_postgres
+python3 scripts/worktree/start_containers.py
+```
+
+### Migration Fails
+
+**Symptom**: Alembic migration errors
+
+**Solution**:
+```bash
+# Verify environment is sourced
+source .vscode/.env
+
+# Check database connection
+psql -h localhost -p $POSTGRES_PORT -U postgres -c "SELECT version();"
+
+# Run migrations manually
+cd backend
+alembic upgrade head
+```
+
+### Service Won't Start in VSCode
+
+**Symptom**: Service fails to launch
+
+**Diagnosis**:
+1. Check `.vscode/.env` exists
+2. Check `.vscode/launch.json` exists
+3. Verify containers are running: `docker ps | grep dev1`
+
+**Solution**:
+```bash
+# Regenerate configuration
+python3 scripts/worktree/setup_worktree.py
+
+# Restart VSCode
+# Try launching services again
+```
+
+## Advanced Usage
+
+### Custom Port Allocation
+
+Edit `scripts/setup_worktree.py` to customize:
+- `increment`: Port increment per attempt (default: 10)
+- `max_attempts`: Maximum attempts to find available port (default: 20)
+- Base ports for each service
+
+### Preserving Additional Settings
+
+Edit `load_existing_env_settings()` in `setup_worktree.py` to add variables to `EXCLUDED_VARS` if you want them regenerated instead of preserved.
+
+### Manual Configuration
+
+You can manually edit `.vscode/.env` after generation, but changes will be lost if you re-run `setup_worktree.py`. To make permanent changes:
+1. Edit `.vscode/launch.template.jsonc` for launch config changes
+2. Edit `scripts/setup_worktree.py` for environment variable defaults
+
+## Files Generated
+
+| File | Description | Commit? |
+|------|-------------|---------|
+| `.vscode/.env` | Environment variables with allocated ports | No (gitignored) |
+| `.vscode/launch.json` | VSCode debug configuration | No (gitignored) |
+| `plans/worktree-quick-start.md` | Quick reference guide | No (optional) |
+
+## Files to Commit
+
+| File | Description |
+|------|-------------|
+| `scripts/setup_worktree.py` | Setup script |
+| `scripts/start_containers.py` | Container manager |
+| `.vscode/launch.template.jsonc` | Launch config template |
+| `scripts/README.md` | This file |
+
+## References
+
+- **Quick Start Guide**: `plans/worktree-quick-start.md` (generated per-worktree)
+- **Implementation Plan**: `plans/worktree-port-allocation-plan.md`
+- **Git Worktrees**: https://git-scm.com/docs/git-worktree
+- **Onyx Docs**: https://docs.onyx.app/

--- a/scripts/worktree/setup_worktree.py
+++ b/scripts/worktree/setup_worktree.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""
+Onyx Worktree Setup Script
+
+Automatically configures a worktree for local development with dynamic port allocation.
+
+Usage:
+    python scripts/worktree/setup_worktree.py
+"""
+
+import os
+import socket
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+
+# ANSI color codes
+class Colors:
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    RED = "\033[0;31m"
+    NC = "\033[0m"  # No Color
+
+
+def print_header(text: str):
+    """Print colored header."""
+    print(f"{Colors.GREEN}=== {text} ==={Colors.NC}")
+
+
+def print_step(text: str):
+    """Print step message."""
+    print(f"\n{Colors.GREEN}{text}{Colors.NC}")
+
+
+def print_substep(text: str):
+    """Print sub-step message."""
+    print(f"{Colors.YELLOW}{text}{Colors.NC}")
+
+
+def print_error(text: str):
+    """Print error message."""
+    print(f"{Colors.RED}ERROR: {text}{Colors.NC}")
+
+
+def is_port_available(port: int) -> bool:
+    """Check if a port is available for binding."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("localhost", port))
+            return True
+        except OSError:
+            return False
+
+
+def find_available_port(
+    base_port: int, service_name: str, increment: int = 10, max_attempts: int = 20
+) -> int:
+    """Find next available port starting from base_port."""
+    print_substep(f"Finding available port for {service_name} (base: {base_port})...")
+
+    for i in range(max_attempts):
+        port = base_port + (i * increment)
+        if is_port_available(port):
+            print(f"{Colors.GREEN}  ✓ Found: {port}{Colors.NC}")
+            return port
+        else:
+            print(f"  ✗ Port {port} in use, trying next...")
+
+    raise RuntimeError(f"Could not find available port for {service_name}")
+
+
+def get_worktree_name() -> str:
+    """Detect worktree name from directory."""
+    workspace_root = Path(__file__).parent.parent.parent.absolute()
+    return workspace_root.name
+
+
+def load_existing_env_settings(workspace_root: Path) -> Dict[str, str]:
+    """
+    Load existing .env settings from current worktree or main repo.
+
+    Priority:
+    1. Current worktree .vscode/.env (if exists)
+    2. Main repo .vscode/.env (if exists)
+    3. Empty dict (no existing settings)
+
+    Returns only non-port-related settings to preserve.
+    """
+    # Variables that should NOT be preserved (will be regenerated)
+    EXCLUDED_VARS = {
+        "PORT",
+        "APP_PORT",
+        "MODEL_SERVER_PORT",
+        "SLACK_BOT_METRICS_PORT",
+        "POSTGRES_PORT",
+        "REDIS_PORT",
+        "VESPA_PORT",
+        "VESPA_TENANT_PORT",
+        "MINIO_PORT",
+        "MINIO_CONSOLE_PORT",
+        "WEB_DOMAIN",
+        "INTERNAL_URL",
+        "S3_ENDPOINT_URL",
+        "WORKTREE_NAME",
+        "CONTAINER_PREFIX",
+        "INDEXING_MODEL_SERVER_PORT",  # Derived from MODEL_SERVER_PORT
+    }
+
+    existing_settings = {}
+
+    # Try current worktree .env first
+    current_env = workspace_root / ".vscode" / ".env"
+
+    # Try main repo .env as fallback
+    main_repo_env = workspace_root.parent.parent / "onyx" / ".vscode" / ".env"
+
+    env_file_to_load = None
+    if current_env.exists():
+        env_file_to_load = current_env
+        print(f"  Loading existing settings from: {current_env}")
+    elif main_repo_env.exists():
+        env_file_to_load = main_repo_env
+        print(f"  Loading settings from main repo: {main_repo_env}")
+
+    if env_file_to_load:
+        with open(env_file_to_load, "r") as f:
+            for line in f:
+                line = line.strip()
+                # Skip comments and empty lines
+                if not line or line.startswith("#"):
+                    continue
+
+                # Parse KEY=VALUE
+                if "=" in line:
+                    key, value = line.split("=", 1)
+                    key = key.strip()
+                    value = value.strip()
+
+                    # Only preserve non-port-related settings
+                    if key not in EXCLUDED_VARS and value:
+                        existing_settings[key] = value
+
+        print(f"  Preserved {len(existing_settings)} settings from existing .env")
+    else:
+        print("  No existing .env found, using defaults")
+
+    return existing_settings
+
+
+def allocate_ports() -> Dict[str, int]:
+    """Allocate ports for all services."""
+    print_step("Step 1: Finding available ports...")
+
+    ports = {
+        "PORT": find_available_port(3000, "Next.js Web"),
+        "APP_PORT": find_available_port(8080, "API Server"),
+        "MODEL_SERVER_PORT": find_available_port(9000, "Model Server"),
+        "SLACK_BOT_METRICS_PORT": find_available_port(8000, "Slack Bot Metrics"),
+        "POSTGRES_PORT": find_available_port(5432, "PostgreSQL"),
+        "REDIS_PORT": find_available_port(6379, "Redis"),
+        "VESPA_PORT": find_available_port(8081, "Vespa"),
+        "VESPA_TENANT_PORT": find_available_port(19071, "Vespa Tenant"),
+        "MINIO_PORT": find_available_port(9004, "MinIO API"),
+        "MINIO_CONSOLE_PORT": find_available_port(9005, "MinIO Console"),
+    }
+
+    return ports
+
+
+def generate_env_file(
+    worktree_name: str,
+    ports: Dict[str, int],
+    workspace_root: Path,
+    existing_settings: Dict[str, str],
+):
+    """Generate .vscode/.env file, preserving existing non-port settings."""
+    print_step("Step 2: Generating .vscode/.env...")
+
+    vscode_dir = workspace_root / ".vscode"
+    vscode_dir.mkdir(exist_ok=True)
+
+    # Helper function to get value from existing settings or use default
+    def get_setting(key: str, default: str) -> str:
+        return existing_settings.get(key, default)
+
+    env_content = f"""##################################################
+# AUTO-GENERATED WORKTREE CONFIGURATION
+# Worktree: {worktree_name}
+# Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+##################################################
+#
+# This file was auto-generated by scripts/setup_worktree.py
+# Ports were dynamically allocated to avoid conflicts.
+# Non-port settings were preserved from existing configuration.
+#
+# To regenerate: python scripts/setup_worktree.py
+##################################################
+
+#####
+# Application Ports (DYNAMICALLY ALLOCATED)
+#####
+# Next.js web server
+PORT={ports['PORT']}
+# Frontend URL
+WEB_DOMAIN=http://localhost:{ports['PORT']}
+# Backend URL (for Next.js rewrites)
+INTERNAL_URL=http://localhost:{ports['APP_PORT']}
+# API Server (FastAPI)
+APP_PORT={ports['APP_PORT']}
+# Model Server (FastAPI)
+MODEL_SERVER_PORT={ports['MODEL_SERVER_PORT']}
+# Slack Bot Prometheus metrics port
+SLACK_BOT_METRICS_PORT={ports['SLACK_BOT_METRICS_PORT']}
+
+# Development features
+UVICORN_RELOAD={get_setting('UVICORN_RELOAD', 'true')}
+
+#####
+# Infrastructure - PostgreSQL (DYNAMICALLY ALLOCATED PORTS)
+#####
+POSTGRES_HOST={get_setting('POSTGRES_HOST', 'localhost')}
+POSTGRES_PORT={ports['POSTGRES_PORT']}
+POSTGRES_USER={get_setting('POSTGRES_USER', 'postgres')}
+POSTGRES_PASSWORD={get_setting('POSTGRES_PASSWORD', 'password')}
+POSTGRES_DB={get_setting('POSTGRES_DB', 'postgres')}
+
+#####
+# Infrastructure - Redis (DYNAMICALLY ALLOCATED PORTS)
+#####
+REDIS_HOST={get_setting('REDIS_HOST', 'localhost')}
+REDIS_PORT={ports['REDIS_PORT']}
+REDIS_PASSWORD={get_setting('REDIS_PASSWORD', '')}
+REDIS_DB_NUMBER={get_setting('REDIS_DB_NUMBER', '0')}
+REDIS_DB_NUMBER_CELERY={get_setting('REDIS_DB_NUMBER_CELERY', '15')}
+REDIS_DB_NUMBER_CELERY_RESULT_BACKEND={get_setting('REDIS_DB_NUMBER_CELERY_RESULT_BACKEND', '14')}
+
+#####
+# Infrastructure - Vespa (DYNAMICALLY ALLOCATED PORTS)
+#####
+VESPA_HOST={get_setting('VESPA_HOST', 'localhost')}
+VESPA_PORT={ports['VESPA_PORT']}
+VESPA_TENANT_PORT={ports['VESPA_TENANT_PORT']}
+
+#####
+# Infrastructure - MinIO (S3) (DYNAMICALLY ALLOCATED PORTS)
+#####
+MINIO_PORT={ports['MINIO_PORT']}
+MINIO_CONSOLE_PORT={ports['MINIO_CONSOLE_PORT']}
+S3_ENDPOINT_URL=http://localhost:{ports['MINIO_PORT']}
+S3_FILE_STORE_BUCKET_NAME={get_setting('S3_FILE_STORE_BUCKET_NAME', 'onyx-file-store-bucket')}
+S3_AWS_ACCESS_KEY_ID={get_setting('S3_AWS_ACCESS_KEY_ID', 'minioadmin')}
+S3_AWS_SECRET_ACCESS_KEY={get_setting('S3_AWS_SECRET_ACCESS_KEY', 'minioadmin')}
+
+#####
+# Service Communication
+#####
+MODEL_SERVER_HOST={get_setting('MODEL_SERVER_HOST', 'localhost')}
+INDEXING_MODEL_SERVER_HOST={get_setting('INDEXING_MODEL_SERVER_HOST', 'localhost')}
+INDEXING_MODEL_SERVER_PORT={ports['MODEL_SERVER_PORT']}
+
+#####
+# Container Configuration
+# Container names: onyx_{worktree_name}_<service>
+# Volumes: onyx_{worktree_name}_<service>_data
+#####
+WORKTREE_NAME={worktree_name}
+CONTAINER_PREFIX=onyx_{worktree_name}
+
+#####
+# Development Settings (PRESERVED FROM EXISTING CONFIG)
+#####
+AUTH_TYPE={get_setting('AUTH_TYPE', 'basic')}
+SKIP_WARM_UP={get_setting('SKIP_WARM_UP', 'True')}
+LOG_ONYX_MODEL_INTERACTIONS={get_setting('LOG_ONYX_MODEL_INTERACTIONS', 'True')}
+LOG_LEVEL={get_setting('LOG_LEVEL', 'debug')}
+DISABLE_LLM_DOC_RELEVANCE={get_setting('DISABLE_LLM_DOC_RELEVANCE', 'False')}
+
+# Cloud UI
+NEXT_PUBLIC_CLOUD_ENABLED={get_setting('NEXT_PUBLIC_CLOUD_ENABLED', 'true')}
+
+# Enterprise Features
+ENABLE_PAID_ENTERPRISE_EDITION_FEATURES={get_setting('ENABLE_PAID_ENTERPRISE_EDITION_FEATURES', 'true')}
+ENABLE_PERMISSION_SYNC={get_setting('ENABLE_PERMISSION_SYNC', 'true')}
+NEXT_PUBLIC_ENABLE_PAID_EE_FEATURES={get_setting('NEXT_PUBLIC_ENABLE_PAID_EE_FEATURES', 'true')}
+
+# Email verification
+REQUIRE_EMAIL_VERIFICATION={get_setting('REQUIRE_EMAIL_VERIFICATION', 'False')}
+
+# Extra connectors
+SHOW_EXTRA_CONNECTORS={get_setting('SHOW_EXTRA_CONNECTORS', 'True')}
+
+# Python
+PYTHONPATH={get_setting('PYTHONPATH', '../backend')}
+PYTHONUNBUFFERED={get_setting('PYTHONUNBUFFERED', '1')}
+
+#####
+# API Keys & Model Configuration (PRESERVED FROM EXISTING CONFIG)
+#####
+"""
+
+    # Add preserved API keys and model settings
+    api_key_vars = [
+        "GEN_AI_API_KEY",
+        "OPENAI_API_KEY",
+        "GEN_AI_MODEL_VERSION",
+        "FAST_GEN_AI_MODEL_VERSION",
+        "EXA_API_KEY",
+        "LANGSMITH_API_KEY",
+        "LANGSMITH_PROJECT",
+        "LANGSMITH_ENDPOINT",
+        "LANGSMITH_TRACING",
+    ]
+
+    for var in api_key_vars:
+        if var in existing_settings:
+            env_content += f"{var}={existing_settings[var]}\n"
+
+    # Add agent search configs
+    env_content += f"""
+# Agent Search configs
+AGENT_RETRIEVAL_STATS={get_setting('AGENT_RETRIEVAL_STATS', 'False')}
+AGENT_RERANKING_STATS={get_setting('AGENT_RERANKING_STATS', 'True')}
+AGENT_MAX_QUERY_RETRIEVAL_RESULTS={get_setting('AGENT_MAX_QUERY_RETRIEVAL_RESULTS', '20')}
+AGENT_RERANKING_MAX_QUERY_RETRIEVAL_RESULTS={get_setting('AGENT_RERANKING_MAX_QUERY_RETRIEVAL_RESULTS', '20')}
+
+#####
+# Additional Settings (PRESERVED FROM EXISTING CONFIG)
+#####
+"""
+
+    # Add any other settings that weren't already included
+    included_vars = {
+        "PORT",
+        "WEB_DOMAIN",
+        "INTERNAL_URL",
+        "APP_PORT",
+        "MODEL_SERVER_PORT",
+        "UVICORN_RELOAD",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_PASSWORD",
+        "REDIS_DB_NUMBER",
+        "REDIS_DB_NUMBER_CELERY",
+        "REDIS_DB_NUMBER_CELERY_RESULT_BACKEND",
+        "VESPA_HOST",
+        "VESPA_PORT",
+        "VESPA_TENANT_PORT",
+        "MINIO_PORT",
+        "MINIO_CONSOLE_PORT",
+        "S3_ENDPOINT_URL",
+        "S3_FILE_STORE_BUCKET_NAME",
+        "S3_AWS_ACCESS_KEY_ID",
+        "S3_AWS_SECRET_ACCESS_KEY",
+        "MODEL_SERVER_HOST",
+        "INDEXING_MODEL_SERVER_HOST",
+        "INDEXING_MODEL_SERVER_PORT",
+        "WORKTREE_NAME",
+        "CONTAINER_PREFIX",
+        "AUTH_TYPE",
+        "SKIP_WARM_UP",
+        "LOG_ONYX_MODEL_INTERACTIONS",
+        "LOG_LEVEL",
+        "DISABLE_LLM_DOC_RELEVANCE",
+        "NEXT_PUBLIC_CLOUD_ENABLED",
+        "ENABLE_PAID_ENTERPRISE_EDITION_FEATURES",
+        "ENABLE_PERMISSION_SYNC",
+        "NEXT_PUBLIC_ENABLE_PAID_EE_FEATURES",
+        "REQUIRE_EMAIL_VERIFICATION",
+        "SHOW_EXTRA_CONNECTORS",
+        "PYTHONPATH",
+        "PYTHONUNBUFFERED",
+        "AGENT_RETRIEVAL_STATS",
+        "AGENT_RERANKING_STATS",
+        "AGENT_MAX_QUERY_RETRIEVAL_RESULTS",
+        "AGENT_RERANKING_MAX_QUERY_RETRIEVAL_RESULTS",
+        *api_key_vars,
+    }
+
+    for key, value in existing_settings.items():
+        if key not in included_vars:
+            env_content += f"{key}={value}\n"
+
+    env_file = vscode_dir / ".env"
+    env_file.write_text(env_content)
+    print(f"{Colors.GREEN}  ✓ Created .vscode/.env{Colors.NC}")
+
+    if existing_settings:
+        print(
+            f"{Colors.GREEN}  ✓ Preserved {len(existing_settings)} settings from existing config{Colors.NC}"
+        )
+
+
+def create_web_env_symlink(workspace_root: Path):
+    """Create symlink from web/.env to .vscode/.env for Next.js."""
+    print_step("Step 2b: Creating web/.env symlink...")
+
+    web_dir = workspace_root / "web"
+    web_env = web_dir / ".env"
+    vscode_env = workspace_root / ".vscode" / ".env"
+
+    # Remove existing symlink or file
+    if web_env.exists() or web_env.is_symlink():
+        web_env.unlink()
+
+    # Create relative symlink
+    web_env.symlink_to(os.path.relpath(vscode_env, web_dir))
+    print(f"{Colors.GREEN}  ✓ Created symlink: web/.env -> ../.vscode/.env{Colors.NC}")
+
+
+def generate_launch_json(ports: Dict[str, int], workspace_root: Path):
+    """Generate .vscode/launch.json from template."""
+    print_step("Step 3: Generating .vscode/launch.json from template...")
+
+    template_path = workspace_root / ".vscode" / "launch.template.jsonc"
+
+    if not template_path.exists():
+        print_error(f"Template not found at {template_path}")
+        print(
+            f"{Colors.YELLOW}Skipping launch.json generation. Run this script again after creating the template.{Colors.NC}"
+        )
+        return
+
+    # Read template
+    with open(template_path, "r") as f:
+        content = f.read()
+
+    # Remove JSONC comments while preserving // in strings (like http://)
+    lines = content.split("\n")
+    json_lines = []
+    for line in lines:
+        # Remove inline comments but preserve strings with //
+        if "//" in line:
+            # Find // that's not inside a string
+            in_string = False
+            escape_next = False
+            comment_pos = -1
+
+            for i, char in enumerate(line):
+                if escape_next:
+                    escape_next = False
+                    continue
+
+                if char == "\\":
+                    escape_next = True
+                    continue
+
+                if char == '"':
+                    in_string = not in_string
+                    continue
+
+                # Check for // outside of strings
+                if (
+                    not in_string
+                    and char == "/"
+                    and i + 1 < len(line)
+                    and line[i + 1] == "/"
+                ):
+                    comment_pos = i
+                    break
+
+            # Remove comment if found
+            if comment_pos >= 0:
+                stripped = line[:comment_pos].rstrip()
+                if stripped:
+                    json_lines.append(stripped)
+            else:
+                json_lines.append(line)
+        else:
+            json_lines.append(line)
+
+    content = "\n".join(json_lines)
+
+    # Replace placeholders
+    content = content.replace("${PORT}", str(ports["PORT"]))
+    content = content.replace("${APP_PORT}", str(ports["APP_PORT"]))
+    content = content.replace("${MODEL_SERVER_PORT}", str(ports["MODEL_SERVER_PORT"]))
+
+    # Write launch.json
+    launch_file = workspace_root / ".vscode" / "launch.json"
+    launch_file.write_text(content)
+    print(f"{Colors.GREEN}  ✓ Generated .vscode/launch.json{Colors.NC}")
+
+
+def print_summary(worktree_name: str, ports: Dict[str, int]):
+    """Print setup summary."""
+    print()
+    print_header("Setup Complete!")
+    print()
+    print(f"Worktree: {worktree_name}")
+    print(f"Container prefix: onyx_{worktree_name}")
+    print()
+    print("Allocated Ports:")
+    print(f"  Web:       {ports['PORT']}")
+    print(f"  API:       {ports['APP_PORT']}")
+    print(f"  Model:     {ports['MODEL_SERVER_PORT']}")
+    print(f"  Postgres:  {ports['POSTGRES_PORT']}")
+    print(f"  Redis:     {ports['REDIS_PORT']}")
+    print(f"  Vespa:     {ports['VESPA_PORT']}")
+    print(f"  MinIO:     {ports['MINIO_PORT']}")
+    print()
+    print("Next Steps:")
+    print("  1. Review/edit .vscode/.env (add API keys, etc.)")
+    print("  2. Start containers: python .vscode/start_containers.py")
+    print("  3. Launch services from VSCode: 'Run All Onyx Services'")
+    print()
+
+
+def main():
+    """Main setup function."""
+    try:
+        print_header("Onyx Worktree Setup")
+        print()
+
+        # Detect worktree
+        worktree_name = get_worktree_name()
+        workspace_root = Path(__file__).parent.parent.parent.absolute()
+
+        print(f"Workspace: {workspace_root}")
+        print(f"Worktree name: {worktree_name}")
+        print()
+
+        # Load existing settings (from current worktree or main repo)
+        existing_settings = load_existing_env_settings(workspace_root)
+
+        # Allocate ports
+        ports = allocate_ports()
+
+        # Generate files
+        generate_env_file(worktree_name, ports, workspace_root, existing_settings)
+        create_web_env_symlink(workspace_root)
+        generate_launch_json(ports, workspace_root)
+
+        # Print summary
+        print_summary(worktree_name, ports)
+
+    except Exception as e:
+        print_error(str(e))
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/worktree/start_containers.py
+++ b/scripts/worktree/start_containers.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Docker Container Management for Onyx Worktrees
+
+Starts, stops, and manages Docker containers for development.
+Reads configuration from .vscode/.env file.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+
+
+class Colors:
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    RED = "\033[0;31m"
+    BLUE = "\033[0;34m"
+    NC = "\033[0m"
+
+
+def load_env_file(env_path: Path) -> Dict[str, str]:
+    """Load environment variables from .env file."""
+    env_vars = {}
+    if not env_path.exists():
+        return env_vars
+
+    with open(env_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, value = line.split("=", 1)
+                env_vars[key.strip()] = value.strip()
+
+    return env_vars
+
+
+def run_command(
+    cmd: List[str], check: bool = True, capture: bool = False
+) -> Optional[subprocess.CompletedProcess]:
+    """Run a shell command."""
+    try:
+        if capture:
+            return subprocess.run(cmd, check=check, capture_output=True, text=True)
+        else:
+            return subprocess.run(cmd, check=check)
+    except subprocess.CalledProcessError as e:
+        if check:
+            raise
+        return e
+
+
+class ContainerManager:
+    """Manage Docker containers for Onyx worktree."""
+
+    def __init__(self):
+        """Initialize container manager with environment config."""
+        # Load .vscode/.env file
+        script_dir = Path(__file__).parent
+        workspace_root = script_dir.parent.parent
+        env_file = workspace_root / ".vscode" / ".env"
+
+        if not env_file.exists():
+            print(f"{Colors.RED}ERROR: .vscode/.env file not found!{Colors.NC}")
+            print(
+                f"{Colors.YELLOW}Please run: python3 scripts/worktree/setup_worktree.py{Colors.NC}"
+            )
+            sys.exit(1)
+
+        # Load environment variables from file
+        env_vars = load_env_file(env_file)
+
+        # Apply to current environment
+        for key, value in env_vars.items():
+            os.environ[key] = value
+
+        print(f"{Colors.BLUE}Loaded configuration from {env_file}{Colors.NC}")
+
+        # Get configuration with validation
+        self.container_prefix = os.getenv("CONTAINER_PREFIX")
+        self.worktree_name = os.getenv("WORKTREE_NAME", "")
+
+        # SAFETY CHECK: Prevent destroying main instance containers
+        if not self.container_prefix:
+            print(
+                f"{Colors.RED}ERROR: CONTAINER_PREFIX not set in .vscode/.env{Colors.NC}"
+            )
+            print(
+                f"{Colors.YELLOW}Please run: python3 scripts/worktree/setup_worktree.py{Colors.NC}"
+            )
+            sys.exit(1)
+
+        if self.container_prefix == "onyx":
+            print(
+                f"{Colors.RED}ERROR: CONTAINER_PREFIX='onyx' is reserved for main instance!{Colors.NC}"
+            )
+            print(
+                f"{Colors.YELLOW}Worktrees should use a different prefix (e.g., 'onyx_dev1').{Colors.NC}"
+            )
+            print(
+                f"{Colors.YELLOW}Please run: python3 scripts/worktree/setup_worktree.py{Colors.NC}"
+            )
+            sys.exit(1)
+
+        # Display configuration
+        print(f"{Colors.GREEN}Container Prefix: {self.container_prefix}{Colors.NC}")
+        if self.worktree_name:
+            print(f"{Colors.GREEN}Worktree Name: {self.worktree_name}{Colors.NC}")
+
+        # Port configuration
+        self.postgres_port = os.getenv("POSTGRES_PORT", "5432")
+        self.redis_port = os.getenv("REDIS_PORT", "6379")
+        self.vespa_port = os.getenv("VESPA_PORT", "8081")
+        self.vespa_tenant_port = os.getenv("VESPA_TENANT_PORT", "19071")
+        self.minio_port = os.getenv("MINIO_PORT", "9004")
+        self.minio_console_port = os.getenv("MINIO_CONSOLE_PORT", "9005")
+
+        # Container names
+        self.postgres_container = f"{self.container_prefix}_postgres"
+        self.redis_container = f"{self.container_prefix}_redis"
+        self.vespa_container = f"{self.container_prefix}_vespa"
+        self.minio_container = f"{self.container_prefix}_minio"
+
+        # Volume names
+        self.postgres_volume = f"{self.container_prefix}_postgres_data"
+        self.redis_volume = f"{self.container_prefix}_redis_data"
+        self.vespa_volume = f"{self.container_prefix}_vespa_data"
+        self.minio_volume = f"{self.container_prefix}_minio_data"
+
+    def stop_containers(self):
+        """Stop all containers."""
+        print(f"{Colors.YELLOW}Stopping existing containers...{Colors.NC}")
+        containers = [
+            self.postgres_container,
+            self.vespa_container,
+            self.redis_container,
+            self.minio_container,
+        ]
+
+        for container in containers:
+            run_command(["docker", "stop", container], check=False, capture=True)
+            run_command(["docker", "rm", container], check=False, capture=True)
+
+    def start_postgres(self):
+        """Start PostgreSQL container."""
+        print(f"{Colors.GREEN}Starting PostgreSQL container...{Colors.NC}")
+
+        cmd = [
+            "docker",
+            "run",
+            "-p",
+            f"{self.postgres_port}:5432",
+            "--name",
+            self.postgres_container,
+            "-e",
+            "POSTGRES_PASSWORD=password",
+            "-d",
+            "-v",
+            f"{self.postgres_volume}:/var/lib/postgresql/data",
+            "postgres",
+            "-c",
+            "max_connections=250",
+        ]
+
+        run_command(cmd)
+
+    def start_vespa(self):
+        """Start Vespa container."""
+        print(f"{Colors.GREEN}Starting Vespa container...{Colors.NC}")
+
+        cmd = [
+            "docker",
+            "run",
+            "--detach",
+            "--name",
+            self.vespa_container,
+            "--hostname",
+            "vespa-container",
+            "--publish",
+            f"{self.vespa_port}:8081",
+            "--publish",
+            f"{self.vespa_tenant_port}:19071",
+            "-v",
+            f"{self.vespa_volume}:/opt/vespa/var",
+            "vespaengine/vespa:8",
+        ]
+
+        run_command(cmd)
+
+    def start_redis(self):
+        """Start Redis container."""
+        print(f"{Colors.GREEN}Starting Redis container...{Colors.NC}")
+
+        cmd = [
+            "docker",
+            "run",
+            "--detach",
+            "--name",
+            self.redis_container,
+            "--publish",
+            f"{self.redis_port}:6379",
+            "-v",
+            f"{self.redis_volume}:/data",
+            "redis",
+        ]
+
+        run_command(cmd)
+
+    def start_minio(self):
+        """Start MinIO container."""
+        print(f"{Colors.GREEN}Starting MinIO container...{Colors.NC}")
+
+        cmd = [
+            "docker",
+            "run",
+            "--detach",
+            "--name",
+            self.minio_container,
+            "--publish",
+            f"{self.minio_port}:9000",
+            "--publish",
+            f"{self.minio_console_port}:9001",
+            "-e",
+            "MINIO_ROOT_USER=minioadmin",
+            "-e",
+            "MINIO_ROOT_PASSWORD=minioadmin",
+            "-v",
+            f"{self.minio_volume}:/data",
+            "minio/minio",
+            "server",
+            "/data",
+            "--console-address",
+            ":9001",
+        ]
+
+        run_command(cmd)
+
+    def run_migrations(self):
+        """Run Alembic migrations."""
+        print(f"{Colors.GREEN}Running Alembic migration...{Colors.NC}")
+
+        # Give Postgres a moment to start
+        print(f"{Colors.YELLOW}Waiting for PostgreSQL to be ready...{Colors.NC}")
+        time.sleep(3)
+
+        # Find backend directory
+        script_dir = Path(__file__).parent
+        workspace_root = script_dir.parent.parent
+        backend_dir = workspace_root / "backend"
+
+        if backend_dir.exists():
+            original_dir = Path.cwd()
+            try:
+                os.chdir(backend_dir)
+                run_command(["alembic", "upgrade", "head"])
+            finally:
+                os.chdir(original_dir)
+        else:
+            print(
+                f"{Colors.YELLOW}Backend directory not found, skipping migrations{Colors.NC}"
+            )
+
+    def print_summary(self):
+        """Print summary of configuration and next steps."""
+        # Get application ports
+        port = os.getenv("PORT", "3000")
+        app_port = os.getenv("APP_PORT", "8080")
+        model_server_port = os.getenv("MODEL_SERVER_PORT", "9000")
+        slack_bot_metrics_port = os.getenv("SLACK_BOT_METRICS_PORT", "8000")
+
+        print()
+        print(f"{Colors.BLUE}{'='*60}{Colors.NC}")
+        print(f"{Colors.GREEN}Onyx Worktree Containers Started{Colors.NC}")
+        print(f"{Colors.BLUE}{'='*60}{Colors.NC}")
+        print()
+
+        if self.worktree_name:
+            print(f"{Colors.YELLOW}Worktree:{Colors.NC} {self.worktree_name}")
+        print(f"{Colors.YELLOW}Container Prefix:{Colors.NC} {self.container_prefix}")
+        print()
+
+        print(f"{Colors.BLUE}Application Ports:{Colors.NC}")
+        print(f"  Next.js Web:       http://localhost:{port}")
+        print(f"  API Server:        http://localhost:{app_port}")
+        print(f"  Model Server:      http://localhost:{model_server_port}")
+        print(f"  Slack Bot Metrics: http://localhost:{slack_bot_metrics_port}")
+        print()
+
+        print(f"{Colors.BLUE}Infrastructure Ports:{Colors.NC}")
+        print(f"  PostgreSQL:        localhost:{self.postgres_port}")
+        print(f"  Redis:             localhost:{self.redis_port}")
+        print(f"  Vespa:             http://localhost:{self.vespa_port}")
+        print(f"  Vespa Tenant:      http://localhost:{self.vespa_tenant_port}")
+        print(f"  MinIO API:         http://localhost:{self.minio_port}")
+        print(f"  MinIO Console:     http://localhost:{self.minio_console_port}")
+        print()
+
+        print(f"{Colors.BLUE}Running Containers:{Colors.NC}")
+        print(f"  {self.postgres_container}")
+        print(f"  {self.redis_container}")
+        print(f"  {self.vespa_container}")
+        print(f"  {self.minio_container}")
+        print()
+
+        print(f"{Colors.GREEN}Next Steps:{Colors.NC}")
+        print("  1. Open VSCode Run & Debug panel (Cmd+Shift+D)")
+        print('  2. Select "Run All Onyx Services"')
+        print("  3. Click Start")
+        print(f"  4. Access application at http://localhost:{port}")
+        print()
+        print(f"{Colors.BLUE}{'='*60}{Colors.NC}")
+        print()
+
+    def start_all(self):
+        """Start all containers."""
+        try:
+            self.stop_containers()
+            self.start_postgres()
+            self.start_vespa()
+            self.start_redis()
+            self.start_minio()
+            self.run_migrations()
+
+            self.print_summary()
+
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}Error starting containers: {e}{Colors.NC}")
+            self.stop_containers()
+            raise
+
+
+def main():
+    """Main entry point."""
+    manager = ContainerManager()
+    manager.start_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8608,6 +8608,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18959,6 +18960,111 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.1.tgz",
+      "integrity": "sha512-kETZBocRux3xITiZtOtVoVvXyQLB7VBxN7L6EPqgI5paZiUlnsgYv4q8diTNYeHmF9EiehydOBo20lTttCbHAg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.1.tgz",
+      "integrity": "sha512-hWg3BtsxQuSKhfe0LunJoqxjO4NEpBmKkE+P2Sroos7yB//OOX3jD5ISP2wv8QdUwtRehMdwYz6VB50mY6hqAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.1.tgz",
+      "integrity": "sha512-UPnOvYg+fjAhP3b1iQStcYPWeBFRLrugEyK/lDKGk7kLNua8t5/DvDbAEFotfV1YfcOY6bru76qN9qnjLoyHCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.1.tgz",
+      "integrity": "sha512-Et81SdWkcRqAJziIgFtsFyJizHoWne4fzJkvjd6V4wEkWTB4MX6J0uByUb0peiJQ4WeAt6GGmMszE5KrXK6WKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.1.tgz",
+      "integrity": "sha512-qBbgYEBRrC1egcG03FZaVfVxrJm8wBl7vr8UFKplnxNRprctdP26xEv9nJ07Ggq4y1adwa0nz2mz83CELY7N6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.1.tgz",
+      "integrity": "sha512-cPuBjYP6I699/RdbHJonb3BiRNEDm5CKEBuJ6SD8k3oLam2fDRMKAvmrli4QMDgT2ixyRJ0+DTkiODbIQhRkeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.1.tgz",
+      "integrity": "sha512-XeEUJsE4JYtfrXe/LaJn3z1pD19fK0Q6Er8Qoufi+HqvdO4LEPyCxLUt4rxA+4RfYo6S9gMlmzCMU2F+AatFqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
## Description

TODO

## How Has This Been Tested?

TODO

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dynamic service ports and add worktree tooling so each git worktree runs its own isolated containers and ports. This lets you run multiple local Onyx instances without conflicts, with simple VSCode integration.

- **New Features**
  - Added scripts/worktree/setup_worktree.py to allocate free ports, preserve non-port env vars, and generate .vscode/.env and launch.json.
  - Added scripts/worktree/start_containers.py to start Postgres, Redis, Vespa, and MinIO with per-worktree names and volumes, then run migrations.
  - Updated .vscode/launch.template.jsonc to use env-driven ports (${PORT}, ${APP_PORT}, ${MODEL_SERVER_PORT}), load .vscode/.env, and add “Start Worktree Containers”.
  - Backend now reads APP_PORT from env; Slack bot metrics port is configurable via SLACK_BOT_METRICS_PORT. .gitignore ignores generated .vscode/.env and launch.json.

- **Migration**
  - In each worktree, run: python3 scripts/worktree/setup_worktree.py, then start containers: python3 scripts/worktree/start_containers.py or VSCode “Start Worktree Containers”.
  - Launch services via VSCode “Run All Onyx Services”. Access web at http://localhost:${PORT}.
  - Do not commit .vscode/.env or .vscode/launch.json (they’re generated and gitignored).

<sup>Written for commit 6de59a98449c6cb8f111f0dc8d20ba517e4c2386. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

