### PR TITLE
fix(ui): Make Private Groups selectable again

### DIFF
--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -118,17 +118,9 @@ export function AccessTypeGroupSelector({
                 <div className="animate-pulse bg-background-200 h-8 w-32 rounded" />
               ) : (
                 <Text mainUiMuted text03>
-                  {isAdmin ? (
-                    <>
-                      This Connector will be visible/accessible by the groups
-                      selected below
-                    </>
-                  ) : (
-                    <>
-                      Curators must select one or more groups to give access to
-                      this Connector
-                    </>
-                  )}
+                  {isAdmin
+                    ? "This Connector will be visible/accessible by the groups selected below"
+                    : "Curators must select one or more groups to give access to this Connector"}
                 </Text>
               )}
             </div>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
When a user goes and tries to create a new connector and makes it private, there is no feedback to select the user group.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested it locally to ensure that we are able to select the User Groups properly.

Before:
<img width="848" height="1168" alt="Screenshot 2025-11-07 at 10 15 21 AM" src="https://github.com/user-attachments/assets/95e6a246-93a8-495c-aaa6-c952cff98cad" />

After:
<img width="818" height="1292" alt="Screenshot 2025-11-07 at 10 15 07 AM" src="https://github.com/user-attachments/assets/dffc7eff-b9bd-40de-bfb5-ffbfaacca6ef" />

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores private group selection when creating a connector, with clear visual feedback and working select/deselect. Updates the UI to use our new Text and Button components for consistent styling.

- **Bug Fixes**
  - Replaced custom group chips with Button (with active state and SvgUsers) so selection works.
  - Added loading skeleton and concise helper text via Text; improved spacing and layout.
  - Removed FiUsers and old styles to align with refresh-components.

<sup>Written for commit ad690fc7b5f85d11d6590516dcfd6e3fefeb2e3e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



