### PR TITLE
fix: openapi generation required fields

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -330,6 +330,10 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     application = FastAPI(
         title="Onyx Backend",
         version=__version__,
+        description="Onyx API for AI-powered chat with search, document indexing, agents, actions, and more",
+        servers=[
+            {"url": f"{WEB_DOMAIN.rstrip('/')}/api", "description": "Onyx API Server"}
+        ],
         lifespan=lifespan_override or lifespan,
     )
     if SENTRY_DSN:


### PR DESCRIPTION
## Description

- Using our OpenAPI (actions) parser as a barometer, the schema we generate for Onyx is not valid/complete --> there are many more issues, but this is the super easy stuff to do for rn

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check
