### PR TITLE
fix: default toggle off for unavailable tools

### DIFF
--- a/web/src/app/admin/configuration/default-assistant/page.tsx
+++ b/web/src/app/admin/configuration/default-assistant/page.tsx
@@ -233,7 +233,7 @@ function DefaultAssistantConfig() {
                 <ToolToggle
                   key={tool.id}
                   tool={tool}
-                  enabled={enabledTools.has(tool.id)}
+                  enabled={enabledTools.has(tool.id) && tool.is_available}
                   onToggle={() => handleToggleTool(tool.id)}
                   disabled={savingTools.has(tool.id)}
                 />


### PR DESCRIPTION
## Description

<img width="1147" height="158" alt="image" src="https://github.com/user-attachments/assets/f2dd624a-114e-4010-9dc2-a54bcc562a90" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tool toggles in the Default Assistant configuration now default to off for unavailable tools, so disabled tools no longer appear enabled. This ensures the UI accurately reflects tool availability.

<sup>Written for commit 5d7b51ff59a14ff0387f9f02875aea1b1920eca1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

