### PR TITLE
fix(tool): Hide Okta Tool

### DIFF
--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -9,6 +9,7 @@ from onyx.db.models import Persona
 from onyx.db.models import PersonaLabel
 from onyx.db.models import StarterMessage
 from onyx.server.features.document_set.models import DocumentSetSummary
+from onyx.server.features.tool.models import should_expose_tool_to_fe
 from onyx.server.features.tool.models import ToolSnapshot
 from onyx.server.models import MinimalUserSnapshot
 from onyx.utils.logger import setup_logger
@@ -127,7 +128,11 @@ class MinimalPersonaSnapshot(BaseModel):
             id=persona.id,
             name=persona.name,
             description=persona.description,
-            tools=[ToolSnapshot.from_model(tool) for tool in persona.tools],
+            tools=[
+                ToolSnapshot.from_model(tool)
+                for tool in persona.tools
+                if should_expose_tool_to_fe(tool)
+            ],
             starter_messages=persona.starter_messages,
             llm_relevance_filter=persona.llm_relevance_filter,
             llm_filter_extraction=persona.llm_filter_extraction,
@@ -204,7 +209,11 @@ class PersonaSnapshot(BaseModel):
             starter_messages=persona.starter_messages,
             llm_relevance_filter=persona.llm_relevance_filter,
             llm_filter_extraction=persona.llm_filter_extraction,
-            tools=[ToolSnapshot.from_model(tool) for tool in persona.tools],
+            tools=[
+                ToolSnapshot.from_model(tool)
+                for tool in persona.tools
+                if should_expose_tool_to_fe(tool)
+            ],
             labels=[PersonaLabelSnapshot.from_model(label) for label in persona.labels],
             owner=(
                 MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)
@@ -266,7 +275,11 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 for user in persona.users
             ],
             groups=[user_group.id for user_group in persona.groups],
-            tools=[ToolSnapshot.from_model(tool) for tool in persona.tools],
+            tools=[
+                ToolSnapshot.from_model(tool)
+                for tool in persona.tools
+                if should_expose_tool_to_fe(tool)
+            ],
             labels=[PersonaLabelSnapshot.from_model(label) for label in persona.labels],
             owner=(
                 MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -19,6 +19,7 @@ from onyx.db.tools import get_tools
 from onyx.db.tools import update_tool
 from onyx.server.features.tool.models import CustomToolCreate
 from onyx.server.features.tool.models import CustomToolUpdate
+from onyx.server.features.tool.models import should_expose_tool_to_fe
 from onyx.server.features.tool.models import ToolSnapshot
 from onyx.tools.built_in_tools import get_built_in_tool_by_id
 from onyx.tools.tool_implementations.custom.openapi_parsing import MethodSpec
@@ -186,6 +187,9 @@ def list_tools(
 
     filtered_tools: list[ToolSnapshot] = []
     for tool in tools:
+        if not should_expose_tool_to_fe(tool):
+            continue
+
         # Check if it's a built-in tool and if it's available
         if tool.in_code_tool_id:
             try:

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -5,6 +5,17 @@ from pydantic import BaseModel
 from onyx.db.models import Tool
 
 
+HIDDEN_TOOL_IDS = {"OktaProfileTool"}
+
+
+def should_expose_tool_to_fe(tool: Tool) -> bool:
+    """Return True when the given tool should be sent to the frontend."""
+    if tool.in_code_tool_id is None:
+        return True
+
+    return tool.in_code_tool_id not in HIDDEN_TOOL_IDS
+
+
 class ToolSnapshot(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Hiding the Okta Tool.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Okta tool in the UI by excluding OktaProfileTool from all tool data sent to the frontend. Users will no longer see or select the Okta tool in personas or the tools list.

- **Bug Fixes**
  - Added should_expose_tool_to_fe with HIDDEN_TOOL_IDS = {"OktaProfileTool"}.
  - Filtered tools in list_tools API and when building persona tool snapshots.
  - No impact to custom tools or other built-in tool availability checks.

<sup>Written for commit 1553c4b762ee063a4d4abfd69502887a4f32bf15. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

