### PR TITLE
chore(gha): reduce size of pr-quality-check instance

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
-        with:
-          metrics: cpu,memory
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Description

Reduces the instance size and converts it to a graviton instance for cost reduction.

## How Has This Been Tested?

Ran over all hooks here: https://github.com/onyx-dot-app/onyx/actions/runs/19184165110/job/54847343852

## Additional Options

- [x] Override Linear Check












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the PR quality-checks GitHub Actions runner size to cut costs by switching from 8cpu-linux-x64 to 2cpu-linux-arm64 (Graviton). Added a metrics step to capture CPU and memory during runs.

<sup>Written for commit 7f418f7119aadb43fbbab83d9cf40d4e9fd65cab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











