### PR TITLE
fix(gha): fix terraform pre-commit test

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # ratchet:hashicorp/setup-terraform@v3
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # ratchet:pre-commit/action@v3.0.1
         with:
           extra_args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || '' }}


### PR DESCRIPTION
## Description

`terraform` isn't installed on the CI runner, so this step [complains](https://github.com/onyx-dot-app/onyx/actions/runs/19182954110/job/54843754614#step:5:229),

```
terraform fmt............................................................Failed
- hook id: terraform-fmt
- exit code: 1

Executable `terraform` not found
```

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19183015503/job/54843943369#step:6:234

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Terraform in the PR quality checks workflow to fix the failing terraform-fmt pre-commit hook in CI. Adds hashicorp/setup-terraform@v3 so the hook runs as expected.

<sup>Written for commit 56bb48810cadeb27f2d6a19838f850b60c9ce124. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

