### PR TITLE
fix(chat): Adding buffer for instructions

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -935,8 +935,8 @@ def _fast_message_stream(
 ) -> Generator[Packet, None, None]:
     # TODO: clean up this jank
     is_responses_api = isinstance(llm_model, OpenAIResponsesModel)
-    prompt_builder = getattr(answer.graph_inputs, "prompt_builder", None)
-    primary_llm = getattr(answer.graph_tooling, "primary_llm", None)
+    prompt_builder = answer.graph_inputs.prompt_builder
+    primary_llm = answer.graph_tooling.primary_llm
     if prompt_builder and primary_llm:
         _reserve_prompt_tokens_for_agent_overhead(
             prompt_builder, primary_llm, tools, prompt_config


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding a small fix for the errors we were seeing with some customers:
```
ERROR:    11/07/2025 09:15:25 PM             process_message.py  864: [API:pjk_Pyv7] Failed to process chat message due to Your input exceeds the context window of this model. Please adjust your input and try again.
Traceback (most recent call last):
  File "/app/onyx/chat/process_message.py", line 832, in stream_chat_message_objects
    yield from _fast_message_stream(
  File "/app/onyx/chat/turn/infra/chat_turn_event_stream.py", line 52, in wrapper
    raise pkt.obj.exception
  File "/app/onyx/chat/turn/infra/chat_turn_event_stream.py", line 39, in run_with_exception_capture
    turn_func(messages, dependencies, *args, **kwargs)
  File "/app/onyx/chat/turn/fast_chat_turn.py", line 268, in fast_chat_turn
    _fast_chat_turn_core(
  File "/app/onyx/chat/turn/fast_chat_turn.py", line 211, in _fast_chat_turn_core
    _run_agent_loop(
  File "/app/onyx/chat/turn/fast_chat_turn.py", line 134, in _run_agent_loop
    streamed, tool_call_events = _process_stream(
                                 ^^^^^^^^^^^^^^^^
  File "/app/onyx/chat/turn/fast_chat_turn.py", line 297, in _process_stream
    for ev in agent_stream:
  File "/app/onyx/agents/agent_sdk/sync_agent_stream_adapter.py", line 76, in __iter__
    raise self._exc
  File "/app/onyx/agents/agent_sdk/sync_agent_stream_adapter.py", line 140, in worker
    async for ev in self.streamed.stream_events():
  File "/usr/local/lib/python3.11/site-packages/agents/result.py", line 270, in stream_events
    raise self._stored_exception
  File "/usr/local/lib/python3.11/site-packages/agents/run.py", line 1012, in _start_streaming
    turn_result = await cls._run_single_turn_streamed(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/agents/run.py", line 1237, in _run_single_turn_streamed
    async for event in model.stream_response(
  File "/usr/local/lib/python3.11/site-packages/agents/models/openai_responses.py", line 185, in stream_response
    async for chunk in stream:
  File "/usr/local/lib/python3.11/site-packages/openai/_streaming.py", line 147, in __aiter__
    async for item in self._iterator:
  File "/usr/local/lib/python3.11/site-packages/openai/_streaming.py", line 193, in __stream__
    raise APIError(
openai.APIError: Your input exceeds the context window of this model. Please adjust your input and try again.
```

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally with small models with hardcoded limits

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents context-window overflow in chat by reserving tokens for agent overhead (tool schemas and custom instructions) before building prompts. Reduces “input exceeds the context window” errors for small-context models.

- **Bug Fixes**
  - Deducts tool schema and custom instruction tokens from prompt_builder.max_tokens using the model’s tokenizer.
  - Gracefully logs and skips reservation if tokenizer or token computation fails.
  - Applies only when prompt_builder and primary_llm are present; otherwise no change.

<sup>Written for commit 5886919e943f7a609469ed4e304565d394023b63. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



