### PR TITLE
chore(gha): pr-python-checks instance update

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -93,7 +93,9 @@ def get_access_for_documents(
     versioned_get_access_for_documents_fn = fetch_versioned_implementation(
         "onyx.access.access", "_get_access_for_documents"
     )
-    return versioned_get_access_for_documents_fn(document_ids, db_session)  # type: ignore
+    return versioned_get_access_for_documents_fn(
+        document_ids, db_session
+    )  # type: ignore
 
 
 def _get_acl_for_user(user: User | None, db_session: Session) -> set[str]:


### PR DESCRIPTION
## Description

Optimizes the instance that runs the python checks (mypy). Mypy is single-threaded and incremental (after I fixed caching here hopefully), so 2 cpu should be sufficient. Similarly, mypy seems quite optimized and in my experiments (N=2) is 3x slower on arm than x64, so keep x64 arch.


## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check






















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the mypy check to the 2cpu-linux-x64 runner, enable CPU/memory metrics, and use runs-on/cache for the mypy cache. Add caching for the uv cache directory to speed up setup.

<sup>Written for commit ed676426810d3df55247c98c9d72b39d3f754766. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





















