### PR TITLE
fix: infinite render on embedding model page

### DIFF
--- a/web/src/components/context/EmbeddingContext.tsx
+++ b/web/src/components/context/EmbeddingContext.tsx
@@ -33,8 +33,8 @@ export const EmbeddingFormProvider: React.FC<{
   const pathname = usePathname();
 
   // Initialize formStep based on the URL parameter
-  const initialStep = parseInt(searchParams?.get("step") || "0", 10);
-  const [formStep, setFormStep] = useState(initialStep);
+  const stepFromUrl = parseInt(searchParams?.get("step") || "0", 10);
+  const [formStep, setFormStep] = useState(stepFromUrl);
   const [formValues, setFormValues] = useState<Record<string, any>>({});
 
   const [allowAdvanced, setAllowAdvanced] = useState(false);
@@ -53,9 +53,6 @@ export const EmbeddingFormProvider: React.FC<{
     setFormStep(2);
   };
 
-  // Extract the specific step value from URL to use as dependency
-  const stepFromUrl = searchParams?.get("step");
-
   useEffect(() => {
     // Update URL when formStep changes
     const updatedSearchParams = new URLSearchParams(
@@ -70,15 +67,14 @@ export const EmbeddingFormProvider: React.FC<{
     } else if (newUrl !== pathname) {
       router.push(newUrl);
     }
-  }, [formStep, router, pathname, stepFromUrl]);
+  }, [formStep, router, pathname]);
 
   // Update formStep when URL changes
   useEffect(() => {
-    const stepValue = parseInt(stepFromUrl || "0", 10);
-    if (stepValue !== formStep) {
-      setFormStep(stepValue);
+    if (stepFromUrl !== formStep) {
+      setFormStep(stepFromUrl);
     }
-  }, [stepFromUrl, formStep]);
+  }, [stepFromUrl]);
 
   const contextValue: EmbeddingFormContextType = {
     formStep,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite render loop on the Embedding model page by correcting effect dependencies for syncing the form step with the URL. The URL and state now stay in sync without re-triggered renders.

- **Bug Fixes**
  - Initialize formStep from stepFromUrl and depend on stepFromUrl for URL→state sync.
  - Remove searchParams from the URL update effect to prevent push loops.

<sup>Written for commit 8c004fda74c0069b984a86ec296255abf4cf31d7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

