### PR TITLE
feat(gha): enable npm caching in CI

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # ratchet:actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: ./web/package-lock.json
 
       - name: Install node dependencies
         working-directory: ./web

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -176,6 +176,8 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # ratchet:actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: ./web/package-lock.json
 
       - name: Install node dependencies
         working-directory: ./web


### PR DESCRIPTION
## Description



## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable npm caching in GitHub Actions for the Jest and Playwright workflows to speed up installs and reduce CI time. Uses setup-node’s npm cache with web/package-lock.json as the dependency path.

<sup>Written for commit 318d80bc7ced46a2975493511780924f7679f62a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



