### PR TITLE
chore(gha): migrate playwright tests to runs-on

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       # needed for pulling external images otherwise, we hit the "Unauthenticated users" limit
       # https://docs.docker.com/docker-hub/usage/
@@ -41,7 +41,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Web Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # ratchet:docker/build-push-action@v4
         with:
           context: ./web
           file: ./web/Dockerfile
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       # needed for pulling external images otherwise, we hit the "Unauthenticated users" limit
       # https://docs.docker.com/docker-hub/usage/
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Backend Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # ratchet:docker/build-push-action@v4
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       # needed for pulling external images otherwise, we hit the "Unauthenticated users" limit
       # https://docs.docker.com/docker-hub/usage/
@@ -103,7 +103,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Model Server Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # ratchet:docker/build-push-action@v4
         with:
           context: ./backend
           file: ./backend/Dockerfile.model_server


### PR DESCRIPTION
## Description


## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check


















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Playwright CI workflow to runs-on runners and simplified Docker builds. Removes explicit AWS ECR setup, adds build caching, and runs on arm64 with runner metrics.

- **Refactors**
  - Moved jobs to runs-on linux arm64 with per-run ID; sized runners per job (web 4cpu, backend/model 2cpu, tests 8cpu) and enabled CPU/memory metrics on key jobs.
  - Removed AWS ECR auth; switched to RUNS_ON_ECR_CACHE tags for push/pull and retagged for docker-compose.
  - Added Docker cache-from/cache-to for web, backend, and model server.

- **Dependencies**
  - Replaced useblacksmith actions with docker/setup-buildx-action v3 and docker/build-push-action v4.
  - Added Docker Hub login to build jobs and kept it in tests (moved after env setup) to avoid rate limits.

<sup>Written for commit 9554736f85238548fd2988bc020fe32c09161922. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















