### PR TITLE
feat(api): Paginated Document Search

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/query_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/query_backend.py
@@ -154,6 +154,9 @@ def handle_search_request(
         for section in top_sections
     ]
 
+    # Track whether the underlying retrieval produced more items than requested
+    has_more_results = len(top_docs) > pagination_limit
+
     # Deduping happens at the last step to avoid harming quality by dropping content early on
     deduped_docs = top_docs
     dropped_inds = None
@@ -174,13 +177,13 @@ def handle_search_request(
 
     paginated_docs = deduped_docs[:pagination_limit]
     llm_indices = [index for index in llm_indices if index < len(paginated_docs)]
-    has_more = len(deduped_docs) > len(paginated_docs)
+    has_more = has_more_results
     pagination = DocumentSearchPagination(
         offset=pagination_offset,
         limit=pagination_limit,
         returned_count=len(paginated_docs),
         has_more=has_more,
-        next_offset=(pagination_offset + len(paginated_docs)) if has_more else None,
+        next_offset=(pagination_offset + pagination_limit) if has_more else None,
     )
 
     return DocumentSearchResponse(


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Our current document search does not allow for pagination but this should be a short-term solution to add this functionality into the codebase

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options
Hit locally:

```
curl -X POST http://localhost:3000/api/query/document-search \
  -H "Authorization: Bearer on_***REDACTED***" \
  -H "Content-Type: application/json" \
  -d '{
        "message": "reset okta password",
        "search_type": "semantic",
        "retrieval_options": { "limit": 5, "offset": 0 },
        "evaluation_type": "basic"
      }'

# Response (truncated)
{
  "top_documents": [
    {
      "document_id": "FILE_CONNECTOR__f23d628b-f9b7-4f78-8a64-fef913df3bc3",
      "semantic_identifier": "Microsoft Entra ID OIDC Guide (3).pdf",
      ...
    },
    ...
  ],
  "llm_indices": [],
  "pagination": {
    "offset": 0,
    "limit": 5,
    "returned_count": 5,
    "has_more": true,
    "next_offset": 5
  }
}
```


- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pagination to the /query/document-search API so clients can fetch results in pages. The response now includes a pagination object, and limit/offset are normalized with safe defaults and validation.

- **New Features**
  - Adds pagination to DocumentSearchResponse with offset, limit, returned_count, has_more, next_offset.
  - Defaults: limit uses NUM_RETURNED_HITS when missing; offset defaults to 0.
  - Validation: limit must be > 0; offset cannot be negative (returns 400 on invalid input).
  - Over-fetches by 1 to set has_more; next_offset computed for easy paging.
  - llm_indices are filtered to match the paginated results only.

<sup>Written for commit 73982fe939b511749fe1308e3959a49e84e02cba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



