### PR TITLE
fix(cohere): Add Billing Handler

### DIFF
--- a/backend/onyx/natural_language_processing/exceptions.py
+++ b/backend/onyx/natural_language_processing/exceptions.py
@@ -2,3 +2,9 @@ class ModelServerRateLimitError(Exception):
     """
     Exception raised for rate limiting errors from the model server.
     """
+
+
+class CohereBillingLimitError(Exception):
+    """
+    Raised when Cohere rejects requests because the billing cap is reached.
+    """


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We are seeing massive spam by Cohere so just handling it properly so that we can fail gracefully instead of spamming our API logs

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally with an expired key

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle Cohere billing-cap errors in reranking to prevent noisy logs and keep search running. When Cohere returns 402, we skip reranking and return the original ordering with a warning.

- **Bug Fixes**
  - Added CohereBillingLimitError to NLP exceptions.
  - Catch Cohere ApiError(402) in cohere_rerank_api and raise CohereBillingLimitError.
  - In semantic_reranking, handle CohereBillingLimitError by skipping rerank and returning chunks as-is; log a warning.

<sup>Written for commit 873c0a7593b84e89e423be9b327bfa2e68a45ad8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

