### PR TITLE
feat(vespa): Add deployment update workflow

### DIFF
--- a/backend/ee/onyx/document_index/vespa/app_config/cloud-deployment.xml.jinja
+++ b/backend/ee/onyx/document_index/vespa/app_config/cloud-deployment.xml.jinja
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<deployment version="1.0">
+    <prod>
+        <region>aws-us-east-1c</region>
+    </prod>
+
+    <!-- AWS PrivateLink Configuration -->
+    <!-- Enable private endpoints to allow VPC connectivity from your AWS account -->
+    <!-- This eliminates the need for NAT gateways and reduces data transfer costs -->
+    <endpoints>
+        <endpoint type="private" container-id="default">
+            <!-- Replace with your AWS account ID -->
+            <allow with="aws-private-link" arn="arn:aws:iam::{{ aws_account_id }}:root" />
+        </endpoint>
+
+        <!-- Optional: Disable public zone endpoints for additional security -->
+        <!-- Uncomment the line below to disable public access -->
+        <!-- <endpoint type="zone" container-id="default" enabled="false" /> -->
+    </endpoints>
+</deployment>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a templated Vespa deployment.xml and updates the Vespa tooling to generate it, enabling AWS PrivateLink and a defined prod region. This improves secure VPC connectivity and makes deployments scriptable.

- New Features
  - Added cloud-deployment.xml.jinja with prod region and PrivateLink endpoint (optional public endpoint disable).
  - Extended onyx_vespa_schemas.py with write_deployment_xml(), plus --deployment-template and --aws-account-id flags to render deployment.xml.

<sup>Written for commit d2f4ea1ddab8b69fe50f802c9f4e6ffe3a60532b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

