### PR TITLE
fix(pegasus): Cleanup

### DIFF
--- a/backend/tests/unit/onyx/llm/test_model_map.py
+++ b/backend/tests/unit/onyx/llm/test_model_map.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import litellm
 
+from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.llm.utils import find_model_obj
 from onyx.llm.utils import get_model_map
 
@@ -77,3 +78,20 @@ def test_no_overwrite_in_model_map() -> None:
         assert result["is_correct"] is True
 
     get_model_map.cache_clear()
+
+
+def test_twelvelabs_pegasus_override_present() -> None:
+    get_model_map.cache_clear()
+    try:
+        model_map = get_model_map()
+        model_obj = find_model_obj(
+            model_map,
+            "twelvelabs",
+            "us.twelvelabs.pegasus-1-2-v1:0",
+        )
+        assert model_obj is not None
+        assert model_obj["max_input_tokens"] == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        assert model_obj["max_tokens"] == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        assert model_obj["supports_reasoning"] is False
+    finally:
+        get_model_map.cache_clear()


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added explicit LiteLLM model overrides for Twelve Labs Pegasus variants to enforce safe token limits and capabilities, ensuring consistent behavior across deployments. Included a unit test to verify the override is applied.

- **Bug Fixes**
  - Added overrides for Pegasus model IDs with max_input/max_tokens set to GEN_AI_MODEL_FALLBACK_MAX_TOKENS and a capped max_output.
  - Set supports_reasoning and supports_vision to false.
  - Only add overrides when missing to avoid overwriting existing entries.
  - Added a test to confirm the override exists and values are correct.

<sup>Written for commit e904d7d4185ace7d52e5b4926de6b022a15bc18c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

