### PR TITLE
chore(runs-on): more instance families and use price-capacity-optimized

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,4 @@
+runners:
+  default:
+    family: ["m7", "c7"]
+    spot: price-capacity-optimized


### PR DESCRIPTION
## Description

I think I'm hitting spot instance availability issues, for example, https://github.com/onyx-dot-app/onyx/actions/runs/19257846686/job/55055877224
<img width="2880" height="1920" alt="20251110_23h17m18s_grim" src="https://github.com/user-attachments/assets/a3ebff14-749f-4ea4-a114-14c202d6b788" />

Supposedly [this `runs-on.yml` file can be used](https://runs-on.com/guides/best-practices) to expand the instance family types and change the spot pricing strategy from the default `price-optimized` to the slightly more convenient `price-capacity-optimized`.

## How Has This Been Tested?

Not too sure

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded default runner instance families to m7 and c7 and switched spot strategy to price-capacity-optimized to reduce spot capacity errors and improve job reliability.

<sup>Written for commit 477330c1f2d43071acd890f38b0b1e0ca319e5e9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

