### PR TITLE
fix: img input support check false vs. none

### DIFF
--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -198,8 +198,9 @@ class ModelConfigurationView(BaseModel):
                 )
             ),
             supports_image_input=(
-                model_configuration_model.supports_image_input
-                or litellm_thinks_model_supports_image_input(
+                val
+                if (val := model_configuration_model.supports_image_input) is not None
+                else litellm_thinks_model_supports_image_input(
                     model_configuration_model.name, provider_name
                 )
             ),


### PR DESCRIPTION
## Description

If we explicitly recorded `False` for image support in our model config DB, that means the provider API returned `False`. Even if LiteLLM map says `True`, we pref the provider/our record. Note that this could go stale if the provider is never refreshed (and a model somehow gains image input support).

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check
