### PR TITLE
fix(gdrive): Checkbox fix

### DIFF
--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -293,15 +293,7 @@ export default function AddConnector({
 
   return (
     <Formik
-      initialValues={{
-        ...createConnectorInitialValues(connector),
-        ...Object.fromEntries(
-          connectorConfigs[connector].advanced_values.map((field) => [
-            field.name,
-            field.default || "",
-          ])
-        ),
-      }}
+      initialValues={createConnectorInitialValues(connector)}
       validationSchema={createConnectorValidationSchema(connector)}
       onSubmit={async (values) => {
         const {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -476,6 +476,7 @@ export const connectorConfigs: Record<
         description:
           "When enabled, Onyx skips files that are shared broadly (domain or public) but require the link to access.",
         name: "exclude_domain_link_only",
+        optional: true,
         default: false,
       },
     ],
@@ -1554,6 +1555,29 @@ For example, specifying .*-support.* as a "channel" will cause the connector to 
     advanced_values: [],
   },
 };
+type ConnectorField = ConnectionConfiguration["values"][number];
+
+const buildInitialValuesForFields = (
+  fields: ConnectorField[]
+): Record<string, any> =>
+  fields.reduce(
+    (acc, field) => {
+      if (field.type === "select") {
+        acc[field.name] = null;
+      } else if (field.type === "list") {
+        acc[field.name] = field.default || [];
+      } else if (field.type === "multiselect") {
+        acc[field.name] = field.default || [];
+      } else if (field.type === "checkbox") {
+        acc[field.name] = field.default ?? false;
+      } else if (field.default !== undefined) {
+        acc[field.name] = field.default;
+      }
+      return acc;
+    },
+    {} as Record<string, any>
+  );
+
 export function createConnectorInitialValues(
   connector: ConfigurableSources
 ): Record<string, any> & AccessTypeGroupSelectorFormType {
@@ -1563,23 +1587,8 @@ export function createConnectorInitialValues(
     name: "",
     groups: [],
     access_type: "public",
-    ...configuration.values.reduce(
-      (acc, field) => {
-        if (field.type === "select") {
-          acc[field.name] = null;
-        } else if (field.type === "list") {
-          acc[field.name] = field.default || [];
-        } else if (field.type === "multiselect") {
-          acc[field.name] = field.default || [];
-        } else if (field.type === "checkbox") {
-          acc[field.name] = field.default || false;
-        } else if (field.default !== undefined) {
-          acc[field.name] = field.default;
-        }
-        return acc;
-      },
-      {} as { [record: string]: any }
-    ),
+    ...buildInitialValuesForFields(configuration.values),
+    ...buildInitialValuesForFields(configuration.advanced_values),
   };
 }
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
For Gdrive, if you didn't interact with the advanced option, it would not allow you to create the connector. 

This PR aims to fix this so that we validate and have default values for the setup.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally with multiple different connector configurations.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google Drive connector creation failing when advanced options are untouched by auto-applying defaults and relaxing checkbox validation.

- **Bug Fixes**
  - Pre-fill defaults for advanced fields so GDrive can be created without opening advanced options.
  - Use nullish coalescing for checkbox defaults to avoid incorrect truthy handling.
  - Mark GDrive’s exclude_domain_link_only as optional.

- **Refactors**
  - Centralized initial value building for standard and advanced fields; removed duplicate initialValues logic in AddConnectorPage.

<sup>Written for commit b9ba2e37da6734ade065dd44e0927d6e630a9ef2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

