### PR TITLE
fix: safari input bar quadrupling new lines

### DIFF
--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -429,7 +429,7 @@ function ChatInputBarInner({
             "bg-transparent",
             "resize-none",
             "placeholder:text-text-03",
-            "whitespace-normal",
+            "whitespace-pre-wrap",
             "break-word",
             "overscroll-contain",
             "overflow-y-auto",

--- a/web/src/app/chat/components/input/SimplifiedChatInputBar.tsx
+++ b/web/src/app/chat/components/input/SimplifiedChatInputBar.tsx
@@ -155,7 +155,7 @@ export function SimplifiedChatInputBar({
                     ? "overflow-y-auto mt-2"
                     : ""
                 }
-                whitespace-normal
+                whitespace-pre-wrap
                 break-word
                 overscroll-contain
                 outline-none


### PR DESCRIPTION
## Description

- Safari input bar was quadrupling new lines in copy paste
- Behavior is now identical to ChatGPT (e.g. multiple spaces are NOT collapsed and exact count of new lines are preserved) 

## How Has This Been Tested?

- Locally both visually and with console logging

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari paste behavior in chat inputs that caused newlines to multiply. Uses pre-wrap so single line breaks are preserved and text still wraps naturally.

- **Bug Fixes**
  - Replace whitespace-normal with whitespace-pre-wrap in ChatInputBar and SimplifiedChatInputBar.
  - Keeps pasted line breaks correct in Safari; no visual change in other browsers.

<sup>Written for commit ce7191fd57a38c8365326583ca189bcffda5427f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

