### PR TITLE
feat(slack federated search scoping - 2/4): Add query construction and filtering

### DIFF
--- a/backend/onyx/context/search/federated/slack_search_utils.py
+++ b/backend/onyx/context/search/federated/slack_search_utils.py
@@ -1,0 +1,569 @@
+import fnmatch
+import json
+import re
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from enum import Enum
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from pydantic import ValidationError
+
+from onyx.configs.app_configs import MAX_SLACK_QUERY_EXPANSIONS
+from onyx.context.search.models import SearchQuery
+from onyx.federated_connectors.slack.models import SlackEntities
+from onyx.llm.interfaces import LLM
+from onyx.llm.utils import message_to_string
+from onyx.onyxbot.slack.models import ChannelType
+from onyx.prompts.federated_search import SLACK_DATE_EXTRACTION_PROMPT
+from onyx.prompts.federated_search import SLACK_QUERY_EXPANSION_PROMPT
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Constants for date extraction heuristics
+DEFAULT_RECENCY_DAYS = 7
+DEFAULT_LATELY_DAYS = 14
+DAYS_PER_WEEK = 7
+DAYS_PER_MONTH = 30
+MAX_CONTENT_WORDS = 3
+
+RECENCY_KEYWORDS = ["recent", "latest", "newest", "last"]
+
+
+class ChannelTypeString(str, Enum):
+    """String representations of Slack channel types."""
+
+    IM = "im"
+    MPIM = "mpim"
+    PRIVATE_CHANNEL = "private_channel"
+    PUBLIC_CHANNEL = "public_channel"
+
+
+def _parse_llm_code_block_response(response: str) -> str:
+    """Remove code block markers from LLM response if present.
+
+    Handles responses wrapped in triple backticks (```) by removing
+    the opening and closing markers.
+
+    Args:
+        response: Raw LLM response string
+
+    Returns:
+        Cleaned response with code block markers removed
+    """
+    response_clean = response.strip()
+    if response_clean.startswith("```"):
+        lines = response_clean.split("\n")
+        lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        response_clean = "\n".join(lines)
+    return response_clean
+
+
+def is_recency_query(query: str) -> bool:
+    return any(
+        re.search(rf"\b{re.escape(keyword)}\b", query, flags=re.IGNORECASE)
+        for keyword in RECENCY_KEYWORDS
+    )
+
+
+def extract_date_range_from_query(
+    query: str,
+    llm: LLM,
+    default_search_days: int,
+) -> int:
+    query_lower = query.lower()
+
+    if re.search(r"\btoday(?:\'?s)?\b", query_lower):
+        return 0
+
+    if re.search(r"\byesterday\b", query_lower):
+        return min(1, default_search_days)
+
+    match = re.search(r"\b(?:last|past)\s+(\d+)\s+days?\b", query_lower)
+    if match:
+        days = int(match.group(1))
+        return min(days, default_search_days)
+
+    if re.search(r"\b(?:last|past|this)\s+week\b", query_lower):
+        return min(DAYS_PER_WEEK, default_search_days)
+
+    match = re.search(r"\b(?:last|past)\s+(\d+)\s+weeks?\b", query_lower)
+    if match:
+        weeks = int(match.group(1))
+        return min(weeks * DAYS_PER_WEEK, default_search_days)
+
+    if re.search(r"\b(?:last|past|this)\s+month\b", query_lower):
+        return min(DAYS_PER_MONTH, default_search_days)
+
+    match = re.search(r"\b(?:last|past)\s+(\d+)\s+months?\b", query_lower)
+    if match:
+        months = int(match.group(1))
+        return min(months * DAYS_PER_MONTH, default_search_days)
+
+    if re.search(r"\brecent(?:ly)?\b", query_lower):
+        return min(DEFAULT_RECENCY_DAYS, default_search_days)
+
+    if re.search(r"\blately\b", query_lower):
+        return min(DEFAULT_LATELY_DAYS, default_search_days)
+
+    try:
+        prompt = SLACK_DATE_EXTRACTION_PROMPT.format(query=query)
+        response = message_to_string(
+            llm.invoke_langchain([HumanMessage(content=prompt)])
+        )
+
+        response_clean = _parse_llm_code_block_response(response)
+
+        try:
+            data = json.loads(response_clean)
+            days_back = data.get("days_back")
+            if days_back is None:
+                logger.debug(
+                    f"LLM date extraction returned null for query: '{query}', using default: {default_search_days} days"
+                )
+                return default_search_days
+        except json.JSONDecodeError:
+            logger.debug(
+                f"Failed to parse LLM date extraction response for query: '{query}', using default: {default_search_days} days"
+            )
+            return default_search_days
+
+        return min(days_back, default_search_days)
+
+    except Exception as e:
+        logger.warning(f"Error extracting date range with LLM: {e}")
+        return default_search_days
+
+
+def matches_exclude_pattern(channel_name: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return False
+
+    channel_norm = channel_name.lower().strip().lstrip("#")
+
+    for pattern in patterns:
+        pattern_norm = pattern.lower().strip().lstrip("#")
+        if fnmatch.fnmatch(channel_norm, pattern_norm):
+            return True
+
+    return False
+
+
+def build_channel_query_filter(
+    parsed_entities: SlackEntities | dict[str, Any],
+    available_channels: list[str] | None = None,
+) -> str:
+    # Parse entities if dict
+    try:
+        if isinstance(parsed_entities, dict):
+            entities = SlackEntities(**parsed_entities)
+        else:
+            entities = parsed_entities
+    except ValidationError:
+        return ""
+
+    search_all_channels = entities.search_all_channels
+
+    if search_all_channels:
+        if not entities.exclude_channels:
+            return ""
+
+        # Can't apply exclusions without available_channels
+        if not available_channels:
+            return ""
+
+        excluded_channels = [
+            ch
+            for ch in available_channels
+            if matches_exclude_pattern(ch, entities.exclude_channels)
+        ]
+        normalized_excluded = [ch.lstrip("#") for ch in excluded_channels]
+
+        exclusion_filters = [f"-in:#{channel}" for channel in normalized_excluded]
+        return " ".join(exclusion_filters)
+
+    if not entities.channels:
+        return ""
+
+    included_channels: list[str] = []
+    for pattern in entities.channels:
+        pattern_norm = pattern.lstrip("#")
+        if "*" in pattern_norm or "?" in pattern_norm:
+            # Glob patterns require available_channels
+            if available_channels:
+                matching = [
+                    ch
+                    for ch in available_channels
+                    if fnmatch.fnmatch(ch.lstrip("#").lower(), pattern_norm.lower())
+                ]
+                included_channels.extend(matching)
+        else:
+            # Exact match: use directly or verify against available_channels
+            if not available_channels or pattern_norm in [
+                ch.lstrip("#") for ch in available_channels
+            ]:
+                included_channels.append(pattern_norm)
+
+    # Apply exclusions to included channels
+    if entities.exclude_channels:
+        included_channels = [
+            ch
+            for ch in included_channels
+            if not matches_exclude_pattern(ch, entities.exclude_channels)
+        ]
+
+    if not included_channels:
+        return ""
+
+    normalized_channels = [ch.lstrip("#") for ch in included_channels]
+    filters = [f"in:#{channel}" for channel in normalized_channels]
+    return " ".join(filters)
+
+
+def get_channel_type(
+    channel_info: dict[str, Any] | None = None,
+    channel_id: str | None = None,
+    channel_metadata: dict[str, dict[str, Any]] | None = None,
+) -> ChannelType:
+    """
+    Determine channel type from channel info dict or by looking up channel_id.
+
+    Args:
+        channel_info: Channel info dict from Slack API (direct mode)
+        channel_id: Channel ID to look up (lookup mode)
+        channel_metadata: Pre-fetched metadata dict (for lookup mode)
+
+    Returns:
+        ChannelType enum
+    """
+    if channel_info is not None:
+        if channel_info.get("is_im"):
+            return ChannelType.IM
+        if channel_info.get("is_mpim"):
+            return ChannelType.MPIM
+        if channel_info.get("is_private"):
+            return ChannelType.PRIVATE_CHANNEL
+        return ChannelType.PUBLIC_CHANNEL
+
+    # Lookup mode: get type from pre-fetched metadata
+    if channel_id and channel_metadata:
+        ch_meta = channel_metadata.get(channel_id)
+        if ch_meta:
+            type_str = ch_meta.get("type")
+            if type_str == ChannelTypeString.IM.value:
+                return ChannelType.IM
+            elif type_str == ChannelTypeString.MPIM.value:
+                return ChannelType.MPIM
+            elif type_str == ChannelTypeString.PRIVATE_CHANNEL.value:
+                return ChannelType.PRIVATE_CHANNEL
+            return ChannelType.PUBLIC_CHANNEL
+
+    return ChannelType.PUBLIC_CHANNEL
+
+
+def should_include_message(channel_type: ChannelType, entities: dict[str, Any]) -> bool:
+    include_dm = entities.get("include_dm", False)
+    include_group_dm = entities.get("include_group_dm", False)
+    include_private = entities.get("include_private_channels", False)
+
+    if channel_type == ChannelType.IM:
+        return include_dm
+    if channel_type == ChannelType.MPIM:
+        return include_group_dm
+    if channel_type == ChannelType.PRIVATE_CHANNEL:
+        return include_private
+    return True
+
+
+def extract_channel_references_from_query(query_text: str) -> set[str]:
+    """Extract channel names referenced in the query text.
+
+    Only matches explicit channel references with prepositions or # symbols:
+    - "in the office channel"
+    - "from the office channel"
+    - "in #office"
+    - "from #office"
+
+    Does NOT match generic phrases like "slack discussions" or "team channel".
+
+    Args:
+        query_text: The user's query text
+
+    Returns:
+        Set of channel names (without # prefix)
+    """
+    channel_references = set()
+    query_lower = query_text.lower()
+
+    # Only match channels with explicit prepositions (in/from) or # prefix
+    # This prevents false positives like "slack discussions" being interpreted as channel "slack"
+    channel_patterns = [
+        r"\bin\s+(?:the\s+)?([a-z0-9_-]+)\s+(?:slack\s+)?channels?\b",  # "in the office channel"
+        r"\bfrom\s+(?:the\s+)?([a-z0-9_-]+)\s+(?:slack\s+)?channels?\b",  # "from the office channel"
+        r"\bin\s+#([a-z0-9_-]+)\b",  # "in #office"
+        r"\bfrom\s+#([a-z0-9_-]+)\b",  # "from #office"
+    ]
+
+    for pattern in channel_patterns:
+        matches = re.finditer(pattern, query_lower)
+        for match in matches:
+            channel_references.add(match.group(1))
+
+    return channel_references
+
+
+def validate_channel_references(
+    channel_references: set[str],
+    entities: dict[str, Any],
+    available_channels: list[str] | None,
+) -> None:
+    """Validate that referenced channels exist and are allowed by entity config.
+
+    Args:
+        channel_references: Set of channel names extracted from query
+        entities: Entity configuration dict
+        available_channels: List of available channel names in workspace
+
+    Raises:
+        ValueError: If channel doesn't exist, is excluded, or not in inclusion list
+    """
+    if not channel_references or not entities:
+        return
+
+    try:
+        parsed_entities = SlackEntities(**entities)
+
+        for channel_name in channel_references:
+            # Check if channel exists
+            if available_channels is not None:
+                # Normalize for comparison (available_channels may or may not have #)
+                normalized_available = [
+                    ch.lstrip("#").lower() for ch in available_channels
+                ]
+                if channel_name.lower() not in normalized_available:
+                    raise ValueError(
+                        f"Channel '{channel_name}' does not exist in your Slack workspace. "
+                        f"Please check the channel name and try again."
+                    )
+
+            # Check if channel is in exclusion list
+            if parsed_entities.exclude_channels:
+                if matches_exclude_pattern(
+                    channel_name, parsed_entities.exclude_channels
+                ):
+                    raise ValueError(
+                        f"Channel '{channel_name}' is excluded from search by your configuration. "
+                        f"Please update your connector settings to search this channel."
+                    )
+
+            # Check if channel is in inclusion list (when search_all_channels is False)
+            if not parsed_entities.search_all_channels:
+                if parsed_entities.channels:
+                    # Normalize channel lists for comparison
+                    normalized_channels = [
+                        ch.lstrip("#").lower() for ch in parsed_entities.channels
+                    ]
+                    if channel_name.lower() not in normalized_channels:
+                        raise ValueError(
+                            f"Channel '{channel_name}' is not in your configured channel list. "
+                            f"Please update your connector settings to include this channel."
+                        )
+
+    except ValidationError:
+        # If entities are malformed, skip validation
+        pass
+
+
+def build_channel_override_query(channel_references: set[str], time_filter: str) -> str:
+    """Build a Slack query with ONLY channel filters and time filter (no keywords).
+
+    Args:
+        channel_references: Set of channel names to search
+        time_filter: Time filter string (e.g., " after:2025-11-07")
+
+    Returns:
+        Query string with __CHANNEL_OVERRIDE__ marker
+    """
+    normalized_channels = [ch.lstrip("#") for ch in channel_references]
+    channel_filter = " ".join([f"in:#{channel}" for channel in normalized_channels])
+    return f"__CHANNEL_OVERRIDE__ {channel_filter}{time_filter}"
+
+
+# Slack-specific stop words (in addition to standard NLTK stop words)
+# These include Slack-specific terms and temporal/recency keywords
+SLACK_SPECIFIC_STOP_WORDS = frozenset(
+    RECENCY_KEYWORDS
+    + [
+        "dm",
+        "dms",
+        "message",
+        "messages",
+        "channel",
+        "channels",
+        "slack",
+        "post",
+        "posted",
+        "posting",
+        "sent",
+    ]
+)
+
+
+def extract_content_words_from_recency_query(
+    query_text: str, channel_references: set[str]
+) -> list[str]:
+    """Extract meaningful content words from a recency query.
+
+    Filters out NLTK stop words, Slack-specific terms, channel references, and proper nouns.
+
+    Args:
+        query_text: The user's query text
+        channel_references: Channel names to exclude from content words
+
+    Returns:
+        List of content words (up to MAX_CONTENT_WORDS)
+    """
+    # Get standard English stop words from NLTK (lazy import)
+    try:
+        from nltk.corpus import stopwords  # type: ignore
+
+        nltk_stop_words = set(stopwords.words("english"))
+    except Exception:
+        # Fallback if NLTK not available
+        nltk_stop_words = set()
+
+    # Combine NLTK stop words with Slack-specific stop words
+    all_stop_words = nltk_stop_words | SLACK_SPECIFIC_STOP_WORDS
+
+    words = query_text.split()
+    content_words = []
+
+    for word in words:
+        clean_word = word.lower().strip(".,!?;:\"'#")
+        # Skip if it's a channel reference or a stop word
+        if clean_word in channel_references:
+            continue
+        if clean_word and clean_word not in all_stop_words and len(clean_word) > 2:
+            clean_word_orig = word.strip(".,!?;:\"'#")
+            if clean_word_orig.lower() not in all_stop_words:
+                content_words.append(clean_word_orig)
+
+    # Filter out proper nouns (capitalized words)
+    content_words_filtered = [word for word in content_words if not word[0].isupper()]
+
+    return content_words_filtered[:MAX_CONTENT_WORDS]
+
+
+def expand_query_with_llm(query_text: str, llm: LLM) -> list[str]:
+    """Use LLM to expand query into multiple search variations.
+
+    Args:
+        query_text: The user's original query
+        llm: LLM instance to use for expansion
+
+    Returns:
+        List of rephrased query strings (up to MAX_SLACK_QUERY_EXPANSIONS)
+    """
+    prompt = SLACK_QUERY_EXPANSION_PROMPT.format(
+        query=query_text, max_queries=MAX_SLACK_QUERY_EXPANSIONS
+    )
+
+    try:
+        response = message_to_string(
+            llm.invoke_langchain([HumanMessage(content=prompt)])
+        )
+
+        response_clean = _parse_llm_code_block_response(response)
+
+        # Split into lines and filter out empty lines
+        rephrased_queries = [
+            line.strip() for line in response_clean.split("\n") if line.strip()
+        ]
+
+        # If no queries generated, use empty query
+        if not rephrased_queries:
+            logger.debug("No content keywords extracted from query expansion")
+            return [""]
+
+        logger.info(
+            f"Expanded query into {len(rephrased_queries)} queries: {rephrased_queries}"
+        )
+        return rephrased_queries[:MAX_SLACK_QUERY_EXPANSIONS]
+
+    except Exception as e:
+        logger.error(f"Error expanding query: {e}")
+        return [query_text]
+
+
+def build_slack_queries(
+    query: SearchQuery,
+    llm: LLM,
+    entities: dict[str, Any] | None = None,
+    available_channels: list[str] | None = None,
+) -> list[str]:
+    """Build Slack query strings with date filtering and query expansion."""
+    default_search_days = 30
+    if entities:
+        try:
+            parsed_entities = SlackEntities(**entities)
+            default_search_days = parsed_entities.default_search_days
+        except ValidationError as e:
+            logger.warning(f"Invalid entities in build_slack_queries: {e}")
+
+    days_back = extract_date_range_from_query(
+        query.original_query or query.query, llm, default_search_days
+    )
+
+    # get time filter
+    time_filter = ""
+    if days_back is not None and days_back >= 0:
+        if days_back == 0:
+            time_filter = " on:today"
+        else:
+            cutoff_date = datetime.now(timezone.utc) - timedelta(days=days_back)
+            time_filter = f" after:{cutoff_date.strftime('%Y-%m-%d')}"
+
+    original_query_text = query.original_query or query.query
+
+    # ALWAYS extract channel references from the query (not just for recency queries)
+    channel_references = extract_channel_references_from_query(original_query_text)
+
+    # Validate channel references against available channels and entity config
+    # This will raise ValueError if channels are invalid
+    if channel_references and entities:
+        try:
+            validate_channel_references(
+                channel_references, entities, available_channels
+            )
+            logger.info(
+                f"Detected and validated channel references: {channel_references}"
+            )
+
+            # If valid channels detected, use ONLY those channels with NO keywords
+            # Return query with ONLY time filter + channel filter (no keywords)
+            return [build_channel_override_query(channel_references, time_filter)]
+        except ValueError as e:
+            # If validation fails, log the error and continue with normal flow
+            logger.warning(f"Channel reference validation failed: {e}")
+            channel_references = set()
+
+    # use llm to generate slack queries (use original query to use same keywords as the user)
+    if is_recency_query(original_query_text):
+        # For recency queries, extract content words (excluding channel names and stop words)
+        content_words = extract_content_words_from_recency_query(
+            original_query_text, channel_references
+        )
+        rephrased_queries = [" ".join(content_words)] if content_words else [""]
+    else:
+        # For other queries, use LLM to expand into multiple variations
+        rephrased_queries = expand_query_with_llm(original_query_text, llm)
+
+    # Build final query strings with time filters
+    return [
+        rephrased_query.strip() + time_filter
+        for rephrased_query in rephrased_queries[:MAX_SLACK_QUERY_EXPANSIONS]
+    ]

--- a/backend/onyx/prompts/federated_search.py
+++ b/backend/onyx/prompts/federated_search.py
@@ -1,6 +1,5 @@
 from onyx.configs.app_configs import MAX_SLACK_QUERY_EXPANSIONS
 
-# TODO: maybe ask it to generate in and from filters, and fuzzy match them later
 SLACK_QUERY_EXPANSION_PROMPT = f"""
 Rewrite the user's query and, if helpful, split it into at most {MAX_SLACK_QUERY_EXPANSIONS} \
 keyword-only queries, so that Slack's keyword search yields the best matches.
@@ -9,21 +8,70 @@ Keep in mind the Slack's search behavior:
 - Pure keyword AND search (no semantics).
 - Word order matters.
 - More words = fewer matches, so keep each query concise.
+- IMPORTANT: Prefer simple 1-2 word queries over longer multi-word queries.
 
-Guidelines:
-1. Remove stop-words and obvious noise.
-2. Remove or down-weight meta-instructions (e.g., "show me", "summary of", "how do I") that are \
-unlikely to appear in the target messages.
-3. Stick with words used in the original query. If you need to add implied keywords (e.g., "when did" -> "date"), \
-create a separate query for it.
-4. If the query has many keywords, produce several focused queries that keep related words together; \
-never explode into single-word queries.
-5. Preserve phrases that belong together (e.g., "performance issues"); a word may appear in multiple queries.
-6. When unsure, produce both a broad and a narrow query.
-7. If the user asks for X or Y, create separate queries for X and Y.
+Critical: Extract ONLY keywords that would actually appear in Slack message content.
 
-Here is the original query:
+DO NOT include:
+- Meta-words: "topics", "conversations", "discussed", "summary", "messages", "big", "main", "talking"
+- Temporal: "today", "yesterday", "week", "month", "recent", "past", "last"
+- Channels/Users: "general", "eng-general", "engineering", "@username"
+
+DO include:
+- Actual content: "performance", "bug", "deployment", "API", "database", "error", "feature"
+
+Examples:
+
+Query: "what are the big topics in eng-general this week?"
+Output:
+(empty - contains only meta-words and temporal terms, no actual content keywords)
+
+Query: "performance issues in eng-general"
+Output:
+performance issues
+performance
+issues
+
+Query: "what did we discuss about the API migration?"
+Output:
+API migration
+API
+migration
+
+Now process this query:
+
 {{query}}
 
-Return EXACTLY the new query(ies), one per line, at most {MAX_SLACK_QUERY_EXPANSIONS}. Nothing else.
+Output:
+"""
+
+SLACK_DATE_EXTRACTION_PROMPT = """
+Extract the date range from the user's query and return it in a structured format.
+
+Current date context:
+- Today: {today}
+- Current time: {current_time}
+
+Guidelines:
+1. Return a JSON object with "days_back" (integer) indicating how many days back to search
+2. If no date/time is mentioned, return {{"days_back": null}}
+3. Interpret relative dates accurately:
+   - "today" or "today's" = 0 days back
+   - "yesterday" = 1 day back
+   - "last week" = 7 days back
+   - "last month" = 30 days back
+   - "last X days" = X days back
+   - "past X days" = X days back
+   - "this week" = 7 days back
+   - "this month" = 30 days back
+4. For creative expressions, interpret intent:
+   - "recent" = 7 days back
+   - "recently" = 7 days back
+   - "lately" = 14 days back
+5. Always be conservative - if uncertain, use a longer time range
+
+User query: {query}
+
+Return ONLY a valid JSON object in this format: {{"days_back": <integer or null>}}
+Nothing else.
 """

--- a/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
+++ b/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
@@ -346,6 +346,8 @@ class TestSlackBotFederatedSearch:
             allowed_private_channel: str | None = None,
             bot_token: str | None = None,
             include_dm: bool = False,
+            entities: dict | None = None,
+            available_channels: list | None = None,
         ) -> list:
             self._captured_filtering_params = {
                 "allowed_private_channel": allowed_private_channel,

--- a/backend/tests/unit/onyx/context/search/federated/test_slack_query_construction.py
+++ b/backend/tests/unit/onyx/context/search/federated/test_slack_query_construction.py
@@ -1,0 +1,332 @@
+from unittest.mock import MagicMock
+
+from onyx.context.search.federated.slack_search_utils import (
+    build_channel_query_filter,
+)
+from onyx.context.search.federated.slack_search_utils import matches_exclude_pattern
+from onyx.onyxbot.slack.models import ChannelType
+
+
+class TestChannelPatternMatching:
+    """Test glob pattern matching for channel exclusion"""
+
+    def test_exact_match(self) -> None:
+        """Test exact channel name match"""
+        assert matches_exclude_pattern("customer-support", ["customer-support"]) is True
+        assert matches_exclude_pattern("engineering", ["customer-support"]) is False
+
+    def test_glob_pattern_star(self) -> None:
+        """Test glob patterns with * wildcard"""
+        # Suffix wildcard
+        assert matches_exclude_pattern("customer-X", ["customer*"]) is True
+        assert matches_exclude_pattern("customer-support", ["customer*"]) is True
+        assert matches_exclude_pattern("engineering", ["customer*"]) is False
+
+        # Prefix wildcard
+        assert matches_exclude_pattern("test-env", ["*-env"]) is True
+        assert matches_exclude_pattern("prod-env", ["*-env"]) is True
+        assert matches_exclude_pattern("test-staging", ["*-env"]) is False
+
+        # Infix wildcard
+        assert matches_exclude_pattern("customer-test-env", ["customer*env"]) is True
+        assert matches_exclude_pattern("customer-prod-env", ["customer*env"]) is True
+        assert matches_exclude_pattern("customer-test", ["customer*env"]) is False
+
+    def test_multiple_patterns(self) -> None:
+        """Test matching against multiple patterns"""
+        patterns = ["test-*", "dev-*", "customer*"]
+
+        assert matches_exclude_pattern("test-env", patterns) is True
+        assert matches_exclude_pattern("dev-env", patterns) is True
+        assert matches_exclude_pattern("customer-X", patterns) is True
+        assert matches_exclude_pattern("prod-env", patterns) is False
+
+    def test_hash_prefix_normalization(self) -> None:
+        """Test that # prefix is handled correctly"""
+        # Pattern has #, channel name doesn't
+        assert matches_exclude_pattern("customer-X", ["#customer*"]) is True
+
+        # Channel name has #, pattern doesn't
+        assert matches_exclude_pattern("#customer-X", ["customer*"]) is True
+
+        # Both have #
+        assert matches_exclude_pattern("#customer-X", ["#customer*"]) is True
+
+    def test_case_insensitive(self) -> None:
+        """Test that matching is case insensitive"""
+        assert matches_exclude_pattern("Customer-Support", ["customer*"]) is True
+        assert matches_exclude_pattern("CUSTOMER-X", ["customer*"]) is True
+        assert matches_exclude_pattern("customer-x", ["CUSTOMER*"]) is True
+
+    def test_whitespace_handling(self) -> None:
+        """Test that whitespace is trimmed"""
+        assert matches_exclude_pattern(" customer-X ", ["customer*"]) is True
+        assert matches_exclude_pattern("customer-X", [" customer* "]) is True
+
+
+class TestChannelQueryFilterBuilding:
+    """Test channel query filter string construction"""
+
+    def test_specific_channels_no_exclude(self) -> None:
+        """Test filter with specific channels, no exclusions"""
+        entities = {
+            "search_all_channels": False,
+            "channels": ["general", "engineering"],
+        }
+
+        filter_str = build_channel_query_filter(entities)
+
+        assert "in:#general" in filter_str
+        assert "in:#engineering" in filter_str
+        assert filter_str.count("in:#") == 2
+
+    def test_specific_channels_with_exclude(self) -> None:
+        """Test filter with specific channels and exclusions"""
+        entities = {
+            "search_all_channels": False,
+            "channels": ["general", "customer-X", "customer-Y", "support"],
+            "exclude_channels": ["customer*"],
+        }
+
+        filter_str = build_channel_query_filter(entities)
+
+        # Should include non-customer channels
+        assert "in:#general" in filter_str
+        assert "in:#support" in filter_str
+
+        # Should exclude customer channels
+        assert "customer-X" not in filter_str
+        assert "customer-Y" not in filter_str
+
+    def test_all_channels_no_exclude(self) -> None:
+        """Test search all channels with no exclusions"""
+        entities = {"search_all_channels": True}
+
+        filter_str = build_channel_query_filter(entities)
+
+        # Should return empty string (no filter)
+        assert filter_str == ""
+
+    def test_all_channels_with_exclude(self) -> None:
+        """Test search all channels with exclusions"""
+        entities = {
+            "search_all_channels": True,
+            "exclude_channels": ["customer*", "test-*"],
+        }
+        available_channels = [
+            "general",
+            "customer-X",
+            "customer-Y",
+            "test-env",
+            "support",
+        ]
+
+        filter_str = build_channel_query_filter(entities, available_channels)
+
+        # Should use negative filters for excluded channels
+        assert "-in:#customer-X" in filter_str
+        assert "-in:#customer-Y" in filter_str
+        assert "-in:#test-env" in filter_str
+
+        # Should NOT include positive filters (we're searching ALL channels, just excluding some)
+        assert "in:#general" not in filter_str
+        assert "in:#support" not in filter_str
+
+    def test_empty_channels_list(self) -> None:
+        """Test with empty channels list"""
+        entities = {"search_all_channels": False, "channels": []}
+
+        # Should raise ValidationError during entity parsing, but if it gets through
+        # should return empty string
+        try:
+            filter_str = build_channel_query_filter(entities)
+            assert filter_str == ""
+        except Exception:
+            # Expected - validation should fail
+            pass
+
+    def test_channel_name_normalization(self) -> None:
+        """Test that channel names are normalized (# removed)"""
+        entities = {
+            "search_all_channels": False,
+            "channels": ["#general", "engineering"],  # One with #, one without
+        }
+
+        filter_str = build_channel_query_filter(entities)
+
+        # Both should be included with in:# prefix
+        assert "in:#general" in filter_str
+        assert "in:#engineering" in filter_str
+
+    def test_invalid_entities(self) -> None:
+        """Test with invalid entities"""
+        entities = {"invalid_field": "value"}
+
+        filter_str = build_channel_query_filter(entities)
+
+        # Should return empty string on validation error
+        assert filter_str == ""
+
+    def test_no_available_channels(self) -> None:
+        """Test exclude patterns when channel list fetch fails"""
+        entities = {
+            "search_all_channels": True,
+            "exclude_channels": ["customer*"],
+        }
+        available_channels = None  # Channel fetch failed
+
+        filter_str = build_channel_query_filter(entities, available_channels)
+
+        # Should return empty string if we can't fetch channels
+        assert filter_str == ""
+
+
+class TestDateExtraction:
+    """Test date range extraction from queries"""
+
+    def test_extract_explicit_days(self) -> None:
+        """Test extracting explicit day ranges"""
+        from onyx.context.search.federated.slack_search_utils import (
+            extract_date_range_from_query,
+        )
+
+        mock_llm = MagicMock()
+
+        # Mock LLM response for "last 7 days"
+        mock_llm.invoke.return_value = MagicMock()
+        mock_llm.invoke.return_value.content = '{"days_back": 7}'
+
+        days = extract_date_range_from_query(
+            "show me results from last 7 days", mock_llm, 30
+        )
+
+        assert days == 7
+
+    def test_enforce_default_search_days_limit(self) -> None:
+        """Test that default_search_days is enforced as hard limit"""
+        from onyx.context.search.federated.slack_search_utils import (
+            extract_date_range_from_query,
+        )
+
+        mock_llm = MagicMock()
+
+        # Mock LLM response for "last 90 days" but limit is 30
+        mock_llm.invoke.return_value = MagicMock()
+        mock_llm.invoke.return_value.content = '{"days_back": 90}'
+
+        days = extract_date_range_from_query(
+            "show me results from last 90 days", mock_llm, 30
+        )
+
+        # Should be capped at 30
+        assert days == 30
+
+    def test_no_date_mentioned(self) -> None:
+        """Test when no date is mentioned in query"""
+        from onyx.context.search.federated.slack_search_utils import (
+            extract_date_range_from_query,
+        )
+
+        mock_llm = MagicMock()
+
+        # Mock LLM response for no date
+        mock_llm.invoke.return_value = MagicMock()
+        mock_llm.invoke.return_value.content = '{"days_back": null}'
+
+        days = extract_date_range_from_query("show me budget reports", mock_llm, 30)
+
+        # Should use default
+        assert days == 30
+
+    def test_llm_failure_fallback(self) -> None:
+        """Test fallback when LLM fails"""
+        from onyx.context.search.federated.slack_search_utils import (
+            extract_date_range_from_query,
+        )
+
+        mock_llm = MagicMock()
+
+        # Mock LLM failure
+        mock_llm.invoke.side_effect = Exception("LLM error")
+
+        days = extract_date_range_from_query("show me results", mock_llm, 30)
+
+        # Should fall back to default
+        assert days == 30
+
+
+class TestChannelTypeFiltering:
+    """Test post-filtering based on channel type"""
+
+    def test_include_public_channels_always(self) -> None:
+        """Test that public channels are always included"""
+        from onyx.context.search.federated.slack_search_utils import (
+            should_include_message,
+        )
+
+        entities = {
+            "include_dm": False,
+            "include_private_channels": False,
+        }
+
+        assert should_include_message(ChannelType.PUBLIC_CHANNEL, entities) is True
+
+    def test_filter_dm_based_on_entities(self) -> None:
+        """Test DM filtering based on include_dm setting"""
+        from onyx.context.search.federated.slack_search_utils import (
+            should_include_message,
+        )
+
+        # DMs enabled
+        entities_with_dm = {"include_dm": True}
+        assert should_include_message(ChannelType.IM, entities_with_dm) is True
+
+        # DMs disabled
+        entities_no_dm = {"include_dm": False}
+        assert should_include_message(ChannelType.IM, entities_no_dm) is False
+
+    def test_filter_group_dm(self) -> None:
+        """Test group DM (MPIM) filtering uses include_group_dm setting"""
+        from onyx.context.search.federated.slack_search_utils import (
+            should_include_message,
+        )
+
+        # Group DMs should follow include_group_dm setting
+        entities_with_group_dm = {"include_group_dm": True}
+        assert should_include_message(ChannelType.MPIM, entities_with_group_dm) is True
+
+        entities_no_group_dm = {"include_group_dm": False}
+        assert should_include_message(ChannelType.MPIM, entities_no_group_dm) is False
+
+    def test_filter_private_channels(self) -> None:
+        """Test private channel filtering"""
+        from onyx.context.search.federated.slack_search_utils import (
+            should_include_message,
+        )
+
+        # Private channels enabled
+        entities_with_private = {"include_private_channels": True}
+        assert (
+            should_include_message(ChannelType.PRIVATE_CHANNEL, entities_with_private)
+            is True
+        )
+
+        # Private channels disabled
+        entities_no_private = {"include_private_channels": False}
+        assert (
+            should_include_message(ChannelType.PRIVATE_CHANNEL, entities_no_private)
+            is False
+        )
+
+    def test_invalid_entities_default_behavior(self) -> None:
+        """Test that invalid entities default to including messages"""
+        from onyx.context.search.federated.slack_search_utils import (
+            should_include_message,
+        )
+
+        invalid_entities = {"invalid_field": "value"}
+
+        # Should default to including (safe behavior)
+        assert (
+            should_include_message(ChannelType.PUBLIC_CHANNEL, invalid_entities) is True
+        )


### PR DESCRIPTION
## Description

Implements query construction and filtering for Slack federated search with modular utilities and intelligent date extraction.

### High-level Flow

When a user submits a search query:

1. **Date Extraction**: Extracts date ranges using fast heuristic patterns first ("today", "yesterday", "last week", "last 30 days", etc.), only falling back to LLM for complex expressions. Always enforces `default_search_days` as a hard cap.
2. **Query Construction**: For recency-focused queries ("recent messages"), extracts content words without expansion. For keyword queries, uses LLM to generate multiple query variants for better recall.
3. **Channel Filtering**: `build_channel_query_filter()` generates Slack `in:#channel` or `-in:#channel` modifiers based on entity configuration, with glob pattern support for exclusions.
4. **Parallel Search**: Executes multiple Slack API searches concurrently with query variants and channel filters.
5. **Post-filtering**: `should_include_message()` filters results by channel type (DM/group DM/private) since Slack API only supports name-based filters.
6. **Result Merging**: Deduplicates and scores results from parallel searches.

### Key Changes

**New file: `slack_search_utils.py`**
- `extract_date_range_from_query()`: Heuristic regex patterns for common date expressions (today, yesterday, last N days/weeks/months), with LLM fallback for complex cases
- `build_slack_queries()`: Query construction with date filters and conditional expansion (recency queries use content words, keyword queries use LLM expansion)
- `build_channel_query_filter()`: Glob pattern matching for channel inclusion/exclusion (supports wildcards like `customer-*`, `test-*`)
- `get_channel_type()`: Unified channel type detection (supports both direct API response dict and cached metadata lookup)
- `should_include_message()`: Entity-based post-filtering for DMs/private channels
- `matches_exclude_pattern()`: Glob pattern matching for channel exclusions
- `is_recency_query()`: Detects time-focused queries for sort order optimization
- `expand_query_with_llm()`: LLM-based query expansion for better recall
- `extract_content_words_from_recency_query()`: Content word extraction for recency queries

**Enhanced `slack_search.py`**
- Channel metadata caching with 24-hour TTL to reduce Slack API calls
- Team ID retrieval via `auth.test` API for workspace identification
- Parallel query execution with result merging and deduplication
- Post-filtering by channel type (DM/private/group DM) based on entity configuration
- Added `SLACK_THREAD_CONTEXT_WINDOW` constant (3 messages before matched message)
- Thread context expansion: includes N messages before matched message for better context
- Improved error handling for deleted/deactivated Slack users (logs debug instead of error)
- Inline code comments for clarity (query construction flow, thread message handling)

**Updated `federated_connector.py`**
- Added `configuration_schema()` method to interface (canonical schema definition)
- Made `entities_schema()` a backwards-compatible wrapper calling `configuration_schema()`
- Updated OAuth scopes to include `users:read` for user profile fetching

  **Tests**
  - Comprehensive unit tests for channel filtering, date extraction, and pattern matching

Part of Linear project: https://linear.app/danswer/project/slack-federated-search-scoping-b8d5473beac4

## PR Stack
1. [feat(slack federated search scoping - 1/4): Add entity filtering configuration](https://github.com/onyx-dot-app/onyx/pull/6174)
2. [feat(slack federated search scoping - 2/4): Add query construction and filtering](https://github.com/onyx-dot-app/onyx/pull/6175) -> you are here
3. [feat(slack federated search scoping - 3/4): Add connector-level config support](https://github.com/onyx-dot-app/onyx/pull/6178)  
4. [feat(slack federated search scoping - 4/4): Add frontend connector config support](https://github.com/onyx-dot-app/onyx/pull/6181)

## How Has This Been Tested?

unit tests + local testing

overall seems to successfully get me a summary of the requested channels. the user message does need to be specific about channels for the response to be good 


https://github.com/user-attachments/assets/4bdf41a3-47aa-4e44-b431-f244e5899a10



## Additional Options

- [ ] [Optional] Override Linear Check






























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust query construction and scoping for Slack federated search. Delivers the Linear project’s scoping rules by enforcing date limits, channel inclusion/exclusion, and DM/private filtering for safer, more relevant results.

- **New Features**
  - LLM-backed date extraction with a hard cap (default_search_days).
  - Channel scoping with include/exclude glob patterns and validated channel overrides; generates in:#channel/-in:#channel filters.
  - Recency-aware queries: timestamp sorting, minimal content keywords, and Slack-optimized AND search expansion.
  - Cached channel metadata via conversations.list (24h TTL) to avoid per-channel API calls.

- **Refactors**
  - Team ID fetched via auth.test for per-team caching and filtering.
  - entities_schema is canonical; configuration_schema is a compat wrapper.
  - Parallel searches with post-filtering by channel type (public/private/DM/MPIM) using include_dm/include_group_dm.
  - Expanded Slack OAuth scopes to include channel and user read access.

<sup>Written for commit 739c1e048118abcf2cfb14050b1c4cd26a1c25f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





























