### PR TITLE
chore(gha): 2cpu runners allow arm and x64

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   discover-test-dirs:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
     steps:
@@ -59,7 +59,7 @@ jobs:
 
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -90,7 +90,7 @@ jobs:
 
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -120,7 +120,7 @@ jobs:
 
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
         with:
@@ -460,7 +460,7 @@ jobs:
           docker compose -f docker-compose.multitenant-dev.yml down -v
 
   required:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
     needs: [integration-tests, multitenant-tests]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   discover-test-dirs:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
     steps:
@@ -54,7 +54,7 @@ jobs:
           echo "test-dirs=$all_dirs" >> $GITHUB_OUTPUT
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -84,7 +84,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -113,7 +113,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:integration-test-model-server-cache,mode=max
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
         with:
@@ -321,7 +321,7 @@ jobs:
 
 
   required:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
     needs: [integration-tests-mit]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -53,7 +53,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -84,7 +84,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   backend-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
 
 
     env:

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   quality-checks:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4


### PR DESCRIPTION
## Description

Remove architecture and family specifications to increase spot instance availability and defer family configuration to `.github/runs-on.yml`

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make 2-CPU GitHub Actions runners architecture-agnostic by replacing arch-specific labels with cpu=2, enabling ARM64 or x64. Standardize runner families to m7+c7 to improve spot capacity.

- **Refactors**
  - Updated runs-on to ["runs-on", "cpu=2", "family=m7+c7", "run-id=${{ github.run_id }}"] and kept "extras=ecr-cache" where used.
  - Removed runner=2cpu-linux-arm64 and dropped r7 from the family list.
  - Updated workflows: pr-integration-tests, pr-mit-integration-tests, pr-playwright-tests, pr-python-tests, pr-quality-checks.

<sup>Written for commit 8edaf564a7f7d5e80ed3cb7697ea2b4a730c884d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



