### PR TITLE
chore(gha): explicit spot pricing

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   discover-test-dirs:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
     steps:
@@ -59,7 +59,7 @@ jobs:
 
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -90,7 +90,7 @@ jobs:
 
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -120,7 +120,7 @@ jobs:
 
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
         with:
@@ -460,7 +460,7 @@ jobs:
           docker compose -f docker-compose.multitenant-dev.yml down -v
 
   required:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
     needs: [integration-tests, multitenant-tests]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   discover-test-dirs:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
     steps:
@@ -54,7 +54,7 @@ jobs:
           echo "test-dirs=$all_dirs" >> $GITHUB_OUTPUT
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -84,7 +84,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -113,7 +113,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:integration-test-model-server-cache,mode=max
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
         with:
@@ -321,7 +321,7 @@ jobs:
 
 
   required:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
     needs: [integration-tests-mit]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -53,7 +53,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-backend-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -84,7 +84,7 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}", "extras=ecr-cache"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   backend-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
 
 
     env:

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   quality-checks:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=price-capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "spot=capacity-optimized", "family=m7+c7+r7", "run-id=${{ github.run_id }}"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4


### PR DESCRIPTION
## Description

I'm noticing jobs not getting picked up by runners, https://github.com/onyx-dot-app/onyx/actions/runs/19280468187/job/55130270521. I haven't been able to root cause, but pretty sure it's related to spot instance availability. This configuration should already be captured by https://github.com/onyx-dot-app/onyx/blob/main/.github/runs-on.yml, but I'm not convinced that is working as expected. In the worst-case, this is a no-op given that.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set spot instance strategy to capacity-optimized for ARM64 runners in PR workflows to improve runner availability and prevent jobs from getting stuck. If the org-level runs-on.yml already applies this, the change is a no-op.

- **Bug Fixes**
  - Added spot=capacity-optimized to runs-on for integration, MIT integration, Playwright, Python, and quality check workflows.

<sup>Written for commit 7b8e00efaca0d8fbc9c530bd4b78f8a42b2c42e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



