### PR TITLE
feat(slack federated search scoping - 3/4): Add connector-level config support

### DIFF
--- a/backend/onyx/federated_connectors/interfaces.py
+++ b/backend/onyx/federated_connectors/interfaces.py
@@ -34,16 +34,34 @@ class FederatedConnector(ABC):
 
         Returns:
             True if entities are valid, False otherwise
+
+        Note: This method is used for backward compatibility with document-set level entities.
+        For connector-level config validation, use validate_config() instead.
         """
+
+    def validate_config(self, config: Dict[str, Any]) -> bool:
+        """
+        Validate that the provided config matches the expected structure.
+
+        This is an alias for validate_entities() to provide clearer semantics
+        when validating connector-level configuration.
+
+        Args:
+            config: Dictionary of configuration to validate
+
+        Returns:
+            True if config is valid, False otherwise
+        """
+        return self.validate_entities(config)
 
     @classmethod
     @abstractmethod
-    def entities_schema(cls) -> Dict[str, EntityField]:
+    def configuration_schema(cls) -> Dict[str, EntityField]:
         """
-        Return the specification of what entities are available for this connector.
+        Return the specification of what configuration fields are available for this connector.
 
         Returns:
-            Dictionary where keys are entity names and values are EntityField objects
+            Dictionary where keys are configuration field names and values are EntityField objects
             describing the expected structure and constraints.
         """
 
@@ -96,7 +114,7 @@ class FederatedConnector(ABC):
 
         Args:
             query: The search query
-            entities: The entities to search within (validated by validate())
+            entities: Connector-level config (entity filtering configuration)
             access_token: The OAuth access token
             limit: Maximum number of results to return
             slack_event_context: Slack-specific context (only used by Slack bot)

--- a/backend/onyx/federated_connectors/slack/federated_connector.py
+++ b/backend/onyx/federated_connectors/slack/federated_connector.py
@@ -281,7 +281,7 @@ class SlackFederatedConnector(FederatedConnector):
 
         Args:
             query: The search query
-            entities: The entities to search within (validated by validate())
+            entities: Connector-level config (entity filtering configuration)
             access_token: The OAuth access token
             limit: Maximum number of results to return
             slack_event_context: Optional Slack context for slack bot
@@ -311,9 +311,9 @@ class SlackFederatedConnector(FederatedConnector):
                 query,
                 access_token,
                 db_session,
+                entities=entities,
                 limit=limit,
                 slack_event_context=slack_event_context,
                 bot_token=bot_token,
-                entities=entities,
                 team_id=team_id,
             )

--- a/backend/onyx/server/federated/models.py
+++ b/backend/onyx/server/federated/models.py
@@ -18,6 +18,7 @@ class FederatedConnectorCredentials(BaseModel):
 class FederatedConnectorRequest(BaseModel):
     source: FederatedConnectorSource
     credentials: FederatedConnectorCredentials
+    config: dict[str, Any] = Field(default_factory=dict)
 
 
 class FederatedConnectorResponse(BaseModel):
@@ -60,6 +61,7 @@ class FederatedConnectorDetail(BaseModel):
     source: FederatedConnectorSource
     name: str
     credentials: FederatedConnectorCredentials
+    config: dict[str, Any] = Field(default_factory=dict)
     oauth_token_exists: bool
     oauth_token_expires_at: datetime | None = None
     document_sets: list[dict[str, Any]] = Field(default_factory=list)
@@ -87,12 +89,19 @@ class FederatedConnectorSummary(BaseModel):
 
 class FederatedConnectorUpdateRequest(BaseModel):
     credentials: FederatedConnectorCredentials | None = None
+    config: dict[str, Any] | None = None
 
 
 class EntitySpecResponse(BaseModel):
     """Response for entity specification"""
 
     entities: dict[str, Any]
+
+
+class ConfigurationSchemaResponse(BaseModel):
+    """Response for configuration schema specification"""
+
+    configuration: dict[str, Any]
 
 
 class CredentialSchemaResponse(BaseModel):

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -560,6 +560,10 @@ export interface CredentialSchemaResponse {
   credentials: Record<string, CredentialFieldSpec>;
 }
 
+export interface ConfigurationSchemaResponse {
+  configuration: Record<string, CredentialFieldSpec>;
+}
+
 export interface FederatedConnectorCreateRequest {
   source: string;
   credentials: Record<string, any>;


### PR DESCRIPTION
## Description

Implements connector-level configuration for federated connectors, replacing per-document-set entity configuration with a centralized config field.

Key changes:

**Backend API & Database:**
- Add `config` field to FederatedConnectorRequest/UpdateRequest/Detail models
- Update `create_federated_connector()` to accept and store config
- Update `update_federated_connector()` to accept and update config
- Include config in FederatedConnectorDetail API responses
- Add `/api/federated/{id}/configuration/schema` endpoint (replaces deprecated `entities_schema`)
- Maintain backwards compatibility with junction table entities field

**Frontend Types:**
- Add `ConfigurationSchemaResponse` interface for typed configuration schemas
- Update FederatedConnector types to include optional config field

**Connector Interface:**
- Add `configuration_schema()` method to FederatedConnectorInterface
- `entities_schema()` becomes a compatibility wrapper calling `configuration_schema()`
- Update SlackFederatedConnector to implement new configuration schema pattern

**Configuration Priority:**
- Connector-level `config` takes priority over junction table `entities`
- Falls back to junction entities for backwards compatibility
- Validates config using connector's configuration_schema when updating

Architecture:
- `config` stored on federated_connector table (generic for all connector types)
- Slack-specific code keeps SlackEntities naming (matches Slack terminology)
- Backwards compatible: connector.config takes priority, falls back to junction entities

Part of Linear project: https://linear.app/danswer/project/slack-federated-search-scoping-b8d5473beac4

## PR Stack
1. [feat(slack federated search scoping - 1/4): Add entity filtering configuration](https://github.com/onyx-dot-app/onyx/pull/6174)
2. [feat(slack federated search scoping - 2/4): Add query construction and filtering](https://github.com/onyx-dot-app/onyx/pull/6175)
3. [feat(slack federated search scoping - 3/4): Add connector-level config support](https://github.com/onyx-dot-app/onyx/pull/6178) -> you are here
4. [feat(slack federated search scoping - 4/4): Add frontend connector config and remove doc set entity editing](https://github.com/onyx-dot-app/onyx/pull/6181)

## How Has This Been Tested?

unit + local testing

## Additional Options

- [ ] [Optional] Override Linear Check
