### PR TITLE
chore(deps): dependabot for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
       - "jmelahman"
     labels:
       - "dependabot:actions"
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    assignees:
+      - "jmelahman"
+    labels:
+      - "dependabot:python"


### PR DESCRIPTION
## Description

The soon the better I guess

## How Has This Been Tested?

Low-risk

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Dependabot for Python packages in /backend with weekly checks. Limit open PRs to 3, assign to @jmelahman, and label them as dependabot:python.

<sup>Written for commit 7320b094a4276ce841793804796ca536b7607543. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

