### PR TITLE
chore: run playwright projects as separate jobs

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -116,8 +116,12 @@ jobs:
 
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]
-    name: Playwright Tests
-    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-playwright-tests", "extras=ecr-cache"]
+    name: Playwright Tests (${{ matrix.project }})
+    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}", "extras=ecr-cache"]
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [admin, no-auth]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
         with:
@@ -226,13 +230,13 @@ jobs:
         run: |
           # Create test-results directory to ensure it exists for artifact upload
           mkdir -p test-results
-          npx playwright test
+          npx playwright test --project ${{ matrix.project }}
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v4
         if: always()
         with:
           # Includes test results and trace.zip files
-          name: playwright-test-results-${{ github.run_id }}
+          name: playwright-test-results-${{ matrix.project }}-${{ github.run_id }}
           path: ./web/test-results/
           retention-days: 30
 
@@ -248,7 +252,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v4
         with:
-          name: docker-logs
+          name: docker-logs-${{ matrix.project }}-${{ github.run_id }}
           path: ${{ github.workspace }}/docker-compose.log
 
       - name: Stop Docker containers


### PR DESCRIPTION
## Description

This change parallelizes the `admin` + `no-auth` playwright projects which currently run sequentially. Should cut playwright roughly runtime in half. Will be a little less because both jobs have to setup the onyx environment. Might be able to optimize that further in a follow up.


## How Has This Been Tested?

main prod
<img width="871" height="87" alt="Screenshot 2025-11-12 at 10 10 38 AM" src="https://github.com/user-attachments/assets/d2eddeaa-7dd7-4ace-aac5-478a81540708" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Playwright admin and no-auth projects as separate matrix jobs to parallelize execution and cut CI test time roughly in half. Each project runs independently with its own artifacts and logs.

- **Refactors**
  - Added matrix for [admin, no-auth] with fail-fast disabled.
  - Included project in job name and runner run-id.
  - Run tests with --project=${{ matrix.project }}.
  - Scoped artifacts and docker logs per project for clearer debugging.

<sup>Written for commit 4f5d834218e0719fb8ccf22b3ea4c0338245f97c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

