### PR TITLE
fix(slackbot): Switch between document set and assistant

### DIFF
--- a/backend/tests/unit/onyx/onyxbot/test_slack_channel_config.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_channel_config.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.db.slack_channel_config import create_slack_channel_persona
+
+
+def test_create_slack_channel_persona_reuses_existing_persona() -> None:
+    db_session = MagicMock()
+    existing_persona = MagicMock()
+    existing_persona.id = 42
+    db_session.scalar.return_value = existing_persona
+
+    fake_tool = MagicMock()
+    fake_tool.id = 7
+
+    with patch(
+        "onyx.db.slack_channel_config.get_builtin_tool",
+        return_value=fake_tool,
+    ), patch("onyx.db.slack_channel_config.upsert_persona") as mock_upsert:
+        mock_upsert.return_value = MagicMock()
+
+        create_slack_channel_persona(
+            db_session=db_session,
+            channel_name="general",
+            document_set_ids=[1],
+        )
+
+    mock_upsert.assert_called_once()
+    assert mock_upsert.call_args.kwargs["persona_id"] == existing_persona.id


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently when you create a slack bot for a channel and then initially set it up with an assistant configuration and then later update to use a document set, the customer sees an error `Error updating OnyxBot config - Assistant with name...`

This is a very odd workflow but since the table has already been updated with this entry, we get a conflict. 

This PR is to fix this issue and properly handle this to ensure that we do proper handling of the issues.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Reproduced the issue and fixed it with this change. Added another test to ensure that this is properly handled for.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack bot config updates when switching between an assistant and a document set by reusing the channel’s existing persona. Prevents duplicate-name errors and allows clean updates.

- **Bug Fixes**
  - If no persona_id exists, find the persona by channel name and upsert using its id.
  - Added a unit test to verify persona reuse.

<sup>Written for commit 3ff724c8e6ce85bc9b25c0126899b9ad9f250fef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

