### PR TITLE
fix: type checking for multiToolTestHelpers

### DIFF
--- a/web/tests/setup/multiToolTestHelpers.tsx
+++ b/web/tests/setup/multiToolTestHelpers.tsx
@@ -44,7 +44,21 @@ export const createToolGroups = (count: number) =>
  * Create minimal mock chatState
  */
 export const createMockChatState = (overrides = {}) => ({
-  assistant: { name: "Test Assistant", id: 1 },
+  assistant: {
+    id: 1,
+    name: "Test Assistant",
+    description: "Test assistant for testing",
+    tools: [],
+    starter_messages: null,
+    document_sets: [],
+    is_public: true,
+    is_visible: true,
+    display_priority: null,
+    is_default_persona: false,
+    builtin_persona: false,
+    owner: null,
+  },
+  handleFeedbackChange: jest.fn().mockResolvedValue(undefined),
   ...overrides,
 });
 


### PR DESCRIPTION
## Description

Fixes type checking for the multi tool renderer test.

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type checking in the multi-tool renderer tests by updating createMockChatState to return a fully-typed assistant object and a handleFeedbackChange mock. This removes TS errors in multiToolTestHelpers and stabilizes test runs.

<sup>Written for commit f482290b49cdd5a734b862b1002c823804aba708. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

