### PR TITLE
fix(slack): Show Channels when Editing Fed Slack

### DIFF
--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -61,6 +61,12 @@ const EntityConfigDialog = ({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isOpen) {
+      setEntities(currentEntities || {});
+    }
+  }, [currentEntities, isOpen]);
+
+  useEffect(() => {
     if (isOpen && connectorId) {
       const fetchEntitySchema = async () => {
         setIsLoading(true);


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We didn't show the channels that were added to a fed slack config in a document set but this PR fixes that.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally to ensure that we pull up the entries that already exist

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the edit experience for Federated Slack configs by showing previously added channels when the dialog opens. Users can now see and update existing channel selections instead of starting from a blank state.

- **Bug Fixes**
  - Initialize entities from currentEntities when the dialog opens to prefill existing Slack channels.

<sup>Written for commit 27395cef8c99544d2043f2b240239ca66433af72. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

