### PR TITLE
fix(slack): Fixing the link coloring

### DIFF
--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -260,7 +260,7 @@ export function SlackChannelConfigFormFields({
                             (viewUnselectableSets) => !viewUnselectableSets
                           )
                         }
-                        className="text-sm text-link"
+                        className="text-sm text-action-link-05"
                       >
                         {viewUnselectableSets
                           ? "Hide un-selectable "
@@ -354,7 +354,7 @@ export function SlackChannelConfigFormFields({
                               !viewSyncEnabledAssistants
                           )
                         }
-                        className="text-sm text-link"
+                        className="text-sm text-action-link-05"
                       >
                         {viewSyncEnabledAssistants
                           ? "Hide un-selectable "
@@ -421,7 +421,7 @@ export function SlackChannelConfigFormFields({
                               !viewSyncEnabledAssistants
                           )
                         }
-                        className="text-sm text-link"
+                        className="text-sm text-action-link-05"
                       >
                         {viewSyncEnabledAssistants
                           ? "Hide un-selectable "


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Fixing the link coloring to make it more obvious that there are other hidden options

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated link styling in the Slack channel config form to use the action link color, making the “Show/Hide un-selectable” toggles clearly visible.
Improves visibility of hidden options in datasets and assistants.

<sup>Written for commit ed84680ba6d9c2cbe4152034447499ddae15229f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

