### PR TITLE
Interfaces

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -689,12 +689,12 @@ def convert_chat_history(
                     # Add each tool call as a separate message with the tool arguments
                     for tool_call in turn_tool_calls:
                         # Create a message containing the tool call information
-                        tool_call_message = f"{tool_call.tool_call_arguments}"
+                        tool_call_message = f"{tool_call.tool_call_arguments}"  # TODO ensure this is a valid dict string
                         simple_messages.append(
                             ChatMessageSimple(
                                 message=tool_call_message,
                                 token_count=tool_call.tool_call_tokens,
-                                message_type=MessageType.ASSISTANT,
+                                message_type=MessageType.TOOL_CALL,
                                 image_files=None,
                             )
                         )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -524,18 +524,20 @@ def stream_chat_message_objects(
         # TODO Need to think of some way to support selected docs from the sidebar
 
         # Reserve a message id for the assistant response for frontend to track packets
-        assistant_response_message_id = reserve_message_id(
+        assistant_response = reserve_message_id(
             db_session=db_session,
             chat_session_id=chat_session_id,
             parent_message=user_message.id,
             message_type=MessageType.ASSISTANT,
         )
+
+        # TODO this may not be needed by the frontend anymore, look into removing potentially
         yield MessageResponseIDInfo(
             user_message_id=user_message.id,
-            reserved_assistant_message_id=assistant_response_message_id,
+            reserved_assistant_message_id=assistant_response.id,
         )
 
-        # Conver the chat history into a simple format that is free of any DB objects
+        # Convert the chat history into a simple format that is free of any DB objects
         # and is easy to parse for the agent loop
         simple_chat_history = convert_chat_history(
             chat_history=chat_history,
@@ -550,6 +552,7 @@ def stream_chat_message_objects(
             persona=persona,
             llm=llm,
             fast_llm=fast_llm,
+            assistant_response=assistant_response,
             db_session=db_session,
         )
 
@@ -592,6 +595,7 @@ def run_agent_loop(
     persona: Persona | None,
     llm: LLM,
     fast_llm: LLM,
+    assistant_response: ChatMessage,
     db_session: Session,
 ) -> Generator[Packet, None, None]:
     raise NotImplementedError("Not implemented")

--- a/backend/onyx/chat/turn/save_turn.py
+++ b/backend/onyx/chat/turn/save_turn.py
@@ -12,8 +12,10 @@ from sqlalchemy.orm import Session
 from onyx.agents.agent_sdk.message_types import AgentSDKMessage
 from onyx.chat.turn.models import FetchedDocumentCacheEntry
 from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import CitationDocInfo
 from onyx.db.chat import create_search_doc_from_inference_section
 from onyx.db.chat import update_db_session_with_messages
+from onyx.db.models import ChatMessage
 from onyx.db.models import ChatMessage__SearchDoc
 from onyx.db.models import Tool
 from onyx.db.models import ToolCall
@@ -21,8 +23,20 @@ from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.server.query_and_chat.streaming_models import MessageDelta
 from onyx.server.query_and_chat.streaming_models import MessageStart
 from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.models import ToolCallInfo
 
 logger = logging.getLogger(__name__)
+
+
+def save_chat_turn(
+    message_text: str,
+    reasoning_tokens: str | None,
+    tool_calls: list[ToolCallInfo],
+    citation_docs_info: list[CitationDocInfo],
+    db_session: Session,
+    assistant_message: ChatMessage,
+) -> None:
+    raise NotImplementedError("Not implemented")
 
 
 def save_turn(

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -294,6 +294,8 @@ class MessageType(str, Enum):
     SYSTEM = "system"  # SystemMessage
     USER = "user"  # HumanMessage
     ASSISTANT = "assistant"  # AIMessage
+    TOOL_CALL = "tool_call"
+    TOOL_CALL_RESPONSE = "tool_call_response"
 
 
 class ChatMessageSimpleType(str, Enum):

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -492,6 +492,11 @@ class SavedSearchDoc(SearchDoc):
         return self.score < other.score
 
 
+class CitationDocInfo(BaseModel):
+    inference_chunk: InferenceChunk
+    citation_number: int | None
+
+
 class SavedSearchDocWithContent(SavedSearchDoc):
     """Used for endpoints that need to return the actual contents of the retrieved
     section in addition to the match_highlights."""

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -568,8 +568,8 @@ def reserve_message_id(
     db_session: Session,
     chat_session_id: UUID,
     parent_message: int,
-    message_type: MessageType,
-) -> int:
+    message_type: MessageType = MessageType.ASSISTANT,
+) -> ChatMessage:
     # Create an empty chat message
     empty_message = ChatMessage(
         chat_session_id=chat_session_id,
@@ -586,10 +586,7 @@ def reserve_message_id(
     # Flush the session to get an ID for the new chat message
     db_session.flush()
 
-    # Get the ID of the newly created message
-    new_id = empty_message.id
-
-    return new_id
+    return empty_message
 
 
 def create_new_chat_message(

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -75,5 +75,17 @@ class GeneratedImage(BaseModel):
     shape: str | None = None
 
 
+class ToolCallInfo(BaseModel):
+    parent_tool_call_id: str | None  # None if attached to the Chat Message directly
+    turn_number: int
+    tool_id: int  # DB tool type id
+    tool_call_id: str
+    reasoning_tokens: str | None
+    tool_call_arguments: dict[str, Any]
+    tool_call_response: (
+        Any  # we would like to use JSON_ro, but can't due to its recursive nature
+    )
+
+
 CHAT_SESSION_ID_PLACEHOLDER = "CHAT_SESSION_ID"
 MESSAGE_ID_PLACEHOLDER = "MESSAGE_ID"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce explicit tool-call message types and typed interfaces to support cleaner agent turn saving and citations. Also refactors message reservation to return the ChatMessage and passes the reserved assistant message through the agent loop.

- New Features
  - Added MessageType.TOOL_CALL and TOOL_CALL_RESPONSE.
  - Added ToolCallInfo and CitationDocInfo models.
  - Added save_chat_turn() API (stub) for saving message text, tool calls, and citations.

- Refactors
  - convert_chat_history now emits TOOL_CALL messages instead of ASSISTANT for tool calls.
  - reserve_message_id returns a ChatMessage (not an int) and defaults type to ASSISTANT.
  - stream path passes assistant_response to run_agent_loop; function signature updated.

<sup>Written for commit 7b7939a0260e425dad32d7e1445106f21edabb2e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

