### PR TITLE
chore(gha): prefer venv over installing python packages to the system

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -22,10 +22,17 @@ runs:
       with:
         python-version: "3.11"
 
+    - name: Create virtual environment
+      shell: bash
+      run: |
+        uv venv ${{ runner.temp }}/venv
+        echo "VENV_PATH=${{ runner.temp }}/venv" >> $GITHUB_ENV
+        echo "${{ runner.temp }}/venv/bin" >> $GITHUB_PATH
+
     - name: Install Python dependencies with uv
       shell: bash
       run: |
-        uv pip install --system \
+        uv pip install \
           -r backend/requirements/default.txt \
           -r backend/requirements/dev.txt \
           -r backend/requirements/model_server.txt


### PR DESCRIPTION
## Description

Prefer a venv to installing python packages to the system as the venv is faster.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GitHub Actions Python setup to a virtual environment instead of system installs. Faster dependency installs and isolated packages.

- **Refactors**
  - Create venv at ${{ runner.temp }}/venv; set VENV_PATH and add venv/bin to PATH.
  - Install requirements with uv pip into the venv (remove --system).

<sup>Written for commit 65ddaf5d878c23010820aeafa9a7a92f20b367ad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



















