### PR TITLE
chore(gha): prefer venv over installing python packages to the system

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -22,10 +22,17 @@ runs:
       with:
         python-version: "3.11"
 
+    - name: Create virtual environment
+      shell: bash
+      run: |
+        uv venv ${{ runner.temp }}/venv
+        echo "VENV_PATH=${{ runner.temp }}/venv" >> $GITHUB_ENV
+        echo "${{ runner.temp }}/venv/bin" >> $GITHUB_PATH
+
     - name: Install Python dependencies with uv
       shell: bash
       run: |
-        uv pip install --system \
+        uv pip install \
           -r backend/requirements/default.txt \
           -r backend/requirements/dev.txt \
           -r backend/requirements/model_server.txt


### PR DESCRIPTION
## Description

This might be faster, but if nothing else, it prevents installing onyx dependencies from breaking/conflicting with packages installed on the host.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a Python virtual environment in GitHub Actions so dependencies install into an isolated venv instead of the system. This avoids conflicts with host packages and may be faster.

- **Refactors**
  - Create venv at ${{ runner.temp }}/venv and add its bin to PATH.
  - Export VENV_PATH to GITHUB_ENV for downstream steps.
  - Remove --system from uv pip install to target the venv.

<sup>Written for commit 04e78bcd837a914f24445549a590679cfef2a4e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

