### PR TITLE
chore(gha): introduce custom AMI for runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,6 +5,8 @@ self-hosted-runner:
     - extras=s3-cache
     - hdd=256
     - runs-on
+    - image=onyx_arm64_image
+    - image=onyx_x64_image
     - runner=1cpu-linux-arm64
     - runner=1cpu-linux-x64
     - runner=2cpu-linux-arm64

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -85,6 +85,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-web-build
       - extras=ecr-cache
     env:
@@ -143,6 +144,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-web-cloud-build
       - extras=ecr-cache
     env:
@@ -206,6 +208,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-backend-build
       - extras=ecr-cache
     env:
@@ -263,6 +266,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-model-server-build
       - volume=40gb
       - extras=ecr-cache
@@ -327,6 +331,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-trivy-scan-web
       - extras=ecr-cache
     env:
@@ -364,6 +369,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-trivy-scan-web-cloud
       - extras=ecr-cache
     env:
@@ -401,6 +407,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-trivy-scan-backend
       - extras=ecr-cache
     env:
@@ -443,6 +450,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
+      - image=onyx_x64_image
       - run-id=${{ github.run_id }}-trivy-scan-model-server
       - extras=ecr-cache
     env:

--- a/.github/workflows/docker-tag-beta.yml
+++ b/.github/workflows/docker-tag-beta.yml
@@ -14,7 +14,11 @@ jobs:
   tag:
     # See https://runs-on.com/runners/linux/
     # use a lower powered instance since this just does i/o to docker hub
-    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-tag"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-tag
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -14,7 +14,11 @@ jobs:
   tag:
     # See https://runs-on.com/runners/linux/
     # use a lower powered instance since this just does i/o to docker hub
-    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-tag"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-tag
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3

--- a/.github/workflows/nightly-scan-licenses.yml
+++ b/.github/workflows/nightly-scan-licenses.yml
@@ -20,7 +20,11 @@ permissions:
 jobs:
   scan-licenses:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on,runner=2cpu-linux-x64,"run-id=${{ github.run_id }}-scan-licenses"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-scan-licenses
 
     steps:
       - name: Checkout code
@@ -81,7 +85,11 @@ jobs:
 
   scan-trivy:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on,runner=2cpu-linux-x64,"run-id=${{ github.run_id }}-scan-trivy"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-scan-trivy
 
     steps:
     - name: Set up Docker Buildx

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=2cpu-linux-arm64
+      - image=onyx_arm64_image
       - ${{ format('run-id={0}-external-dependency-unit-tests-job-{1}', github.run_id, strategy['job-index']) }}
       - extras=s3-cache
     strategy:

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -12,7 +12,12 @@ on:
 jobs:
   helm-chart-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on,runner=8cpu-linux-x64,hdd=256,"run-id=${{ github.run_id }}-helm-chart-check"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-x64
+      - image=onyx_x64_image
+      - hdd=256
+      - run-id=${{ github.run_id }}-helm-chart-check
 
     # fetch-depth 0 is required for helm/chart-testing-action
     steps:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -60,7 +60,12 @@ jobs:
 
 
   build-backend-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-backend-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-backend-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -91,7 +96,12 @@ jobs:
 
 
   build-model-server-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-model-server-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-model-server-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -121,7 +131,12 @@ jobs:
 
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}-build-integration-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-integration-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -156,6 +171,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-arm64
+      - image=onyx_arm64_image
       - ${{ format('run-id={0}-integration-tests-job-{1}', github.run_id, strategy['job-index']) }}
       - extras=ecr-cache
 
@@ -316,7 +332,12 @@ jobs:
         build-model-server-image,
         build-integration-image,
       ]
-    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-multitenant-tests", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-multitenant-tests
+      - extras=ecr-cache
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -55,7 +55,12 @@ jobs:
           echo "test-dirs=$all_dirs" >> $GITHUB_OUTPUT
 
   build-backend-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-backend-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-backend-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -85,7 +90,12 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-model-server-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-model-server-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -114,7 +124,12 @@ jobs:
           cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:integration-test-model-server-cache,mode=max
 
   build-integration-image:
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}-build-integration-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-integration-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code
@@ -149,6 +164,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-arm64
+      - image=onyx_arm64_image
       - ${{ format('run-id={0}-integration-tests-mit-job-{1}', github.run_id, strategy['job-index']) }}
       - extras=ecr-cache
 

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -36,7 +36,12 @@ env:
 
 jobs:
   build-web-image:
-    runs-on: [runs-on, runner=4cpu-linux-arm64, "run-id=${{ github.run_id }}-build-web-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=4cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-web-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -67,7 +72,12 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-backend-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-backend-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-backend-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -98,7 +108,12 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-build-model-server-image", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-build-model-server-image
+      - extras=ecr-cache
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -131,7 +146,12 @@ jobs:
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]
     name: Playwright Tests (${{ matrix.project }})
-    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}
+      - extras=ecr-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -15,7 +15,12 @@ jobs:
     # See https://runs-on.com/runners/linux/
     # Note: Mypy seems quite optimized for x64 compared to arm64.
     # Similarly, mypy is single-threaded and incremental, so 2cpu is sufficient.
-    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-mypy-check", "extras=s3-cache"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-mypy-check
+      - extras=s3-cache
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -122,7 +122,12 @@ env:
 jobs:
   connectors-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=8cpu-linux-x64, "run-id=${{ github.run_id }}-connectors-check", "extras=s3-cache"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-connectors-check
+      - extras=s3-cache
 
     env:
       PYTHONPATH: ./backend

--- a/.github/workflows/pr-python-model-tests.yml
+++ b/.github/workflows/pr-python-model-tests.yml
@@ -28,7 +28,11 @@ env:
 jobs:
   model-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on,runner=8cpu-linux-x64,"run-id=${{ github.run_id }}-model-check"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-model-check
 
     env:
       PYTHONPATH: ./backend

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -13,7 +13,11 @@ on:
 jobs:
   backend-check:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}-backend-check"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-backend-check
 
 
     env:

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   quality-checks:
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=1cpu-linux-arm64, "run-id=${{ github.run_id }}-quality-checks"]
+    runs-on:
+      - runs-on
+      - runner=1cpu-linux-arm64
+      - image=onyx_arm64_image
+      - run-id=${{ github.run_id }}-quality-checks
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4

--- a/.github/workflows/tag-nightly.yml
+++ b/.github/workflows/tag-nightly.yml
@@ -9,7 +9,11 @@ permissions:
 
 jobs:
   create-and-push-tag:
-    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-create-and-push-tag"]
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - image=onyx_x64_image
+      - run-id=${{ github.run_id }}-create-and-push-tag
 
     steps:
       # actions using GITHUB_TOKEN cannot trigger another workflow, but we do want this to trigger docker pushes


### PR DESCRIPTION
## Description

Custom AMI with Playwright and Docker images pre-installed.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add custom runner AMIs for ARM64 and x64 with Playwright and common Docker images pre-installed to speed up CI and cut setup time. Workflows opt in via image=onyx_arm64_image and image=onyx_x64_image across builds, tests, and scans.

- **New Features**
  - Opted workflows into AMIs via runs-on labels: ARM64 (Playwright, integration, multitenant/MIT, backend/quality, external dependency unit tests, ARM64 Docker builds) and x64 (deployment, nightly scans, Helm chart checks, Python checks/tests, connector/model tests, tag jobs).
  - Updated actionlint to recognize image=onyx_arm64_image and image=onyx_x64_image; switched tests to use the Playwright CLI (no npx).

<sup>Written for commit 9b2509ad24392f61daf06cd29ba524efbac90280. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



























