### PR TITLE
chore(runs-on): define custom AMI specs

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,1 +1,1 @@
-_extend: .github.private
+_extend: .github-private


### PR DESCRIPTION
## Description

I think runs-on is only referring to this `.github/runs-on.yml` at HEAD, so check in [the custom image definitions](https://runs-on.com/configuration/custom-images/).

## How Has This Been Tested?

no-op

## Additional Options

- [x] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated runs-on configuration to extend from .github.private, sourcing custom AMI specs for Onyx Ubuntu 24 full images on x64 and arm64.
Workflows still use onyx_x64_image and onyx_arm64_image.

<sup>Written for commit e0f6e80ea3d20c4f8fb1e8a5cc0c4b21d2ffc4d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







