### PR TITLE
fix: show agent descriptions

### DIFF
--- a/web/src/app/chat/components/WelcomeMessage.tsx
+++ b/web/src/app/chat/components/WelcomeMessage.tsx
@@ -27,25 +27,30 @@ export default function WelcomeMessage() {
         "mb-6"
       )}
     >
-      <div className="flex items-center">
-        {isDefaultAgent ? (
-          <div
-            data-testid="onyx-logo"
-            className="flex flex-row items-center gap-4"
-          >
-            <Logo size="default" />
-            <Text headingH2>{greeting}</Text>
-          </div>
-        ) : (
-          <div
-            data-testid="assistant-name-display"
-            className="flex flex-row items-center justify-center gap-3"
-          >
+      {isDefaultAgent ? (
+        <div
+          data-testid="onyx-logo"
+          className="flex flex-row items-center gap-4"
+        >
+          <Logo size="default" />
+          <Text headingH2>{greeting}</Text>
+        </div>
+      ) : (
+        <div
+          data-testid="assistant-name-display"
+          className="flex flex-col items-center gap-3 w-full max-w-[50rem]"
+        >
+          <div className="flex flex-row items-center gap-3">
             <AgentIcon agent={currentAgent} />
             <Text headingH2>{currentAgent.name}</Text>
           </div>
-        )}
-      </div>
+          {currentAgent.description && (
+            <Text secondaryBody text03>
+              {currentAgent.description}
+            </Text>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

- Restore original behavior by community request
- Does not display Default Agent description
- Maintains a max width, but does not truncate
- Looks fine with onboarding flow if somehow a user finds themselves on a custom agent on first log in

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show agent descriptions in the chat welcome message for non-default agents, fixing the missing description issue. The layout now stacks the agent name and description, centered with a max width for better readability.

<sup>Written for commit efbd20c6f16d61b467528442a1f21ece2226c0b6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

