### PR TITLE
fix(web): Additional Page Retries

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -746,6 +746,7 @@ class WebConnector(LoadConnector):
                     )
                     time.sleep(delay)
 
+                result: ScrapeResult | None = None
                 try:
                     result = self._do_scrape(index, initial_url, session_ctx)
                 except Exception as e:
@@ -756,6 +757,9 @@ class WebConnector(LoadConnector):
                         logger.warning(
                             f"Giving up on {initial_url} after {self.MAX_RETRIES} attempts due to repeated errors."
                         )
+                    continue
+
+                if result is None:
                     continue
 
                 if result.retry:


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Trying to prevent some errors in the Web Connector that we have seen. 

```
Traceback (most recent call last):
  File "/app/onyx/background/indexing/run_docfetching.py", line 1128, in connector_document_extraction
    for document_batch, failure, next_checkpoint in connector_runner.run(
  File "/app/onyx/connectors/connector_runner.py", line 194, in run
    for document_batch in self.connector.load_from_state():
  File "/app/onyx/connectors/web/connector.py", line 711, in load_from_state
    session_ctx.initialize()
  File "/app/onyx/connectors/web/connector.py", line 67, in initialize
    self.playwright, self.playwright_context = start_playwright()
                                               ^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/web/connector.py", line 276, in start_playwright
    browser = playwright.chromium.launch(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/playwright/sync_api/_generated.py", line 14502, in launch
    self._sync(
  File "/usr/local/lib/python3.11/site-packages/playwright/_impl/_sync_base.py", line 115, in _sync
    return task.result()
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/playwright/_impl/_browser_type.py", line 98, in launch
    await self._channel.send(
  File "/usr/local/lib/python3.11/site-packages/playwright/_impl/_connection.py", line 69, in send
    return await self._connection.wrap_api_call(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/playwright/_impl/_connection.py", line 558, in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TargetClosedError: BrowserType.launch: Target page, context or browser has been closed
Browser logs:

<launching> /app/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell --disable-field-trial-config --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=AcceptCHFrame,AvoidUnnecessaryBeforeUnloadCheckSync,DestroyProfileOnBrowserClose,DialMediaRouteProvider,GlobalMediaControls,HttpsUpgrades,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate,AutoDeElevate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --unsafely-disable-devtools-self-xss-warnings --edge-skip-compat-layer-relaunch --enable-automation --headless --hide-scrollbars --mute-audio --blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4 --no-sandbox --disable-blink-features=AutomationControlled --disable-features=IsolateOrigins,site-per-process --disable-site-isolation-trials --user-data-dir=/tmp/playwright_chromiumdev_profile-yKHGzX --remote-debugging-pipe --no-startup-window
<launched> pid=2306098
[pid=2306098][err] [1112/025925.636998:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
Call log:
  - <launching> /app/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell --disable-field-trial-config --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=AcceptCHFrame,AvoidUnnecessaryBeforeUnloadCheckSync,DestroyProfileOnBrowserClose,DialMediaRouteProvider,GlobalMediaControls,HttpsUpgrades,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate,AutoDeElevate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --unsafely-disable-devtools-self-xss-warnings --edge-skip-compat-layer-relaunch --enable-automation --headless --hide-scrollbars --mute-audio --blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4 --no-sandbox --disable-blink-features=AutomationControlled --disable-features=IsolateOrigins,site-per-process --disable-site-isolation-trials --user-data-dir=/tmp/playwright_chromiumdev_profile-yKHGzX --remote-debugging-pipe --no-startup-window
  - <launched> pid=2306098
  - [pid=2306098][err] [1112/025925.636998:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
  - [pid=2306098] <gracefully close start>
  - [pid=2306098] <kill>
  - [pid=2306098] <will force kill>
  - [pid=2306098][err] [0100/000000.692796:WARNING:sandbox/policy/linux/sandbox_linux.cc:414] InitializeSandbox() called with multiple threads in process gpu-process.
  - [pid=2306098] <process did exit: exitCode=null, signal=SIGSEGV>
  - [pid=2306098] starting temporary directories cleanup
  - [pid=2306098] finished temporary directories cleanup
  - [pid=2306098] <gracefully close end>
```

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran locally to try and reproduce the issue with the fix and was not seeing any errors.

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safer Playwright launch with a GPU-disabled fallback and hardens page retries and loading to reduce Web Connector flakiness and “Target page/context/browser has been closed” errors.

- **Bug Fixes**
  - Retry Chromium launch with GPU disabled when the browser closes during startup.
  - Catch SSL errors on HEAD requests and fall back to fetching via the browser.
  - Reduce network idle wait timeout and handle timeouts during infinite scroll without failing.
  - Improve page fetch retry loop with backoff and clear give-up logging.

- **Refactors**
  - Extract helpers for building headers, creating the browser context, and launching with custom args.
  - Centralize launch flags and error message constants for easier maintenance.

<sup>Written for commit 088672698bd964169cee4e92c55399c5c3d63c93. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





