### PR TITLE
Saving the turn

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -35,6 +35,7 @@ from onyx.chat.turn.infra.emitter import get_default_emitter
 from onyx.chat.turn.models import ChatTurnDependencies
 from onyx.configs.chat_configs import CHAT_TARGET_CHUNK_PERCENTAGE
 from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
+from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SavedSearchDoc
@@ -511,7 +512,7 @@ def stream_chat_message_objects(
         # it should use the search tool with the project filter on
         disable_internal_search = bool(
             chat_session.project_id
-            and persona is None
+            and persona.id is DEFAULT_PERSONA_ID
             and (project_file_texts or not project_as_filter)
         )
 

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -497,7 +497,7 @@ class SavedSearchDoc(SearchDoc):
 
 
 class CitationDocInfo(BaseModel):
-    inference_chunk: SearchDoc
+    search_doc: SearchDoc
     citation_number: int | None
 
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -20,6 +20,7 @@ from onyx.configs.app_configs import CURATORS_CANNOT_VIEW_OR_EDIT_NON_OWNED_ASSI
 from onyx.configs.app_configs import DISABLE_AUTH
 from onyx.configs.chat_configs import CONTEXT_CHUNKS_ABOVE
 from onyx.configs.chat_configs import CONTEXT_CHUNKS_BELOW
+from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.context.search.enums import RecencyBiasSetting
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
@@ -45,11 +46,9 @@ from onyx.utils.variable_functionality import fetch_versioned_implementation
 
 logger = setup_logger()
 
-DEFAULT_BEHAVIOR_PERSONA_ID = 0
-
 
 def get_default_behavior_persona(db_session: Session) -> Persona | None:
-    stmt = select(Persona).where(Persona.id == DEFAULT_BEHAVIOR_PERSONA_ID)
+    stmt = select(Persona).where(Persona.id == DEFAULT_PERSONA_ID)
     return db_session.scalars(stmt).first()
 
 

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.models import Tool
+from onyx.db.models import ToolCall
 from onyx.server.features.tool.models import Header
 from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES
 from onyx.utils.headers import HeaderItemDict
@@ -163,3 +164,62 @@ def get_builtin_tool(
         raise RuntimeError(f"Tool type {tool_type.__name__} not found in the database.")
 
     return db_tool
+
+
+def create_tool_call_no_commit(
+    chat_session_id: UUID,
+    parent_chat_message_id: int | None,
+    turn_number: int,
+    tool_id: int,
+    tool_call_id: str,
+    tool_call_arguments: dict[str, Any],
+    tool_call_response: Any,
+    tool_call_tokens: int,
+    db_session: Session,
+    *,
+    parent_tool_call_id: int | None = None,
+    depth: int = -1,
+    reasoning_tokens: str | None = None,
+    add_only: bool = True,
+) -> ToolCall:
+    """
+    Create a ToolCall entry in the database.
+
+    Args:
+        chat_session_id: The chat session ID
+        parent_chat_message_id: The parent chat message ID
+        turn_number: The turn number for this tool call
+        tool_id: The tool ID
+        tool_call_id: The tool call ID (string identifier from LLM)
+        tool_call_arguments: The tool call arguments
+        tool_call_response: The tool call response
+        tool_call_tokens: The number of tokens in the tool call arguments
+        db_session: The database session
+        parent_tool_call_id: Optional parent tool call ID (for nested tool calls)
+        depth: The depth in the tool call tree (default -1, should be calculated after parent references are set)
+        reasoning_tokens: Optional reasoning tokens
+        commit: If True, commit the transaction; if False, flush only
+
+    Returns:
+        The created ToolCall object
+    """
+    tool_call = ToolCall(
+        chat_session_id=chat_session_id,
+        parent_chat_message_id=parent_chat_message_id,
+        parent_tool_call_id=parent_tool_call_id,
+        turn_number=turn_number,
+        depth=depth,
+        tool_id=tool_id,
+        tool_call_id=tool_call_id,
+        reasoning_tokens=reasoning_tokens,
+        tool_call_arguments=tool_call_arguments,
+        tool_call_response=tool_call_response,
+        tool_call_tokens=tool_call_tokens,
+    )
+
+    db_session.add(tool_call)
+    if not add_only:
+        db_session.add(tool_call)
+    else:
+        db_session.flush()
+    return tool_call

--- a/examples/mcp/onyx_server/README.md
+++ b/examples/mcp/onyx_server/README.md
@@ -22,7 +22,7 @@ flags take precedence):
 - `ONYX_API_BASE_URL` – Base URL for the Onyx API. Defaults to
   `http://localhost:3000/api`.
 - `ONYX_API_KEY` – Bearer token used for Onyx API authentication.
-- `ONYX_DEFAULT_PERSONA_ID` – Persona that should be selected when a new chat
+- `DEFAULT_PERSONA_ID` – Persona that should be selected when a new chat
   session is created. Defaults to `0`.
 
 ## Running the server


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured turn-saving flow that persists assistant messages, tool calls (with parent linking and depth), and citations/search docs. Also standardizes default persona handling via DEFAULT_PERSONA_ID.

- **New Features**
  - save_chat_turn writes message text, reasoning tokens, citations, and linked SearchDocs in one commit.
  - Creates ToolCall rows without committing, then links parent_tool_call_id and computes depth; tokenizes arguments with safe fallback.
  - New DB helpers: add_search_docs_to_chat_message and create_db_search_doc(commit flag, default semantic_id).
  - CitationDocInfo now carries search_doc; DB entries are created directly from it.
  - fast_chat_turn uses a local final-answer extractor; turn saving call is temporarily commented out pending integration.

- **Migration**
  - Rename env var ONYX_DEFAULT_PERSONA_ID to DEFAULT_PERSONA_ID.
  - Update code using CitationDocInfo.inference_chunk to CitationDocInfo.search_doc.

<sup>Written for commit f8e1143549217776eab7de705d4d846526aef77d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

