### PR TITLE
Use turbo instead

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "lib/opal"
   ],
   "scripts": {
-    "dev": "next dev --webpack",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Description

Re-revert back to `turbopack`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Next.js dev server to Turbopack by updating the dev script to use --turbopack instead of --webpack. This speeds up local development (faster startup and HMR) with no changes to production build or start scripts.

<sup>Written for commit 102297d5a7d1d7032ec0e7bb5740771b6d9c009d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

