### PR TITLE
chore(deployments): prefer ecr over s3 as docker cache backend

### DIFF
--- a/.github/workflows/docker-build-push-backend-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-backend-container-on-tag.yml
@@ -21,6 +21,7 @@ jobs:
       - runner=${{ matrix.platform == 'linux/amd64' && '8cpu-linux-x64' || '8cpu-linux-arm64' }}
       - run-id=${{ format('{0}-build-and-push-{1}-job-{2}', github.run_id, matrix.platform == 'linux/amd64' && 'linux-amd64' || 'linux-arm64', strategy['job-index']) }}
       - tag=platform-${{ matrix.platform }}
+      - extras=ecr-cache
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +30,8 @@ jobs:
           - linux/arm64
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -90,8 +93,10 @@ jobs:
             ONYX_VERSION=${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/backend-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/backend-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: |
+            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache,mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
@@ -17,6 +17,7 @@ jobs:
       - runner=${{ matrix.platform == 'linux/amd64' && '8cpu-linux-x64' || '8cpu-linux-arm64' }}
       - run-id=${{ format('{0}-build-{1}-job-{2}', github.run_id, matrix.platform == 'linux/amd64' && 'linux-amd64' || 'linux-arm64', strategy['job-index']) }}
       - tag=platform-${{ matrix.platform }}
+      - extras=ecr-cache
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +26,8 @@ jobs:
           - linux/arm64
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -73,8 +76,10 @@ jobs:
             NODE_OPTIONS=--max-old-space-size=8192
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/cloudweb-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/cloudweb-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: |
+            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:cloudweb-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:cloudweb-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache,mode=max
           # no-cache needed due to weird interactions with the builds for different platforms
           # NOTE(rkuo): this may not be true any more with the proper cache prefixing by architecture - currently testing with it off
 

--- a/.github/workflows/docker-build-push-model-server-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-model-server-container-on-tag.yml
@@ -53,10 +53,12 @@ jobs:
     needs: [check_model_server_changes]
     if: needs.check_model_server_changes.outputs.changed == 'true'
     runs-on:
-      [runs-on, runner=8cpu-linux-x64, "run-id=${{ github.run_id }}-amd64"]
+      [runs-on, runner=8cpu-linux-x64, "run-id=${{ github.run_id }}-amd64", "extras=ecr-cache"]
     env:
       PLATFORM_PAIR: linux-amd64
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
@@ -91,18 +93,22 @@ jobs:
             ONYX_VERSION=${{ github.ref_name }}
           outputs: type=registry
           provenance: false
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: |
+            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache,mode=max
 #           no-cache: true
 
   build-arm64:
     needs: [check_model_server_changes]
     if: needs.check_model_server_changes.outputs.changed == 'true'
     runs-on:
-      [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-arm64"]
+      [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-arm64", "extras=ecr-cache"]
     env:
       PLATFORM_PAIR: linux-arm64
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
@@ -137,8 +143,10 @@ jobs:
             ONYX_VERSION=${{ github.ref_name }}
           outputs: type=registry
           provenance: false
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/model-server-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: |
+            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache,mode=max
 
   merge-and-scan:
     needs: [build-amd64, build-arm64, check_model_server_changes]

--- a/.github/workflows/docker-build-push-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-web-container-on-tag.yml
@@ -35,6 +35,7 @@ jobs:
       - runner=${{ matrix.platform == 'linux/amd64' && '8cpu-linux-x64' || '8cpu-linux-arm64' }}
       - run-id=${{ format('{0}-build-{1}-job-{2}', github.run_id, matrix.platform == 'linux/amd64' && 'linux-amd64' || 'linux-arm64', strategy['job-index']) }}
       - tag=platform-${{ matrix.platform }}
+      - extras=ecr-cache
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +44,8 @@ jobs:
           - linux/arm64
 
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -101,8 +104,10 @@ jobs:
 
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/web-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/${{ env.DEPLOYMENT }}/web-${{ env.PLATFORM_PAIR }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: |
+            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache,mode=max
           # no-cache needed due to weird interactions with the builds for different platforms
           # NOTE(rkuo): this may not be true any more with the proper cache prefixing by architecture - currently testing with it off
 


### PR DESCRIPTION
## Description

Having [issues](https://github.com/onyx-dot-app/onyx/actions/runs/19352291251/job/55366349846#step:7:1393) with S3 as a cache backend,

```
Error: buildx failed with: ERROR: failed to build: failed to solve: error writing layer blob: upload multipart failed, upload id:
...
InvalidPart: One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.
```

ECR should be faster and more reliable as a cache backend + this standardizes with presubmits (meaning if ECR has issues, we can fix in presubmits, etc.).

## How Has This Been Tested?

Erm

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Docker build cache from S3 to ECR across all tag build workflows to fix flaky multipart upload errors and speed up builds. Cache images are stored per service and architecture in ECR, with the latest image used as a secondary source.

- **Refactors**
  - Replace S3 cache-from/cache-to with ECR registry refs: {RUNS_ON_ECR_CACHE}:<service>-<deployment>-<platform>-cache.
  - Add runs-on/action step and extras=ecr-cache to standardize runner config.
  - Include REGISTRY_IMAGE:latest in cache-from to reuse existing layers.

- **Migration**
  - Ensure the ECR repo in RUNS_ON_ECR_CACHE exists and runners have pull/push permissions.
  - No changes to image publishing; builds still push to REGISTRY_IMAGE.

<sup>Written for commit 783c4a0d0b8b701d1eacbc2c6f77c99bfc711c47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

