### PR TITLE
chore(deployments): remove unnecessary install of build-essentials

### DIFF
--- a/.github/workflows/docker-build-push-backend-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-backend-container-on-tag.yml
@@ -76,11 +76,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Install build-essential
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-
       - name: Backend Image Docker Build and Push
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6


### PR DESCRIPTION
## Description

I'm fairly confident this isn't needed and it's otherwise causing [flakes](https://github.com/onyx-dot-app/onyx/actions/runs/19353979142/job/55371610612), so remove

## How Has This Been Tested?

Erm

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the build-essential install step from the backend image build workflow to prevent flaky CI runs and reduce build time. The Docker build doesn’t need toolchain packages on the runner, so this has no impact on the resulting image.

<sup>Written for commit c069f8d781cf889545aaacc793624a0b86428fd3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

