### PR TITLE
fix: Fix inputs overflowing in Settings page

### DIFF
--- a/web/src/refresh-components/inputs/InputTypeIn.tsx
+++ b/web/src/refresh-components/inputs/InputTypeIn.tsx
@@ -42,7 +42,7 @@ export interface InputTypeInProps
   // Right section of the input, e.g. password toggle icon
   rightSection?: React.ReactNode;
 
-  placeholder: string;
+  placeholder?: string;
 
   // Controls whether the clear (X) button is shown when there is a value
   showClearButton?: boolean;

--- a/web/src/sections/sidebar/Settings/UserSettings.tsx
+++ b/web/src/sections/sidebar/Settings/UserSettings.tsx
@@ -19,7 +19,6 @@ import {
 import { Loader2, Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import Button from "@/refresh-components/buttons/Button";
-import { Input } from "@/components/ui/input";
 import { deleteAllChatSessions } from "@/app/chat/services/lib";
 import { SourceIcon } from "@/components/SourceIcon";
 import { ValidSources } from "@/lib/types";
@@ -36,6 +35,7 @@ import SvgXOctagon from "@/icons/x-octagon";
 import { PATManagement } from "@/components/user/PATManagement";
 import DefaultModalLayout from "@/refresh-components/layouts/DefaultModalLayout";
 import SvgSettings from "@/icons/settings";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 
 type SettingsSection =
   | "general"
@@ -531,10 +531,10 @@ export default function UserSettings() {
               </div>
             )}
             {activeSection === "personalization" && (
-              <div className="space-y-6">
+              <div className="flex flex-col gap-4">
                 <div>
                   <h3 className="text-lg font-medium">Name</h3>
-                  <Input
+                  <InputTypeIn
                     value={personalizationValues.name}
                     onChange={(event) =>
                       updatePersonalizationField("name", event.target.value)
@@ -553,7 +553,7 @@ export default function UserSettings() {
                 </div>
                 <div>
                   <h3 className="text-lg font-medium">Role</h3>
-                  <Input
+                  <InputTypeIn
                     value={personalizationValues.role}
                     onChange={(event) =>
                       updatePersonalizationField("role", event.target.value)
@@ -639,7 +639,7 @@ export default function UserSettings() {
                     >
                       Current Password
                     </label>
-                    <Input
+                    <InputTypeIn
                       id="currentPassword"
                       type="password"
                       value={currentPassword}
@@ -655,7 +655,7 @@ export default function UserSettings() {
                     >
                       New Password
                     </label>
-                    <Input
+                    <InputTypeIn
                       id="newPassword"
                       type="password"
                       value={newPassword}
@@ -671,7 +671,7 @@ export default function UserSettings() {
                     >
                       Confirm New Password
                     </label>
-                    <Input
+                    <InputTypeIn
                       id="confirmPassword"
                       type="password"
                       value={confirmPassword}


### PR DESCRIPTION
## Description

Fixes inputs in Settings modal.

Addresses: https://linear.app/danswer/issue/DAN-3068/update-settings-inputs.

## Screenshots

### Light

<img width="5088" height="3798" alt="image" src="https://github.com/user-attachments/assets/4ced7a12-652e-435f-a30b-888ffae10b18" />

### Dark

<img width="5088" height="3798" alt="image" src="https://github.com/user-attachments/assets/0c2630b0-f25d-4a19-ba4d-b60b4b01d241" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes input overflow in the Settings modal by switching to the refreshed input component and adjusting layout spacing. Resolves Linear DAN-3068.

- **Bug Fixes**
  - Replaced Input with InputTypeIn for Name, Role, and Password fields.
  - Made placeholder optional in InputTypeIn to match usage.
  - Updated personalization section layout to flex-col with gap to prevent overflow.

<sup>Written for commit 631423db9a358ba0ce93ec1fb820bce8169d49df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

