### PR TITLE
fix(userfiles): remove fixed width in AssistantEditor and ProjectContextPanel

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -1170,7 +1170,7 @@ export default function AssistantEditor({
 
                                     return displayedFiles.map((fileData) => {
                                       return (
-                                        <div key={fileData.id} className="w-40">
+                                        <div key={fileData.id}>
                                           <FileCard
                                             file={fileData as ProjectFile}
                                             hideProcessingState

--- a/web/src/app/chat/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/chat/components/projects/ProjectContextPanel.tsx
@@ -218,7 +218,7 @@ export default function ProjectContextPanel({
               <div className="hidden sm:flex gap-1 relative">
                 {(() => {
                   return allCurrentProjectFiles.slice(0, 4).map((f) => (
-                    <div key={f.id} className="w-40">
+                    <div key={f.id}>
                       <FileCard
                         file={f}
                         removeFile={async (fileId: string) => {


### PR DESCRIPTION
## Description
This pull request makes a minor UI adjustment by removing the fixed width (`w-40`) from containers that wrap `FileCard` components in two locations. This will allow the file cards to be more responsive and adapt to their parent container's width.

* Removed the `w-40` class from the file card container in `AssistantEditor` to improve layout flexibility.
* Removed the `w-40` class from the file card container in `ProjectContextPanel` for consistent responsive design.

Before:
<img width="1760" height="1034" alt="image" src="https://github.com/user-attachments/assets/f2e9caad-c62c-4a9a-9e59-1bffd3f75f7d" />

After:
<img width="976" height="742" alt="Screenshot 2025-11-14 at 12 10 19 PM" src="https://github.com/user-attachments/assets/9cd75552-72a1-4637-8442-2e142bedc23f" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the fixed width from FileCard wrappers in AssistantEditor and ProjectContextPanel so file cards flex to the available space and render consistently across screen sizes. This improves responsive layout and prevents cramped displays in narrow containers.

<sup>Written for commit bb586aab4701ee4965615bff600bd0353b17a05f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

