### PR TITLE
fix: Assistant instruction ignored

### DIFF
--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -296,10 +296,13 @@ class PromptConfig(BaseModel):
             else ""
         )
 
+        # Check if this persona is the default assistant
+        is_default_persona = default_persona and model.id == default_persona.id
+
         # If this persona IS the default assistant, custom_instruction should be None
         # Otherwise, it should be the persona's system_prompt
         custom_instruction = None
-        if not model.is_default_persona:
+        if not is_default_persona:
             custom_instruction = model.system_prompt or None
 
         # Handle prompt overrides
@@ -310,7 +313,7 @@ class PromptConfig(BaseModel):
 
         # If there's an override, apply it to the appropriate field
         if override_system_prompt:
-            if model.is_default_persona:
+            if is_default_persona:
                 default_behavior_system_prompt = override_system_prompt
             else:
                 custom_instruction = override_system_prompt


### PR DESCRIPTION
## Description

#6242 Admin-created assistants (with is_default_persona=True) were using the base assistant's instructions instead of their own. The code was confusing the is_default_persona flag (which means "admin-created, visible to all") with actually being the base assistant.

Fixed PromptConfig.from_model() to check if an assistant is the base assistant by comparing IDs (model.id == default_persona.id) instead of checking the is_default_persona flag.

## How Has This Been Tested?

Confirmed in Langfuse that admin-created assistants now send their own instructions to the LLM.

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes admin-created assistants sending the base assistant’s instructions. We now detect the true default assistant by ID, so personas use their own prompts and overrides. Addresses Linear #6242.

- **Bug Fixes**
  - Identify the default assistant by comparing model.id to default_persona.id instead of using the is_default_persona flag.
  - Apply override_system_prompt to default_behavior_system_prompt only for the default assistant, and to custom_instruction for personas.

<sup>Written for commit a39130e72b43d73e4047179caa25125b58d1a3ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

