### PR TITLE
fix: gpt-5 output formatting

### DIFF
--- a/backend/onyx/chat/prompt_builder/answer_prompt_builder.py
+++ b/backend/onyx/chat/prompt_builder/answer_prompt_builder.py
@@ -13,11 +13,11 @@ from onyx.chat.prompt_builder.citations_prompt import compute_max_llm_input_toke
 from onyx.chat.prompt_builder.utils import translate_history_to_basemessages
 from onyx.file_store.models import InMemoryChatFile
 from onyx.llm.interfaces import LLMConfig
-from onyx.llm.llm_provider_options import OPENAI_PROVIDER_NAME
 from onyx.llm.models import PreviousMessage
 from onyx.llm.utils import build_content_with_imgs
 from onyx.llm.utils import check_message_tokens
 from onyx.llm.utils import message_to_prompt_and_imgs
+from onyx.llm.utils import model_needs_formatting_reenabled
 from onyx.llm.utils import model_supports_image_input
 from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.prompts.chat_prompts import CHAT_USER_CONTEXT_FREE_PROMPT
@@ -48,12 +48,9 @@ def default_build_system_message_v2(
         prompt_config.default_behavior_system_prompt or DEFAULT_SYSTEM_PROMPT
     )
 
-    # See https://simonwillison.net/tags/markdown/ for context on this temporary fix
-    # for o-series markdown generation
-    if (
-        llm_config.model_provider == OPENAI_PROVIDER_NAME
-        and llm_config.model_name.startswith("o")
-    ):
+    # See https://simonwillison.net/tags/markdown/ for context on why this is needed
+    # for OpenAI reasoning models to have correct markdown generation
+    if model_needs_formatting_reenabled(llm_config.model_name):
         system_prompt = CODE_BLOCK_MARKDOWN + system_prompt
 
     tag_handled_prompt = handle_onyx_date_awareness(
@@ -134,13 +131,11 @@ def default_build_system_message(
         prompt_config.custom_instructions
         or prompt_config.default_behavior_system_prompt
     )
-    # See https://simonwillison.net/tags/markdown/ for context on this temporary fix
-    # for o-series markdown generation
-    if (
-        llm_config.model_provider == OPENAI_PROVIDER_NAME
-        and llm_config.model_name.startswith("o")
-    ):
+    # See https://simonwillison.net/tags/markdown/ for context on why this is needed
+    # for OpenAI reasoning models to have correct markdown generation
+    if model_needs_formatting_reenabled(llm_config.model_name):
         system_prompt = CODE_BLOCK_MARKDOWN + system_prompt
+
     tag_handled_prompt = handle_onyx_date_awareness(
         system_prompt,
         prompt_config,

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -1,6 +1,7 @@
 import copy
 import io
 import json
+import re
 from collections.abc import Callable
 from collections.abc import Iterator
 from functools import lru_cache
@@ -914,3 +915,24 @@ def is_true_openai_model(model_provider: str, model_name: str) -> bool:
             f"Failed to determine if {model_provider}/{model_name} is a true OpenAI model"
         )
         return False
+
+
+def model_needs_formatting_reenabled(model_name: str) -> bool:
+    # See https://simonwillison.net/tags/markdown/ for context on why this is needed
+    # for OpenAI reasoning models to have correct markdown generation
+
+    # Models that need formatting re-enabled
+    model_names = ["gpt-5.1", "gpt-5", "o3", "o1"]
+
+    # Pattern matches if any of these model names appear with word boundaries
+    # Word boundaries include: start/end of string, space, hyphen, or forward slash
+    pattern = (
+        r"(?:^|[\s\-/])("
+        + "|".join(re.escape(name) for name in model_names)
+        + r")(?:$|[\s\-/])"
+    )
+
+    if re.search(pattern, model_name):
+        return True
+
+    return False

--- a/backend/tests/unit/onyx/llm/test_formatting_reenabled.py
+++ b/backend/tests/unit/onyx/llm/test_formatting_reenabled.py
@@ -1,0 +1,207 @@
+from onyx.llm.utils import model_needs_formatting_reenabled
+
+
+def test_gpt_5_exact_match() -> None:
+    """Test that gpt-5 model name exactly matches."""
+    assert model_needs_formatting_reenabled("gpt-5") is True
+
+
+def test_o3_exact_match() -> None:
+    """Test that o3 model name exactly matches."""
+    assert model_needs_formatting_reenabled("o3") is True
+
+
+def test_o1_exact_match() -> None:
+    """Test that o1 model name exactly matches."""
+    assert model_needs_formatting_reenabled("o1") is True
+
+
+def test_gpt_5_with_provider_prefix() -> None:
+    """Test that gpt-5 with provider prefix matches."""
+    assert model_needs_formatting_reenabled("openai/gpt-5") is True
+
+
+def test_o3_with_provider_prefix() -> None:
+    """Test that o3 with provider prefix matches."""
+    assert model_needs_formatting_reenabled("openai/o3") is True
+
+
+def test_o1_with_provider_prefix() -> None:
+    """Test that o1 with provider prefix matches."""
+    assert model_needs_formatting_reenabled("openai/o1") is True
+
+
+def test_gpt_5_with_suffix() -> None:
+    """Test that gpt-5 with suffix matches."""
+    assert model_needs_formatting_reenabled("gpt-5-preview") is True
+    assert model_needs_formatting_reenabled("gpt-5-mini") is True
+    assert model_needs_formatting_reenabled("gpt-5-turbo") is True
+
+
+def test_o3_with_suffix() -> None:
+    """Test that o3 with suffix matches."""
+    assert model_needs_formatting_reenabled("o3-mini") is True
+    assert model_needs_formatting_reenabled("o3-preview") is True
+    assert model_needs_formatting_reenabled("o3-max") is True
+
+
+def test_o1_with_suffix() -> None:
+    """Test that o1 with suffix matches."""
+    assert model_needs_formatting_reenabled("o1-preview") is True
+    assert model_needs_formatting_reenabled("o1-mini") is True
+    assert model_needs_formatting_reenabled("o1-max") is True
+
+
+def test_gpt_5_with_provider_and_suffix() -> None:
+    """Test that gpt-5 with provider prefix and suffix matches."""
+    assert model_needs_formatting_reenabled("openai/gpt-5-preview") is True
+    assert model_needs_formatting_reenabled("openai/gpt-5-mini") is True
+
+
+def test_o3_with_provider_and_suffix() -> None:
+    """Test that o3 with provider prefix and suffix matches."""
+    assert model_needs_formatting_reenabled("openai/o3-mini") is True
+    assert model_needs_formatting_reenabled("openai/o3-preview") is True
+
+
+def test_o1_with_provider_and_suffix() -> None:
+    """Test that o1 with provider prefix and suffix matches."""
+    assert model_needs_formatting_reenabled("openai/o1-preview") is True
+    assert model_needs_formatting_reenabled("openai/o1-mini") is True
+
+
+def test_gpt_5_with_space_boundary() -> None:
+    """Test that gpt-5 with space boundary matches."""
+    assert model_needs_formatting_reenabled("openai gpt-5") is True
+    assert model_needs_formatting_reenabled("gpt-5 preview") is True
+
+
+def test_o3_with_space_boundary() -> None:
+    """Test that o3 with space boundary matches."""
+    assert model_needs_formatting_reenabled("openai o3") is True
+    assert model_needs_formatting_reenabled("o3 mini") is True
+
+
+def test_o1_with_space_boundary() -> None:
+    """Test that o1 with space boundary matches."""
+    assert model_needs_formatting_reenabled("openai o1") is True
+    assert model_needs_formatting_reenabled("o1 preview") is True
+
+
+def test_gpt_5_with_slash_boundary() -> None:
+    """Test that gpt-5 with slash boundary matches."""
+    assert model_needs_formatting_reenabled("provider/gpt-5") is True
+    assert model_needs_formatting_reenabled("gpt-5/version") is True
+
+
+def test_o3_with_slash_boundary() -> None:
+    """Test that o3 with slash boundary matches."""
+    assert model_needs_formatting_reenabled("provider/o3") is True
+    assert model_needs_formatting_reenabled("o3/version") is True
+
+
+def test_o1_with_slash_boundary() -> None:
+    """Test that o1 with slash boundary matches."""
+    assert model_needs_formatting_reenabled("provider/o1") is True
+    assert model_needs_formatting_reenabled("o1/version") is True
+
+
+def test_gpt_4_does_not_match() -> None:
+    """Test that gpt-4 does not match."""
+    assert model_needs_formatting_reenabled("gpt-4") is False
+    assert model_needs_formatting_reenabled("gpt-4-turbo") is False
+    assert model_needs_formatting_reenabled("gpt-4o") is False
+    assert model_needs_formatting_reenabled("openai/gpt-4") is False
+
+
+def test_gpt_3_5_does_not_match() -> None:
+    """Test that gpt-3.5-turbo does not match."""
+    assert model_needs_formatting_reenabled("gpt-3.5-turbo") is False
+    assert model_needs_formatting_reenabled("openai/gpt-3.5-turbo") is False
+
+
+def test_o2_does_not_match() -> None:
+    """Test that o2 does not match."""
+    assert model_needs_formatting_reenabled("o2") is False
+    assert model_needs_formatting_reenabled("o2-preview") is False
+    assert model_needs_formatting_reenabled("openai/o2") is False
+
+
+def test_o4_does_not_match() -> None:
+    """Test that o4 does not match."""
+    assert model_needs_formatting_reenabled("o4") is False
+    assert model_needs_formatting_reenabled("o4-mini") is False
+    assert model_needs_formatting_reenabled("openai/o4") is False
+
+
+def test_other_models_do_not_match() -> None:
+    """Test that other common models do not match."""
+    assert model_needs_formatting_reenabled("claude-3-5-sonnet-20241022") is False
+    assert model_needs_formatting_reenabled("gemini-1.5-pro") is False
+    assert model_needs_formatting_reenabled("llama3.1") is False
+    assert model_needs_formatting_reenabled("mistral-large") is False
+
+
+def test_case_sensitivity() -> None:
+    """Test that model names are case-sensitive."""
+    assert model_needs_formatting_reenabled("GPT-5") is False
+    assert model_needs_formatting_reenabled("O3") is False
+    assert model_needs_formatting_reenabled("O1") is False
+    assert model_needs_formatting_reenabled("Gpt-5") is False
+
+
+def test_models_with_gpt_5_in_middle() -> None:
+    """Test that models containing gpt-5 in the middle match."""
+    assert model_needs_formatting_reenabled("something-gpt-5-suffix") is True
+    assert model_needs_formatting_reenabled("prefix/gpt-5/suffix") is True
+
+
+def test_models_with_o3_in_middle() -> None:
+    """Test that models containing o3 in the middle match."""
+    assert model_needs_formatting_reenabled("something-o3-suffix") is True
+    assert model_needs_formatting_reenabled("prefix/o3/suffix") is True
+
+
+def test_models_with_o1_in_middle() -> None:
+    """Test that models containing o1 in the middle match."""
+    assert model_needs_formatting_reenabled("something-o1-suffix") is True
+    assert model_needs_formatting_reenabled("prefix/o1/suffix") is True
+
+
+def test_models_that_contain_but_not_match() -> None:
+    """Test that models containing the strings but not matching word boundaries do not match."""
+    # These should not match because they don't have proper word boundaries
+    assert (
+        model_needs_formatting_reenabled("gpt-50") is False
+    )  # gpt-5 is part of gpt-50
+    assert model_needs_formatting_reenabled("o30") is False  # o3 is part of o30
+    assert model_needs_formatting_reenabled("o10") is False  # o1 is part of o10
+    assert model_needs_formatting_reenabled("gpt-51") is False
+    assert (
+        model_needs_formatting_reenabled("somethingo3") is False
+    )  # no boundary before o3
+    assert (
+        model_needs_formatting_reenabled("o3something") is False
+    )  # no boundary after o3
+
+
+def test_empty_string() -> None:
+    """Test that empty string does not match."""
+    assert model_needs_formatting_reenabled("") is False
+
+
+def test_real_litellm_model_names() -> None:
+    """Test with real model names that might appear in litellm."""
+    # Based on common patterns from models.litellm.ai
+    assert model_needs_formatting_reenabled("openai/gpt-5") is True
+    assert model_needs_formatting_reenabled("openai/o3-mini") is True
+    assert model_needs_formatting_reenabled("openai/o1-preview") is True
+
+    # These should not match
+    assert model_needs_formatting_reenabled("openai/gpt-4o") is False
+    assert model_needs_formatting_reenabled("openai/gpt-4-turbo") is False
+    assert (
+        model_needs_formatting_reenabled("anthropic/claude-3-5-sonnet-20241022")
+        is False
+    )
+    assert model_needs_formatting_reenabled("google/gemini-1.5-pro") is False


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect markdown/code block formatting in responses from OpenAI reasoning models (gpt-5, gpt-5.1, o1, o3). Replaces a fragile provider check with a robust model detector to re-enable formatting when needed.

- **Bug Fixes**
  - Added model_needs_formatting_reenabled with regex matching for gpt-5/gpt-5.1/o1/o3 variants (including prefixes/suffixes and slashes).
  - Updated answer_prompt_builder to use the new detector and removed the provider-based check.
  - Added comprehensive unit tests covering positive matches and non-matches.

<sup>Written for commit 252ee1a318865603dc90ac099ff0ac9cb7210686. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

