### PR TITLE
chore(deployments): add ability to trigger dry-run build

### DIFF
--- a/.github/workflows/docker-build-push-backend-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-backend-container-on-tag.yml
@@ -12,6 +12,7 @@ env:
 
   # tag nightly builds with "edge"
   EDGE_TAG: ${{ startsWith(github.ref_name, 'nightly-latest') }}
+  IS_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   build-and-push:
@@ -72,7 +73,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -85,11 +86,11 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'workflow_dispatch' }}
+          push: ${{ env.IS_DRY_RUN != 'true' }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ env.IS_DRY_RUN != 'true' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY_IMAGE) || format('type=docker,name={0}', env.REGISTRY_IMAGE) }}
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
@@ -102,7 +103,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v4
         with:
           name: backend-digests-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}

--- a/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-cloud-web-container-on-tag.yml
@@ -10,6 +10,7 @@ on:
 env:
   REGISTRY_IMAGE: onyxdotapp/onyx-web-server-cloud
   DEPLOYMENT: cloud
+  IS_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   build:
@@ -51,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -64,7 +65,7 @@ jobs:
           context: ./web
           file: ./web/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'workflow_dispatch' }}
+          push: ${{ env.IS_DRY_RUN != 'true' }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
             NEXT_PUBLIC_CLOUD_ENABLED=true
@@ -77,7 +78,7 @@ jobs:
             NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK=true
             NODE_OPTIONS=--max-old-space-size=8192
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ env.IS_DRY_RUN != 'true' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY_IMAGE) || format('type=docker,name={0}', env.REGISTRY_IMAGE) }}
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:cloudweb-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
@@ -92,7 +93,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v4
         with:
           name: cloudweb-digests-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}

--- a/.github/workflows/docker-build-push-model-server-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-model-server-container-on-tag.yml
@@ -14,6 +14,7 @@ env:
 
   # tag nightly builds with "edge"
   EDGE_TAG: ${{ startsWith(github.ref_name, 'nightly-latest') }}
+  IS_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
 
@@ -77,7 +78,7 @@ jobs:
             network=host
 
       - name: Login to Docker Hub
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -89,11 +90,11 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile.model_server
           platforms: linux/amd64
-          push: ${{ github.event_name != 'workflow_dispatch' }}
+          push: ${{ env.IS_DRY_RUN != 'true' }}
           tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}-amd64
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-          outputs: type=registry
+          outputs: ${{ env.IS_DRY_RUN != 'true' && 'type=registry' || 'type=docker' }}
           provenance: false
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
@@ -128,7 +129,7 @@ jobs:
             network=host
 
       - name: Login to Docker Hub
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -140,11 +141,11 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile.model_server
           platforms: linux/arm64
-          push: ${{ github.event_name != 'workflow_dispatch' }}
+          push: ${{ env.IS_DRY_RUN != 'true' }}
           tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}-arm64
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-          outputs: type=registry
+          outputs: ${{ env.IS_DRY_RUN != 'true' && 'type=registry' || 'type=docker' }}
           provenance: false
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache

--- a/.github/workflows/docker-build-push-web-container-on-tag.yml
+++ b/.github/workflows/docker-build-push-web-container-on-tag.yml
@@ -13,6 +13,7 @@ env:
   EDGE_TAG: ${{ startsWith(github.ref_name, 'nightly-latest') }}
 
   DEPLOYMENT: standalone
+  IS_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   precheck:
@@ -86,7 +87,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -99,13 +100,13 @@ jobs:
           context: ./web
           file: ./web/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'workflow_dispatch' }}
+          push: ${{ env.IS_DRY_RUN != 'true' }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
             NODE_OPTIONS=--max-old-space-size=8192
 
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ env.IS_DRY_RUN != 'true' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY_IMAGE) || format('type=docker,name={0}', env.REGISTRY_IMAGE) }}
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-${{ env.DEPLOYMENT }}-${{ env.PLATFORM_PAIR }}-cache
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
@@ -120,7 +121,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'workflow_dispatch'
+        if: env.IS_DRY_RUN != 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v4
         with:
           name: web-digests-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}


### PR DESCRIPTION
## Description

Adds the ability to trigger a deployment without pushing a tag. On trigger, no images are uploaded to remote.

## How Has This Been Tested?

Triggered a build here: https://github.com/onyx-dot-app/onyx/actions/runs/19374572421/job/55438674161

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add manual “dry-run” builds for container workflows to validate builds without creating tags or publishing images. Manual runs build images locally but skip all publish and scan steps.

- **New Features**
  - Added workflow_dispatch to backend, web, cloud-web, and model-server workflows.
  - For workflow_dispatch runs: skip Docker login, image push, digest upload, and merge/scan steps; buildx still runs with the same build args.

<sup>Written for commit 17650fc1c738f8a7d3d4919d3820392e77552dfa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





