### PR TITLE
chore(tests): allow REDIS_CLOUD_PYTEST_PASSWORD to be empty

### DIFF
--- a/backend/tests/unit/onyx/test_redis.py
+++ b/backend/tests/unit/onyx/test_redis.py
@@ -10,7 +10,7 @@ logger = setup_logger()
 
 
 @pytest.mark.skipif(
-    os.getenv("REDIS_CLOUD_PYTEST_PASSWORD") is None,
+    os.getenv("REDIS_CLOUD_PYTEST_PASSWORD", "") == "",
     reason="Environment variable REDIS_CLOUD_PYTEST_PASSWORD is not set",
 )
 def test_redis_ssl() -> None:


### PR DESCRIPTION
## Description

I think this [dependabot failure](https://github.com/onyx-dot-app/onyx/actions/runs/19375284311/job/55441040313?pr=6248#step:6:432) is because we have [this env set](https://github.com/onyx-dot-app/onyx/actions/runs/19375284311/workflow?pr=6248#L21) but it's resolving to an empty string.

We could also set this for dependabot, but I can't find its value and not sure it's worth.

## How Has This Been Tested?

Captured by presubmit,

```
REDIS_CLOUD_PYTEST_PASSWORD="" pytest backend/tests/unit/onyx/test_redis.py
```

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Redis SSL test to skip when REDIS_CLOUD_PYTEST_PASSWORD is missing or empty, not just unset. This prevents CI failures in Dependabot runs where the variable is defined but blank.

<sup>Written for commit 6eb65fa06e24851963a29215d8e894f0de94f74e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



