### PR TITLE
chore(deployments): fix actions/checkout typo

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0eb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Docker meta
         id: meta
@@ -169,7 +169,7 @@ jobs:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0eb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Docker meta
         id: meta
@@ -253,7 +253,7 @@ jobs:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0eb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Docker meta
         id: meta
@@ -336,7 +336,7 @@ jobs:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0eb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
## Description

Fixes a typo introduced in https://github.com/onyx-dot-app/onyx/commit/530d6d8284b5516f0842690bf955d317859cafc4

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19378089924

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the pinned actions/checkout reference across the deployment workflow. Restores the checkout step and unblocks CI builds and deployments.

<sup>Written for commit 7f2337a8e64e37981e7444d1cfa94e9fc68432bb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

