### PR TITLE
chore: foss sync readme

### DIFF
--- a/backend/scripts/make_foss_repo.sh
+++ b/backend/scripts/make_foss_repo.sh
@@ -44,7 +44,25 @@ echo "=== Recreating empty enterprise directory ==="
 mkdir -p backend/ee
 touch backend/ee/__init__.py
 git add backend/ee
-git commit -m "Add enterprise directory and __init__.py"
+
+echo "=== Updating README ==="
+
+cat > /tmp/foss_notice.txt << 'EOF'
+
+> [!NOTE]
+> **This is the FOSS (Free and Open Source Software) version of Onyx**
+> 
+> This repository is 100% MIT-licensed and automatically synced with the [main Onyx repository](https://github.com/onyx-dot-app/onyx). The [main repository](https://github.com/onyx-dot-app/onyx) is recommended for most users. This FOSS version is maintained for users with strict open-source licensing requirements.
+> 
+> ---
+
+EOF
+
+sed -i '/<a name="readme-top"><\/a>/r /tmp/foss_notice.txt' README.md
+sed -i 's/utm_source=onyx_repo/utm_source=foss_repo/g' README.md
+
+git add README.md
+git commit -m "README"
 
 echo "=== Creating blob callback script ==="
 cat > /tmp/license_replacer.py << 'PYEOF'


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the FOSS sync script to insert a clear FOSS notice into the README and switch UTM tracking to foss_repo, so the public repo points users to the main Onyx repo and clarifies licensing.

- **New Features**
  - Injects a FOSS notice below the README top anchor during sync.
  - Replaces utm_source=onyx_repo with utm_source=foss_repo.

<sup>Written for commit 49cfb92fbef8095d01f5b93807b96e1b58be41c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

