### PR TITLE
chore: [Running GitHub actions for #6243]

### DIFF
--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -296,10 +296,13 @@ class PromptConfig(BaseModel):
             else ""
         )
 
+        # Check if this persona is the default assistant
+        is_default_persona = default_persona and model.id == default_persona.id
+
         # If this persona IS the default assistant, custom_instruction should be None
         # Otherwise, it should be the persona's system_prompt
         custom_instruction = None
-        if not model.is_default_persona:
+        if not is_default_persona:
             custom_instruction = model.system_prompt or None
 
         # Handle prompt overrides
@@ -310,7 +313,7 @@ class PromptConfig(BaseModel):
 
         # If there's an override, apply it to the appropriate field
         if override_system_prompt:
-            if model.is_default_persona:
+            if is_default_persona:
                 default_behavior_system_prompt = override_system_prompt
             else:
                 custom_instruction = override_system_prompt


### PR DESCRIPTION
Automated mirror of PR #6243 so private CI can run.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed default assistant detection in chat persona mapping so the default persona doesn’t get a custom_instruction and system prompt overrides apply to the right field. Prevents misapplied overrides and incorrect behavior for the default assistant.

- **Bug Fixes**
  - Replaced model.is_default_persona with an explicit check against default_persona.id (is_default_persona).
  - Applied the check to set custom_instruction to None for the default persona and route override_system_prompt to default_behavior_system_prompt; non-default personas use system_prompt or the override as custom_instruction.

<sup>Written for commit a39130e72b43d73e4047179caa25125b58d1a3ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

