### PR TITLE
feat(docker): reduce the size of web image: 298MB->203MB

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,11 +17,15 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# pull in source code / package.json / package-lock.json
-COPY . .
+# Copy package files first for better layer caching
+# This layer will be cached unless package.json or package-lock.json changes
+COPY package.json package-lock.json ./
 
-# Install dependencies
+# Install dependencies (cached layer unless package files change)
 RUN npm ci
+
+# Copy the rest of the source code
+COPY . .
 
 # needed to get the `standalone` dir we expect later
 ENV NEXT_PRIVATE_STANDALONE=true
@@ -64,7 +68,7 @@ ARG NEXT_PUBLIC_CLOUD_ENABLED
 ENV NEXT_PUBLIC_CLOUD_ENABLED=${NEXT_PUBLIC_CLOUD_ENABLED}
 
 ARG NEXT_PUBLIC_SENTRY_DSN
-ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN} 
+ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
 
 ARG NEXT_PUBLIC_GTM_ENABLED
 ENV NEXT_PUBLIC_GTM_ENABLED=${NEXT_PUBLIC_GTM_ENABLED}
@@ -81,20 +85,19 @@ ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}
 # Add NODE_OPTIONS argument
 ARG NODE_OPTIONS
 
-# Use NODE_OPTIONS in the build command
-RUN NODE_OPTIONS="${NODE_OPTIONS}" npx next build
+# Build the application
+RUN NODE_OPTIONS="${NODE_OPTIONS}" npx next build && \
+    # Remove global node modules, since they are not needed by the actual app
+    # (all dependencies are copied over into the `/app` dir itself). These
+    # global modules may be outdated and trigger security scans.
+    rm -rf /usr/local/lib/node_modules
 
 # Step 2. Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
 
-# Remove global node modules, since they are not needed by the actual app
-# (all dependencies are copied over into the `/app` dir itself). These
-# global modules may be outdated and trigger security scans.
-RUN rm -rf /usr/local/lib/node_modules
-
-# Not needed, set by compose 
-# ENV NODE_ENV production  
+# Not needed, set by compose
+# ENV NODE_ENV production
 
 # Disable automatic telemetry collection
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -147,7 +150,7 @@ ARG NEXT_PUBLIC_CLOUD_ENABLED
 ENV NEXT_PUBLIC_CLOUD_ENABLED=${NEXT_PUBLIC_CLOUD_ENABLED}
 
 ARG NEXT_PUBLIC_SENTRY_DSN
-ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN} 
+ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
 
 ARG NEXT_PUBLIC_GTM_ENABLED
 ENV NEXT_PUBLIC_GTM_ENABLED=${NEXT_PUBLIC_GTM_ENABLED}
@@ -161,8 +164,8 @@ ENV NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK=${NEXT_PUBLIC_INCLUDE_ERROR_POP
 ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}
 
-# Note: Don't expose ports here, Compose will handle that for us if necessary. 
-# If you want to run this without compose, specify the ports to 
+# Note: Don't expose ports here, Compose will handle that for us if necessary.
+# If you want to run this without compose, specify the ports to
 # expose via cli
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Description

Remove the `node_modules` in the same build stage that introduces them to prevent them from lingering in the intermediate layers of the image.

Also, only copy in the `package.json` and `package-lock.json` before running `npm ci` so that we can cache that layer more frequently. Before, it would re-run every time `/web/**` changed, now it should only run whenever the package jsons change.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the web Docker image size from 298MB to 203MB by consolidating install/build into one layer and cleaning up global node modules and npm cache during the build.

- **Refactors**
  - Run npm ci and next build in a single RUN with NODE_OPTIONS.
  - Remove /usr/local/lib/node_modules and clean npm cache in the builder stage to prevent leftover layers.
  - Minor ENV formatting cleanup (trimmed whitespace).

<sup>Written for commit e3fc25a61e0db897c2997a3a47ddc28fcb107915. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





