### PR TITLE
chore(docker): install node deps before copying source

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 # Copy package files first for better layer caching
 # This layer will be cached unless package.json or package-lock.json changes
 COPY package.json package-lock.json ./
+COPY lib/opal/package.json ./lib/opal/
 
 # Install dependencies
 RUN npm ci


### PR DESCRIPTION
## Description

Installing dependencies only depends on the package.json and its lockfile. Installing deps before copying source allows docker to cache these layers in cases only the source code changes saving about 30s.

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize Docker build caching by installing Node dependencies before copying the source. Copies package.json, package-lock.json, and lib/opal/package.json first, runs npm ci, then copies the rest so rebuilds skip dependency install when only source changes, saving ~30s.

<sup>Written for commit eee73ff5f4ad67281561504234a99a7abc3685d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











