### PR TITLE
fix(tests): Connector Creation Test fix

### DIFF
--- a/backend/tests/integration/common_utils/managers/cc_pair.py
+++ b/backend/tests/integration/common_utils/managers/cc_pair.py
@@ -345,10 +345,15 @@ class CCPairManager:
                 if not fetched_cc_pair.in_progress:
                     continue
 
-                if fetched_cc_pair.docs_indexed >= num_docs:
+                progress = fetched_cc_pair.latest_index_attempt_docs_indexed
+                if progress is None:
+                    progress = fetched_cc_pair.docs_indexed
+
+                if progress >= num_docs:
                     print(
                         "Indexed at least the requested number of docs: "
                         f"cc_pair={cc_pair.id} "
+                        f"latest_attempt_docs_indexed={fetched_cc_pair.latest_index_attempt_docs_indexed} "
                         f"docs_indexed={fetched_cc_pair.docs_indexed} "
                         f"num_docs={num_docs}"
                     )


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Fixing a test that has been broken for a while now

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Connector Creation integration test by correctly checking indexing progress using the latest attempt count, reducing flakiness and false failures.

- **Bug Fixes**
  - Use latest_index_attempt_docs_indexed as the primary progress metric; fallback to docs_indexed when None.
  - Print both latest_attempt_docs_indexed and docs_indexed in the success message for easier debugging.

<sup>Written for commit 6a54f6edf85478fed56546969c09094ac21f7a50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

