### PR TITLE
chore(mypy): color output in CI

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Run MyPy
         working-directory: ./backend
+        env:
+          MYPY_FORCE_COLOR: 1
+          TERM: xterm-256color
         run: mypy .
 
       - name: Check import order with reorder-python-imports


### PR DESCRIPTION
## Description

Color the mypy output in CI.

## How Has This Been Tested?

<img width="655" height="268" alt="20251115_17h18m25s_grim" src="https://github.com/user-attachments/assets/7e1214aa-63c4-4bd7-9a1e-cf442b85c5a7" />


## Additional Options

- [x] Override Linear Check
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds colorized MyPy output in CI to make type errors easier to read. Forces color by setting MYPY_FORCE_COLOR and TERM in the workflow.

<sup>Written for commit d038f7fbcb4b4a11daaf26c662d16b8faf3d0e39. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















