### PR TITLE
chore(scripts): only run check_lazy_imports on changed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,15 +65,12 @@ repos:
         language: system
         pass_filenames: false
         files: \.tf$
+
       - id: check-lazy-imports
-        name: Check lazy imports are not directly imported
+        name: Check lazy imports
         entry: python3 backend/scripts/check_lazy_imports.py
         language: system
         files: ^backend/(?!\.venv/).*\.py$
-        pass_filenames: false
-        # Note: pass_filenames is false because tsc must check the entire
-        # project, but the files filter ensures this only runs when relevant
-        # files change. Using --incremental for faster subsequent checks.
 
   # We would like to have a mypy pre-commit hook, but due to the fact that
   # pre-commit runs in it's own isolated environment, we would need to install


### PR DESCRIPTION
## Description

about 1.8s faster on pre-commit

#### before

```
$ time prek run --files backend/onyx/agents/agent_sdk/message_format.py > /dev/null
prek run --files backend/onyx/agents/agent_sdk/message_format.py > /dev/null  2.11s user 0.22s system 106% cpu 2.199 total
```

#### after

```
$ time prek run --files backend/onyx/agents/agent_sdk/message_format.py > /dev/null
prek run --files backend/onyx/agents/agent_sdk/message_format.py > /dev/null  0.42s user 0.19s system 123% cpu 0.499 total
```

## How Has This Been Tested?

```
[0] ~/code/onyx [jamison/check_lazy_import-files !] 2025-11-15 17:50:08
$ python3 backend/scripts/check_lazy_imports.py backend/onyx/llm/litellm_singleton/__init__.py
...
❌ Eager import violations found in onyx/llm/litellm_singleton/__init__.py:
2025-11-15 17:50:09,191 - __main__ - ERROR -   Line 7: import litellm
2025-11-15 17:50:09,191 - __main__ - ERROR -   💡 You must lazy import litellm within functions when needed

[1] ~/code/onyx [jamison/check_lazy_import-files !] 2025-11-15 17:50:09
$ python3 backend/scripts/check_lazy_imports.py                                               
...
❌ Eager import violations found in onyx/llm/litellm_singleton/__init__.py:
2025-11-15 17:50:14,357 - __main__ - ERROR -   Line 7: import litellm
2025-11-15 17:50:14,357 - __main__ - ERROR -   💡 You must lazy import litellm within functions when needed
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run check_lazy_imports only on changed files via pre-commit. This speeds up single-file runs by ~1.8s.

- **New Features**
  - Pre-commit now passes changed backend Python files to the checker; if no paths are provided, it scans all backend files.
  - Script accepts file/directory arguments, applies shared filters (ignores tests and venv/cache dirs), and limits checks to the backend directory.

<sup>Written for commit 19e2d04e917a3f820084d288e7da1bddb96f4a26. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

