### PR TITLE
chore(docker): strip node

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -32,7 +32,7 @@ RUN npm ci
 COPY . .
 
 # ONYX_VERSION inherited from build args, redeclared for this stage
-ARG ONYX_VERSION=0.0.0-dev
+ARG ONYX_VERSION
 ENV ONYX_VERSION=${ONYX_VERSION}
 
 # needed to get the `standalone` dir we expect later


### PR DESCRIPTION
## Description

An attempt to reduce the size of the web image. It seems dangerous but maybe worth.

```
$ docker images                                  
REPOSITORY                     TAG                                  IMAGE ID       CREATED              SIZE
jamison/onyx-web-server        after                                29fcfcc7199f   About a minute ago   169MB
jamison/onyx-web-server        before                               be32e15e9389   6 minutes ago        203MB
```

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check




























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce the web image size by switching the runtime to minimal Alpine and stripping debug symbols from the Node binary. The app still builds on node:20-alpine and runs with the copied Node binary and required runtime libs.

- **Refactors**
  - Install only the runtime libs needed: libc6-compat, libstdc++, libgcc, libcrypto3, libssl3, ca-certificates
  - Strip the Node binary in a separate stage and copy it into the final image
  - Remove the global node_modules cleanup step (not applicable in the new final image)

<sup>Written for commit af8e07b369717a4d7ace4cc85fcd0931e284f45d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



























