### PR TITLE
chore(deployment): increase model-server builder to 40GB disk

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -16,7 +16,7 @@ self-hosted-runner:
     - runner=16cpu-linux-arm64
     - runner=16cpu-linux-x64
     - ubuntu-slim # Currently in public preview
-    - volume=30gb
+    - volume=40gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -323,7 +323,7 @@ jobs:
       - runs-on
       - runner=2cpu-linux-x64
       - run-id=${{ github.run_id }}-model-server-build
-      - volume=30gb
+      - volume=40gb
       - extras=ecr-cache
     env:
       REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}


### PR DESCRIPTION
## Description

Hitting no space left on device with 30gb: https://github.com/onyx-dot-app/onyx/actions/runs/19400154883/job/55506526309#step:8:968

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19400232774

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase self-hosted runner disk from 30GB to 40GB for the model-server build to prevent “no space left on device” failures. Updates actionlint and deployment workflow labels to use the new volume size.

<sup>Written for commit b8742fe0879de9543237f63cbdcc89a4c7192539. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

