### PR TITLE
fix: assistant reordering

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -184,9 +184,9 @@ function AppSidebarInner() {
           }
         }
 
-        // Use visibleAgents instead of prev to ensure indices match
-        const reordered = arrayMove(visibleAgents, activeIndex, overIndex);
-        return reordered;
+        // Use visibleAgents instead of prev to ensure the indices match
+        // with `visibleAgentIds`
+        return arrayMove(visibleAgents, activeIndex, overIndex);
       });
     },
     [


### PR DESCRIPTION
## Description

Now 
https://github.com/user-attachments/assets/6d6d1053-2936-484c-a183-b12950c4e565


## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assistant drag-and-drop reordering in the sidebar so moves follow the visible list and don’t scramble order.

- **Bug Fixes**
  - Use visibleAgents in arrayMove to match rendered indices.
  - Add visibleAgents to useCallback deps to keep reorder logic in sync.

<sup>Written for commit a13d1df32d1ee3e3a70040d5a6632dcc7610b42a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



