### PR TITLE
fix: disable aggressive caching for Next.js static assets in dev

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -33,6 +33,7 @@ const nextConfig = {
     unoptimized: true, // Disable image optimization to avoid requiring Sharp
   },
   async headers() {
+    const isDev = process.env.NODE_ENV === "development";
     return [
       {
         source: "/(.*)",
@@ -62,12 +63,13 @@ const nextConfig = {
       },
       {
         // Cache static assets (images, icons, fonts, etc.) to prevent refetching and re-renders
-        // This helps eliminate icon flickering and improves performance
-        source: "/_next/static/:path*", // Matches static assets served by Next.js
+        source: "/_next/static/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable", // Cache for 1 year, mark as immutable
+            value: isDev
+              ? "no-cache, must-revalidate" // Dev: always check if fresh
+              : "public, max-age=2592000, immutable", // Prod: cache for 30 days
           },
         ],
       },


### PR DESCRIPTION
## Description

This change adjusts client-side caching for Next.js static assets (CSS/JS) when developing locally. Having no cache expiration was causing stale CSS to remain in browser caches during local dev. Now we always refresh in dev mode (no-cache, must-revalidate). Also reduced production cache from 1 year to 30 days for better cache hygiene.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale CSS/JS during local dev by updating Cache-Control headers for Next.js static assets. Dev now always revalidates; prod cache is reduced to 30 days to limit long-lived staleness.

- **Bug Fixes**
  - Dev: set Cache-Control to "no-cache, must-revalidate" for /_next/static/*.
  - Prod: set Cache-Control to "public, max-age=2592000, immutable" (30 days), down from 1 year.

<sup>Written for commit 0ee79a8ea229e06b8c5915da301364a5c42a5af9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



