### PR TITLE
fix(permsync): don't fail on empty group ids

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -197,7 +197,7 @@ def get_documents_for_connector_credential_pair_limited_columns(
         doc_row = DocumentRow(
             id=row.id,
             doc_metadata=row.doc_metadata,
-            external_user_group_ids=row.external_user_group_ids,
+            external_user_group_ids=row.external_user_group_ids or [],
         )
         doc_rows.append(doc_row)
     return doc_rows


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permission sync crashes when documents have empty or null external_user_group_ids. We now default to [] in DocumentRow construction to keep document fetching and downstream logic safe.

<sup>Written for commit 39fa6c23337aee42269705a037a938aa2f82aaf5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

