### PR TITLE
chore(tests): increase size of integration test runner

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,6 +17,7 @@ self-hosted-runner:
     - runner=16cpu-linux-x64
     - ubuntu-slim # Currently in public preview
     - volume=40gb
+    - volume=80gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -121,7 +121,7 @@ jobs:
 
 
   build-integration-image:
-    runs-on: [runs-on, runner=4cpu-linux-x64, "run-id=${{ github.run_id }}-build-integration-image", "extras=ecr-cache", "volume=40gb"]
+    runs-on: [runs-on, runner=4cpu-linux-x64, "run-id=${{ github.run_id }}-build-integration-image", "extras=ecr-cache", "volume=80gb"]
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - name: Checkout code


### PR DESCRIPTION
## Description

Might be needed for connectors/indexing tests

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase CI integration test runner from 4cpu ARM64 to 8cpu x64 to better handle connectors/indexing tests. Align runners to linux/amd64, remove arm64 image pulls, attach an 80GB volume for integration image builds, and enable CPU and memory metrics reporting.

<sup>Written for commit 4892888c40f9d5e58e961d5fbcb939992debd5f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













