### PR TITLE
feat(modal): Implement a new modal component

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -132,10 +132,9 @@ const useModalContext = () => {
 const ModalContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    hideCloseButton?: boolean;
     size?: "main" | "medium" | "small" | "tall" | "mini";
   }
->(({ className, children, hideCloseButton, size, ...props }, ref) => {
+>(({ className, children, size, ...props }, ref) => {
   const closeButtonRef = React.useRef<HTMLDivElement>(null);
   const [hasAttemptedClose, setHasAttemptedClose] = React.useState(false);
   const hasUserTypedRef = React.useRef(false);
@@ -158,7 +157,17 @@ const ModalContent = React.forwardRef<
       return;
     }
 
-    const target = e.target as HTMLInputElement | HTMLTextAreaElement;
+    const target = e.target as HTMLElement;
+
+    // Only handle input and textarea elements
+    if (
+      !(
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement
+      )
+    ) {
+      return;
+    }
 
     // Skip non-text inputs
     if (


### PR DESCRIPTION
## Description

Introduces a new modal system built on Radix UI with compound component architecture (Modal.Content, Modal.Header, Modal.Body, Modal.Footer, etc.), 5 size variants (main/medium/small/tall/mini), and unsaved changes protection that requires double-confirmation before closing when user has typed input.
Fully accessible with proper ARIA attributes, smooth animations, and comprehensive customization via className props.

Addresses: https://linear.app/danswer/issue/DAN-3087/revamp-modal-component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented a new accessible Modal component with a compound API, five size variants, and protection against accidental closes after the user types. This standardizes modals across the app and improves UX, accessibility, and customization.

- **New Features**
  - Compound API: Modal.Content, Header, Body, Footer, Title, Description, Icon, CloseButton, Overlay.
  - Five sizes: main, medium, small, tall, mini.
  - Unsaved changes guard: first Escape/outside click after typing is blocked and focuses the close button; second attempt closes.
  - Accessible defaults via Radix Dialog (proper ARIA, focus management, portal), with overlay and blur.
  - Smooth open/close animations; full styling control via className.
  - Close button with focus ring and optional onClose callback.

<sup>Written for commit cee4b1904087b9920575ad3d889a1177cb519a6f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->