### PR TITLE
chore(deps): upgrade psutil: 5.9.8->7.1.3

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -53,7 +53,7 @@ openai==2.6.1
 openpyxl==3.0.10
 passlib==1.7.4
 playwright==1.55.0
-psutil==5.9.5
+psutil==7.1.3
 psycopg2-binary==2.9.9
 puremagic==1.28
 pyairtable==3.0.1


### PR DESCRIPTION
## Description

This is pulled in transitively by the model_server. Without https://github.com/onyx-dot-app/onyx/pull/6291, the model_server installs this latest version. With that change, this `5.9.5` version fails to install in the model_server image (it seems there are no prebuilt wheels at the version and building from source fails). 

## How Has This Been Tested?

Captured by presubmit

## Additional Options

- [x] Override Linear Check
