### PR TITLE
chore(deployments): run trivy scanners separate from build and push

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -100,11 +100,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # ratchet:docker/metadata-action@v5
         with:
-          images: ${{ github.event_name == 'workflow_dispatch' && format('{0}:web-{1}', env.RUNS_ON_ECR_CACHE, needs.determine-builds.outputs.sanitized-tag) || env.REGISTRY_IMAGE }}
+          images: ${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.event_name == 'workflow_dispatch' && needs.determine-builds.outputs.sanitized-tag || github.ref_name }}
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && format('web-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-stable == 'true' && 'latest' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
@@ -158,11 +158,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # ratchet:docker/metadata-action@v5
         with:
-          images: ${{ github.event_name == 'workflow_dispatch' && format('{0}:web-cloud-{1}', env.RUNS_ON_ECR_CACHE, needs.determine-builds.outputs.sanitized-tag) || env.REGISTRY_IMAGE }}
+          images: ${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.event_name == 'workflow_dispatch' && needs.determine-builds.outputs.sanitized-tag || github.ref_name }}
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && format('web-cloud-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
@@ -221,11 +221,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # ratchet:docker/metadata-action@v5
         with:
-          images: ${{ github.event_name == 'workflow_dispatch' && format('{0}:backend-{1}', env.RUNS_ON_ECR_CACHE, needs.determine-builds.outputs.sanitized-tag) || env.REGISTRY_IMAGE }}
+          images: ${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.event_name == 'workflow_dispatch' && needs.determine-builds.outputs.sanitized-tag || github.ref_name }}
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && format('backend-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-stable-standalone == 'true' && 'latest' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
@@ -281,11 +281,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # ratchet:docker/metadata-action@v5
         with:
-          images: ${{ github.event_name == 'workflow_dispatch' && format('{0}:model-server-{1}', env.RUNS_ON_ECR_CACHE, needs.determine-builds.outputs.sanitized-tag) || env.REGISTRY_IMAGE }}
+          images: ${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.event_name == 'workflow_dispatch' && needs.determine-builds.outputs.sanitized-tag || github.ref_name }}
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && format('model-server-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-stable-standalone == 'true' && 'latest' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ github.event_name != 'workflow_dispatch' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}


### PR DESCRIPTION
## Description

Three major changes:
- We now always push regardless of dry-run or not. On dry-run, we push the ephemeral ECR registry rather than the official Dockerhub.
- Always run the Trivy scanner, including on dry-run, fetching the image from the ephemeral ECR registry.
- Run the trivy in separate jobs from the build and push. Gives us slightly better UX + faster notifications on build failure.

The original intention here seemed to be to load these images and immediately scan them. I'm having issues loading the images, I think because they're cross-platform, so it makes sense to just run them separately.

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19446073291

## Additional Options

- [x]  Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Trivy scans into separate jobs and made builds always push, using the ephemeral ECR registry for dry-runs. This improves CI feedback and ensures scans run on every build.

- **Refactors**
  - Build jobs always push; dry-runs tag to ECR cache (web, web-cloud, backend, model-server) with sanitized tags.
  - Added separate Trivy scan jobs per image, running after successful builds.
  - Scans DockerHub images on standard runs and ECR images on dry-runs.
  - Backend scan uses .trivyignore for expected exclusions.

<sup>Written for commit 251e51558f29168e28618c581ce6182b46e7b568. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





