### PR TITLE
feat: add mcp server to docker

### DIFF
--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -21,7 +21,7 @@ upstream web_server {
 }
 
 upstream mcp_server {
-    server ${ONYX_BACKEND_API_HOST}:8090 fail_timeout=0;
+    server ${ONYX_MCP_SERVER_HOST}:8090 fail_timeout=0;
 }
 
 server {
@@ -32,7 +32,6 @@ server {
     access_log /var/log/nginx/access.log custom_main;
 
     # MCP Server - must come BEFORE /api location
-    # Phase 1: HTTP POST only, no streaming/SSE
     location /mcp {
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -39,7 +39,7 @@ upstream web_server {
 }
 
 upstream mcp_server {
-    server api_server:8090 fail_timeout=0;
+    server mcp_server:8090 fail_timeout=0;
 }
 
 server {
@@ -50,7 +50,6 @@ server {
     access_log /var/log/nginx/access.log custom_main;
 
     # MCP Server - must come BEFORE /api location
-    # Phase 1: HTTP POST only, no streaming/SSE
     location /mcp {
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -39,7 +39,7 @@ upstream web_server {
 }
 
 upstream mcp_server {
-    server ${ONYX_BACKEND_API_HOST}:8090 fail_timeout=0;
+    server ${ONYX_MCP_SERVER_HOST}:8090 fail_timeout=0;
 }
 
 server {
@@ -50,7 +50,6 @@ server {
     access_log /var/log/nginx/access.log custom_main;
 
     # MCP Server - must come BEFORE /api location
-    # Phase 1: HTTP POST only, no streaming/SSE
     location /mcp {
         # misc headers
         proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/data/nginx/run-nginx.sh
+++ b/deployment/data/nginx/run-nginx.sh
@@ -1,6 +1,7 @@
 # fill in the template
 export ONYX_BACKEND_API_HOST="${ONYX_BACKEND_API_HOST:-api_server}"
 export ONYX_WEB_SERVER_HOST="${ONYX_WEB_SERVER_HOST:-web_server}"
+export ONYX_MCP_SERVER_HOST="${ONYX_MCP_SERVER_HOST:-mcp_server}"
 
 export SSL_CERT_FILE_NAME="${SSL_CERT_FILE_NAME:-ssl.crt}"
 export SSL_CERT_KEY_FILE_NAME="${SSL_CERT_KEY_FILE_NAME:-ssl.key}"
@@ -12,9 +13,10 @@ export NGINX_PROXY_READ_TIMEOUT="${NGINX_PROXY_READ_TIMEOUT:-300}"
 
 echo "Using API server host: $ONYX_BACKEND_API_HOST"
 echo "Using web server host: $ONYX_WEB_SERVER_HOST"
+echo "Using MCP server host: $ONYX_MCP_SERVER_HOST"
 echo "Using nginx proxy timeouts - connect: ${NGINX_PROXY_CONNECT_TIMEOUT}s, send: ${NGINX_PROXY_SEND_TIMEOUT}s, read: ${NGINX_PROXY_READ_TIMEOUT}s"
 
-envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME $ONYX_BACKEND_API_HOST $ONYX_WEB_SERVER_HOST $NGINX_PROXY_CONNECT_TIMEOUT $NGINX_PROXY_SEND_TIMEOUT $NGINX_PROXY_READ_TIMEOUT' < "/etc/nginx/conf.d/$1" > /etc/nginx/conf.d/app.conf
+envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME $ONYX_BACKEND_API_HOST $ONYX_WEB_SERVER_HOST $ONYX_MCP_SERVER_HOST $NGINX_PROXY_CONNECT_TIMEOUT $NGINX_PROXY_SEND_TIMEOUT $NGINX_PROXY_READ_TIMEOUT' < "/etc/nginx/conf.d/$1" > /etc/nginx/conf.d/app.conf
 
 # wait for the api_server to be ready
 echo "Waiting for API server to boot up; this may take a minute or two..."

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -12,7 +12,10 @@ services:
   api_server:
     ports:
       - "8080:8080"
-      - "8090:8090"  # MCP Server
+
+  mcp_server:
+    ports:
+      - "8090:8090"
 
   relational_db:
     ports:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -165,6 +165,51 @@ services:
     environment:
       - INTERNAL_URL=${INTERNAL_URL:-http://api_server:8080}
 
+  mcp_server:
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile
+    command: >
+      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-false}\" = \"true\" ]; then
+        echo 'Starting Onyx MCP Server' &&
+        uvicorn onyx.mcp_server.api:mcp_app --host 0.0.0.0 --port 8090;
+      else
+        echo 'MCP server is disabled (set MCP_SERVER_ENABLED=true to enable)' &&
+        sleep infinity;
+      fi"
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      - relational_db
+      - cache
+    restart: unless-stopped
+    # DEV: To expose ports, either:
+    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+    # 2. Uncomment the ports below
+    # ports:
+    #   - "8090:8090"
+    environment:
+      - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
+      - REDIS_HOST=${REDIS_HOST:-cache}
+      # MCP Server Configuration
+      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+      - MCP_SERVER_NAME=${MCP_SERVER_NAME:-Onyx}
+      - MCP_SERVER_VERSION=${MCP_SERVER_VERSION:-1.0.0}
+      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+    # Optional, only for debugging purposes
+    volumes:
+      - mcp_server_logs:/var/log/onyx
+
   inference_model_server:
     image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
     build:
@@ -391,5 +436,6 @@ volumes:
   # Logs preserved across container restarts
   api_server_logs:
   background_logs:
+  mcp_server_logs:
   inference_model_server_logs:
   indexing_model_server_logs:

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -71,6 +71,19 @@ MINIO_ROOT_PASSWORD=minioadmin
 # NGINX_PROXY_SEND_TIMEOUT=300
 # NGINX_PROXY_READ_TIMEOUT=300
 
+## MCP Server Configuration
+## The MCP (Model Context Protocol) server allows external MCP clients to interact with Onyx
+## Set to true to enable the MCP server (disabled by default)
+# MCP_SERVER_ENABLED=false
+## Server name exposed to MCP clients
+# MCP_SERVER_NAME=Onyx
+## Server version exposed to MCP clients
+# MCP_SERVER_VERSION=1.0.0
+## Port for the MCP server (defaults to 8090)
+# MCP_SERVER_PORT=8090
+## CORS origins for MCP clients (comma-separated list)
+# MCP_SERVER_CORS_ORIGINS=
+
 ## Celery Configuration
 # CELERY_BROKER_POOL_LIMIT=
 # CELERY_WORKER_DOCFETCHING_CONCURRENCY=


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP server deployment for Docker Compose and Helm, with NGINX routing at /mcp. The server runs on port 8090 via a dedicated mcp_server service; Helm is disabled by default.

- **New Features**
  - Docker: add mcp_server service, optional 8090 exposure in dev compose, MCP_SERVER_* env vars, set ONYX_MCP_SERVER_HOST (default: mcp_server), and route /mcp via NGINX.
  - Docker: add mcp_server_logs volume for log persistence.
  - NGINX: templates and run script updated to use ONYX_MCP_SERVER_HOST with MCP-specific timeouts and proxying.
  - Helm: new mcp-server Deployment and Service with health probes; nginx-conf adds upstream and /mcp location.
  - Config: values.yaml adds mcp_server settings (image, ports, resources, labels); default replicaCount is 0.

- **Migration**
  - Docker: set MCP_SERVER_ENABLED=true (optional: MCP_SERVER_PORT/CORS/NAME/VERSION); use /mcp endpoint; expose 8090 via docker-compose.dev.yml or uncomment ports.
  - Helm: set mcp_server.replicaCount > 0; customize image.tag/ports as needed.

<sup>Written for commit b300b40a4a419bcbc9f0f4b2b2cfebe67c81056b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









