### PR TITLE
part 1: no-op PC provider and interfaces

### DIFF
--- a/backend/onyx/llm/prompt_cache/__init__.py
+++ b/backend/onyx/llm/prompt_cache/__init__.py
@@ -1,0 +1,22 @@
+"""Prompt caching framework for LLM providers.
+
+This module provides a framework for enabling prompt caching across different
+LLM providers. It supports both implicit caching (automatic provider-side caching)
+and explicit caching (with cache metadata management).
+"""
+
+from onyx.llm.prompt_cache.cache_manager import CacheManager
+from onyx.llm.prompt_cache.cache_manager import generate_cache_key_hash
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
+from onyx.llm.prompt_cache.utils import normalize_language_model_input
+
+__all__ = [
+    "CacheManager",
+    "CacheMetadata",
+    "generate_cache_key_hash",
+    "normalize_language_model_input",
+    "NoOpPromptCacheProvider",
+    "PromptCacheProvider",
+]

--- a/backend/onyx/llm/prompt_cache/cache_manager.py
+++ b/backend/onyx/llm/prompt_cache/cache_manager.py
@@ -1,0 +1,199 @@
+"""Cache manager for storing and retrieving prompt cache metadata."""
+
+import hashlib
+import json
+from datetime import datetime
+from datetime import timezone
+
+from onyx.key_value_store.store import PgRedisKVStore
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.utils import normalize_language_model_input
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+REDIS_KEY_PREFIX = "prompt_cache:"
+# Cache TTL multiplier - store caches slightly longer than provider TTL
+# This allows for some clock skew and ensures we don't lose cache metadata prematurely
+CACHE_TTL_MULTIPLIER = 1.2
+
+
+class CacheManager:
+    """Manages storage and retrieval of prompt cache metadata."""
+
+    def __init__(self, kv_store: PgRedisKVStore | None = None) -> None:
+        """Initialize the cache manager.
+
+        Args:
+            kv_store: Optional key-value store. If None, creates a new PgRedisKVStore.
+        """
+        self._kv_store = kv_store or PgRedisKVStore()
+
+    def _build_cache_key(
+        self,
+        provider: str,
+        model_name: str,
+        cache_key_hash: str,
+        tenant_id: str | None = None,
+    ) -> str:
+        """Build a Redis/PostgreSQL key for cache metadata.
+
+        Args:
+            provider: LLM provider name (e.g., "openai", "anthropic")
+            model_name: Model name
+            cache_key_hash: Hash of the cacheable prefix content
+            tenant_id: Tenant ID. If None, uses current tenant from context.
+
+        Returns:
+            Cache key string
+        """
+        if tenant_id is None:
+            tenant_id = get_current_tenant_id()
+        return f"{REDIS_KEY_PREFIX}{tenant_id}:{provider}:{model_name}:{cache_key_hash}"
+
+    def store_cache_metadata(
+        self,
+        metadata: CacheMetadata,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Store cache metadata.
+
+        Args:
+            metadata: Cache metadata to store
+            ttl_seconds: Optional TTL in seconds. If None, uses provider default.
+        """
+        try:
+            cache_key = self._build_cache_key(
+                metadata.provider,
+                metadata.model_name,
+                metadata.cache_key,
+                metadata.tenant_id,
+            )
+
+            # Update last_accessed timestamp
+            metadata.last_accessed = datetime.now(timezone.utc)
+
+            # Serialize metadata
+            metadata_dict = metadata.model_dump(mode="json")
+
+            # Store in key-value store
+            # Note: PgRedisKVStore doesn't support TTL directly, but Redis will
+            # handle expiration. For PostgreSQL persistence, we rely on cleanup
+            # based on last_accessed timestamp.
+            self._kv_store.store(cache_key, metadata_dict, encrypt=False)
+
+            logger.debug(
+                f"Stored cache metadata for provider={metadata.provider}, "
+                f"model={metadata.model_name}, cache_key={metadata.cache_key[:16]}..."
+            )
+        except Exception as e:
+            # Best-effort: log and continue
+            logger.warning(f"Failed to store cache metadata: {str(e)}")
+
+    def retrieve_cache_metadata(
+        self,
+        provider: str,
+        model_name: str,
+        cache_key_hash: str,
+        tenant_id: str | None = None,
+    ) -> CacheMetadata | None:
+        """Retrieve cache metadata.
+
+        Args:
+            provider: LLM provider name
+            model_name: Model name
+            cache_key_hash: Hash of the cacheable prefix content
+            tenant_id: Tenant ID. If None, uses current tenant from context.
+
+        Returns:
+            CacheMetadata if found, None otherwise
+        """
+        try:
+            cache_key = self._build_cache_key(
+                provider, model_name, cache_key_hash, tenant_id
+            )
+            metadata_dict = self._kv_store.load(cache_key, refresh_cache=False)
+
+            # Deserialize metadata
+            metadata = CacheMetadata.model_validate(metadata_dict)
+
+            # Update last_accessed timestamp
+            metadata.last_accessed = datetime.now(timezone.utc)
+            self.store_cache_metadata(metadata)
+
+            logger.debug(
+                f"Retrieved cache metadata for provider={provider}, "
+                f"model={model_name}, cache_key={cache_key_hash[:16]}..."
+            )
+            return metadata
+        except Exception as e:
+            # Best-effort: log and continue
+            logger.debug(f"Cache metadata not found or error retrieving: {str(e)}")
+            return None
+
+    def delete_cache_metadata(
+        self,
+        provider: str,
+        model_name: str,
+        cache_key_hash: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Delete cache metadata.
+
+        Args:
+            provider: LLM provider name
+            model_name: Model name
+            cache_key_hash: Hash of the cacheable prefix content
+            tenant_id: Tenant ID. If None, uses current tenant from context.
+        """
+        try:
+            cache_key = self._build_cache_key(
+                provider, model_name, cache_key_hash, tenant_id
+            )
+            self._kv_store.delete(cache_key)
+            logger.debug(
+                f"Deleted cache metadata for provider={provider}, "
+                f"model={model_name}, cache_key={cache_key_hash[:16]}..."
+            )
+        except Exception as e:
+            # Best-effort: log and continue
+            logger.warning(f"Failed to delete cache metadata: {str(e)}")
+
+
+def generate_cache_key_hash(
+    cacheable_prefix: LanguageModelInput,
+    provider: str,
+    model_name: str,
+    tenant_id: str,
+) -> str:
+    """Generate a deterministic cache key hash from cacheable prefix.
+
+    Args:
+        cacheable_prefix: LanguageModelInput (str or Sequence[ChatCompletionMessage])
+        provider: LLM provider name
+        model_name: Model name
+        tenant_id: Tenant ID
+
+    Returns:
+        SHA256 hash as hex string
+    """
+    # Normalize to Sequence[ChatCompletionMessage] for consistent hashing
+    messages = normalize_language_model_input(cacheable_prefix)
+    # Convert to list of dicts for serialization
+    messages_dict = [dict(msg) for msg in messages]
+
+    # Serialize messages in a deterministic way
+    # Include only content, roles, and order - exclude timestamps or dynamic fields
+    serialized = json.dumps(
+        {
+            "messages": messages_dict,
+            "provider": provider,
+            "model": model_name,
+            "tenant_id": tenant_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/backend/onyx/llm/prompt_cache/interfaces.py
+++ b/backend/onyx/llm/prompt_cache/interfaces.py
@@ -1,0 +1,20 @@
+"""Interfaces and data structures for prompt caching."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CacheMetadata(BaseModel):
+    """Metadata for cached prompt prefixes."""
+
+    cache_key: str
+    provider: str
+    model_name: str
+    tenant_id: str
+    created_at: datetime
+    last_accessed: datetime
+    # Provider-specific metadata
+    # TODO: Add explicit caching support in future PR
+    # vertex_block_numbers: dict[str, str] | None = None  # message_hash -> block_number
+    # anthropic_cache_id: str | None = None

--- a/backend/onyx/llm/prompt_cache/providers/__init__.py
+++ b/backend/onyx/llm/prompt_cache/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider adapters for prompt caching."""

--- a/backend/onyx/llm/prompt_cache/providers/base.py
+++ b/backend/onyx/llm/prompt_cache/providers/base.py
@@ -1,0 +1,70 @@
+"""Base interface for provider-specific prompt caching adapters."""
+
+from abc import ABC
+from abc import abstractmethod
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+
+
+class PromptCacheProvider(ABC):
+    """Abstract base class for provider-specific prompt caching logic."""
+
+    @abstractmethod
+    def supports_caching(self) -> bool:
+        """Whether this provider supports prompt caching.
+
+        Returns:
+            True if caching is supported, False otherwise
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare_messages_for_caching(
+        self,
+        cacheable_prefix: LanguageModelInput | None,
+        suffix: LanguageModelInput,
+        continuation: bool,
+        cache_metadata: CacheMetadata | None,
+    ) -> LanguageModelInput:
+        """Transform messages to enable caching.
+
+        Args:
+            cacheable_prefix: Optional cacheable prefix (can be str or Sequence[ChatCompletionMessage])
+            suffix: Non-cacheable suffix (can be str or Sequence[ChatCompletionMessage])
+            continuation: If True, suffix should be appended to the last message
+                of cacheable_prefix rather than being separate messages.
+                Note: When cacheable_prefix is a string, it should remain in its own
+                content block even if continuation=True.
+            cache_metadata: Optional cache metadata from previous requests
+
+        Returns:
+            Combined and transformed messages ready for LLM API call
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def extract_cache_metadata(
+        self,
+        response: dict,  # Provider-specific response object
+        cache_key: str,
+    ) -> CacheMetadata | None:
+        """Extract cache metadata from API response.
+
+        Args:
+            response: Provider-specific response dictionary
+            cache_key: Cache key used for this request
+
+        Returns:
+            CacheMetadata if extractable, None otherwise
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_cache_ttl_seconds(self) -> int:
+        """Get cache TTL in seconds for this provider.
+
+        Returns:
+            TTL in seconds
+        """
+        raise NotImplementedError

--- a/backend/onyx/llm/prompt_cache/providers/noop.py
+++ b/backend/onyx/llm/prompt_cache/providers/noop.py
@@ -1,0 +1,89 @@
+"""No-op provider adapter for providers without caching support."""
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.utils import normalize_language_model_input
+
+
+class NoOpPromptCacheProvider(PromptCacheProvider):
+    """No-op adapter for providers that don't support prompt caching."""
+
+    def supports_caching(self) -> bool:
+        """No-op providers don't support caching."""
+        return False
+
+    def prepare_messages_for_caching(
+        self,
+        cacheable_prefix: LanguageModelInput | None,
+        suffix: LanguageModelInput,
+        continuation: bool,
+        cache_metadata: CacheMetadata | None,
+    ) -> LanguageModelInput:
+        """Return messages unchanged (no caching support).
+
+        Args:
+            cacheable_prefix: Optional cacheable prefix (can be str or Sequence[ChatCompletionMessage])
+            suffix: Non-cacheable suffix (can be str or Sequence[ChatCompletionMessage])
+            continuation: Whether to append suffix to last prefix message.
+                Note: When cacheable_prefix is a string, it remains in its own content block.
+            cache_metadata: Cache metadata (ignored)
+
+        Returns:
+            Combined messages (prefix + suffix)
+        """
+        # Normalize inputs
+        if cacheable_prefix is None:
+            return suffix
+
+        prefix_msgs = normalize_language_model_input(cacheable_prefix)
+        suffix_msgs = normalize_language_model_input(suffix)
+
+        # Handle continuation flag
+        # Special case: if cacheable_prefix was originally a string, keep it in its own block
+        was_prefix_string = isinstance(cacheable_prefix, str)
+
+        if continuation and prefix_msgs and not was_prefix_string:
+            # Append suffix content to last message of prefix
+            result = list(prefix_msgs)
+            last_msg = dict(result[-1])
+            suffix_first = dict(suffix_msgs[0]) if suffix_msgs else {}
+
+            # Combine content
+            if "content" in last_msg and "content" in suffix_first:
+                if isinstance(last_msg["content"], str) and isinstance(
+                    suffix_first["content"], str
+                ):
+                    last_msg["content"] = last_msg["content"] + suffix_first["content"]
+                else:
+                    # Handle list content (multimodal)
+                    prefix_content = (
+                        last_msg["content"]
+                        if isinstance(last_msg["content"], list)
+                        else [{"type": "text", "text": last_msg["content"]}]
+                    )
+                    suffix_content = (
+                        suffix_first["content"]
+                        if isinstance(suffix_first["content"], list)
+                        else [{"type": "text", "text": suffix_first["content"]}]
+                    )
+                    last_msg["content"] = prefix_content + suffix_content
+
+            result[-1] = last_msg
+            result.extend(suffix_msgs[1:])
+            return result
+
+        # Simple concatenation (or prefix was a string, so keep separate)
+        return list(prefix_msgs) + list(suffix_msgs)
+
+    def extract_cache_metadata(
+        self,
+        response: dict,
+        cache_key: str,
+    ) -> CacheMetadata | None:
+        """No cache metadata to extract."""
+        return None
+
+    def get_cache_ttl_seconds(self) -> int:
+        """Return default TTL (not used for no-op)."""
+        return 0

--- a/backend/onyx/llm/prompt_cache/utils.py
+++ b/backend/onyx/llm/prompt_cache/utils.py
@@ -1,0 +1,30 @@
+"""Utility functions for prompt caching."""
+
+from collections.abc import Sequence
+from typing import Any
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.message_types import ChatCompletionMessage
+from onyx.llm.message_types import UserMessageWithText
+
+
+def normalize_language_model_input(
+    input: LanguageModelInput,
+) -> Sequence[ChatCompletionMessage]:
+    """Normalize LanguageModelInput to Sequence[ChatCompletionMessage]."""
+    if isinstance(input, str):
+        # Convert string to user message
+        return [UserMessageWithText(role="user", content=input)]
+    else:
+        return input
+
+
+def normalize_content(
+    content: str | list[str | dict[str, Any]] | Any,
+) -> list[str | dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    elif isinstance(content, list):
+        return content
+    else:
+        raise ValueError(f"Unsupported content type: {type(content)}")


### PR DESCRIPTION
## Description

first step in prompt caching support: basic pass-through provider and interfaces

## How Has This Been Tested?

n/a, will test full system

## Additional Options

- [ ] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the prompt caching framework scaffolding with a pass-through (no-op) provider and shared interfaces. No behavior changes yet; all requests continue unchanged.

- **New Features**
  - CacheManager to store and retrieve CacheMetadata in PgRedisKVStore with tenant-aware keys.
  - Deterministic cache key hashing from normalized messages plus provider, model, and tenant.
  - Provider base interface for message preparation, metadata extraction, and TTL.
  - NoOpPromptCacheProvider that leaves messages unchanged; handles optional continuation when the prefix isn’t a string.
  - Utilities to normalize LanguageModelInput and content; public exports added in package __init__.

<sup>Written for commit 1c27d414f1ca76e33ce6878c3e1af2b8a631ad07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







