### PR TITLE
phase 2: provider support

### DIFF
--- a/backend/onyx/llm/prompt_cache/__init__.py
+++ b/backend/onyx/llm/prompt_cache/__init__.py
@@ -8,15 +8,27 @@ and explicit caching (with cache metadata management).
 from onyx.llm.prompt_cache.cache_manager import CacheManager
 from onyx.llm.prompt_cache.cache_manager import generate_cache_key_hash
 from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.anthropic import AnthropicPromptCacheProvider
 from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.providers.factory import get_provider_adapter
 from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
+from onyx.llm.prompt_cache.providers.openai import OpenAIPromptCacheProvider
+from onyx.llm.prompt_cache.providers.vertex import VertexAIPromptCacheProvider
+from onyx.llm.prompt_cache.utils import combine_messages_with_continuation
 from onyx.llm.prompt_cache.utils import normalize_language_model_input
+from onyx.llm.prompt_cache.utils import prepare_messages_with_cacheable_transform
 
 __all__ = [
+    "AnthropicPromptCacheProvider",
     "CacheManager",
     "CacheMetadata",
+    "combine_messages_with_continuation",
     "generate_cache_key_hash",
+    "get_provider_adapter",
     "normalize_language_model_input",
     "NoOpPromptCacheProvider",
+    "OpenAIPromptCacheProvider",
+    "prepare_messages_with_cacheable_transform",
     "PromptCacheProvider",
+    "VertexAIPromptCacheProvider",
 ]

--- a/backend/onyx/llm/prompt_cache/providers/__init__.py
+++ b/backend/onyx/llm/prompt_cache/providers/__init__.py
@@ -1,1 +1,17 @@
 """Provider adapters for prompt caching."""
+
+from onyx.llm.prompt_cache.providers.anthropic import AnthropicPromptCacheProvider
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.providers.factory import get_provider_adapter
+from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
+from onyx.llm.prompt_cache.providers.openai import OpenAIPromptCacheProvider
+from onyx.llm.prompt_cache.providers.vertex import VertexAIPromptCacheProvider
+
+__all__ = [
+    "AnthropicPromptCacheProvider",
+    "get_provider_adapter",
+    "NoOpPromptCacheProvider",
+    "OpenAIPromptCacheProvider",
+    "PromptCacheProvider",
+    "VertexAIPromptCacheProvider",
+]

--- a/backend/onyx/llm/prompt_cache/providers/anthropic.py
+++ b/backend/onyx/llm/prompt_cache/providers/anthropic.py
@@ -1,0 +1,90 @@
+"""Anthropic provider adapter for prompt caching."""
+
+from collections.abc import Sequence
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.message_types import ChatCompletionMessage
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.utils import prepare_messages_with_cacheable_transform
+
+
+def _add_anthropic_cache_control(
+    messages: Sequence[ChatCompletionMessage],
+) -> Sequence[ChatCompletionMessage]:
+    """Add cache_control parameter to messages for Anthropic caching.
+
+    Args:
+        messages: Messages to transform
+
+    Returns:
+        Messages with cache_control added
+    """
+    cacheable_messages: list[ChatCompletionMessage] = []
+    for msg in messages:
+        msg_dict = dict(msg)
+        # Add cache_control parameter
+        # Anthropic supports up to 4 cache breakpoints
+        msg_dict["cache_control"] = {"type": "ephemeral"}
+        cacheable_messages.append(msg_dict)  # type: ignore
+    return cacheable_messages
+
+
+class AnthropicPromptCacheProvider(PromptCacheProvider):
+    """Anthropic adapter for prompt caching (explicit caching with cache_control)."""
+
+    def supports_caching(self) -> bool:
+        """Anthropic supports explicit prompt caching."""
+        return True
+
+    def prepare_messages_for_caching(
+        self,
+        cacheable_prefix: LanguageModelInput | None,
+        suffix: LanguageModelInput,
+        continuation: bool,
+        cache_metadata: CacheMetadata | None,
+    ) -> LanguageModelInput:
+        """Prepare messages for Anthropic caching.
+
+        Anthropic requires cache_control parameter on cacheable messages.
+        We add cache_control={"type": "ephemeral"} to all cacheable prefix messages.
+
+        Args:
+            cacheable_prefix: Optional cacheable prefix
+            suffix: Non-cacheable suffix
+            continuation: Whether to append suffix to last prefix message
+            cache_metadata: Cache metadata (for future explicit caching support)
+
+        Returns:
+            Combined messages with cache_control on cacheable messages
+        """
+        return prepare_messages_with_cacheable_transform(
+            cacheable_prefix=cacheable_prefix,
+            suffix=suffix,
+            continuation=continuation,
+            transform_cacheable=_add_anthropic_cache_control,
+        )
+
+    def extract_cache_metadata(
+        self,
+        response: dict,
+        cache_key: str,
+    ) -> CacheMetadata | None:
+        """Extract cache metadata from Anthropic response.
+
+        Anthropic may return cache identifiers in the response.
+        For now, we don't extract detailed metadata (future explicit caching support).
+
+        Args:
+            response: Anthropic API response dictionary
+            cache_key: Cache key used for this request
+
+        Returns:
+            CacheMetadata if extractable, None otherwise
+        """
+        # TODO: Extract cache identifiers from response when implementing explicit caching
+        return None
+
+    def get_cache_ttl_seconds(self) -> int:
+        """Get cache TTL for Anthropic (5 minutes default)."""
+        return 300

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -1,0 +1,30 @@
+"""Factory for creating provider-specific prompt cache adapters."""
+
+from onyx.llm.llm_provider_options import ANTHROPIC_PROVIDER_NAME
+from onyx.llm.llm_provider_options import OPENAI_PROVIDER_NAME
+from onyx.llm.llm_provider_options import VERTEXAI_PROVIDER_NAME
+from onyx.llm.prompt_cache.providers.anthropic import AnthropicPromptCacheProvider
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
+from onyx.llm.prompt_cache.providers.openai import OpenAIPromptCacheProvider
+from onyx.llm.prompt_cache.providers.vertex import VertexAIPromptCacheProvider
+
+
+def get_provider_adapter(provider: str) -> PromptCacheProvider:
+    """Get the appropriate prompt cache provider adapter for a given provider.
+
+    Args:
+        provider: Provider name (e.g., "openai", "anthropic", "vertex_ai")
+
+    Returns:
+        PromptCacheProvider instance for the given provider
+    """
+    if provider == OPENAI_PROVIDER_NAME:
+        return OpenAIPromptCacheProvider()
+    elif provider == ANTHROPIC_PROVIDER_NAME:
+        return AnthropicPromptCacheProvider()
+    elif provider == VERTEXAI_PROVIDER_NAME:
+        return VertexAIPromptCacheProvider()
+    else:
+        # Default to no-op for providers without caching support
+        return NoOpPromptCacheProvider()

--- a/backend/onyx/llm/prompt_cache/providers/openai.py
+++ b/backend/onyx/llm/prompt_cache/providers/openai.py
@@ -1,0 +1,69 @@
+"""OpenAI provider adapter for prompt caching."""
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.utils import prepare_messages_with_cacheable_transform
+
+
+class OpenAIPromptCacheProvider(PromptCacheProvider):
+    """OpenAI adapter for prompt caching (implicit caching)."""
+
+    def supports_caching(self) -> bool:
+        """OpenAI supports automatic prompt caching."""
+        return True
+
+    def prepare_messages_for_caching(
+        self,
+        cacheable_prefix: LanguageModelInput | None,
+        suffix: LanguageModelInput,
+        continuation: bool,
+        cache_metadata: CacheMetadata | None,
+    ) -> LanguageModelInput:
+        """Prepare messages for OpenAI caching.
+
+        OpenAI handles caching automatically, so we just normalize and combine
+        the messages. The provider will automatically cache prefixes >1024 tokens.
+
+        Args:
+            cacheable_prefix: Optional cacheable prefix
+            suffix: Non-cacheable suffix
+            continuation: Whether to append suffix to last prefix message
+            cache_metadata: Cache metadata (ignored for implicit caching)
+
+        Returns:
+            Combined messages ready for LLM API call
+        """
+        # No transformation needed for OpenAI (implicit caching)
+        return prepare_messages_with_cacheable_transform(
+            cacheable_prefix=cacheable_prefix,
+            suffix=suffix,
+            continuation=continuation,
+            transform_cacheable=None,
+        )
+
+    def extract_cache_metadata(
+        self,
+        response: dict,
+        cache_key: str,
+    ) -> CacheMetadata | None:
+        """Extract cache metadata from OpenAI response.
+
+        OpenAI responses may include cached_tokens in the usage field.
+        For implicit caching, we don't need to store much metadata.
+
+        Args:
+            response: OpenAI API response dictionary
+            cache_key: Cache key used for this request
+
+        Returns:
+            CacheMetadata if extractable, None otherwise
+        """
+        # For implicit caching, OpenAI handles everything automatically
+        # We could extract cached_tokens from response.get("usage", {}).get("cached_tokens")
+        # but for now, we don't need to store metadata for implicit caching
+        return None
+
+    def get_cache_ttl_seconds(self) -> int:
+        """Get cache TTL for OpenAI (1 hour max)."""
+        return 3600

--- a/backend/onyx/llm/prompt_cache/providers/vertex.py
+++ b/backend/onyx/llm/prompt_cache/providers/vertex.py
@@ -1,0 +1,80 @@
+"""Vertex AI provider adapter for prompt caching."""
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.prompt_cache.interfaces import CacheMetadata
+from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
+from onyx.llm.prompt_cache.utils import prepare_messages_with_cacheable_transform
+
+
+class VertexAIPromptCacheProvider(PromptCacheProvider):
+    """Vertex AI adapter for prompt caching (implicit caching for this PR)."""
+
+    def supports_caching(self) -> bool:
+        """Vertex AI supports prompt caching (implicit and explicit)."""
+        return True
+
+    def prepare_messages_for_caching(
+        self,
+        cacheable_prefix: LanguageModelInput | None,
+        suffix: LanguageModelInput,
+        continuation: bool,
+        cache_metadata: CacheMetadata | None,
+    ) -> LanguageModelInput:
+        """Prepare messages for Vertex AI caching.
+
+        For this PR, we only implement implicit caching (automatic, similar to OpenAI).
+        Vertex handles implicit caching automatically, so we just normalize and combine.
+
+        TODO (explicit caching - future PR):
+        - If cache_metadata exists and has vertex_block_numbers: Replace message content
+          with {"cache_block_id": "<block_number>"}
+        - If not: Add cache_control={"type": "ephemeral"} to cacheable messages
+
+        Args:
+            cacheable_prefix: Optional cacheable prefix
+            suffix: Non-cacheable suffix
+            continuation: Whether to append suffix to last prefix message
+            cache_metadata: Cache metadata (for future explicit caching support)
+
+        Returns:
+            Combined messages ready for LLM API call
+        """
+        # For implicit caching, no transformation needed (Vertex handles caching automatically)
+        # TODO (explicit caching - future PR):
+        # - Check cache_metadata for vertex_block_numbers
+        # - Create transform function that replaces messages with cache_block_id if available
+        # - Or adds cache_control parameter if not using cached blocks
+        return prepare_messages_with_cacheable_transform(
+            cacheable_prefix=cacheable_prefix,
+            suffix=suffix,
+            continuation=continuation,
+            transform_cacheable=None,
+        )
+
+    def extract_cache_metadata(
+        self,
+        response: dict,
+        cache_key: str,
+    ) -> CacheMetadata | None:
+        """Extract cache metadata from Vertex AI response.
+
+        For this PR (implicit caching): Extract basic cache usage info if available.
+        TODO (explicit caching - future PR): Extract block numbers from response
+        and store in metadata.
+
+        Args:
+            response: Vertex AI API response dictionary
+            cache_key: Cache key used for this request
+
+        Returns:
+            CacheMetadata if extractable, None otherwise
+        """
+        # For implicit caching, Vertex handles everything automatically
+        # TODO (explicit caching - future PR):
+        # - Extract cache block numbers from response
+        # - Store in cache_metadata.vertex_block_numbers
+        return None
+
+    def get_cache_ttl_seconds(self) -> int:
+        """Get cache TTL for Vertex AI (5 minutes)."""
+        return 300

--- a/backend/onyx/llm/prompt_cache/utils.py
+++ b/backend/onyx/llm/prompt_cache/utils.py
@@ -1,7 +1,8 @@
 """Utility functions for prompt caching."""
 
+from collections.abc import Callable
 from collections.abc import Sequence
-from typing import Any
+from typing import cast
 
 from onyx.llm.interfaces import LanguageModelInput
 from onyx.llm.message_types import ChatCompletionMessage
@@ -11,7 +12,14 @@ from onyx.llm.message_types import UserMessageWithText
 def normalize_language_model_input(
     input: LanguageModelInput,
 ) -> Sequence[ChatCompletionMessage]:
-    """Normalize LanguageModelInput to Sequence[ChatCompletionMessage]."""
+    """Normalize LanguageModelInput to Sequence[ChatCompletionMessage].
+
+    Args:
+        input: LanguageModelInput (str or Sequence[ChatCompletionMessage])
+
+    Returns:
+        Sequence of ChatCompletionMessage objects
+    """
     if isinstance(input, str):
         # Convert string to user message
         return [UserMessageWithText(role="user", content=input)]
@@ -19,12 +27,98 @@ def normalize_language_model_input(
         return input
 
 
-def normalize_content(
-    content: str | list[str | dict[str, Any]] | Any,
-) -> list[str | dict[str, Any]]:
-    if isinstance(content, str):
-        return [{"type": "text", "text": content}]
-    elif isinstance(content, list):
-        return content
-    else:
-        raise ValueError(f"Unsupported content type: {type(content)}")
+def combine_messages_with_continuation(
+    prefix_msgs: Sequence[ChatCompletionMessage],
+    suffix_msgs: Sequence[ChatCompletionMessage],
+    continuation: bool,
+    was_prefix_string: bool,
+) -> Sequence[ChatCompletionMessage]:
+    """Combine prefix and suffix messages, handling continuation flag.
+
+    Args:
+        prefix_msgs: Normalized cacheable prefix messages
+        suffix_msgs: Normalized suffix messages
+        continuation: If True and prefix is not a string, append suffix content
+            to the last message of prefix
+        was_prefix_string: Whether the original prefix was a string (strings
+            remain in their own content block even if continuation=True)
+
+    Returns:
+        Combined messages
+    """
+    if continuation and prefix_msgs and not was_prefix_string:
+        # Append suffix content to last message of prefix
+        result = list(prefix_msgs)
+        last_msg = dict(result[-1])
+        suffix_first = dict(suffix_msgs[0]) if suffix_msgs else {}
+
+        # Combine content
+        if "content" in last_msg and "content" in suffix_first:
+            if isinstance(last_msg["content"], str) and isinstance(
+                suffix_first["content"], str
+            ):
+                last_msg["content"] = last_msg["content"] + suffix_first["content"]
+            else:
+                # Handle list content (multimodal)
+                prefix_content = (
+                    last_msg["content"]
+                    if isinstance(last_msg["content"], list)
+                    else [{"type": "text", "text": last_msg["content"]}]
+                )
+                suffix_content = (
+                    suffix_first["content"]
+                    if isinstance(suffix_first["content"], list)
+                    else [{"type": "text", "text": suffix_first["content"]}]
+                )
+                last_msg["content"] = prefix_content + suffix_content
+
+        result[-1] = cast(ChatCompletionMessage, last_msg)
+        result.extend(suffix_msgs[1:])
+        return result
+
+    # Simple concatenation (or prefix was a string, so keep separate)
+    return list(prefix_msgs) + list(suffix_msgs)
+
+
+def prepare_messages_with_cacheable_transform(
+    cacheable_prefix: LanguageModelInput | None,
+    suffix: LanguageModelInput,
+    continuation: bool,
+    transform_cacheable: (
+        Callable[[Sequence[ChatCompletionMessage]], Sequence[ChatCompletionMessage]]
+        | None
+    ) = None,
+) -> LanguageModelInput:
+    """Prepare messages for caching with optional transformation of cacheable prefix.
+
+    This is a shared utility that handles the common flow:
+    1. Normalize inputs
+    2. Optionally transform cacheable messages
+    3. Combine with continuation handling
+
+    Args:
+        cacheable_prefix: Optional cacheable prefix
+        suffix: Non-cacheable suffix
+        continuation: Whether to append suffix to last prefix message
+        transform_cacheable: Optional function to transform cacheable messages
+            (e.g., add cache_control parameter). If None, messages are used as-is.
+
+    Returns:
+        Combined messages ready for LLM API call
+    """
+    if cacheable_prefix is None:
+        return suffix
+
+    prefix_msgs = normalize_language_model_input(cacheable_prefix)
+    suffix_msgs = normalize_language_model_input(suffix)
+
+    # Apply transformation to cacheable messages if provided
+    if transform_cacheable is not None:
+        prefix_msgs = transform_cacheable(prefix_msgs)
+
+    # Handle continuation flag
+    was_prefix_string = isinstance(cacheable_prefix, str)
+
+    return combine_messages_with_continuation(
+        prefix_msgs, suffix_msgs, continuation, was_prefix_string
+    )


### PR DESCRIPTION
## Description

Add support for multiple providers

## How Has This Been Tested?

n/a, to be tested in stage 3

## Additional Options

- [ ] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added provider-specific prompt cache adapters (OpenAI, Anthropic, Vertex AI) and a factory to select the right adapter. Unified message preparation and continuation handling so caching works consistently across providers.

- **New Features**
  - Adapters: OpenAI (implicit), Anthropic (adds cache_control), Vertex AI (implicit for now).
  - Factory get_provider_adapter with a NoOp fallback.
  - Exposed adapters and new utilities via package exports.

- **Refactors**
  - Centralized message normalization/combination in prepare_messages_with_cacheable_transform and combine_messages_with_continuation.
  - NoOp provider now uses shared utilities, removing duplicated logic.

<sup>Written for commit 17dc64148d08850f6c9e3bdaed541b4b37bc3f90. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





