### PR TITLE
chore(deployments): remove driver-opts from model-server build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -268,8 +268,6 @@ jobs:
       - extras=ecr-cache
     env:
       REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
-      DOCKER_BUILDKIT: 1
-      BUILDKIT_PROGRESS: plain
       DEPLOYMENT: ${{ contains(github.ref_name, 'cloud') && 'cloud' || 'standalone' }}
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2


### PR DESCRIPTION
## Description

I can't think of any reason to include this (https://github.com/onyx-dot-app/onyx/pull/3476 doesn't have any clues either) and possibly causing uploads to fail, https://onyx-company.slack.com/archives/C09SV2JABD1/p1763461488439279

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19476830727

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Buildx driver-opts (custom image and network=host) and BuildKit env vars from the model-server deployment workflow to use default Buildx settings. This simplifies builds and aims to prevent intermittent Docker image upload failures during deployment.

<sup>Written for commit 3ab1267310cf78c6cb87cb150f7506b99213b376. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

