### PR TITLE
chore(deployments): separate builds by platform

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -368,6 +368,8 @@ jobs:
     env:
       REGISTRY_IMAGE: onyxdotapp/onyx-web-server-cloud
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
@@ -513,6 +515,8 @@ jobs:
     env:
       REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-backend-cloud' || 'onyxdotapp/onyx-backend' }}
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
@@ -663,6 +667,8 @@ jobs:
     env:
       REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Description

I don't think we're going to get sufficient cache hits on the frontend image build to make this viable. There's also a high chance cross-platform (particularly with `type=inline` caching) is causing https://onyx-company.slack.com/archives/C09SV2JABD1/p1763461488439279. At the least, might be helpful to more easily know if these issues are platform-specific at a glance. Also, native builds are probably more correct and avoid qemu emulation issues anwyays, so probably just worth.

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19482834606

## Additional Options

- [x] Override Linear Check


















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Docker builds by platform (amd64 and arm64) and publish multi-arch manifests. This improves reliability, cache isolation, and makes platform-specific failures easier to spot.

- **Refactors**
  - Split web, cloud web, backend, and model-server into per-arch jobs (amd64, arm64) with merge steps to create multi-arch manifests.
  - Push images by digest and assemble tags using docker buildx imagetools.
  - Use arch-specific cache keys with inline caching to avoid cross-platform collisions.
  - Update Trivy scans and Slack failure notifications to run after manifest merge and report per-job failures.

<sup>Written for commit 471a49bd9c0027775520b705c2b0924ccdeb782e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















