### PR TITLE
fix(tests): test_partial_match_in_model_map AssertionError

### DIFF
--- a/backend/tests/unit/onyx/llm/test_model_map.py
+++ b/backend/tests/unit/onyx/llm/test_model_map.py
@@ -37,7 +37,7 @@ def test_partial_match_in_model_map() -> None:
         "supports_audio_output": False,
         "supports_function_calling": True,
         "supports_response_schema": True,
-        "supports_system_messages": True,
+        "supports_system_messages": False,
         "supports_tool_choice": True,
         "supports_vision": True,
     }
@@ -46,13 +46,13 @@ def test_partial_match_in_model_map() -> None:
     assert result1 is not None
     for key, value in _EXPECTED_FIELDS.items():
         assert key in result1
-        assert result1[key] == value
+        assert result1[key] == value, "Unexpected value for key: {}".format(key)
 
     result2 = find_model_obj(model_map, "openai", "gemma-3-27b-it")
     assert result2 is not None
     for key, value in _EXPECTED_FIELDS.items():
         assert key in result2
-        assert result2[key] == value
+        assert result2[key] == value, "Unexpected value for key: {}".format(key)
 
     get_model_map.cache_clear()
 


### PR DESCRIPTION
## Description

It seems this model's capabilities upstream have changed causing this test to now fail (previously green commits fail).

Closes https://github.com/onyx-dot-app/onyx/actions/runs/19481962288/job/55755343954#step:6:431

## How Has This Been Tested?

`pytest backend/tests/unit/onyx/llm/test_model_map.py`

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update test_partial_match_in_model_map to reflect upstream model capability changes and resolve the failing AssertionError. Also improve assertion messages for clearer failures.

- **Bug Fixes**
  - Set supports_system_messages expected value to False.
  - Added messages to equality assertions for easier debugging.

<sup>Written for commit fb78c222c95d12efb18be1f079f725377fd47a1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

