### PR TITLE
chore(deployments): set provenance=false and flag debug

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -609,6 +609,7 @@ jobs:
           outputs: type=image,name=${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
           provenance: false
+          sbom: false
           buildx-flags: ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
 
   build-model-server-arm64:
@@ -668,6 +669,7 @@ jobs:
           outputs: type=image,name=${{ github.event_name == 'workflow_dispatch' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
           provenance: false
+          sbom: false
           buildx-flags: ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
 
   merge-model-server:


### PR DESCRIPTION
## Description

Claude suggested this and it was set originally. Doesn't seem incredibly useful either way. Worst-case, remove after root-causing the `400`s

## How Has This Been Tested?

`prek run actionlint`

## Additional Options

- [x] Override Linear Check










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable optional Docker Buildx debug and no-cache, and disable image provenance and SBOM in deployment builds to help diagnose 400 errors during pushes.
Adds --debug to BuildKit and Buildx when DOCKER_DEBUG=true, no-cache when DOCKER_NO_CACHE=true, and sets provenance: false and sbom: false for both amd64 and arm64 model-server builds.

<sup>Written for commit 1e8cb115b137d98fddd0b406698e0b15f116eb67. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









