### PR TITLE
chore(deployments): "buildx-flags"->"build-args"

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -600,6 +600,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
+            ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
           cache-from: |
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-amd64
@@ -610,7 +611,6 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
           provenance: false
           sbom: false
-          buildx-flags: ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
 
   build-model-server-arm64:
     needs: determine-builds


### PR DESCRIPTION
## Description

Claude is trolling me.

## How Has This Been Tested?

w/ DOCKER_DEBUG=true: https://github.com/onyx-dot-app/onyx/actions/runs/19509101404/job/55843663380
w/ DOCKER_DEBUG=false: https://github.com/onyx-dot-app/onyx/actions/runs/19509237742/job/55844176056#step:8:244

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Docker debug toggle from buildx-flags to build-args in the deployment workflow so the build action correctly receives the debug flag. Removes the unsupported buildx-flags input.

- **Bug Fixes**
  - Passes --debug via build-args when DOCKER_DEBUG=true.
  - Removes buildx-flags to prevent ignored/invalid configuration.

<sup>Written for commit 8ad02b23f9402c3bf546d3fca2bd5e0a57cd198f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

