### PR TITLE
chore(deployments): correctly set `--debug` for docker build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -593,6 +593,8 @@ jobs:
       - name: Build and push AMD64
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
+        env:
+          DEBUG: ${{ vars.DOCKER_DEBUG == 'true' && 1 || 0 }}
         with:
           context: ./backend
           file: ./backend/Dockerfile.model_server
@@ -610,7 +612,6 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
           provenance: false
           sbom: false
-          buildx-flags: ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
 
   build-model-server-arm64:
     needs: determine-builds
@@ -653,6 +654,8 @@ jobs:
       - name: Build and push ARM64
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
+        env:
+          DEBUG: ${{ vars.DOCKER_DEBUG == 'true' && 1 || 0 }}
         with:
           context: ./backend
           file: ./backend/Dockerfile.model_server
@@ -670,7 +673,6 @@ jobs:
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
           provenance: false
           sbom: false
-          buildx-flags: ${{ vars.DOCKER_DEBUG == 'true' && '--debug' || '' }}
 
   merge-model-server:
     needs:


### PR DESCRIPTION
## Description

Everyone is trolling me.

Apparently this is equivalent to passing `--debug` to `docker build`, https://github.com/docker/build-push-action/discussions/1304#discussioncomment-11889786

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19512627528/job/55856054811#step:8:78

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Docker build logs to plain progress by using the DEBUG env, replacing the deprecated buildx --debug flag. This aligns our CI builds with docker build --debug and simplifies configuration.

- **Refactors**
  - Pass DEBUG env based on DOCKER_DEBUG (1 when true, else 0).
  - Remove buildx-flags usage.
  - Applied to both AMD64 and ARM64 model server builds.

<sup>Written for commit 5b486470cb1291c070a807201ffb87c971e2a266. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

