### PR TITLE
chore(dev): nginx container port 80 respects HOST_PORT_80

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -3,7 +3,7 @@
 # =============================================================================
 # This is the default configuration for Onyx. This file is fairly configurable,
 # also see env.template for possible settings.
-# 
+#
 # PRODUCTION DEPLOYMENT CHECKLIST:
 # To convert this setup to a production deployment following best practices,
 # follow the checklist below. Note that there are other ways to secure the Onyx
@@ -300,7 +300,7 @@ services:
       - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
       - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
     ports:
-      - "80:80"
+      - "${HOST_PORT_80:-80}:80"
       - "${HOST_PORT:-3000}:80" # allow for localhost:3000 usage, since that is the norm
     volumes:
       - ../data/nginx:/etc/nginx/conf.d
@@ -319,7 +319,7 @@ services:
     # in order to make this work on both Unix-like systems and windows
     # PRODUCTION: Change to app.conf.template.prod for production nginx config
     command: >
-      /bin/sh -c "dos2unix /etc/nginx/conf.d/run-nginx.sh 
+      /bin/sh -c "dos2unix /etc/nginx/conf.d/run-nginx.sh
       && /etc/nginx/conf.d/run-nginx.sh app.conf.template"
 
   cache:


### PR DESCRIPTION
## Description

I use [rootless docker](https://docs.docker.com/engine/security/rootless/) which fails to bind this port (`80` is `privileged`) with,

```
Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint onyx-nginx-1 (d14bdec5fe1558cec91c6df16cf88621b1994bc9cb8ac7cdc675db7de5904085): error while calling RootlessKit PortManager.AddPort(): cannot expose privileged port 80, you can add 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024), or set CAP_NET_BIND_SERVICE on rootlesskit binary, or choose a larger port number (>= 1024): listen tcp4 0.0.0.0:80: bind: permission denied
```

so let users re-map port `80` along with `3000`.

## How Has This Been Tested?

```
HOST_PORT=8000 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows configuring the nginx service’s port 80 host mapping via HOST_PORT_80, so rootless Docker can run without binding privileged port 80. Defaults still expose 80 and 3000 to the container’s port 80.

- **Migration**
  - To use an unprivileged port: HOST_PORT_80=8000 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d

<sup>Written for commit 923b3f2d8e94a1c2c1dda83fe5e64b4c16347f98. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





