### PR TITLE
fix: featured assistant typo

### DIFF
--- a/web/src/app/admin/assistants/PersonaTable.tsx
+++ b/web/src/app/admin/assistants/PersonaTable.tsx
@@ -185,7 +185,7 @@ export function PersonasTable({
 
           const title = isDefault
             ? "Remove Featured Assistant"
-            : "Set Featurd Assistant";
+            : "Set Featured Assistant";
           const buttonText = isDefault ? "Remove Feature" : "Set as Featured";
           const text = isDefault
             ? `Are you sure you want to remove the featured status of ${personaToToggleDefault.name}?`


### PR DESCRIPTION
## Description

fixing this 

<img width="1016" height="516" alt="image" src="https://github.com/user-attachments/assets/4641206f-390a-4529-b346-74a9d674e60d" />


## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the Admin Assistants table: changed “Set Featurd Assistant” to “Set Featured Assistant” to improve clarity.

<sup>Written for commit 667e94c1691c1e41e3d51d4bec6a554006df78d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

