### PR TITLE
chore(gha): playwright browser cache is arch-aware

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -7,9 +7,9 @@ runs:
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # ratchet:runs-on/cache@v4
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('backend/requirements/default.txt') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('backend/requirements/default.txt') }}
         restore-keys: |
-          ${{ runner.os }}-playwright-
+          ${{ runner.os }}-${{ runner.arch }}-playwright-
 
     - name: Install playwright
       shell: bash


### PR DESCRIPTION
## Description

This https://github.com/onyx-dot-app/onyx/actions/runs/19521299496/job/55885162164#step:8:376,

```
E           [pid=2556][err] /home/runner/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell: 1: Syntax error: "&" unexpected (expecting ")")
```

looks like a caching issue and specifically from using a cross-platform browser(?). At the very least, this should rotate the cache and unblock for a bit.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Playwright browser cache in GitHub Actions architecture-aware to prevent restoring mismatched Chromium binaries across runners. Adds runner.arch to the cache key and restore keys so x64 and ARM runners use the correct binaries.

<sup>Written for commit 008db10be2869025dda8116c2fe5c29cb1a42aa8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

