### PR TITLE
SECURITY FIX: CVE-2023-38545 and CVE-2023-38546

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -125,18 +125,18 @@ def get_versions() -> AllVersions:
             onyx=latest_stable_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
         dev=ContainerVersions(
             onyx=latest_dev_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
         migration=ContainerVersions(
             onyx="airgapped-intfloat-nomic-migration",
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
     )

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -154,7 +154,7 @@ def test_versions_endpoint(client: TestClient) -> None:
     assert migration["onyx"] == "airgapped-intfloat-nomic-migration"
     assert migration["relational_db"] == "postgres:15.2-alpine"
     assert migration["index"] == "vespaengine/vespa:8.277.17"
-    assert migration["nginx"] == "nginx:1.25.4-alpine"
+    assert migration["nginx"] == "nginx:1.25.5-alpine"
 
     # Verify versions are different between stable and dev
     assert stable["onyx"] != dev["onyx"], "Stable and dev versions should be different"

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
@@ -109,7 +109,7 @@ Resources:
       Family: !Sub ${Environment}-${ServiceName}-TaskDefinition
       ContainerDefinitions:
         - Name: nginx
-          Image: nginx:1.25.4-alpine
+          Image: nginx:1.25.5-alpine
           Cpu: 0
           PortMappings:
             - Name: nginx-80-tcp

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -404,7 +404,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -188,7 +188,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -212,7 +212,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -224,7 +224,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -193,7 +193,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -283,7 +283,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up


### PR DESCRIPTION
## Description

Update nginx image from nginx:1.23.4-alpine to nginx:1.25-alpine to address curl/libcurl vulnerabilities (CVE-2023-38545 and CVE-2023-38546). The newer Alpine-based image includes curl/libcurl 8.4.0+ which contains the security patches.

- [CVE-2023-38545: SOCKS5 heap buffer overflow](https://curl.se/docs/CVE-2023-38545.html)
- [CVE-2023-38546: cookie injection with none file](https://curl.se/docs/CVE-2023-38546.html)

## How Has This Been Tested?

These changes have been applied to and test with our self-hosted onyx app.

Before:

```
[ec2-user@ip-10-25-117-175 ~]$ docker --version
Docker version 25.0.8, build 0bab007
[ec2-user@ip-10-25-117-175 ~]$ docker exec 1a238d896b25 curl --version
curl 7.88.1 (x86_64-alpine-linux-musl) libcurl/7.88.1 OpenSSL/3.0.8 zlib/1.2.13 brotli/1.0.9 nghttp2/1.51.0
Release-Date: 2023-02-20
```

After:

```
[ec2-user@ip-10-25-117-175 docker_compose]$ docker exec 5b4aab73499f curl --version
curl 8.5.0 (x86_64-alpine-linux-musl) libcurl/8.5.0 OpenSSL/3.1.4 zlib/1.3.1 brotli/1.1.0 c-ares/1.27.0 libidn2/2.3.4 nghttp2/1.58.0
Release-Date: 2023-12-06
```

## Additional Options

- [ ] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade nginx to 1.25.5-alpine across all environments to pull patched curl/libcurl and fix CVE-2023-38545 and CVE-2023-38546. This mitigates the SOCKS5 heap overflow and cookie injection risks.

- **Dependencies**
  - Bump nginx image to nginx:1.25.5-alpine in ECS and all docker-compose files.
  - Update container version mapping in get_state.py for stable, dev, and migration.
  - Adjust versions test to expect nginx:1.25.5-alpine.

- **Migration**
  - Redeploy services to pull the new nginx image (docker-compose pull/up or ECS deploy).

<sup>Written for commit 3ffd32d6637435e478e3e69031914f1623fa2ee4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







