### PR TITLE
chore: [Running GitHub actions for #6356]

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -125,18 +125,18 @@ def get_versions() -> AllVersions:
             onyx=latest_stable_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
         dev=ContainerVersions(
             onyx=latest_dev_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
         migration=ContainerVersions(
             onyx="airgapped-intfloat-nomic-migration",
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
-            nginx="nginx:1.25.4-alpine",
+            nginx="nginx:1.25.5-alpine",
         ),
     )

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -154,7 +154,7 @@ def test_versions_endpoint(client: TestClient) -> None:
     assert migration["onyx"] == "airgapped-intfloat-nomic-migration"
     assert migration["relational_db"] == "postgres:15.2-alpine"
     assert migration["index"] == "vespaengine/vespa:8.277.17"
-    assert migration["nginx"] == "nginx:1.25.4-alpine"
+    assert migration["nginx"] == "nginx:1.25.5-alpine"
 
     # Verify versions are different between stable and dev
     assert stable["onyx"] != dev["onyx"], "Stable and dev versions should be different"

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
@@ -109,7 +109,7 @@ Resources:
       Family: !Sub ${Environment}-${ServiceName}-TaskDefinition
       ContainerDefinitions:
         - Name: nginx
-          Image: nginx:1.25.4-alpine
+          Image: nginx:1.25.5-alpine
           Cpu: 0
           PortMappings:
             - Name: nginx-80-tcp

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -404,7 +404,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -188,7 +188,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -212,7 +212,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -224,7 +224,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -193,7 +193,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -283,7 +283,7 @@ services:
         max-file: "6"
 
   nginx:
-    image: nginx:1.25.4-alpine
+    image: nginx:1.25.5-alpine
     restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up


### PR DESCRIPTION
Automated mirror of PR #6356 so private CI can run.

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade nginx to 1.25.5-alpine across deployments and version reporting to standardize on a supported release and keep tests in sync.

- **Dependencies**
  - Bumped nginx image from 1.23.4-alpine to 1.25.5-alpine in ECS and all docker-compose files.
  - Updated get_state() container versions and the versions API test to reflect the new nginx tag.

<sup>Written for commit 3ffd32d6637435e478e3e69031914f1623fa2ee4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



