### PR TITLE
fix(migration): exa env var into db

### DIFF
--- a/backend/alembic/versions/3c9a65f1207f_seed_exa_provider_from_env.py
+++ b/backend/alembic/versions/3c9a65f1207f_seed_exa_provider_from_env.py
@@ -86,5 +86,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Preserve any manually configured Exa provider rows; nothing to undo here.
     return


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds the Exa internet search provider from the EXA_API_KEY environment variable during migration and encrypts the API key. Activates it only if no provider is active; no-op if the env var is missing or the provider already exists.

- **Migration**
  - Set EXA_API_KEY before running migrations.
  - Inserts provider named “Exa” with type “exa.”
  - Skips insert if it already exists; safe to rerun.
  - Downgrade is a no-op to preserve existing Exa provider rows.

<sup>Written for commit 4e29a1785637fdb800395621c574ea9e87a2405c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









