### PR TITLE
chore(deployments): fix nightly tagging + add alerts & workflow_dispatch

### DIFF
--- a/.github/workflows/tag-nightly.yml
+++ b/.github/workflows/tag-nightly.yml
@@ -3,31 +3,29 @@ name: Nightly Tag Push
 on:
   schedule:
     - cron: "0 10 * * *" # Runs every day at 2 AM PST / 3 AM PDT / 10 AM UTC
+  workflow_dispatch:
 
 permissions:
   contents: write # Allows pushing tags to the repository
 
 jobs:
   create-and-push-tag:
-    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-create-and-push-tag"]
+    runs-on: ubuntu-slim
 
     steps:
       # actions using GITHUB_TOKEN cannot trigger another workflow, but we do want this to trigger docker pushes
       # see https://github.com/orgs/community/discussions/27028#discussioncomment-3254367 for the workaround we
       # implement here which needs an actual user's deploy key
-
-      # Additional NOTE: even though this is named "rkuo", the actual key is tied to the onyx repo
-      # and not rkuo's personal account. It is fine to leave this key as is!
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
         with:
-          ssh-key: "${{ secrets.RKUO_DEPLOY_KEY }}"
-          persist-credentials: false
+          ssh-key: "${{ secrets.DEPLOY_KEY }}"
+          persist-credentials: true
 
       - name: Set up Git user
         run: |
-          git config user.name "Richard Kuo [bot]"
-          git config user.email "rkuo[bot]@onyx.app"
+          git config user.name "Onyx Bot [bot]"
+          git config user.email "onyx-bot[bot]@onyx.app"
 
       - name: Check for existing nightly tag
         id: check_tag
@@ -55,3 +53,12 @@ jobs:
         run: |
           TAG_NAME="nightly-latest-$(date +'%Y%m%d')"
           git push origin $TAG_NAME
+
+      - name: Send Slack notification
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          title: "🚨 Nightly Tag Push Failed"
+          ref-name: ${{ github.ref_name }}
+          failed-jobs: "create-and-push-tag"


### PR DESCRIPTION
## Description

`persist-credentials: false` introduced in https://github.com/onyx-dot-app/onyx/commit/482b2c42041a2211fb385fbe79fb1c64366adbb2#diff-05ddaaff5585d884f6dcbc42f31deb48b583dd4d1654dcd63f00881a1bb7adc5R25 broke this last night, https://github.com/onyx-dot-app/onyx/actions/runs/19533091560

Went ahead and rotated the deploy key + switched to `ubuntu-slim` (cheaper, more reliable maybe) + added `workflow_dispatch` and alerts in case it fails again.

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/19550946833

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly tag push workflow so tags are reliably created and pushed, and adds a manual trigger and failure alerts to catch issues quickly. Also switches the job to the ubuntu-slim runner and rotates the deploy key.

- **Bug Fixes**
  - Use DEPLOY_KEY with persist-credentials: true to push tags and trigger downstream workflows.
  - Update bot identity to “Onyx Bot [bot]” for consistent commits.

- **New Features**
  - Add workflow_dispatch to run the job on demand.
  - Send Slack alerts on failure via MONITOR_DEPLOYMENTS_WEBHOOK.

<sup>Written for commit 7fbe254a4c8aac5c678e1a8bd8c3089934182c07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

