### PR TITLE
chore: prevent sentry spam on fake issue

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -116,7 +116,7 @@ def _concurrent_embedding(
             # the model to fail to encode texts. It's pretty rare and we want to allow
             # concurrent embedding, hence we retry (the specific error is
             # "RuntimeError: Already borrowed" and occurs in the transformers library)
-            logger.error(f"Error encoding texts, retrying: {e}")
+            logger.warning(f"Error encoding texts, retrying: {e}")
             time.sleep(ENCODING_RETRY_DELAY)
     return model.encode(texts, normalize_embeddings=normalize_embeddings)
 


### PR DESCRIPTION
## Description

https://onyx-vl.sentry.io/issues/6873160110/events/91f06d8c269e4aa6a3558e8fd00b1acf/?project=4509930631725056&query=is%3Aunresolved&referrer=previous-event

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Sentry noise by logging the transient "Already borrowed" encoding error as a warning instead of an error during concurrent embedding retries. Retry behavior is unchanged.

<sup>Written for commit dc32e9253302fa94e10505f457e58821d8567db5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

