### PR TITLE
chore(docker): breakup model-server model layers

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -1,4 +1,42 @@
-FROM python:3.11.7-slim-bookworm
+# Base stage with dependencies
+FROM python:3.11.7-slim-bookworm AS base
+
+ENV DANSWER_RUNNING_IN_DOCKER="true" \
+    HF_HOME=/app/.cache/huggingface
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
+
+RUN mkdir -p /app/.cache/huggingface
+
+COPY ./requirements/model_server.txt /tmp/requirements.txt
+RUN uv pip install --system --no-cache-dir --upgrade \
+        -r /tmp/requirements.txt && \
+    rm -rf ~/.cache/uv /tmp/*.txt
+
+# Stage for downloading tokenizers
+FROM base AS tokenizers
+RUN python -c "from transformers import AutoTokenizer; \
+AutoTokenizer.from_pretrained('distilbert-base-uncased'); \
+AutoTokenizer.from_pretrained('mixedbread-ai/mxbai-rerank-xsmall-v1');"
+
+# Stage for downloading Onyx models
+FROM base AS onyx-models
+RUN python -c "from huggingface_hub import snapshot_download; \
+snapshot_download(repo_id='onyx-dot-app/hybrid-intent-token-classifier'); \
+snapshot_download(repo_id='onyx-dot-app/information-content-model');"
+
+# Stage for downloading embedding and reranking models
+FROM base AS embedding-models
+RUN python -c "from huggingface_hub import snapshot_download; \
+snapshot_download('nomic-ai/nomic-embed-text-v1'); \
+snapshot_download('mixedbread-ai/mxbai-rerank-xsmall-v1');"
+
+# Initialize SentenceTransformer to cache the custom architecture
+RUN python -c "from sentence_transformers import SentenceTransformer; \
+SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);"
+
+# Final stage - combine all downloads
+FROM base AS final
 
 LABEL com.danswer.maintainer="founders@onyx.app"
 LABEL com.danswer.description="This image is for the Onyx model server which runs all of the \
@@ -6,44 +44,19 @@ AI models for Onyx. This container and all the code is MIT Licensed and free for
 You can find it at https://hub.docker.com/r/onyx/onyx-model-server. For more details, \
 visit https://github.com/onyx-dot-app/onyx."
 
-ENV DANSWER_RUNNING_IN_DOCKER="true" \
-    HF_HOME=/app/.cache/huggingface
-
-COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
-
 # Create non-root user for security best practices
-RUN mkdir -p /app && \
-    groupadd -g 1001 onyx && \
-    useradd -u 1001 -g onyx -m -s /bin/bash onyx  && \
-    chown -R onyx:onyx /app && \
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
     mkdir -p /var/log/onyx && \
     chmod 755 /var/log/onyx && \
     chown onyx:onyx /var/log/onyx
 
-COPY ./requirements/model_server.txt /tmp/requirements.txt
-RUN uv pip install --system --no-cache-dir --upgrade \
-        -r /tmp/requirements.txt && \
-    rm -rf ~/.cache/uv /tmp/*.txt
-
-# Pre-downloading models for setups with limited egress
-# Download tokenizers, distilbert for the Onyx model
-# Download model weights
-# Run Nomic to pull in the custom architecture and have it cached locally
-RUN python -c "from transformers import AutoTokenizer; \
-AutoTokenizer.from_pretrained('distilbert-base-uncased'); \
-AutoTokenizer.from_pretrained('mixedbread-ai/mxbai-rerank-xsmall-v1'); \
-from huggingface_hub import snapshot_download; \
-snapshot_download(repo_id='onyx-dot-app/hybrid-intent-token-classifier'); \
-snapshot_download(repo_id='onyx-dot-app/information-content-model'); \
-snapshot_download('nomic-ai/nomic-embed-text-v1'); \
-snapshot_download('mixedbread-ai/mxbai-rerank-xsmall-v1'); \
-from sentence_transformers import SentenceTransformer; \
-SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);" && \
-    # In case the user has volumes mounted to /app/.cache/huggingface that they've downloaded while
-    # running Onyx, move the current contents of the cache folder to a temporary location to ensure
-    # it's preserved in order to combine with the user's cache contents
-    mv /app/.cache/huggingface /app/.cache/temp_huggingface && \
-    chown -R onyx:onyx /app
+# In case the user has volumes mounted to /app/.cache/huggingface that they've downloaded while
+# running Onyx, move the current contents of the cache folder to a temporary location to ensure
+# it's preserved in order to combine with the user's cache contents
+COPY --chown=onyx:onyx --from=tokenizers /app/.cache/huggingface /app/.cache/temp_huggingface
+COPY --chown=onyx:onyx --from=onyx-models /app/.cache/huggingface /app/.cache/temp_huggingface
+COPY --chown=onyx:onyx --from=embedding-models /app/.cache/huggingface /app/.cache/temp_huggingface
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

It's suspected these [failed deployments](https://github.com/onyx-dot-app/onyx/actions/runs/19550959288/job/55990767365#step:8:394) are related to this monolithic models download layer failing to be uploaded to Docker Hub.

I think this builds faster anyways as these stages are able to be run in parallel.

I suspect the real culprit here is the `pip install` layer which is 6GB (3GB more than this model layer). Most of that is from `torch` which makes me think ~~we could replace the base image from `python-slim` to something like https://hub.docker.com/r/pytorch/pytorch/tags~~, but worth trying this first. EDIT: `pytorch/pytorch` only uploads amd64 images :/

## How Has This Been Tested?

```
[0] ~/code/onyx/backend [jamison/bust-model_server] 2025-11-20 15:15:24
$ docker run --rm onyxdotapp/onyx-model-server:before bash -c 'du -d 1 -h /app/.cache/temp_huggingface'
264K	/app/.cache/temp_huggingface/xet
264K	/app/.cache/temp_huggingface/modules
2.9G	/app/.cache/temp_huggingface/hub
2.9G	/app/.cache/temp_huggingface

[0] ~/code/onyx/backend [jamison/bust-model_server] 2025-11-20 15:15:30
$ docker run --rm onyxdotapp/onyx-model-server:after bash -c 'du -d 1 -h /app/.cache/temp_huggingface/hub' 
28K	/app/.cache/temp_huggingface/hub/.locks
501M	/app/.cache/temp_huggingface/hub/models--mixedbread-ai--mxbai-rerank-xsmall-v1
724K	/app/.cache/temp_huggingface/hub/models--distilbert-base-uncased
1.7G	/app/.cache/temp_huggingface/hub/models--nomic-ai--nomic-embed-text-v1
132K	/app/.cache/temp_huggingface/hub/models--nomic-ai--nomic-bert-2048
419M	/app/.cache/temp_huggingface/hub/models--onyx-dot-app--information-content-model
256M	/app/.cache/temp_huggingface/hub/models--onyx-dot-app--hybrid-intent-token-classifier
2.9G	/app/.cache/temp_huggingface/hub
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the model downloads in the model-server Dockerfile into separate build stages to reduce layer upload failures and speed up builds through better parallelism and caching.

- **Refactors**
  - Introduced a base stage with dependencies, then separate stages for tokenizers, Onyx models, and embedding/reranker models.
  - Pre-warm SentenceTransformer cache for nomic-ai/nomic-embed-text-v1.
  - Combine downloaded caches into /app/.cache/temp_huggingface in the final stage with correct ownership.
  - Moved labels to the final stage and kept non-root user setup.

<sup>Written for commit 78467c0194ff051e384d812c413b50c2b0f2aa02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

