### PR TITLE
fix(OOM): Limit images processed

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -541,6 +541,11 @@ BLOB_STORAGE_SIZE_THRESHOLD = int(
     os.environ.get("BLOB_STORAGE_SIZE_THRESHOLD", 20 * 1024 * 1024)
 )
 
+# Maximum number of images to process per document
+# Documents with more images will have image processing limited to prevent OOM
+# Set to 0 to disable image processing entirely, -1 for unlimited
+MAX_IMAGES_PER_DOCUMENT = int(os.environ.get("MAX_IMAGES_PER_DOCUMENT", 100))
+
 JIRA_CONNECTOR_LABELS_TO_SKIP = [
     ignored_tag
     for ignored_tag in os.environ.get("JIRA_CONNECTOR_LABELS_TO_SKIP", "").split(",")


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent OOMs during indexing by capping how many images are processed per document. Adds a configurable MAX_IMAGES_PER_DOCUMENT with sensible defaults and clear logging when images are skipped.

- **Bug Fixes**
  - Limit image processing per document via MAX_IMAGES_PER_DOCUMENT (default 100; 0 disables; -1 unlimited).
  - Skip extra images with placeholder text while preserving sections for consistent indexing.
  - Add warnings when limiting, debug logs per skipped image, and an info-level batch summary.

<sup>Written for commit 3874be3aa3e6449d7dc896a6be9a5dd923482abf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

