### PR TITLE
feat(UserFilesModal): add file count divider and conditional rendering

### DIFF
--- a/web/src/components/modals/UserFilesModal.tsx
+++ b/web/src/components/modals/UserFilesModal.tsx
@@ -20,7 +20,7 @@ import AttachmentButton from "@/refresh-components/buttons/AttachmentButton";
 import Modal from "@/refresh-components/Modal";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
-import { Separator } from "@/components/ui/separator";
+import CounterSeparator from "@/refresh-components/CounterSeparator";
 
 function getIcon(
   file: ProjectFile,
@@ -263,14 +263,10 @@ export default function UserFilesModal({
 
                 {/* File count divider - only show when not searching or filtering */}
                 {!search.trim() && !showOnlySelected && (
-                  <div className="flex items-center justify-center gap-2 px-4 pb-2">
-                    <Separator className="flex-1 my-0 bg-border-01" />
-                    <Text text03 secondaryBody>
-                      {recentFiles.length}{" "}
-                      {recentFiles.length === 1 ? "File" : "Files"}
-                    </Text>
-                    <Separator className="flex-1 my-0 bg-border-01" />
-                  </div>
+                  <CounterSeparator
+                    count={recentFiles.length}
+                    text={recentFiles.length === 1 ? "File" : "Files"}
+                  />
                 )}
               </ScrollIndicatorDiv>
             )}


### PR DESCRIPTION
## Description
This pull request enhances the `UserFilesModal` component UI by adding a file count divider and improving layout consistency, particularly in the modal footer. The changes focus on user experience improvements and minor layout adjustments.

## How Has This Been Tested?
Tested from UI

## Additional Options

- [ ] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves UserFilesModal with a centered file count divider and a cleaner footer that only shows selection controls when relevant. Also aligns the Done button for consistent layout.

- **New Features**
  - Show a file count divider when not searching or filtering.
  - Render selection controls in the footer only if onPickRecent is provided.
  - Right-align the Done button to maintain layout when controls are hidden.

<sup>Written for commit cd8dd329dd3134ba56ba8a32c927141dc1257d5c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



