### PR TITLE
fix(docker): chown /app directory

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,13 @@ ENV DANSWER_RUNNING_IN_DOCKER="true" \
     DO_NOT_TRACK="true" \
     PLAYWRIGHT_BROWSERS_PATH="/app/.cache/ms-playwright"
 
+# Create non-root user for security best practices
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
+    mkdir -p /var/log/onyx && \
+    chmod 755 /var/log/onyx && \
+    chown onyx:onyx /var/log/onyx
+
 COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 
 # Install system dependencies
@@ -51,6 +58,7 @@ RUN uv pip install --system --no-cache-dir --upgrade \
     pip uninstall -y py && \
     playwright install chromium && \
     playwright install-deps chromium && \
+    chown -R onyx:onyx /app && \
     ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     # Cleanup for CVEs and size reduction
     # https://github.com/tornadoweb/tornado/issues/3107
@@ -93,13 +101,6 @@ tiktoken.get_encoding('cl100k_base')"
 
 # Set up application files
 WORKDIR /app
-
-# Create non-root user for security best practices
-RUN groupadd -g 1001 onyx && \
-    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
-    mkdir -p /var/log/onyx && \
-    chmod 755 /var/log/onyx && \
-    chown onyx:onyx /var/log/onyx
 
 # Enterprise Version Files
 COPY --chown=onyx:onyx ./ee /app/ee


### PR DESCRIPTION
## Description

https://github.com/onyx-dot-app/onyx/pull/5805 left the `/app` directory owned by root which was unintended.

## How Has This Been Tested?

```
$ cd backend && docker bake backend
$ docker run -it --rm --user onyx onyxdotapp/onyx-backend:latest ls -alh /app
total 48K
drwxr-xr-x  1 onyx onyx 4.0K Nov 22 01:20 .
drwxr-xr-x  1 root root 4.0K Nov 22 01:27 ..
drwxr-xr-x  3 onyx oynx 4.0K Nov 21 17:30 .cache
drwxr-xr-x  3 onyx onyx 4.0K Nov 11 00:36 alembic
-rw-r--r--  1 onyx onyx 3.4K Nov 11 00:36 alembic.ini
drwxr-xr-x  3 onyx onyx 4.0K Nov 11 00:36 alembic_tenants
drwxr-xr-x  2 onyx onyx 4.0K Nov 11 00:36 assets
drwxr-xr-x  3 onyx onyx 4.0K Nov 11 00:36 ee
drwxr-xr-x 32 onyx onyx 4.0K Nov 21 17:51 onyx
drwxr-xr-x  1 onyx onyx 4.0K Nov 22 01:20 scripts
drwxr-xr-x  2 onyx onyx 4.0K Nov 21 17:51 shared_configs
drwxr-xr-x  3 onyx onyx 4.0K Nov 11 00:36 static
```

And confirmed no change in image size,
```
$ docker images
REPOSITORY                     TAG                                  IMAGE ID       CREATED             SIZE
onyxdotapp/onyx-backend        before                               329a46707cf2   2 seconds ago       2.89GB
onyxdotapp/onyx-backend        after                                8dc52d385748   2 minutes ago       2.89GB
```

## Additional Options

- [x] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ownership of /app in the backend Docker image by chowning it to onyx:onyx during build. This prevents permission errors when running as the non-root onyx user and corrects unintended root ownership from a recent change.

<sup>Written for commit 4c31c95aa065354aecb0b231577ba340ff8a8973. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







