### PR TITLE
chore(gha): increase playwright runner volume size: 40->50gb

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,6 +17,7 @@ self-hosted-runner:
     - runner=16cpu-linux-x64
     - ubuntu-slim # Currently in public preview
     - volume=40gb
+    - volume=50gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -154,7 +154,12 @@ jobs:
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]
     name: Playwright Tests (${{ matrix.project }})
-    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-arm64
+      - "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}"
+      - "extras=ecr-cache"
+      - volume=50gb
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Supposedly https://github.com/onyx-dot-app/onyx/pull/6343 increased the disk required for the playwright runner, so this updates it so jobs don't hang.

## How Has This Been Tested?



## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase GitHub Actions Playwright runner disk volume from 40GB to 50GB to prevent jobs hanging due to higher disk usage after recent changes.
Updated actionlint config and the pr-playwright-tests workflow to set volume=50gb on the self-hosted runner.

<sup>Written for commit 3b21c71b3438caf7d9e1809275a71ebf4ab7e7d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

