### PR TITLE
chore(gha): increase size of integration runner

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -18,6 +18,7 @@ self-hosted-runner:
     - ubuntu-slim # Currently in public preview
     - volume=40gb
     - volume=50gb
+    - volume=60gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -181,6 +181,7 @@ jobs:
       - runner=8cpu-linux-arm64
       - ${{ format('run-id={0}-integration-tests-job-{1}', github.run_id, strategy['job-index']) }}
       - extras=ecr-cache
+      - volume=60gb
 
     strategy:
       fail-fast: false
@@ -347,7 +348,12 @@ jobs:
         build-model-server-image,
         build-integration-image,
       ]
-    runs-on: [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}-multitenant-tests", "extras=ecr-cache"]
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-arm64
+      - "run-id=${{ github.run_id }}-multitenant-tests"
+      - "extras=ecr-cache"
+      - volume=60gb
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2


### PR DESCRIPTION
## Description

why is this flaking :raised_eyebrow: 

## How Has This Been Tested?



## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the GitHub Actions integration test runner from 4cpu to 8cpu, add a 60GB volume, and enable CPU, memory, and disk metrics. This should reduce flakiness and improve runtime by giving the job more resources and visibility into resource usage.

<sup>Written for commit 56c044b378c687ecbe9d9d38f741ea3864dc94e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





