### PR TITLE
fix: Fix non-persistence issue with input-select

### DIFF
--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -161,19 +161,33 @@ const InputSelectRoot = React.forwardRef<HTMLDivElement, InputSelectRootProps>(
     );
 
     // Item registry for displaying selected item with icon in trigger
-    const itemsRef = React.useRef<Map<string, ItemRegistration>>(new Map());
+    // Using useState instead of useRef so registration triggers re-renders
+    const [items, setItems] = React.useState<Map<string, ItemRegistration>>(
+      () => new Map()
+    );
 
     const registerItem = React.useCallback((item: ItemRegistration) => {
-      itemsRef.current.set(item.value, item);
+      setItems((prev) => {
+        const next = new Map(prev);
+        next.set(item.value, item);
+        return next;
+      });
     }, []);
 
     const unregisterItem = React.useCallback((value: string) => {
-      itemsRef.current.delete(value);
+      setItems((prev) => {
+        const next = new Map(prev);
+        next.delete(value);
+        return next;
+      });
     }, []);
 
-    const getItem = React.useCallback((value: string) => {
-      return itemsRef.current.get(value);
-    }, []);
+    const getItem = React.useCallback(
+      (value: string) => {
+        return items.get(value);
+      },
+      [items]
+    );
 
     const contextValue = React.useMemo<InputSelectContextValue>(
       () => ({


### PR DESCRIPTION
## Description

In a modal that contained an InputSelect, opening that modal would correctly render the InputSelect's trigger (i.e., if the InputSelect was for the theme-preference and "Light Mode" was selected, it would properly render "Light Mode" when the modal was opened for the first time).

However, after closing the modal and then re-opening it, the InputSelect would show the default placeholder text, even if the proper option was still "selected" in the background (i.e., even if "Light Mode" was selected in the dropdown, "Select an option" would be the text that was rendered in the trigger).

This PR fixes the above issue.

Addresses: https://linear.app/danswer/issue/DAN-3105/hotfix-for-non-persistence-issue-with-inputselect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes InputSelect showing the placeholder after a modal re-open by switching the item registry from useRef to useState to trigger re-renders (Linear DAN-3105). The trigger now consistently displays the selected option.

<sup>Written for commit 20f42fab8d3cd8a0846ac7b580ab3c43a9842f4e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

