### PR TITLE
fix(AppSidebar): prevent overlay flash on sidebar for chatpage

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, memo, useMemo, useState, useEffect } from "react";
+import { useCallback, memo, useMemo, useState } from "react";
 import { useSettingsContext } from "@/components/settings/SettingsProvider";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import Text from "@/refresh-components/texts/Text";
 import ChatButton from "@/sections/sidebar/ChatButton";
 import AgentButton from "@/sections/sidebar/AgentButton";
+import useIsMounted from "@/hooks/useIsMounted";
 import { DragEndEvent } from "@dnd-kit/core";
 import {
   DndContext,
@@ -508,12 +509,7 @@ MemoizedAppSidebarInner.displayName = "AppSidebar";
 export default function AppSidebar() {
   const { folded, setFolded } = useAppSidebarContext();
   const { isMobile } = useScreenSize();
-  const [isMounted, setIsMounted] = useState(false);
-
-  // Ensure mobile sidebar starts closed on page load/refresh
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const isMounted = useIsMounted();
 
   if (!isMobile)
     return (


### PR DESCRIPTION
## Description
Prevent the mobile sidebar overlay from rendering during initial mount to eliminate the unwanted shadow/overlay effect that appeared when refreshing the chat page.

## How Has This Been Tested?
Tested from UI

## Additional Options

- [ ] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the mobile sidebar overlay from flashing on the chat page during load/refresh by rendering it only after the component mounts. Removes the unwanted shadow while keeping sidebar behavior unchanged.

- **Bug Fixes**
  - Gate overlay rendering with useIsMounted so it appears only after mount and still respects the folded state.

<sup>Written for commit 2f5c72fc648af09f8a1e1e2de915a2b58fadbf96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



