### PR TITLE
chore(docker): make container startup checks case-less-sensitive

### DIFF
--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
@@ -124,7 +124,7 @@ Resources:
             - "/bin/sh"
             - "-c"
             - >
-              val="${DISABLE_MODEL_SERVER:-false}"; if [ "$val" = "True" ] || [ "$val" = "true" ]; then echo 'Skipping service...';
+              if [ "${DISABLE_MODEL_SERVER}" = "True" ] || [ "${DISABLE_MODEL_SERVER}" = "true" ]; then echo 'Skipping service...';
               exit 0; else exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000; fi
           PortMappings:
             - Name: model-server

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
@@ -124,7 +124,7 @@ Resources:
             - "/bin/sh"
             - "-c"
             - >
-              val="${DISABLE_MODEL_SERVER:-false}"; if [ "$val" = "True" ] || [ "$val" = "true" ]; then echo 'Skipping service...';
+              if [ "${DISABLE_MODEL_SERVER}" = "True" ] || [ "${DISABLE_MODEL_SERVER}" = "true" ]; then echo 'Skipping service...';
               exit 0; else exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000; fi
           PortMappings:
             - Name: model-server

--- a/deployment/docker_compose/docker-compose.model-server-test.yml
+++ b/deployment/docker_compose/docker-compose.model-server-test.yml
@@ -7,8 +7,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -312,8 +312,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -342,8 +341,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -466,8 +464,7 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command: >
       "
-      val=\"$${CODE_INTERPRETER_BETA_ENABLED:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      if [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"True\" ] || [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"true\" ]; then
         exec bash ./entrypoint.sh code-interpreter-api;
       else
         echo 'Skipping code interpreter';

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -122,8 +122,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -149,8 +148,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -125,8 +125,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -154,8 +153,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -281,8 +279,7 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command: >
       "
-      val=\"$${CODE_INTERPRETER_BETA_ENABLED:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      if [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"True\" ] || [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"true\" ]; then
         exec bash ./entrypoint.sh code-interpreter-api;
       else
         echo 'Skipping code interpreter';

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -154,8 +154,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -183,8 +182,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -311,8 +309,7 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command: >
       "
-      val=\"$${CODE_INTERPRETER_BETA_ENABLED:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      if [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"True\" ] || [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"true\" ]; then
         exec bash ./entrypoint.sh code-interpreter-api;
       else
         echo 'Skipping code interpreter';

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -116,8 +116,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -141,8 +140,7 @@ services:
       context: ../../backend
       dockerfile: Dockerfile.model_server
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -180,8 +180,7 @@ services:
     #           count: all
     #           capabilities: [gpu]
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -217,8 +216,7 @@ services:
     #           count: all
     #           capabilities: [gpu]
     command: >
-      /bin/sh -c "val=\"${DISABLE_MODEL_SERVER:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
@@ -373,8 +371,7 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command: >
       "
-      val=\"$${CODE_INTERPRETER_BETA_ENABLED:-false}\";
-      if [ \"$val\" = \"True\" ] || [ \"$val\" = \"true\" ]; then
+      if [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"True\" ] || [ \"$${CODE_INTERPRETER_BETA_ENABLED}\" = \"true\" ]; then
         exec bash ./entrypoint.sh code-interpreter-api;
       else
         echo 'Skipping code interpreter';


### PR DESCRIPTION
## Description

- check for True or true (although true is standard, we've unfortunately used True previously and forcing true would be a breaking change

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make container startup checks accept "True" or "true" for model server and code interpreter. Prevents accidental starts/skips across Docker Compose and ECS.

- **Bug Fixes**
  - Check DISABLE_MODEL_SERVER and CODE_INTERPRETER_BETA_ENABLED against "True" or "true" before starting services.
  - Applied to ECS Fargate templates and all docker-compose variants.

<sup>Written for commit 0969ee28e13a533c22534a450fb98c67c45b6ed2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





