### PR TITLE
feat(api): Add need mem logger

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -523,6 +523,16 @@ def update_docs_updated_at__no_commit(
     db_session: Session,
 ) -> None:
     doc_ids = list(ids_to_new_updated_at.keys())
+
+    # Log only when loading large batches
+    if len(doc_ids) > 100:
+        import psutil
+
+        mem_before = psutil.Process().memory_info().rss / (1024 * 1024)
+        logger.warning(
+            f"[MEM] Loading {len(doc_ids)} docs for update, mem: {mem_before:.0f}MB"
+        )
+
     documents_to_update = (
         db_session.query(DbDocument).filter(DbDocument.id.in_(doc_ids)).all()
     )
@@ -535,6 +545,15 @@ def update_docs_last_modified__no_commit(
     document_ids: list[str],
     db_session: Session,
 ) -> None:
+    # Log only when loading large batches
+    if len(document_ids) > 100:
+        import psutil
+
+        mem_before = psutil.Process().memory_info().rss / (1024 * 1024)
+        logger.warning(
+            f"[MEM] Loading {len(document_ids)} docs for last_modified, mem: {mem_before:.0f}MB"
+        )
+
     documents_to_update = (
         db_session.query(DbDocument).filter(DbDocument.id.in_(document_ids)).all()
     )
@@ -549,6 +568,15 @@ def update_docs_chunk_count__no_commit(
     doc_id_to_chunk_count: dict[str, int],
     db_session: Session,
 ) -> None:
+    # Log only when loading large batches
+    if len(document_ids) > 100:
+        import psutil
+
+        mem_before = psutil.Process().memory_info().rss / (1024 * 1024)
+        logger.warning(
+            f"[MEM] Loading {len(document_ids)} docs for chunk_count, mem: {mem_before:.0f}MB"
+        )
+
     documents_to_update = (
         db_session.query(DbDocument).filter(DbDocument.id.in_(document_ids)).all()
     )

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -554,6 +554,11 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     if LOG_ENDPOINT_LATENCY:
         add_latency_logging_middleware(application, logger)
 
+    # Add memory tracking middleware (only logs when memory is high)
+    from onyx.server.middleware.memory_tracking import MemoryTrackingMiddleware
+
+    application.add_middleware(MemoryTrackingMiddleware)
+
     add_onyx_request_id_middleware(application, "API", logger)
 
     # Ensure all routes have auth enabled or are explicitly marked as public

--- a/backend/onyx/server/middleware/memory_tracking.py
+++ b/backend/onyx/server/middleware/memory_tracking.py
@@ -1,0 +1,60 @@
+"""Lightweight memory tracking middleware that only logs when memory is high."""
+
+import psutil
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Only log when memory exceeds these thresholds (MB)
+MEMORY_WARNING_THRESHOLD = 2000  # 2GB - log warning
+MEMORY_CRITICAL_THRESHOLD = 2500  # 2.5GB - log error
+MEMORY_DELTA_THRESHOLD = 200  # Log if single request uses >200MB
+
+
+class MemoryTrackingMiddleware(BaseHTTPMiddleware):
+    """Tracks memory usage for requests, only logging when thresholds are exceeded."""
+
+    async def dispatch(self, request: Request, call_next):
+        process = psutil.Process()
+        mem_before_mb = process.memory_info().rss / (1024 * 1024)
+
+        # Only check expensive endpoints or when already high
+        should_track = mem_before_mb > MEMORY_WARNING_THRESHOLD or any(
+            path in request.url.path
+            for path in [
+                "/send-message",
+                "/upload",
+                "/indexing",
+                "/search",
+                "/query",
+            ]
+        )
+
+        if not should_track:
+            return await call_next(request)
+
+        # Track memory for concerning requests
+        response = await call_next(request)
+
+        mem_after_mb = process.memory_info().rss / (1024 * 1024)
+        mem_delta_mb = mem_after_mb - mem_before_mb
+
+        # Only log if memory is high or spike is large
+        if mem_after_mb > MEMORY_CRITICAL_THRESHOLD:
+            logger.error(
+                f"[MEM CRITICAL] {mem_after_mb:.0f}MB after {request.method} "
+                f"{request.url.path} (+{mem_delta_mb:.0f}MB)"
+            )
+        elif (
+            mem_after_mb > MEMORY_WARNING_THRESHOLD
+            or mem_delta_mb > MEMORY_DELTA_THRESHOLD
+        ):
+            logger.warning(
+                f"[MEM HIGH] {mem_after_mb:.0f}MB after {request.method} "
+                f"{request.url.path} (+{mem_delta_mb:.0f}MB)"
+            )
+
+        return response


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lightweight memory tracking to the API and batch logging in document updates to catch high memory usage on heavy requests. Logs only when thresholds are exceeded to keep noise low.

- **New Features**
  - Added MemoryTrackingMiddleware that logs warnings at >2GB, errors at >2.5GB, and spikes >200MB per request.
  - Tracks expensive endpoints (/send-message, /upload, /indexing, /search, /query) or when memory is already high.
  - Added psutil-based logging in document batch operations (>100 docs) for updated_at, last_modified, and chunk_count.

<sup>Written for commit 37ebfaf8bae1ab5666090cbc4ce99ed9ea9532c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

