### PR TITLE
feat(claude): Add Gov Cloud Names

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -1010,6 +1010,20 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "us.anthropic.claude-sonnet-4-20250514-v1:0": "Claude 4 Sonnet (US)",
   "us.anthropic.claude-sonnet-4-5-20250929-v1:0": "Claude 4.5 Sonnet (US)",
   "us.anthropic.claude-haiku-4-5-20251001-v1:0": "Claude 4.5 Haiku (US)",
+  "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0":
+    "Claude 4.5 Sonnet (US Gov)",
+  "us-gov.anthropic.claude-sonnet-4-20250514-v1:0": "Claude 4 Sonnet (US Gov)",
+  "us-gov.anthropic.claude-haiku-4-5-20251001-v1:0":
+    "Claude 4.5 Haiku (US Gov)",
+  "us-gov.anthropic.claude-3-5-haiku-20241022-v1:0":
+    "Claude 3.5 Haiku (US Gov)",
+  "us-gov.anthropic.claude-3-5-sonnet-20241022-v2:0":
+    "Claude 3.5 Sonnet v2 (US Gov)",
+  "us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0":
+    "Claude 3.7 Sonnet (US Gov)",
+  "us-gov.anthropic.claude-3-haiku-20240307-v1:0": "Claude 3 Haiku (US Gov)",
+  "us-gov.anthropic.claude-opus-4-1-20250805-v1:0": "Claude Opus 4.1 (US Gov)",
+  "us-gov.anthropic.claude-opus-4-20250514-v1:0": "Claude Opus 4 (US Gov)",
   "us.deepseek.r1-v1:0": "DeepSeek R1 (US)",
   "us.meta.llama3-1-405b-instruct-v1:0": "Llama 3.1 405B (US)",
   "us.meta.llama3-1-70b-instruct-v1:0": "Llama 3.1 70B (US)",


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Just some clean up to make the product prettier

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add display names for Anthropic Claude US Gov Cloud models so the UI shows friendly names instead of raw IDs. Improves clarity in model pickers for Gov Cloud users.

- **New Features**
  - Mapped us-gov Anthropic model IDs to human-readable names in MODEL_DISPLAY_NAMES.
  - UI-only change; no API or behavior changes.

<sup>Written for commit 8ed6465cc9aeb26dad3d8d790212f27252a7b492. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

