### PR TITLE
feat(claude): Adding Opus 4.5

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -919,6 +919,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "claude-3-7-sonnet-202502019": "Claude 3.7 Sonnet",
   "claude-sonnet-4-5-20250929": "Claude 4.5 Sonnet",
   "claude-haiku-4-5-20251001": "Claude 4.5 Haiku",
+  "claude-opus-4-5-20251101": "Claude 4.5 Opus",
 
   // Google Models
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Updating UI for https://www.anthropic.com/news/claude-opus-4-5

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Claude 4.5 Opus (claude-opus-4-5-20251101) to the model display map so it shows the correct name in the UI and can be selected like other Claude models.

<sup>Written for commit 7d226fbcb963d434b2cea53126afc66c3fc7ef97. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

