### PR TITLE
feat(helm): Add Deployment Labels

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.10
+version: 0.4.11
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-api-server
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.api.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.api.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.api.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-beat
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_beat.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.celery_beat.replicaCount }}
   selector:
@@ -22,6 +25,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_beat.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_beat.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_docfetching.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_docfetching.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_docfetching.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_docfetching.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_docfetching.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_docprocessing.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_docprocessing.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_docprocessing.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_docprocessing.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_docprocessing.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-heavy
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_heavy.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_heavy.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_heavy.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_heavy.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_heavy.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-light
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_light.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_light.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_light.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_light.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_light.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_monitoring.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_monitoring.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_monitoring.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_monitoring.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_monitoring.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-primary
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_primary.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_primary.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_primary.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_primary.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_primary.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_user_file_processing.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_user_file_processing.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_user_file_processing.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_user_file_processing.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_user_file_processing.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -102,5 +108,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
-
 

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-celery-worker-user-files-indexing
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.celery_worker_user_files_indexing.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.celery_worker_user_files_indexing.autoscaling.enabled }}
   replicas: {{ .Values.celery_worker_user_files_indexing.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.celery_worker_user_files_indexing.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.celery_worker_user_files_indexing.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-indexing-model
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.indexCapability.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.indexCapability.replicaCount }}
   selector:
@@ -22,6 +25,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.indexCapability.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.indexCapability.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-slackbot
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.slackbot.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -21,6 +24,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.slackbot.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.slackbot.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "onyx.fullname" . }}-web-server
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.webserver.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.webserver.autoscaling.enabled }}
   replicas: {{ .Values.webserver.replicaCount }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.webserver.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.webserver.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Needed to support custom labels that a customer may want to set.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Helm Template locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional deploymentLabels to all Onyx Helm Deployments so users can set custom labels on both the Deployment and pods. Bumps chart version to 0.4.11.

- **New Features**
  - Adds .Values.<component>.deploymentLabels for api, webserver, slackbot, indexing-model, and all celery workers.
  - Labels are applied to Deployment metadata and pod template labels.
  - Safe default: no change if unset.

- **Migration**
  - To use, set deploymentLabels in your values (e.g., api.deploymentLabels: { environment: prod, team: platform }).

<sup>Written for commit 1dfc8fbc6c7a70e6767b0052c6fbad546f8c4db8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

