### PR TITLE
chore(python): update stale external type stubs

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -23,7 +23,7 @@ types-html5lib==1.1.11.13
 types-oauthlib==3.2.0.9
 types-passlib==1.7.7.20240106
 types-Pillow==10.2.0.20240822
-types-psutil==5.9.5.17
+types-psutil==7.1.3.20251125
 types-psycopg2==2.9.21.10
 types-python-dateutil==2.8.19.13
 types-pytz==2023.3.1.1
@@ -32,6 +32,5 @@ types-regex==2023.3.23.1
 types-requests==2.32.0.20250328
 types-retry==0.9.9.3
 types-setuptools==68.0.0.3
-types-urllib3==1.26.25.14
 voyageai==0.2.3
 ipykernel==6.29.5


### PR DESCRIPTION
## Description

I forgot to update the `psutil` type stubs in https://github.com/onyx-dot-app/onyx/pull/6300 and noticed we use `urllib3` > 2 which is typed, https://github.com/urllib3/urllib3/blob/main/src/urllib3/py.typed

## How Has This Been Tested?

Captured by mypy

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Python type stubs: bump types-psutil and remove types-urllib3 since urllib3 v2 ships built-in types. This improves mypy accuracy and avoids redundant stubs.

- **Dependencies**
  - Upgrade types-psutil to 7.1.3.20251125
  - Remove types-urllib3 (urllib3 provides built-in typing)

<sup>Written for commit c38df609a13908c6c6c4683d89ed2b3def9866df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

