### PR TITLE
feat(claude): update claude models

### DIFF
--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -163,8 +163,14 @@ IGNORABLE_ANTHROPIC_MODELS = [
 ANTHROPIC_PROVIDER_NAME = "anthropic"
 
 ANTHROPIC_VISIBLE_MODEL_NAMES = [
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-1",
+    "claude-opus-4-20250514",
     "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-5",
     "claude-sonnet-4-20250514",
+    "claude-haiku-4-5",
+    "claude-3-7-sonnet-latest",
 ]
 
 AZURE_PROVIDER_NAME = "azure"

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -920,6 +920,15 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "claude-sonnet-4-5-20250929": "Claude 4.5 Sonnet",
   "claude-haiku-4-5-20251001": "Claude 4.5 Haiku",
   "claude-opus-4-5-20251101": "Claude 4.5 Opus",
+  "claude-opus-4-1-20250805": "Claude 4.1 Opus",
+  "claude-opus-4-1": "Claude 4.1 Opus",
+  "claude-opus-4-20250514": "Claude 4 Opus",
+  "claude-4-opus-20250514": "Claude 4 Opus",
+  "claude-sonnet-4-5": "Claude 4.5 Sonnet (Latest)",
+  "claude-sonnet-4-20250514": "Claude 4 Sonnet",
+  "claude-4-sonnet-20250514": "Claude 4 Sonnet",
+  "claude-haiku-4-5": "Claude 4.5 Haiku (Latest)",
+  "claude-3-7-sonnet-latest": "Claude 3.7 Sonnet (Latest)",
 
   // Google Models
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Anthropic provider to surface the latest Claude models and added readable display names in the UI. Users can now select Claude 4.5 (Opus/Sonnet/Haiku), Claude 4.1 Opus, Claude 4 (Opus/Sonnet), and Claude 3.7 Sonnet.

- **New Features**
  - Backend: Added visible model IDs for new Claude variants (e.g., opus 4.5/4.1/4, sonnet 4.5/4, haiku 4.5, 3.7 sonnet latest).
  - Frontend: Mapped new IDs and aliases to friendly names in the model picker (including dated variants) for consistent labels.

<sup>Written for commit 97be80f27e4cbe752ee271dd52c129b44ac163b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

