### PR TITLE
feat(MCP): attempt to reduce mcp server memory minimum

### DIFF
--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -15,8 +15,8 @@ from starlette.types import Receive
 from starlette.types import Scope
 from starlette.types import Send
 
-from onyx.configs.app_configs import MCP_SERVER_CORS_ORIGINS
 from onyx.mcp_server.auth import OnyxTokenVerifier
+from onyx.mcp_server.config import MCP_SERVER_CORS_ORIGINS
 from onyx.mcp_server.utils import shutdown_http_client
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/mcp_server/config.py
+++ b/backend/onyx/mcp_server/config.py
@@ -1,0 +1,30 @@
+"""Configuration for the MCP server.
+
+Reads directly from environment variables to avoid importing heavy dependencies
+from the main Onyx codebase (e.g., fastapi_users via onyx.configs.app_configs).
+
+These values must match the definitions in onyx.configs.app_configs.
+"""
+
+import os
+
+
+# API server connection settings
+APP_PORT = 8080
+# API_PREFIX is used to prepend a base path for all API routes
+# generally used if using a reverse proxy which doesn't support stripping the `/api`
+# prefix from requests directed towards the API server. In these cases, set this to `/api`
+APP_API_PREFIX = os.environ.get("API_PREFIX", "")
+
+# MCP server settings
+MCP_SERVER_ENABLED = os.environ.get("MCP_SERVER_ENABLED", "").lower() == "true"
+MCP_SERVER_PORT = int(os.environ.get("MCP_SERVER_PORT") or 8090)
+
+# CORS origins for MCP clients (comma-separated)
+# Local dev: "http://localhost:*"
+# Production: "https://trusted-client.com,https://another-client.com"
+MCP_SERVER_CORS_ORIGINS = [
+    origin.strip()
+    for origin in os.environ.get("MCP_SERVER_CORS_ORIGINS", "").split(",")
+    if origin.strip()
+]

--- a/backend/onyx/mcp_server/models.py
+++ b/backend/onyx/mcp_server/models.py
@@ -1,0 +1,177 @@
+"""Lightweight Pydantic models and enums for MCP server.
+
+These models mirror the structure of the main Onyx models to avoid importing
+dependencies from the main Onyx codebase. This allows the MCP server to be
+run as a completely standalone service.
+
+IMPORTANT: These models and enums must stay in sync with their source counterparts.
+See backend/tests/unit/mcp_server/test_model_sync.py for validation tests.
+
+Source locations:
+- DocumentSource: onyx.configs.constants.DocumentSource
+- SearchType: onyx.context.search.enums.SearchType
+- LLMEvaluationType: onyx.context.search.enums.LLMEvaluationType
+- IndexFilters: onyx.context.search.models.IndexFilters
+- RetrievalDetails: onyx.context.search.models.RetrievalDetails
+- DocumentSearchRequest: onyx.server.query_and_chat.models.DocumentSearchRequest
+"""
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+# Enums
+
+
+class DocumentSource(str, Enum):
+    """Lightweight copy of onyx.configs.constants.DocumentSource
+
+    Document source types for filtering search results.
+    """
+
+    INGESTION_API = "ingestion_api"
+    SLACK = "slack"
+    WEB = "web"
+    GOOGLE_DRIVE = "google_drive"
+    GMAIL = "gmail"
+    REQUESTTRACKER = "requesttracker"
+    GITHUB = "github"
+    GITBOOK = "gitbook"
+    GITLAB = "gitlab"
+    GURU = "guru"
+    BOOKSTACK = "bookstack"
+    OUTLINE = "outline"
+    CONFLUENCE = "confluence"
+    JIRA = "jira"
+    SLAB = "slab"
+    PRODUCTBOARD = "productboard"
+    FILE = "file"
+    NOTION = "notion"
+    ZULIP = "zulip"
+    LINEAR = "linear"
+    HUBSPOT = "hubspot"
+    DOCUMENT360 = "document360"
+    GONG = "gong"
+    GOOGLE_SITES = "google_sites"
+    ZENDESK = "zendesk"
+    LOOPIO = "loopio"
+    DROPBOX = "dropbox"
+    SHAREPOINT = "sharepoint"
+    TEAMS = "teams"
+    SALESFORCE = "salesforce"
+    DISCOURSE = "discourse"
+    AXERO = "axero"
+    CLICKUP = "clickup"
+    MEDIAWIKI = "mediawiki"
+    WIKIPEDIA = "wikipedia"
+    ASANA = "asana"
+    S3 = "s3"
+    R2 = "r2"
+    GOOGLE_CLOUD_STORAGE = "google_cloud_storage"
+    OCI_STORAGE = "oci_storage"
+    XENFORO = "xenforo"
+    NOT_APPLICABLE = "not_applicable"
+    DISCORD = "discord"
+    FRESHDESK = "freshdesk"
+    FIREFLIES = "fireflies"
+    EGNYTE = "egnyte"
+    AIRTABLE = "airtable"
+    HIGHSPOT = "highspot"
+    IMAP = "imap"
+    BITBUCKET = "bitbucket"
+    TESTRAIL = "testrail"
+    MOCK_CONNECTOR = "mock_connector"
+    USER_FILE = "user_file"
+
+
+class SearchType(str, Enum):
+    """Lightweight copy of onyx.context.search.enums.SearchType"""
+
+    KEYWORD = "keyword"
+    SEMANTIC = "semantic"
+    INTERNET = "internet"
+
+
+class LLMEvaluationType(str, Enum):
+    """Lightweight copy of onyx.context.search.enums.LLMEvaluationType"""
+
+    AGENTIC = "agentic"
+    BASIC = "basic"
+    SKIP = "skip"
+    UNSPECIFIED = "unspecified"
+
+
+# Pydantic Models
+
+
+class Tag(BaseModel):
+    """Lightweight copy of onyx.context.search.models.Tag"""
+
+    tag_key: str
+    tag_value: str
+
+
+class BaseFilters(BaseModel):
+    """Lightweight copy of onyx.context.search.models.BaseFilters
+
+    Only includes fields used by the MCP server.
+    """
+
+    source_type: list[DocumentSource] | None = None
+    document_set: list[str] | None = None
+    time_cutoff: datetime | None = None
+    tags: list[Tag] | None = None
+
+
+class UserFileFilters(BaseModel):
+    """Lightweight copy of onyx.context.search.models.UserFileFilters"""
+
+    user_file_ids: list[UUID] | None = None
+    project_id: int | None = None
+
+
+class IndexFilters(BaseFilters, UserFileFilters):
+    """Lightweight copy of onyx.context.search.models.IndexFilters
+
+    Only includes fields used by the MCP server for document search requests.
+    The full IndexFilters has additional fields for KG search that aren't needed here.
+    """
+
+    access_control_list: list[str] | None = None
+    tenant_id: str | None = None
+
+
+class ChunkContext(BaseModel):
+    """Lightweight copy of onyx.context.search.models.ChunkContext"""
+
+    chunks_above: int | None = None
+    chunks_below: int | None = None
+    full_doc: bool = False
+
+
+class RetrievalDetails(ChunkContext):
+    """Lightweight copy of onyx.context.search.models.RetrievalDetails
+
+    Only includes fields used by the MCP server.
+    """
+
+    filters: BaseFilters | None = None
+    enable_auto_detect_filters: bool | None = None
+    offset: int | None = None
+    limit: int | None = None
+
+
+class DocumentSearchRequest(ChunkContext):
+    """Lightweight copy of onyx.server.query_and_chat.models.DocumentSearchRequest
+
+    Only includes fields used by the MCP server for the document search endpoint.
+    """
+
+    message: str
+    search_type: SearchType
+    retrieval_options: RetrievalDetails
+    recency_bias_multiplier: float = 1.0
+    evaluation_type: LLMEvaluationType

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -3,17 +3,17 @@
 from datetime import datetime
 from typing import Any
 
-from onyx.configs.constants import DocumentSource
-from onyx.context.search.enums import LLMEvaluationType
-from onyx.context.search.enums import SearchType
-from onyx.context.search.models import IndexFilters
-from onyx.context.search.models import RetrievalDetails
 from onyx.mcp_server.api import mcp_server
+from onyx.mcp_server.models import DocumentSearchRequest
+from onyx.mcp_server.models import DocumentSource
+from onyx.mcp_server.models import IndexFilters
+from onyx.mcp_server.models import LLMEvaluationType
+from onyx.mcp_server.models import RetrievalDetails
+from onyx.mcp_server.models import SearchType
 from onyx.mcp_server.utils import get_api_server_url
 from onyx.mcp_server.utils import get_http_client
 from onyx.mcp_server.utils import get_indexed_sources
 from onyx.mcp_server.utils import require_access_token
-from onyx.server.query_and_chat.models import DocumentSearchRequest
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/mcp_server/utils.py
+++ b/backend/onyx/mcp_server/utils.py
@@ -8,8 +8,8 @@ import httpx
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.dependencies import get_access_token
 
-from onyx.configs.app_configs import APP_API_PREFIX
-from onyx.configs.app_configs import APP_PORT
+from onyx.mcp_server.config import APP_API_PREFIX
+from onyx.mcp_server.config import APP_PORT
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/mcp_server_main.py
+++ b/backend/onyx/mcp_server_main.py
@@ -2,8 +2,8 @@
 
 import uvicorn
 
-from onyx.configs.app_configs import MCP_SERVER_ENABLED
-from onyx.configs.app_configs import MCP_SERVER_PORT
+from onyx.mcp_server.config import MCP_SERVER_ENABLED
+from onyx.mcp_server.config import MCP_SERVER_PORT
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/tests/unit/mcp_server/test_model_sync.py
+++ b/backend/tests/unit/mcp_server/test_model_sync.py
@@ -1,0 +1,275 @@
+"""Ensure MCP lightweight models and enums stay in sync with their source counterparts.
+
+The MCP server uses lightweight copies of Onyx models and enums to avoid importing
+heavy dependencies like SQLAlchemy. This also allows the MCP server to run as a standalone
+service. These tests ensure the lightweight copies don't diverge from the source.
+
+If these tests fail, update onyx/mcp_server/models.py to match changes in the source.
+"""
+
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel
+
+from onyx.configs.constants import DocumentSource as SourceDocumentSource
+from onyx.context.search.enums import LLMEvaluationType as SourceLLMEvaluationType
+from onyx.context.search.enums import SearchType as SourceSearchType
+from onyx.context.search.models import BaseFilters as SourceBaseFilters
+from onyx.context.search.models import ChunkContext as SourceChunkContext
+from onyx.context.search.models import IndexFilters as SourceIndexFilters
+from onyx.context.search.models import RetrievalDetails as SourceRetrievalDetails
+from onyx.context.search.models import Tag as SourceTag
+from onyx.context.search.models import UserFileFilters as SourceUserFileFilters
+from onyx.mcp_server.models import BaseFilters as MCPBaseFilters
+from onyx.mcp_server.models import ChunkContext as MCPChunkContext
+from onyx.mcp_server.models import DocumentSearchRequest as MCPDocumentSearchRequest
+from onyx.mcp_server.models import DocumentSource as MCPDocumentSource
+from onyx.mcp_server.models import IndexFilters as MCPIndexFilters
+from onyx.mcp_server.models import LLMEvaluationType as MCPLLMEvaluationType
+from onyx.mcp_server.models import RetrievalDetails as MCPRetrievalDetails
+from onyx.mcp_server.models import SearchType as MCPSearchType
+from onyx.mcp_server.models import Tag as MCPTag
+from onyx.mcp_server.models import UserFileFilters as MCPUserFileFilters
+from onyx.server.query_and_chat.models import (
+    DocumentSearchRequest as SourceDocumentSearchRequest,
+)
+
+# Source enums
+# Source models
+# MCP enums
+# MCP models
+
+
+def get_model_fields(model_class: type[BaseModel]) -> set[str]:
+    """Get field names from a Pydantic model."""
+    return set(model_class.model_fields.keys())
+
+
+def get_enum_values(enum_class: type[Enum]) -> set[str]:
+    """Get all string values from a str enum."""
+    return {str(member.value) for member in enum_class}
+
+
+def get_enum_names(enum_class: type[Enum]) -> set[str]:
+    """Get all member names from an enum."""
+    return {member.name for member in enum_class}
+
+
+# =============================================================================
+# Enum Sync Tests
+# =============================================================================
+
+
+class TestEnumSync:
+    """Ensure MCP enums have all values from source enums."""
+
+    @pytest.mark.parametrize(
+        "source_enum,mcp_enum,enum_name",
+        [
+            (SourceDocumentSource, MCPDocumentSource, "DocumentSource"),
+            (SourceSearchType, MCPSearchType, "SearchType"),
+            (SourceLLMEvaluationType, MCPLLMEvaluationType, "LLMEvaluationType"),
+        ],
+    )
+    def test_mcp_enum_has_all_source_values(
+        self, source_enum: type[Enum], mcp_enum: type[Enum], enum_name: str
+    ) -> None:
+        """MCP enums must have all values from source enums.
+
+        If source adds a new enum value, MCP must add it too, otherwise
+        the API server might return values MCP can't deserialize.
+        """
+        source_values = get_enum_values(source_enum)
+        mcp_values = get_enum_values(mcp_enum)
+
+        missing = source_values - mcp_values
+        assert not missing, (
+            f"MCP {enum_name} is missing values from source: {missing}. "
+            f"Add these to onyx/mcp_server/models.py"
+        )
+
+    @pytest.mark.parametrize(
+        "source_enum,mcp_enum,enum_name",
+        [
+            (SourceDocumentSource, MCPDocumentSource, "DocumentSource"),
+            (SourceSearchType, MCPSearchType, "SearchType"),
+            (SourceLLMEvaluationType, MCPLLMEvaluationType, "LLMEvaluationType"),
+        ],
+    )
+    def test_mcp_enum_no_extra_values(
+        self, source_enum: type[Enum], mcp_enum: type[Enum], enum_name: str
+    ) -> None:
+        """MCP enums should not have values that don't exist in source.
+
+        Extra values would allow MCP to send invalid data to the API server.
+        """
+        source_values = get_enum_values(source_enum)
+        mcp_values = get_enum_values(mcp_enum)
+
+        extra = mcp_values - source_values
+        assert not extra, (
+            f"MCP {enum_name} has values not in source: {extra}. "
+            f"Remove these from onyx/mcp_server/models.py or add to source."
+        )
+
+    @pytest.mark.parametrize(
+        "source_enum,mcp_enum,enum_name",
+        [
+            (SourceDocumentSource, MCPDocumentSource, "DocumentSource"),
+            (SourceSearchType, MCPSearchType, "SearchType"),
+            (SourceLLMEvaluationType, MCPLLMEvaluationType, "LLMEvaluationType"),
+        ],
+    )
+    def test_enum_names_match(
+        self, source_enum: type[Enum], mcp_enum: type[Enum], enum_name: str
+    ) -> None:
+        """Enum member names should match between source and MCP."""
+        source_names = get_enum_names(source_enum)
+        mcp_names = get_enum_names(mcp_enum)
+
+        # Check that MCP has all source names
+        missing = source_names - mcp_names
+        assert not missing, (
+            f"MCP {enum_name} is missing member names: {missing}. "
+            f"Add these to onyx/mcp_server/models.py"
+        )
+
+
+# =============================================================================
+# Model Sync Tests
+# =============================================================================
+
+
+class TestMCPModelsSubsetOfSource:
+    """MCP model fields should be a subset of source model fields.
+
+    If an MCP model has a field that doesn't exist in the source model,
+    serialization will include extra data that the API server doesn't expect.
+    """
+
+    @pytest.mark.parametrize(
+        "source_model,mcp_model,model_name",
+        [
+            (SourceTag, MCPTag, "Tag"),
+            (SourceBaseFilters, MCPBaseFilters, "BaseFilters"),
+            (SourceUserFileFilters, MCPUserFileFilters, "UserFileFilters"),
+            (SourceIndexFilters, MCPIndexFilters, "IndexFilters"),
+            (SourceChunkContext, MCPChunkContext, "ChunkContext"),
+            (SourceRetrievalDetails, MCPRetrievalDetails, "RetrievalDetails"),
+            (
+                SourceDocumentSearchRequest,
+                MCPDocumentSearchRequest,
+                "DocumentSearchRequest",
+            ),
+        ],
+    )
+    def test_mcp_fields_exist_in_source(
+        self, source_model: type[BaseModel], mcp_model: type[BaseModel], model_name: str
+    ) -> None:
+        source_fields = get_model_fields(source_model)
+        mcp_fields = get_model_fields(mcp_model)
+        extra_fields = mcp_fields - source_fields
+
+        assert not extra_fields, (
+            f"MCP {model_name} has fields not in source: {extra_fields}. "
+            f"These fields will be serialized but the API server doesn't expect them. "
+            f"Remove them from onyx/mcp_server/models.py or add them to the source model."
+        )
+
+
+class TestMCPModelsFieldTypes:
+    """Verify field types match between MCP and source models."""
+
+    @pytest.mark.parametrize(
+        "source_model,mcp_model,model_name",
+        [
+            (SourceTag, MCPTag, "Tag"),
+            (SourceBaseFilters, MCPBaseFilters, "BaseFilters"),
+            (SourceIndexFilters, MCPIndexFilters, "IndexFilters"),
+            (SourceRetrievalDetails, MCPRetrievalDetails, "RetrievalDetails"),
+            (
+                SourceDocumentSearchRequest,
+                MCPDocumentSearchRequest,
+                "DocumentSearchRequest",
+            ),
+        ],
+    )
+    def test_shared_field_types_match(
+        self, source_model: type[BaseModel], mcp_model: type[BaseModel], model_name: str
+    ) -> None:
+        """Fields present in both models should have compatible types."""
+        source_fields = source_model.model_fields
+        mcp_fields = mcp_model.model_fields
+
+        shared_fields = set(source_fields.keys()) & set(mcp_fields.keys())
+
+        mismatches = []
+        for field_name in shared_fields:
+            source_annotation = source_fields[field_name].annotation
+            mcp_annotation = mcp_fields[field_name].annotation
+
+            # Compare string representations since types might be defined differently
+            # but still be compatible (e.g., list[str] vs List[str])
+            source_str = str(source_annotation)
+            mcp_str = str(mcp_annotation)
+
+            # Normalize some common differences
+            source_normalized = source_str.replace("typing.", "").replace(
+                "List", "list"
+            )
+            mcp_normalized = mcp_str.replace("typing.", "").replace("List", "list")
+
+            # Allow for different module paths to the same enum
+            # e.g., onyx.configs.constants.DocumentSource vs onyx.mcp_server.models.DocumentSource
+            source_normalized = source_normalized.replace("onyx.configs.constants.", "")
+            source_normalized = source_normalized.replace(
+                "onyx.context.search.enums.", ""
+            )
+            source_normalized = source_normalized.replace(
+                "onyx.context.search.models.", ""
+            )
+            mcp_normalized = mcp_normalized.replace("onyx.mcp_server.models.", "")
+
+            if source_normalized != mcp_normalized:
+                mismatches.append(f"  {field_name}: source={source_str}, mcp={mcp_str}")
+
+        # Allow some type differences as long as they're compatible for JSON serialization
+        # This is a soft check - we warn but don't fail on all mismatches
+        if mismatches:
+            pytest.skip(
+                f"Type differences in {model_name} (may be OK if JSON-compatible):\n"
+                + "\n".join(mismatches)
+            )
+
+
+class TestNewSourceFieldsWarning:
+    """Warn when source models add new fields that MCP might want to use."""
+
+    @pytest.mark.parametrize(
+        "source_model,mcp_model,model_name",
+        [
+            (SourceIndexFilters, MCPIndexFilters, "IndexFilters"),
+            (SourceRetrievalDetails, MCPRetrievalDetails, "RetrievalDetails"),
+            (
+                SourceDocumentSearchRequest,
+                MCPDocumentSearchRequest,
+                "DocumentSearchRequest",
+            ),
+        ],
+    )
+    def test_warn_on_new_source_fields(
+        self, source_model: type[BaseModel], mcp_model: type[BaseModel], model_name: str
+    ) -> None:
+        """Informational: show fields in source that aren't in MCP model."""
+        source_fields = get_model_fields(source_model)
+        mcp_fields = get_model_fields(mcp_model)
+        new_fields = source_fields - mcp_fields
+
+        if new_fields:
+            # This is informational, not a failure
+            # These fields exist in source but MCP doesn't use them (which is fine)
+            pytest.skip(
+                f"{model_name} has source fields not in MCP copy: {new_fields}. "
+                f"This is OK if MCP doesn't need them."
+            )


### PR DESCRIPTION
## Description
Cursor's MCP Server Memory Analysis

The 46 MB traced + ~30-40 MB Python runtime = ~80 MB container.

| Component | Memory | Notes |
|-----------|--------|-------|
| Python runtime | ~30-40 MB | Unavoidable |
| Pydantic | 9.2 MB | Data validation |
| httpx | 10.4 MB | HTTP client |
| FastAPI | 5.4 MB | Web framework |
| FastMCP | 20.5 MB | MCP protocol - biggest framework dep |
| MCP app code | 0.5 MB | Our code |
| **Total** | **~80 MB** | |

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce MCP server baseline memory by replacing heavy imports with lightweight local config and models. The server can run more independently with a smaller footprint.

- **Refactors**
  - Added onyx.mcp_server.config to read env vars (APP_API_PREFIX, APP_PORT, MCP_SERVER_ENABLED, MCP_SERVER_PORT, MCP_SERVER_CORS_ORIGINS) and updated api/utils/main to use it.
  - Introduced lightweight Pydantic models/enums for search requests and switched tools/search to use them, avoiding imports from the main Onyx stack.
  - Added unit tests to ensure MCP models/enums stay in sync with their source counterparts.

<sup>Written for commit 247a12b8d0f56e84a527f6fcc105c27a3b56086b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

