### PR TITLE
refactor(tests): use PATManager for tests that use PATs

### DIFF
--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -29,6 +29,18 @@ This means the flow is:
 """
 
 
+class DATestPAT(BaseModel):
+    """Personal Access Token model for testing."""
+
+    id: int
+    name: str
+    token: str | None = None  # Raw token - only present on initial creation
+    token_display: str
+    created_at: str
+    expires_at: str | None = None
+    last_used_at: str | None = None
+
+
 class DATestAPIKey(BaseModel):
     api_key_id: int
     api_key_display: str

--- a/backend/tests/integration/tests/mcp/test_mcp_server_auth.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_auth.py
@@ -36,12 +36,12 @@ def test_mcp_server_auth_invalid_token(reset: None) -> None:
 
 def test_mcp_server_auth_valid_token(reset: None, admin_user: DATestUser) -> None:
     """Test MCP server accepts requests with a valid bearer token."""
-    token_data = PATManager.create(
+    pat = PATManager.create(
         name="Test MCP Token",
         expiration_days=7,
         user_performing_action=admin_user,
     )
-    access_token = token_data["token"]
+    access_token = pat.token
 
     # Test connection with MCP protocol request
     response = requests.post(

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -92,12 +92,12 @@ def _call_search_tool(
 
 def _auth_headers(user: DATestUser, name: str) -> dict[str, str]:
     """Create authorization headers with a PAT token."""
-    token_data = PATManager.create(
+    pat = PATManager.create(
         name=name,
         expiration_days=7,
         user_performing_action=user,
     )
-    return {"Authorization": f"Bearer {token_data['token']}"}
+    return {"Authorization": f"Bearer {pat.token}"}
 
 
 def _seed_document_and_wait_for_indexing(

--- a/backend/tests/integration/tests/pat/test_pat_api.py
+++ b/backend/tests/integration/tests/pat/test_pat_api.py
@@ -10,13 +10,16 @@ Test Suite:
 6. test_pat_role_based_access_control - Admin vs Basic vs Curator permissions
 """
 
+import time
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import requests
 
 from onyx.auth.schemas import UserRole
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -25,71 +28,51 @@ def test_pat_lifecycle_happy_path(reset: None) -> None:
     """Complete PAT lifecycle: create, authenticate, revoke."""
     user: DATestUser = UserManager.create(name="pat_user")
 
-    create_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "My Integration Token", "expiration_days": 30},
-        headers=user.headers,
+    # Create PAT
+    pat = PATManager.create(
+        name="My Integration Token",
+        expiration_days=30,
+        user_performing_action=user,
     )
-    assert create_response.status_code == 200
-    created_data = create_response.json()
 
-    assert "id" in created_data
-    assert "name" in created_data
-    assert created_data["name"] == "My Integration Token"
-    assert "token" in created_data  # Raw token only returned on creation
-    assert "token_display" in created_data
-    assert "created_at" in created_data
-    assert "expires_at" in created_data
+    assert pat.id is not None
+    assert pat.name == "My Integration Token"
+    assert pat.token is not None  # Raw token only returned on creation
+    assert pat.token_display is not None
+    assert pat.created_at is not None
+    assert pat.expires_at is not None
 
-    raw_token = created_data["token"]
-    token_id = created_data["id"]
-    token_display = created_data["token_display"]
+    assert pat.token.startswith("onyx_pat_")
+    assert len(pat.token) > 20
 
-    assert raw_token.startswith("onyx_pat_")
-    assert len(raw_token) > 20
+    assert "****" in pat.token_display
+    assert pat.token_display.startswith("onyx_pat_")
 
-    assert "****" in token_display
-    assert token_display.startswith("onyx_pat_")
-
-    list_response = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user.headers,
-    )
-    assert list_response.status_code == 200
-    tokens = list_response.json()
+    # List PATs
+    tokens = PATManager.list(user)
     assert len(tokens) == 1
-    assert tokens[0]["id"] == token_id
-    assert tokens[0]["name"] == "My Integration Token"
-    assert tokens[0]["token_display"] == token_display
-    assert "token" not in tokens[0]
+    assert tokens[0].id == pat.id
+    assert tokens[0].name == "My Integration Token"
+    assert tokens[0].token_display == pat.token_display
+    assert tokens[0].token is None
 
-    auth_response = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {raw_token}"},
-    )
+    # Authenticate with PAT
+    auth_response = PATManager.authenticate(pat.token)
     assert auth_response.status_code == 200
     me_data = auth_response.json()
     assert me_data["email"] == user.email
     assert me_data["id"] == user.id
 
-    revoke_response = requests.delete(
-        f"{API_SERVER_URL}/user/pats/{token_id}",
-        headers=user.headers,
-    )
-    assert revoke_response.status_code == 200
+    # Revoke PAT
+    PATManager.revoke(pat.id, user)
 
-    revoked_auth_response = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {raw_token}"},
-    )
+    # Verify revoked token fails authentication
+    revoked_auth_response = PATManager.authenticate(pat.token)
     assert revoked_auth_response.status_code == 403  # Revoked token returns 403
 
-    list_after_revoke = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user.headers,
-    )
-    assert list_after_revoke.status_code == 200
-    assert len(list_after_revoke.json()) == 0
+    # Verify token is no longer listed
+    tokens_after_revoke = PATManager.list(user)
+    assert len(tokens_after_revoke) == 0
 
 
 def test_pat_user_isolation_and_authentication(reset: None) -> None:
@@ -99,76 +82,59 @@ def test_pat_user_isolation_and_authentication(reset: None) -> None:
     user_a: DATestUser = UserManager.create(name="user_a")
     user_b: DATestUser = UserManager.create(name="user_b")
 
-    user_a_tokens = []
+    # Create tokens for both users
+    user_a_pats = []
     for i in range(2):
-        response = requests.post(
-            f"{API_SERVER_URL}/user/pats",
-            json={"name": f"User A Token {i+1}", "expiration_days": 30},
-            headers=user_a.headers,
+        pat = PATManager.create(
+            name=f"User A Token {i+1}",
+            expiration_days=30,
+            user_performing_action=user_a,
         )
-        assert response.status_code == 200
-        user_a_tokens.append(
-            {
-                "id": response.json()["id"],
-                "token": response.json()["token"],
-            }
-        )
+        user_a_pats.append(pat)
 
-    user_b_tokens = []
+    user_b_pats = []
     for i in range(2):
-        response = requests.post(
-            f"{API_SERVER_URL}/user/pats",
-            json={"name": f"User B Token {i+1}", "expiration_days": 30},
-            headers=user_b.headers,
+        pat = PATManager.create(
+            name=f"User B Token {i+1}",
+            expiration_days=30,
+            user_performing_action=user_b,
         )
-        assert response.status_code == 200
-        user_b_tokens.append(
-            {
-                "id": response.json()["id"],
-                "token": response.json()["token"],
-            }
-        )
+        user_b_pats.append(pat)
 
-    for user, token_info in [(user_a, user_a_tokens[0]), (user_b, user_b_tokens[0])]:
-        me_response = requests.get(
-            f"{API_SERVER_URL}/me",
-            headers={"Authorization": f"Bearer {token_info['token']}"},
-        )
+    # Verify PATs authenticate as the correct users
+    for user, pat in [(user_a, user_a_pats[0]), (user_b, user_b_pats[0])]:
+        assert pat.token is not None
+        me_response = PATManager.authenticate(pat.token)
         assert me_response.status_code == 200
         me_data = me_response.json()
         assert me_data["email"] == user.email
         assert me_data["id"] == user.id
 
-    user_a_list = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user_a.headers,
-    )
-    assert user_a_list.status_code == 200
-    assert len(user_a_list.json()) == 2
+    # Verify each user only sees their own tokens
+    user_a_list = PATManager.list(user_a)
+    assert len(user_a_list) == 2
 
-    user_b_list = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user_b.headers,
-    )
-    assert user_b_list.status_code == 200
-    assert len(user_b_list.json()) == 2
+    user_b_list = PATManager.list(user_b)
+    assert len(user_b_list) == 2
 
+    # Verify user A cannot delete user B's token using their PAT
+    assert user_a_pats[0].token is not None
     delete_response = requests.delete(
-        f"{API_SERVER_URL}/user/pats/{user_b_tokens[0]['id']}",
-        headers={"Authorization": f"Bearer {user_a_tokens[0]['token']}"},
+        f"{API_SERVER_URL}/user/pats/{user_b_pats[0].id}",
+        headers=PATManager.get_auth_headers(user_a_pats[0].token),
+        timeout=60,
     )
     assert delete_response.status_code == 404
 
-    user_b_list_after = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user_b.headers,
-    )
-    assert user_b_list_after.status_code == 200
-    assert len(user_b_list_after.json()) == 2
+    # Verify user B's token still exists
+    user_b_list_after = PATManager.list(user_b)
+    assert len(user_b_list_after) == 2
 
+    # Verify deleting non-existent token returns 404
     delete_fake = requests.delete(
         f"{API_SERVER_URL}/user/pats/999999",
         headers=user_a.headers,
+        timeout=60,
     )
     assert delete_fake.status_code == 404
 
@@ -177,22 +143,20 @@ def test_pat_expiration_flow(reset: None) -> None:
     """Expiration timestamp is end-of-day (23:59:59 UTC); never-expiring tokens work; revoked tokens fail."""
     user: DATestUser = UserManager.create(name="expiration_user")
 
-    create_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Expiring Token", "expiration_days": 7},
-        headers=user.headers,
+    # Create expiring token
+    pat = PATManager.create(
+        name="Expiring Token",
+        expiration_days=7,
+        user_performing_action=user,
     )
-    assert create_response.status_code == 200
-    token_data = create_response.json()
 
-    assert token_data["expires_at"] is not None
-    expires_at = datetime.fromisoformat(token_data["expires_at"].replace("Z", "+00:00"))
+    assert pat.expires_at is not None
+    expires_at = datetime.fromisoformat(pat.expires_at.replace("Z", "+00:00"))
 
+    # Verify end-of-day expiration
     assert expires_at.hour == 23
     assert expires_at.minute == 59
     assert expires_at.second == 59
-
-    from datetime import timezone
 
     # Calculate expected end-of-day 7 days from now
     now = datetime.now(timezone.utc)
@@ -201,85 +165,85 @@ def test_pat_expiration_flow(reset: None) -> None:
         tzinfo=timezone.utc
     )
     # Allow for small timing differences (within a day)
-    assert (
-        abs((expires_at - expected_expiry).total_seconds()) < 86400
-    )  # 1 day in seconds
+    assert abs((expires_at - expected_expiry).total_seconds()) < 86400  # 1 day
 
-    no_expiry_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Never Expiring Token", "expiration_days": None},
-        headers=user.headers,
+    # Create never-expiring token
+    never_expiring_pat = PATManager.create(
+        name="Never Expiring Token",
+        expiration_days=None,
+        user_performing_action=user,
     )
-    assert no_expiry_response.status_code == 200
-    no_expiry_data = no_expiry_response.json()
-    assert no_expiry_data["expires_at"] is None
+    assert never_expiring_pat.expires_at is None
 
-    never_expiring_token = no_expiry_data["token"]
-    never_expiring_token_id = no_expiry_data["id"]
-    auth_response = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {never_expiring_token}"},
-    )
+    # Verify never-expiring token works
+    assert never_expiring_pat.token is not None
+    auth_response = PATManager.authenticate(never_expiring_pat.token)
     assert auth_response.status_code == 200
 
-    revoke_response = requests.delete(
-        f"{API_SERVER_URL}/user/pats/{never_expiring_token_id}",
-        headers=user.headers,
-    )
-    assert revoke_response.status_code == 200
+    # Revoke the never-expiring token
+    PATManager.revoke(never_expiring_pat.id, user)
 
-    revoked_auth_response = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {never_expiring_token}"},
-    )
-    assert revoked_auth_response.status_code == 403  # Revoked token returns 403
+    # Verify revoked token fails (token var still holds the revoked value)
+    revoked_auth_response = PATManager.authenticate(never_expiring_pat.token)
+    assert revoked_auth_response.status_code == 403
 
 
 def test_pat_validation_errors(reset: None) -> None:
     """Validate input errors: empty name, name too long, negative/zero expiration."""
     user: DATestUser = UserManager.create(name="validation_user")
 
+    # Empty name should fail
     empty_name_response = requests.post(
         f"{API_SERVER_URL}/user/pats",
         json={"name": "", "expiration_days": 30},
         headers=user.headers,
+        timeout=60,
     )
     assert empty_name_response.status_code == 422
 
+    # Name too long should fail
     long_name = "a" * 101
     long_name_response = requests.post(
         f"{API_SERVER_URL}/user/pats",
         json={"name": long_name, "expiration_days": 30},
         headers=user.headers,
+        timeout=60,
     )
     assert long_name_response.status_code == 422
 
+    # Negative expiration should fail
     negative_exp_response = requests.post(
         f"{API_SERVER_URL}/user/pats",
         json={"name": "Test Token", "expiration_days": -1},
         headers=user.headers,
+        timeout=60,
     )
     assert negative_exp_response.status_code == 422
 
+    # Zero expiration should fail
     zero_exp_response = requests.post(
         f"{API_SERVER_URL}/user/pats",
         json={"name": "Test Token", "expiration_days": 0},
         headers=user.headers,
+        timeout=60,
     )
     assert zero_exp_response.status_code == 422
 
+    # Max length name (100 chars) should succeed
     valid_name = "a" * 100
-    valid_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": valid_name, "expiration_days": 7},
-        headers=user.headers,
+    valid_pat = PATManager.create(
+        name=valid_name,
+        expiration_days=7,
+        user_performing_action=user,
     )
-    assert valid_response.status_code == 200
+    assert valid_pat.id is not None
 
+    # Missing name should fail
     missing_name_response = requests.post(
         f"{API_SERVER_URL}/user/pats",
         json={"expiration_days": 30},
         headers=user.headers,
+        timeout=60,
     )
     assert missing_name_response.status_code == 422
 
@@ -288,72 +252,58 @@ def test_pat_sorting_and_last_used(reset: None) -> None:
     """PATs are sorted by created_at DESC; last_used_at updates after authentication."""
     user: DATestUser = UserManager.create(name="sorting_user")
 
-    token1_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "First Token", "expiration_days": 30},
-        headers=user.headers,
+    # Create tokens with small delays to ensure different timestamps
+    token1 = PATManager.create(
+        name="First Token",
+        expiration_days=30,
+        user_performing_action=user,
     )
-    assert token1_response.status_code == 200
-    token1_data = token1_response.json()
-    token1_raw = token1_data["token"]
-
-    import time
 
     time.sleep(0.1)
 
-    token2_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Second Token", "expiration_days": 30},
-        headers=user.headers,
+    PATManager.create(
+        name="Second Token",
+        expiration_days=30,
+        user_performing_action=user,
     )
-    assert token2_response.status_code == 200
 
     time.sleep(0.1)
 
-    token3_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Third Token", "expiration_days": 30},
-        headers=user.headers,
+    PATManager.create(
+        name="Third Token",
+        expiration_days=30,
+        user_performing_action=user,
     )
-    assert token3_response.status_code == 200
 
-    list_response = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user.headers,
-    )
-    assert list_response.status_code == 200
-    tokens = list_response.json()
+    # Verify sorted by created_at DESC (newest first)
+    tokens = PATManager.list(user)
     assert len(tokens) == 3
 
-    assert tokens[0]["name"] == "Third Token"
-    assert tokens[1]["name"] == "Second Token"
-    assert tokens[2]["name"] == "First Token"
+    assert tokens[0].name == "Third Token"
+    assert tokens[1].name == "Second Token"
+    assert tokens[2].name == "First Token"
 
+    # Verify all tokens have no last_used_at initially
     for token in tokens:
-        assert token["last_used_at"] is None
+        assert token.last_used_at is None
 
-    auth_response = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {token1_raw}"},
-    )
+    # Use the first token (oldest)
+    assert token1.token is not None
+    auth_response = PATManager.authenticate(token1.token)
     assert auth_response.status_code == 200
 
     time.sleep(0.5)
 
-    list_after_use = requests.get(
-        f"{API_SERVER_URL}/user/pats",
-        headers=user.headers,
-    )
-    assert list_after_use.status_code == 200
-    tokens_after_use = list_after_use.json()
+    # Verify last_used_at is updated for the used token only
+    tokens_after_use = PATManager.list(user)
 
-    token1_after_use = next(t for t in tokens_after_use if t["name"] == "First Token")
-    assert token1_after_use["last_used_at"] is not None
+    token1_after_use = next(t for t in tokens_after_use if t.name == "First Token")
+    assert token1_after_use.last_used_at is not None
 
-    token2_after_use = next(t for t in tokens_after_use if t["name"] == "Second Token")
-    token3_after_use = next(t for t in tokens_after_use if t["name"] == "Third Token")
-    assert token2_after_use["last_used_at"] is None
-    assert token3_after_use["last_used_at"] is None
+    token2_after_use = next(t for t in tokens_after_use if t.name == "Second Token")
+    token3_after_use = next(t for t in tokens_after_use if t.name == "Third Token")
+    assert token2_after_use.last_used_at is None
+    assert token3_after_use.last_used_at is None
 
 
 def test_pat_role_based_access_control(reset: None) -> None:
@@ -363,6 +313,7 @@ def test_pat_role_based_access_control(reset: None) -> None:
     - Curator/Global Curator PATs: Access to management endpoints
     - Basic PAT: Denied access to admin and management endpoints
     """
+    # Create users with different roles
     admin_user: DATestUser = UserManager.create(name="admin_user")
     assert admin_user.role == UserRole.ADMIN
 
@@ -387,42 +338,43 @@ def test_pat_role_based_access_control(reset: None) -> None:
     )
     assert global_curator_user.role == UserRole.GLOBAL_CURATOR
 
-    admin_pat_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Admin Token", "expiration_days": 7},
-        headers=admin_user.headers,
+    # Create PATs for each user
+    admin_pat = PATManager.create(
+        name="Admin Token",
+        expiration_days=7,
+        user_performing_action=admin_user,
     )
-    assert admin_pat_response.status_code == 200
-    admin_token = admin_pat_response.json()["token"]
 
-    basic_pat_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Basic Token", "expiration_days": 7},
-        headers=basic_user.headers,
+    basic_pat = PATManager.create(
+        name="Basic Token",
+        expiration_days=7,
+        user_performing_action=basic_user,
     )
-    assert basic_pat_response.status_code == 200
-    basic_token = basic_pat_response.json()["token"]
 
-    curator_pat_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Curator Token", "expiration_days": 7},
-        headers=curator_user.headers,
+    curator_pat = PATManager.create(
+        name="Curator Token",
+        expiration_days=7,
+        user_performing_action=curator_user,
     )
-    assert curator_pat_response.status_code == 200
-    curator_token = curator_pat_response.json()["token"]
 
-    global_curator_pat_response = requests.post(
-        f"{API_SERVER_URL}/user/pats",
-        json={"name": "Global Curator Token", "expiration_days": 7},
-        headers=global_curator_user.headers,
+    global_curator_pat = PATManager.create(
+        name="Global Curator Token",
+        expiration_days=7,
+        user_performing_action=global_curator_user,
     )
-    assert global_curator_pat_response.status_code == 200
-    global_curator_token = global_curator_pat_response.json()["token"]
 
+    # Verify all tokens are present (type narrowing for mypy)
+    assert admin_pat.token is not None
+    assert basic_pat.token is not None
+    assert curator_pat.token is not None
+    assert global_curator_pat.token is not None
+
+    # Test admin-only endpoint access
     print("\n[Test] Admin PAT accessing admin-only endpoint...")
     admin_endpoint_response = requests.get(
         f"{API_SERVER_URL}/admin/api-key",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers=PATManager.get_auth_headers(admin_pat.token),
+        timeout=60,
     )
     assert admin_endpoint_response.status_code == 200
     print("[✓] Admin PAT successfully accessed /admin/api-key")
@@ -430,7 +382,8 @@ def test_pat_role_based_access_control(reset: None) -> None:
     print("\n[Test] Basic PAT accessing admin endpoint...")
     basic_admin_response = requests.get(
         f"{API_SERVER_URL}/admin/api-key",
-        headers={"Authorization": f"Bearer {basic_token}"},
+        headers=PATManager.get_auth_headers(basic_pat.token),
+        timeout=60,
     )
     assert basic_admin_response.status_code == 403
     print("[✓] Basic PAT correctly denied access (403) to /admin/api-key")
@@ -438,7 +391,8 @@ def test_pat_role_based_access_control(reset: None) -> None:
     print("\n[Test] Curator PAT accessing admin-only endpoint...")
     curator_admin_response = requests.get(
         f"{API_SERVER_URL}/admin/api-key",
-        headers={"Authorization": f"Bearer {curator_token}"},
+        headers=PATManager.get_auth_headers(curator_pat.token),
+        timeout=60,
     )
     assert curator_admin_response.status_code == 403
     print("[✓] Curator PAT correctly denied access (403) to /admin/api-key")
@@ -446,89 +400,88 @@ def test_pat_role_based_access_control(reset: None) -> None:
     print("\n[Test] Global Curator PAT accessing admin-only endpoint...")
     global_curator_admin_response = requests.get(
         f"{API_SERVER_URL}/admin/api-key",
-        headers={"Authorization": f"Bearer {global_curator_token}"},
+        headers=PATManager.get_auth_headers(global_curator_pat.token),
+        timeout=60,
     )
     assert global_curator_admin_response.status_code == 403
     print("[✓] Global Curator PAT correctly denied access (403) to /admin/api-key")
 
+    # Test management endpoint access
     print("\n[Test] Testing management endpoint access for curators...")
 
     admin_manage_response = requests.get(
         f"{API_SERVER_URL}/manage/admin/connector",
-        headers={"Authorization": f"Bearer {admin_token}"},
+        headers=PATManager.get_auth_headers(admin_pat.token),
+        timeout=60,
     )
     assert admin_manage_response.status_code == 200
     print("[✓] Admin PAT can access /manage/admin/connector")
 
     curator_manage_response = requests.get(
         f"{API_SERVER_URL}/manage/admin/connector",
-        headers={"Authorization": f"Bearer {curator_token}"},
+        headers=PATManager.get_auth_headers(curator_pat.token),
+        timeout=60,
     )
     assert curator_manage_response.status_code == 200
     print("[✓] Curator PAT can access /manage/admin/connector")
 
     global_curator_manage_response = requests.get(
         f"{API_SERVER_URL}/manage/admin/connector",
-        headers={"Authorization": f"Bearer {global_curator_token}"},
+        headers=PATManager.get_auth_headers(global_curator_pat.token),
+        timeout=60,
     )
     assert global_curator_manage_response.status_code == 200
     print("[✓] Global Curator PAT can access /manage/admin/connector")
 
     basic_manage_response = requests.get(
         f"{API_SERVER_URL}/manage/admin/connector",
-        headers={"Authorization": f"Bearer {basic_token}"},
+        headers=PATManager.get_auth_headers(basic_pat.token),
+        timeout=60,
     )
     assert basic_manage_response.status_code in [403, 401]
     print(
-        f"[✓] Basic PAT correctly denied access ({basic_manage_response.status_code}) to /manage/admin/connector"
+        f"[✓] Basic PAT correctly denied access ({basic_manage_response.status_code}) "
+        "to /manage/admin/connector"
     )
 
+    # Verify PATs authenticate with correct identity and role
     print("\n[Test] Verifying PATs authenticate as correct users with correct roles...")
 
-    admin_me = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
+    admin_me = PATManager.authenticate(admin_pat.token)
     assert admin_me.status_code == 200
     assert admin_me.json()["email"] == admin_user.email
     assert admin_me.json()["role"] == UserRole.ADMIN.value
 
-    basic_me = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {basic_token}"},
-    )
+    basic_me = PATManager.authenticate(basic_pat.token)
     assert basic_me.status_code == 200
     assert basic_me.json()["email"] == basic_user.email
     assert basic_me.json()["role"] == UserRole.BASIC.value
 
-    curator_me = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {curator_token}"},
-    )
+    curator_me = PATManager.authenticate(curator_pat.token)
     assert curator_me.status_code == 200
     assert curator_me.json()["email"] == curator_user.email
     assert curator_me.json()["role"] == UserRole.CURATOR.value
 
-    global_curator_me = requests.get(
-        f"{API_SERVER_URL}/me",
-        headers={"Authorization": f"Bearer {global_curator_token}"},
-    )
+    global_curator_me = PATManager.authenticate(global_curator_pat.token)
     assert global_curator_me.status_code == 200
     assert global_curator_me.json()["email"] == global_curator_user.email
     assert global_curator_me.json()["role"] == UserRole.GLOBAL_CURATOR.value
 
     print("[✓] All PATs authenticate with correct user identity and role")
 
+    # Verify all PATs can access basic endpoints
     print("\n[Test] All PATs can access basic endpoints...")
-    for token, user_name in [
-        (admin_token, "Admin"),
-        (basic_token, "Basic"),
-        (curator_token, "Curator"),
-        (global_curator_token, "Global Curator"),
+    for pat, user_name in [
+        (admin_pat, "Admin"),
+        (basic_pat, "Basic"),
+        (curator_pat, "Curator"),
+        (global_curator_pat, "Global Curator"),
     ]:
+        assert pat.token is not None
         persona_response = requests.get(
             f"{API_SERVER_URL}/persona",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=PATManager.get_auth_headers(pat.token),
+            timeout=60,
         )
         assert persona_response.status_code == 200
         print(f"[✓] {user_name} PAT can access /persona endpoint")
@@ -539,10 +492,12 @@ def test_pat_role_based_access_control(reset: None) -> None:
         "  - Admin PAT: Full access to admin-only endpoints (/admin/*, /manage/admin/*)"
     )
     print(
-        "  - Curator PAT: Access to management endpoints (/manage/admin/*), denied on admin-only (/admin/*)"
+        "  - Curator PAT: Access to management endpoints (/manage/admin/*), "
+        "denied on admin-only (/admin/*)"
     )
     print(
-        "  - Global Curator PAT: Access to management endpoints (/manage/admin/*), denied on admin-only (/admin/*)"
+        "  - Global Curator PAT: Access to management endpoints (/manage/admin/*), "
+        "denied on admin-only (/admin/*)"
     )
     print("  - Basic PAT: Denied access to admin and management endpoints")
     print("  - All PATs: Can access basic endpoints (/persona, /me, etc.)")


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored PAT-related integration tests to use a shared PATManager with a typed DATestPAT model, reducing duplication and improving readability and type safety. No production behavior changes.

- **Refactors**
  - PATManager now returns DATestPAT, adds authenticate() and get_auth_headers(), and list() returns List[DATestPAT].
  - Added DATestPAT model (id, name, token, token_display, timestamps).
  - Updated tests to use PATManager for create/list/revoke/auth (pat_api, mcp auth/search); simplified assertions to typed fields.
  - Added small sleeps/timeouts where needed to stabilize last_used_at and HTTP calls.

<sup>Written for commit 47afc45b17a006ccc58ccb7d65af8d9c44858fcd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

