### PR TITLE
chore(google): Naming update from Vertex to Gemini

### DIFF
--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -42,6 +42,7 @@ from onyx.llm.interfaces import LLMConfig
 from onyx.llm.interfaces import STANDARD_TOOL_CHOICE_OPTIONS
 from onyx.llm.interfaces import ToolChoiceOptions
 from onyx.llm.llm_provider_options import AZURE_PROVIDER_NAME
+from onyx.llm.llm_provider_options import GOOGLE_GENAI_PROVIDER_ALIASES
 from onyx.llm.llm_provider_options import OLLAMA_PROVIDER_NAME
 from onyx.llm.llm_provider_options import VERTEX_CREDENTIALS_FILE_KWARG
 from onyx.llm.llm_provider_options import VERTEX_LOCATION_KWARG
@@ -326,10 +327,10 @@ class LitellmLLM(LLM):
         # env variables)
         if custom_config:
             # Specifically pass in "vertex_credentials" / "vertex_location" as a
-            # model_kwarg to the completion call for vertex AI. More details here:
+            # model_kwarg to the completion call for Google Gen AI (Vertex AI). More details here:
             # https://docs.litellm.ai/docs/providers/vertex
             for k, v in custom_config.items():
-                if model_provider == "vertex_ai":
+                if model_provider in GOOGLE_GENAI_PROVIDER_ALIASES:
                     if k == VERTEX_CREDENTIALS_FILE_KWARG:
                         model_kwargs[k] = v
                         continue

--- a/backend/onyx/natural_language_processing/constants.py
+++ b/backend/onyx/natural_language_processing/constants.py
@@ -13,7 +13,7 @@ from shared_configs.enums import EmbedTextType
 DEFAULT_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_COHERE_MODEL = "embed-english-light-v3.0"
 DEFAULT_VOYAGE_MODEL = "voyage-large-2-instruct"
-DEFAULT_VERTEX_MODEL = "text-embedding-005"
+DEFAULT_GEMINI_MODEL = "text-embedding-005"
 
 
 class EmbeddingModelTextType:

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -69,14 +69,16 @@ DEV_LOGGING_ENABLED = os.environ.get("DEV_LOGGING_ENABLED", "").lower() == "true
 LOG_LEVEL = os.environ.get("LOG_LEVEL") or "info"
 
 # Timeout for API-based embedding models
-# NOTE: does not apply for Google VertexAI, since the python client doesn't
+# NOTE: does not apply for Google Gen AI, since the python client doesn't
 # allow us to specify a custom timeout
 API_BASED_EMBEDDING_TIMEOUT = int(os.environ.get("API_BASED_EMBEDDING_TIMEOUT", "600"))
 
-# Local batch size for VertexAI embedding models currently calibrated for item size of 512 tokens
+# Local batch size for Google Gen AI (formerly VertexAI) embedding models currently calibrated for item size of 512 tokens
 # NOTE: increasing this value may lead to API errors due to token limit exhaustion per call.
-VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE = int(
-    os.environ.get("VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE", "25")
+GOOGLE_GENAI_EMBEDDING_LOCAL_BATCH_SIZE = int(
+    os.environ.get("GOOGLE_GENAI_EMBEDDING_LOCAL_BATCH_SIZE")
+    or os.environ.get("VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE")
+    or "25"
 )
 
 # Only used for OpenAI

--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -6,6 +6,7 @@ export enum LLMProviderName {
   OLLAMA_CHAT = "ollama_chat",
   AZURE = "azure",
   OPENROUTER = "openrouter",
+  GOOGLE_GENAI = "google_genai",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
 }

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -39,6 +39,7 @@ export const getProviderIcon = (
     llama: MetaIcon,
     ollama_chat: OllamaIcon,
     gemini: GeminiIcon,
+    google_genai: GeminiIcon,
     deepseek: DeepseekIcon,
     claude: AnthropicIcon,
     anthropic: AnthropicIcon,

--- a/web/src/components/embedding/interfaces.tsx
+++ b/web/src/components/embedding/interfaces.tsx
@@ -262,9 +262,9 @@ export const AVAILABLE_CLOUD_PROVIDERS: CloudEmbeddingProvider[] = [
     icon: GoogleIcon,
     docsLink: "https://docs.onyx.app/admin/advanced_configs/search_configs",
     description:
-      "Offers a wide range of AI services including language and vision models",
+      "Gemini (Google Gen AI) offers a wide range of language and vision models",
     apiLink: "https://console.cloud.google.com/apis/credentials",
-    costslink: "https://cloud.google.com/vertex-ai/pricing",
+    costslink: "https://cloud.google.com/products/genai/pricing",
     embedding_models: [
       {
         provider_type: EmbeddingProvider.GOOGLE,

--- a/web/src/refresh-components/onboarding/components/LLMFormikEffects.tsx
+++ b/web/src/refresh-components/onboarding/components/LLMFormikEffects.tsx
@@ -93,6 +93,7 @@ const LLMFormikEffects = ({
         if (isEmpty(values.api_key) || isEmpty(values.api_base))
           shouldReset = true;
         break;
+      case LLMProviderName.GOOGLE_GENAI:
       case LLMProviderName.VERTEX_AI:
         if (isEmpty(values?.custom_config?.vertex_credentials))
           shouldReset = true;

--- a/web/src/refresh-components/onboarding/components/llmValidationSchema.ts
+++ b/web/src/refresh-components/onboarding/components/llmValidationSchema.ts
@@ -113,6 +113,7 @@ export const getValidationSchema = (
           ),
       });
 
+    case "google_genai":
     case "vertex_ai":
       return Yup.object().shape({
         ...baseSchema,

--- a/web/src/refresh-components/onboarding/constants.tsx
+++ b/web/src/refresh-components/onboarding/constants.tsx
@@ -97,6 +97,7 @@ export const PROVIDER_ICON_MAP: Record<
   [LLMProviderName.ANTHROPIC]: SvgClaude,
   [LLMProviderName.BEDROCK]: SvgAws,
   [LLMProviderName.AZURE]: AzureIcon,
+  [LLMProviderName.GOOGLE_GENAI]: GeminiIcon,
   [LLMProviderName.VERTEX_AI]: GeminiIcon,
   [LLMProviderName.OPENAI]: SvgOpenai,
   [LLMProviderName.OLLAMA_CHAT]: SvgOllama,
@@ -156,9 +157,9 @@ export const MODAL_CONTENT_MAP: Record<string, any> = {
         "This model will be used by Onyx by default for Ollama.",
     },
   },
-  [LLMProviderName.VERTEX_AI]: {
+  [LLMProviderName.GOOGLE_GENAI]: {
     description:
-      "Connect to Google Cloud Vertex AI and set up your Gemini models.",
+      "Connect to Google Gemini (Google Gen AI) and set up your Gemini models.",
     display_name: "Gemini",
     field_metadata: {
       vertex_credentials: (
@@ -167,7 +168,25 @@ export const MODAL_CONTENT_MAP: Record<string, any> = {
           <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
             API key
           </InlineExternalLink>
-          {" from Google Cloud Vertex AI to access your models."}
+          {" from Google Cloud to access your models."}
+        </>
+      ),
+      default_model_name:
+        "This model will be used by Onyx by default for Gemini.",
+    },
+  },
+  [LLMProviderName.VERTEX_AI]: {
+    description:
+      "Connect to Google Gemini (formerly Vertex AI) and set up your Gemini models.",
+    display_name: "Gemini",
+    field_metadata: {
+      vertex_credentials: (
+        <>
+          {"Paste your "}
+          <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
+            API key
+          </InlineExternalLink>
+          {" from Google Cloud to access your models."}
         </>
       ),
       default_model_name:
@@ -285,6 +304,7 @@ export const PROVIDER_TAB_CONFIG: Record<string, ProviderTabConfig> = {
 };
 
 export const PROVIDER_SKIP_FIELDS: Record<string, string[]> = {
+  [LLMProviderName.GOOGLE_GENAI]: ["vertex_location"],
   [LLMProviderName.VERTEX_AI]: ["vertex_location"],
 };
 

--- a/web/tests/e2e/chat/onboarding_flow.spec.ts
+++ b/web/tests/e2e/chat/onboarding_flow.spec.ts
@@ -155,7 +155,7 @@ test.describe("First user onboarding flow", () => {
       { title: "Claude", subtitle: "Anthropic" },
       { title: "Azure OpenAI", subtitle: "Microsoft Azure Cloud" },
       { title: "Amazon Bedrock", subtitle: "AWS" },
-      { title: "Gemini", subtitle: "Google Cloud Vertex AI" },
+      { title: "Gemini", subtitle: "Google Gen AI" },
       { title: "OpenRouter", subtitle: "OpenRouter" },
       { title: "Ollama", subtitle: "Ollama" },
       { title: "Custom LLM Provider", subtitle: "LiteLLM Compatible APIs" },


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Might break up this PR but this is just slowly doing the migration for Gemini

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the Vertex AI provider to Google Gemini (Google Gen AI) with full backward compatibility. Updates backend mappings, model defaults, and UI copy/icons while keeping existing vertex_ai configs working.

- **Refactors**
  - Added google_genai provider and alias set with vertex_ai; normalize provider names across the app.
  - Keep litellm compatibility by mapping google_genai → vertex_ai where required.
  - Updated default/visible Gemini models and provider descriptor names.
  - Ensure vertex_credentials and vertex_location are passed when provider is in the alias set.
  - Use normalized provider for reasoning detection, token limits, and image-support checks.
  - Renamed embedding defaults (DEFAULT_GEMINI_MODEL) and added GOOGLE_GENAI_EMBEDDING_LOCAL_BATCH_SIZE (falls back to VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE).
  - Updated UI labels, icons, validation, docs/pricing links, and onboarding E2E to “Google Gen AI”.

- **Migration**
  - No breaking changes; existing vertex_ai configs continue to work.
  - Prefer GOOGLE_GENAI_EMBEDDING_LOCAL_BATCH_SIZE; the old env var still works.
  - New setups can use provider google_genai; vertex_ai remains supported.

<sup>Written for commit 475d2395d6432c9572e6ceffc2c8921d0a8c2dbd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

