### PR TITLE
chore(langfuse): Remove Env Var

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -754,8 +754,6 @@ BRAINTRUST_MAX_CONCURRENCY = int(os.environ.get("BRAINTRUST_MAX_CONCURRENCY") or
 # Langfuse API credentials - if provided, Langfuse tracing will be enabled
 LANGFUSE_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY") or ""
 LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY") or ""
-# Langfuse host URL (defaults to cloud instance)
-LANGFUSE_HOST = os.environ.get("LANGFUSE_HOST") or "https://cloud.langfuse.com"
 
 TOKEN_BUDGET_GLOBALLY_ENABLED = (
     os.environ.get("TOKEN_BUDGET_GLOBALLY_ENABLED", "").lower() == "true"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
This is not used anymore

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Purely a deletion

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused LANGFUSE_HOST env var from app_configs to clean up deprecated Langfuse config.
Langfuse tracing behavior is unchanged and still controlled by LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY.

<sup>Written for commit a69e9fda9d744eb83c2aa336a1dfb7e642bd652a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

