### PR TITLE
fix: spinner during CSV load

### DIFF
--- a/web/src/components/tools/CSVContent.tsx
+++ b/web/src/components/tools/CSVContent.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/table";
 import { ContentComponentProps } from "./ExpandableContentWrapper";
 import { WarningCircle } from "@phosphor-icons/react";
-import "../spinner.css";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 
 const CsvContent: React.FC<ContentComponentProps> = ({
   fileDescriptor,
@@ -79,7 +79,7 @@ const CsvContent: React.FC<ContentComponentProps> = ({
   if (isLoading || isFetching) {
     return (
       <div className="flex items-center justify-center h-[300px]">
-        <div className="loader ease-linear rounded-full border-8 border-t-8 border-background-200 h-8 w-8"></div>
+        <SimpleLoader />
       </div>
     );
   }


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a spinner while CSV data loads and prevents the mobile sidebar overlay from flashing on initial page load.

- **Bug Fixes**
  - CSV preview: added isFetching state, imported spinner.css, and replaced the skeleton with a spinner to cover both initial and fetch states.
  - Mobile sidebar: render the backdrop only after mount via useIsMounted to avoid the overlay flash.

<sup>Written for commit 889c3a2a93315414a8d97fd33809a219d18ded71. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



