### PR TITLE
chore(gha): enable uv caching

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -11,6 +11,7 @@ runs:
       uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # ratchet:astral-sh/setup-uv@v3
       with:
         enable-cache: true
+        python-version: "3.11"
 
     - name: Compute requirements hash
       id: req-hash

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -27,6 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # ratchet:astral-sh/setup-uv@v7.1.4
         with:
           enable-cache: true
+          python-version: "3.11"
 
       - name: Validate requirements lock files
         run: ./backend/scripts/compile_requirements.py --check


### PR DESCRIPTION
## Description

## How Has This Been Tested?

## Additional Options

- [x] Override Linear Check












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable uv caching in GitHub Actions to speed up Python CI runs and reduce setup time. Turn on enable-cache and pin python-version to 3.11 in both the shared setup action and the PR workflow.

<sup>Written for commit 9ef6bd8abd9787763a723e89f1cc9d7dd043e908. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











