### PR TITLE
fix(google): Fix embedding scopes

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -278,7 +278,8 @@ class CloudEmbedding:
 
         service_account_info = json.loads(self.api_key)
         credentials = service_account.Credentials.from_service_account_info(
-            service_account_info
+            service_account_info,
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
         )
         project_id = service_account_info["project_id"]
         location = (


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding scopes for the Google Embedding models setup. 

Apparently Vertex AI under the hood handles this for you and implicitly set scopes but the Google SDK did not mention this and does not set it unless you set it yourself.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally by trying to enable the embedding model before the change and resulted in an error that was fixed once we added the scope

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cloud-platform OAuth scope to Google service account credentials used by Vertex AI embeddings. Fixes the authentication error when enabling the embedding model.

<sup>Written for commit 555e7018b32bda742ec59b3fbbea014d4221c359. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

