### PR TITLE
chore(logs): When final doc for context pruning gets pruned, that prob doesn't need to be an error

### DIFF
--- a/backend/onyx/chat/prune_and_merge.py
+++ b/backend/onyx/chat/prune_and_merge.py
@@ -306,7 +306,7 @@ def _apply_pruning(
             # less than 75 tokens are available to try and avoid this situation
             # from occurring in the first place
             if final_doc_content_length <= 0:
-                logger.error(
+                logger.debug(
                     f"Final section ({sections[final_section_ind].center_chunk.semantic_identifier}) content "
                     "length is less than 0. Removing this section from the final prompt."
                 )


### PR DESCRIPTION
## Description

This was spamming Sentry even though there are several other pruning steps in this function which only emit debug level logs. Pruning is intended behavior and there is nothing Onyx or the user can do about it, so this should not be an error.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the log level from error to debug when the final section is removed during context pruning. This prevents unnecessary Sentry alerts for expected pruning behavior.

- **Bug Fixes**
  - Changed logger.error to logger.debug when final_doc_content_length <= 0 to reduce log spam and match other pruning steps.

<sup>Written for commit 586deb29a88adfd6776ea398a4574b4da88e4f73. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

