### PR TITLE
chore(deps): upgrade supervisor 4.2.5->4.3.0

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -946,8 +946,6 @@ secretstorage==3.5.0 ; sys_platform == 'linux'
 sendgrid==6.11.0
 sentry-sdk==2.14.0
     # via onyx
-setuptools==80.9.0
-    # via supervisor
 shapely==2.0.6
     # via google-cloud-aiplatform
 shellingham==1.5.4
@@ -996,7 +994,7 @@ starlette==0.47.2
 stone==3.3.1
     # via dropbox
 stripe==10.12.0
-supervisor==4.2.5
+supervisor==4.3.0
 sympy==1.13.1
     # via onnxruntime
 tabulate==0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ backend = [
     "slack-sdk==3.20.2",
     "SQLAlchemy[mypy]==2.0.15",
     "starlette==0.47.2",
-    "supervisor==4.2.5",
+    "supervisor==4.3.0",
     "RapidFuzz==3.13.0",
     "tiktoken==0.7.0",
     "timeago==1.0.16",

--- a/uv.lock
+++ b/uv.lock
@@ -3738,7 +3738,7 @@ backend = [
     { name = "sqlalchemy", extras = ["mypy"], specifier = "==2.0.15" },
     { name = "starlette", specifier = "==0.47.2" },
     { name = "stripe", specifier = "==10.12.0" },
-    { name = "supervisor", specifier = "==4.2.5" },
+    { name = "supervisor", specifier = "==4.3.0" },
     { name = "tiktoken", specifier = "==0.7.0" },
     { name = "timeago", specifier = "==1.0.16" },
     { name = "trafilatura", specifier = "==1.12.2" },
@@ -5955,14 +5955,11 @@ wheels = [
 
 [[package]]
 name = "supervisor"
-version = "4.2.5"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/37/517989b05849dd6eaa76c148f24517544704895830a50289cbbf53c7efb9/supervisor-4.2.5.tar.gz", hash = "sha256:34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12", size = 466073, upload-time = "2022-12-24T01:02:43.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/b5/37e7a3706de436a8a2d75334711dad1afb4ddffab09f25e31d89e467542f/supervisor-4.3.0.tar.gz", hash = "sha256:4a2bf149adf42997e1bb44b70c43b613275ec9852c3edacca86a9166b27e945e", size = 468912, upload-time = "2025-08-23T18:25:02.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/7a/0ad3973941590c040475046fef37a2b08a76691e61aa59540828ee235a6e/supervisor-4.2.5-py2.py3-none-any.whl", hash = "sha256:2ecaede32fc25af814696374b79e42644ecaba5c09494c51016ffda9602d0f08", size = 319561, upload-time = "2022-12-24T01:02:40.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/65/5e726c372da8a5e35022a94388b12252710aad0c2351699c3d76ae8dba78/supervisor-4.3.0-py2.py3-none-any.whl", hash = "sha256:0bcb763fddafba410f35cbde226aa7f8514b9fb82eb05a0c85f6588d1c13f8db", size = 320736, upload-time = "2025-08-23T18:25:00.767Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Drops setuptools as a runtime dep.

I thought this was origin of this,

> /home/jamison/code/onyx/.venv/lib/python3.11/site-packages/ddtrace/internal/module.py:300: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.

but not sure (turns out it was [dropbox](https://github.com/onyx-dot-app/onyx/pull/6467) but was exposed by this change).

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded supervisor to 4.3.0 to drop setuptools as a runtime dependency and avoid pkg_resources deprecation warnings.

- **Dependencies**
  - Bumped supervisor to 4.3.0 across pyproject, uv.lock, and requirements.
  - Removed setuptools from backend requirements.

<sup>Written for commit 8039eca6d58acda13d9472bef33a9d227e6f4773. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





