### PR TITLE
chore(deps): upgrade dropbox 11.36.2->12.0.2

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -208,7 +208,7 @@ docstring-parser==0.17.0
     #   google-cloud-aiplatform
 docutils==0.22.3
     # via rich-rst
-dropbox==11.36.2
+dropbox==12.0.2
 email-validator==2.2.0
     # via
     #   fastapi-users
@@ -408,7 +408,6 @@ jinja2==3.1.6
     # via
     #   distributed
     #   litellm
-    #   stone
 jira==3.10.5
 jiter==0.12.0
     # via openai
@@ -657,7 +656,6 @@ packaging==24.2
     #   opentelemetry-instrumentation
     #   pytest
     #   pywikibot
-    #   stone
     #   unstructured-client
 pandas==2.2.3
     # via markitdown
@@ -995,7 +993,7 @@ starlette==0.47.2
     #   fastapi
     #   mcp
     #   prometheus-fastapi-instrumentator
-stone==3.3.9
+stone==3.3.1
     # via dropbox
 stripe==10.12.0
 supervisor==4.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ backend = [
     "zulip==0.8.2",
     "hubspot-api-client==8.1.0",
     "asana==5.0.8",
-    "dropbox==11.36.2",
+    "dropbox==12.0.2",
     "shapely==2.0.6",
     "stripe==10.12.0",
     "urllib3==2.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1215,16 +1215,16 @@ wheels = [
 
 [[package]]
 name = "dropbox"
-version = "11.36.2"
+version = "12.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
     { name = "stone" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/0f/2059c5ef8669e625a533661a2054a82241696954df6662aeee51a34b1022/dropbox-11.36.2.tar.gz", hash = "sha256:d48d3d16d486c78b11c14a1c4a28a2611fbf5a0d0a358b861bfd9482e603c500", size = 585092, upload-time = "2023-06-12T23:39:46.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/56/ac085f58e8e0d0bcafdf98c2605e454ac946e3d0c72679669ae112dc30be/dropbox-12.0.2.tar.gz", hash = "sha256:50057fd5ad5fcf047f542dfc6747a896e7ef982f1b5f8500daf51f3abd609962", size = 560236, upload-time = "2024-06-03T16:45:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/96/1cd39be567d8e361fc06a4135e40ddbf1410f99524771a7f3e5807a26a35/dropbox-11.36.2-py3-none-any.whl", hash = "sha256:a21e4d2bcbeb1d8067ff87969aea48792c9a8266182491153feff2be9c1b9c8f", size = 594038, upload-time = "2023-06-12T23:39:44.245Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/95d8204d9a20fbdb353c5f8e4229b0fcb90f22b96f8246ff1f47c8a45fd5/dropbox-12.0.2-py3-none-any.whl", hash = "sha256:c5b7e9c2668adb6b12dcecd84342565dc50f7d35ab6a748d155cb79040979d1c", size = 572076, upload-time = "2024-06-03T16:45:28.153Z" },
 ]
 
 [[package]]
@@ -3665,7 +3665,7 @@ backend = [
     { name = "ddtrace", specifier = "==3.10.0" },
     { name = "discord-py", specifier = "==2.4.0" },
     { name = "distributed", specifier = "==2023.8.1" },
-    { name = "dropbox", specifier = "==11.36.2" },
+    { name = "dropbox", specifier = "==12.0.2" },
     { name = "exa-py", specifier = "==1.15.4" },
     { name = "fastapi-limiter", specifier = "==0.1.6" },
     { name = "fastapi-users", specifier = "==14.0.1" },
@@ -5929,17 +5929,15 @@ wheels = [
 
 [[package]]
 name = "stone"
-version = "3.3.9"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "packaging" },
     { name = "ply" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/f0/efe39177ad1415ce277160e3186d74e3446d5c47d0b53de089448b7976de/stone-3.3.9.tar.gz", hash = "sha256:8f1298683f60ffa9e43edbfd55beb0a20993235d5c751e7adb3030dc16d17fad", size = 194103, upload-time = "2025-04-01T02:25:07.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/6f/ef25bbc1aefeb9c905d527f1d3cd3f41f22f40566d33001b8bb14ae0cdaf/stone-3.3.1.tar.gz", hash = "sha256:4ef0397512f609757975f7ec09b35639d72ba7e3e17ce4ddf399578346b4cb50", size = 190888, upload-time = "2022-01-25T21:32:16.729Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/53/abeff3103fc2e21f37d0081d5d9693fa7a32ad688553cf4760da5e0ef17d/stone-3.3.9-py3-none-any.whl", hash = "sha256:2008318b8eed65bbf38f8c20dbebb4823dc92a813a2b61c3a09d8b9743a7b14e", size = 162989, upload-time = "2025-04-01T02:25:05.614Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/92/d0c83f63d3518e5f0b8a311937c31347349ec9a47b209ddc17f7566f58fc/stone-3.3.1-py3-none-any.whl", hash = "sha256:e15866fad249c11a963cce3bdbed37758f2e88c8ff4898616bc0caeb1e216047", size = 162257, upload-time = "2022-01-25T21:32:15.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

I originally thought `supervisor` was responsible for the `pkg_resources` deprecation warning (https://github.com/onyx-dot-app/onyx/pull/6466), but that change exposed that `dropbox` has an undeclared runtime dep on setuptools.

## How Has This Been Tested?

Confirmed locally the deprecation warning is gone.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the Dropbox library to 12.0.2 to remove the pkg_resources deprecation warning and drop the implicit setuptools runtime dependency.

- **Dependencies**
  - Bumped dropbox 11.36.2 → 12.0.2 in pyproject and backend requirements.
  - Pinned stone to 3.3.1; no longer pulls jinja2/packaging via stone.
  - Updated uv.lock.

<sup>Written for commit 19317ce0abb32aaa2c65d6fae0c442d329814ac1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

