### PR TITLE
Stop Signal Handling

### DIFF
--- a/backend/onyx/chat/infra.py
+++ b/backend/onyx/chat/infra.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from collections.abc import Generator
+from queue import Empty
 from queue import Queue
 from typing import Any
 
@@ -32,28 +33,93 @@ def get_default_emitter() -> Emitter:
     return emitter
 
 
+def run_with_emitter_wrapper(
+    func: Callable[..., None],
+    emitter: Emitter,
+    is_connected: Callable[[], bool],
+    *args: Any,
+    **kwargs: Any,
+) -> Generator[Packet, None]:
+    """
+    Explicit wrapper function that runs a function in a background thread
+    with event streaming capabilities.
+
+    The wrapped function should accept emitter as first arg and use it to emit
+    Packet objects. This wrapper polls every 300ms to check if stop signal is set.
+
+    Args:
+        func: The function to wrap (should accept emitter as first arg)
+        emitter: Emitter instance for sending packets
+        is_connected: Callable that returns False when stop signal is set
+        *args: Additional positional arguments for func
+        **kwargs: Additional keyword arguments for func
+
+    Usage:
+        packets = run_with_emitter_wrapper(
+            my_func,
+            emitter=emitter,
+            is_connected=check_func,
+            arg1, arg2, kwarg1=value1
+        )
+        for packet in packets:
+            # Process packets
+            pass
+    """
+
+    def run_with_exception_capture() -> None:
+        try:
+            func(emitter, *args, **kwargs)
+        except Exception as e:
+            # If execution fails, emit an exception packet
+            emitter.emit(
+                Packet(
+                    turn_index=0,
+                    obj=PacketException(type="error", exception=e),
+                )
+            )
+
+    # Run the function in a background thread
+    thread = run_in_background(run_with_exception_capture)
+
+    try:
+        while True:
+            # Poll queue with 300ms timeout for natural stop signal checking
+            try:
+                pkt: Packet = emitter.bus.get(timeout=0.3)
+            except Empty:
+                # Timeout - check stop signal and continue
+                if not is_connected():
+                    # Stop signal detected, kill the thread
+                    break
+                continue
+
+            # Handle received packet
+            if pkt.obj == OverallStop(type="stop"):
+                yield pkt
+                break
+            elif isinstance(pkt.obj, PacketException):
+                raise pkt.obj.exception
+            else:
+                yield pkt
+
+            # Also check stop signal after yielding each packet
+            if not is_connected():
+                break
+    finally:
+        # Only wait for thread if it wasn't stopped by user
+        if is_connected():
+            wait_on_background(thread)
+        # If stopped by user, we just let the thread die without waiting
+
+
 def emitter_generator_wrapper(
     wrapped_func: Callable[..., None],
 ) -> Callable[..., Generator[Packet, None]]:
     """
-    Decorator that wraps a function to provide event streaming capabilities.
+    DEPRECATED: Use run_with_emitter_wrapper instead for explicit control.
 
-    The wrapped function should accept any arguments and use an Emitter to emit
-    Packet objects. The decorator converts the function into a generator that
-    yields Packets from the emitter's bus.
-
-    Usage:
-    @emitter_generator_wrapper
-    def my_func(emitter, *args, **kwargs):
-        # Your logic here - use emitter.emit() to send packets
-        emitter.emit(Packet(ind=0, obj=SomeEvent(...)))
-        pass
-
-    Then call it like:
-    generator = my_func(emitter, *args, **kwargs)
-    for packet in generator:
-        # Process packets
-        pass
+    Legacy decorator that wraps a function to provide event streaming capabilities.
+    Kept for backward compatibility with existing code.
     """
 
     def wrapper(emitter: Emitter, *args: Any, **kwargs: Any) -> Generator[Packet, None]:
@@ -61,8 +127,6 @@ def emitter_generator_wrapper(
             try:
                 wrapped_func(emitter, *args, **kwargs)
             except Exception as e:
-                # Ok if we don't know the actual turn or tab, if it's failed at this level
-                # the entire flow is dead
                 emitter.emit(
                     Packet(
                         turn_index=0,

--- a/backend/onyx/chat/state.py
+++ b/backend/onyx/chat/state.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from onyx.context.search.models import SearchDoc
+from onyx.tools.models import ToolCallInfo
+
+
+class LLMLoopStateContainer:
+    """Container for accumulating state during LLM loop execution.
+
+    This container holds the partial state that can be saved to the database
+    if the generation is stopped by the user or completes normally.
+    """
+
+    def __init__(self):
+        self.tool_calls: list[ToolCallInfo] = []
+        self.reasoning_tokens: str | None = None
+        self.answer_tokens: str | None = None
+        # Store citation mapping for building citation_docs_info during partial saves
+        self.citation_to_doc: dict[int, SearchDoc] = {}
+
+    def add_tool_call(self, tool_call: ToolCallInfo) -> None:
+        """Add a tool call to the accumulated state."""
+        self.tool_calls.append(tool_call)
+
+    def set_reasoning_tokens(self, reasoning: str | None) -> None:
+        """Set the reasoning tokens from the final answer generation."""
+        self.reasoning_tokens = reasoning
+
+    def set_answer_tokens(self, answer: str | None) -> None:
+        """Set the answer tokens from the final answer generation."""
+        self.answer_tokens = answer
+
+    def set_citation_mapping(self, citation_to_doc: dict[int, Any]) -> None:
+        """Set the citation mapping from citation processor."""
+        self.citation_to_doc = citation_to_doc


### PR DESCRIPTION
## Description
Add incremental state saving and explicit stop signal handling for LLM loop, enabling partial saves when generation is stopped.

[Provide a brief description of the changes in this PR]

Changes:

- Add `run_with_emitter_wrapper` to replace the decorator pattern, with explicit 300ms polling for stop signals

- Add `LLMLoopStateContainer` to accumulate state (answer, reasoning, citations, tool calls) incrementally during execution

- Refactor run_llm_loop to save state incrementally instead of only at completion

- Move final save_chat_turn call to process_message.py to handle both normal completion and user-stopped cases

- Deprecate `emitter_generator_wrapper` in favor of the explicit wrapper function

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
<img width="807" height="204" alt="Screenshot 2025-11-27 at 10 03 54 PM" src="https://github.com/user-attachments/assets/aaa69a54-90f9-4198-9566-2c8082996682" />

<img width="818" height="234" alt="Screenshot 2025-11-27 at 10 04 03 PM" src="https://github.com/user-attachments/assets/043f31f4-e1a5-4aef-a81b-858949c4ff4f" />

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit stop-signal polling and incremental state saving in the LLM loop so partial answers, citations, and tool calls are preserved when a generation is stopped. Also updates chat history handling and web search tooling, and hardens CI/build.

- **New Features**
  - Replaced decorator with run_with_emitter_wrapper (300ms stop-signal polling); deprecated emitter_generator_wrapper.
  - Added LLMLoopStateContainer to capture and save answer, reasoning, citations, and tool calls incrementally; final save happens in process_message.py for both normal and stopped runs.
  - Introduced OpenURLTool and internet search provider infrastructure; added Firecrawl, Google PSE, and a built-in crawler clients.
  - Updated agent message formatting and moved query/search to chunk-based models and pipeline.

- **Migration**
  - Run Alembic migrations (new chat history schema, internet_search_provider table, federated_connector config, and OpenURLTool seeding).
  - Optionally set EXA_API_KEY to auto-seed the Exa provider during migration.
  - Rebuild images using updated Dockerfiles and docker-bake targets (backend and model-server).

<sup>Written for commit b68d3d20d91a9cb0cd05e325717a91d8988d2f14. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

