### PR TITLE
feat(vertex-ai): add Gemini 3 Pro and Claude Opus 4.5 models

### DIFF
--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -182,6 +182,8 @@ VERTEX_LOCATION_KWARG = "vertex_location"
 VERTEXAI_DEFAULT_MODEL = "gemini-2.5-flash"
 VERTEXAI_DEFAULT_FAST_MODEL = "gemini-2.5-flash-lite"
 VERTEXAI_MODEL_NAMES = [
+    # 3.0 pro models
+    "gemini-3-pro-preview",
     # 2.5 pro models
     "gemini-2.5-pro",
     VERTEXAI_DEFAULT_MODEL,
@@ -197,6 +199,7 @@ VERTEXAI_MODEL_NAMES = [
     # "gemini-2.0-flash-exp-image-generation",
     # "gemini-2.0-flash-thinking-exp-01-21",
     # Anthropic models
+    "claude-opus-4-5",
     "claude-sonnet-4-5",
     "claude-haiku-4-5",
     "claude-opus-4-1@20250805",

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -924,6 +924,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "claude-opus-4-1": "Claude 4.1 Opus",
   "claude-opus-4-20250514": "Claude 4 Opus",
   "claude-4-opus-20250514": "Claude 4 Opus",
+  "claude-opus-4-5": "Claude 4.5 Opus (Latest)",
   "claude-sonnet-4-5": "Claude 4.5 Sonnet (Latest)",
   "claude-sonnet-4-20250514": "Claude 4 Sonnet",
   "claude-4-sonnet-20250514": "Claude 4 Sonnet",
@@ -931,6 +932,9 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "claude-3-7-sonnet-latest": "Claude 3.7 Sonnet (Latest)",
 
   // Google Models
+
+  // 3.0 pro models
+  "gemini-3-pro-preview": "Gemini 3 Pro (Preview)",
 
   // 2.5 pro models
   "gemini-2.5-pro": "Gemini 2.5 Pro",


### PR DESCRIPTION
Add support for new models available in Vertex AI:
- gemini-3-pro-preview (Gemini 3 Pro with advanced reasoning)
- claude-opus-4-5 (Claude 4.5 Opus latest)

- Backend: Added models to VERTEXAI_MODEL_NAMES
- Frontend: Added display names in MODEL_DISPLAY_NAMES

## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Vertex AI support for Gemini 3 Pro (preview) and Claude 4.5 Opus, making them selectable in the UI and usable by the backend. Defaults remain unchanged.

- **New Features**
  - Backend: added both models to VERTEXAI_MODEL_NAMES.
  - Frontend: added display names to MODEL_DISPLAY_NAMES.

<sup>Written for commit f25c2e27990ba642eca057a70d683ca3a0f5858e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

