### PR TITLE
fix(WebSearch): adjust Separator styling for improved layout consistency

### DIFF
--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -1332,7 +1332,7 @@ export default function Page() {
         </div>
 
         <div className="mt-1 flex w-full max-w-[960px] flex-col gap-8 px-4 py-6">
-          <Separator className="my-0 bg-border-01" />
+          <Separator className="py-0" />
 
           <div className="flex flex-col gap-3 self-stretch">
             <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Description
Fix separator

## How Has This Been Tested?
From UI
<img width="1174" height="702" alt="Screenshot 2025-11-30 at 11 04 07 AM" src="https://github.com/user-attachments/assets/4607f177-76b9-424c-8a43-06d8e79c39e3" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the Separator styling in the Web Search admin configuration page to fix spacing and improve layout consistency. Replaced the custom background and margin with neutral padding to use default styles.

<sup>Written for commit c62a49aaecf32d6355bcf43fbd2f2e99cc0e3abf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

