### PR TITLE
chore(gha): remove duplicate python checks

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -100,12 +100,3 @@ jobs:
           MYPY_FORCE_COLOR: 1
           TERM: xterm-256color
         run: mypy .
-
-      - name: Check import order with reorder-python-imports
-        working-directory: ./backend
-        run: |
-          find ./onyx -name "*.py" | xargs reorder-python-imports --py311-plus
-
-      - name: Check code formatting with Black
-        working-directory: ./backend
-        run: black --check .


### PR DESCRIPTION
## Description

These are now obsolete as they're run as part of pre-commit in CI. Moreover, these are slightly less efficient as they run over the entire codebase rather than the pre-commit step which calculates the delta with the merge-base.

Also, the existing UX is kinda confusing given this job is called `mypy-check` and there can be non-mypy failures.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate Black and import-order checks from the PR GitHub Action. These are handled by pre-commit in CI, so runs are faster and the mypy job no longer reports non-mypy failures.

- **Refactors**
  - Removed Black and reorder-python-imports steps from pr-python-checks.yml; pre-commit covers them on diffs.
  - mypy step remains, focused solely on type checking.

<sup>Written for commit 5f8bd93f8d6708d357345d9a0b68cf415b3a7884. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

