### PR TITLE
fix: Edit separator

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -1263,7 +1263,7 @@ export default function AssistantEditor({
                     </div>
                   </div>
                 </div>
-                <Separator className="max-w-4xl mt-0" />
+                <Separator />
 
                 <div className="-mt-2">
                   <div className="flex gap-x-2 mb-2 items-center">

--- a/web/src/refresh-components/Separator.tsx
+++ b/web/src/refresh-components/Separator.tsx
@@ -37,7 +37,9 @@ function SeparatorInner(
   const isHorizontal = orientation === "horizontal";
 
   return (
-    <div className={cn(isHorizontal ? "py-4" : "px-4", className)}>
+    <div
+      className={cn(isHorizontal ? "py-4 w-full" : "px-4 h-full", className)}
+    >
       <SeparatorPrimitive.Root
         ref={ref}
         decorative={decorative}


### PR DESCRIPTION
## Description

Make separator expand the full width / height (depending on the orientation).

Addresses: https://linear.app/danswer/issue/DAN-3122/make-separator-extend-the-entire-width-height-depending-on-orientation.

## Screenshots

<img width="975" height="725" alt="image" src="https://github.com/user-attachments/assets/8f5d9432-dc97-442b-a5b6-272555d39b78" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Separator to span the full width (horizontal) or height (vertical), fixing layout gaps and ensuring consistent dividers. Addresses Linear DAN-3122.

- **Bug Fixes**
  - Apply w-full/h-full based on orientation in Separator.
  - Remove max-width override in AssistantEditor to allow full-span divider.

<sup>Written for commit 373b5f506e2c7167f3e914b48a204bcab7458744. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->