### PR TITLE
Fix Alembic Downgrade just in case

### DIFF
--- a/backend/alembic/versions/a852cbe15577_new_chat_history.py
+++ b/backend/alembic/versions/a852cbe15577_new_chat_history.py
@@ -409,6 +409,7 @@ def downgrade() -> None:
         sa.Column("queries", postgresql.JSONB(), nullable=True),
         sa.Column("generated_images", postgresql.JSONB(), nullable=True),
         sa.Column("additional_data", postgresql.JSONB(), nullable=True),
+        sa.Column("file_ids", postgresql.JSONB(), nullable=True),
         sa.ForeignKeyConstraint(
             ["primary_question_id", "iteration_nr"],
             [


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Alembic downgrade for the new chat history migration by adding the missing file_ids JSONB column when recreating the table. This keeps rollback in sync with the previous schema and prevents downgrade failures.

<sup>Written for commit 0ad6f475bb5373f928a56a0863a42457efc96312. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

