### PR TITLE
feat(helm): PGInto Workflow

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.12
+version: 0.4.13
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -22,6 +22,10 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- $pgIntoChecksum := include "onyx.pgInto.checksumAnnotation" . }}
+        {{- if $pgIntoChecksum }}
+        {{- $pgIntoChecksum | nindent 8 }}
+        {{- end }}
       {{- with .Values.api.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -77,12 +81,12 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.api.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $apiVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.api.volumeMounts) }}
+          {{- if $apiVolumeMounts }}
+          {{- $apiVolumeMounts | nindent 10 }}
           {{- end }}
-      {{- with .Values.api.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $apiVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.api.volumes) }}
+      {{- if $apiVolumes }}
+      {{- $apiVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -1,0 +1,50 @@
+{{- if (include "onyx.pgInto.enabled" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "onyx.pgInto.configMapName" . }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+data:
+  pginto: |
+    #!/usr/bin/env sh
+    set -eu
+
+    HOST="${POSTGRES_HOST:-localhost}"
+    PORT="${POSTGRES_PORT:-5432}"
+    USER="${POSTGRES_USER:-postgres}"
+    DB="${POSTGRES_DB:-postgres}"
+    PSQL_BIN="${PGINTO_PSQL_BIN:-{{ default "psql" .Values.tooling.pgInto.psqlBinary }}}"
+
+    if ! command -v "${PSQL_BIN}" >/dev/null 2>&1; then
+      echo "psql client '${PSQL_BIN}' not found in PATH" >&2
+      exit 1
+    fi
+
+    if [ -z "${PGPASSWORD:-}" ] && [ -n "${POSTGRES_PASSWORD:-}" ]; then
+      export PGPASSWORD="${POSTGRES_PASSWORD}"
+    fi
+
+    if [ -z "${PGPASSWORD:-}" ]; then
+      printf "Postgres password: " >&2
+      if command -v stty >/dev/null 2>&1; then
+        stty -echo || true
+      fi
+      if ! read -r PGPASSWORD; then
+        echo "failed to read password" >&2
+        exit 1
+      fi
+      if command -v stty >/dev/null 2>&1; then
+        stty echo || true
+      fi
+      printf "\n" >&2
+      export PGPASSWORD
+    fi
+
+    if [ -n "${POSTGRES_SSLMODE:-}" ] && [ -z "${PGSSLMODE:-}" ]; then
+      export PGSSLMODE="${POSTGRES_SSLMODE}"
+    fi
+
+    echo "Connecting to ${DB} on ${HOST}:${PORT} as ${USER}"
+    exec "${PSQL_BIN}" -h "${HOST}" -p "${PORT}" -U "${USER}" "${DB}" "$@"
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -144,6 +144,15 @@ indexCapability:
 config:
   envConfigMapName: env-configmap
 
+tooling:
+  pgInto:
+    # -- Mounts a small helper script into app pods that opens psql using the pod's POSTGRES_* env vars.
+    enabled: false
+    # -- Where to place the helper inside the container.
+    mountPath: /usr/local/bin/pginto
+    # -- Which client binary to call; change if your image uses a non-default path.
+    psqlBinary: psql
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Creating a new workflow to connect to the Posgtres Database specifically from the API pod in order to simplify the access and easily setup DB connections.

This is purely a quality of life improvement

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Helm template and generated the manifest that we applied to the test cluster.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional pgInto helper to the Helm chart that mounts a psql convenience script into pods (API first) to connect to Postgres using the pod’s POSTGRES_* env vars. Chart version bumped to 0.4.13; feature is off by default.

- **New Features**
  - ConfigMap with pginto script and checksum annotation for rollout.
  - Templated helpers to enable/disable and merge volumes/volumeMounts safely.
  - api-deployment updated to mount the script when enabled.
  - New values under tooling.pgInto (enabled, mountPath, psqlBinary).

<sup>Written for commit 33a464923840acbf7306c754187e1b21b89f8409. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

