### PR TITLE
feat(pginto): Support IAM Auth

### DIFF
--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -39,35 +39,7 @@ data:
       if [ -z "${PGSSLMODE:-}" ]; then
         export PGSSLMODE=require
       fi
-      PGPASSWORD="$("${PY_BIN}" - "${HOST}" "${PORT}" "${USER}" "${REGION}" <<'PY')"
-import sys
-
-try:
-    import boto3
-except ImportError as exc:
-    sys.stderr.write(f"boto3 is required for IAM auth: {exc}\n")
-    sys.exit(1)
-
-host, port, user, region = sys.argv[1:]
-try:
-    port_int = int(port)
-except ValueError as exc:
-    sys.stderr.write(f"invalid port '{port}': {exc}\n")
-    sys.exit(1)
-
-try:
-    client = boto3.client("rds", region_name=region)
-    token = client.generate_db_auth_token(
-        DBHostname=host,
-        Port=port_int,
-        DBUsername=user,
-    )
-    sys.stdout.write(token)
-except Exception as exc:
-    sys.stderr.write(f"failed to generate IAM auth token: {exc}\n")
-    sys.exit(1)
-PY
-"
+      PGPASSWORD="$("${PY_BIN}" -c 'import sys,boto3; host,port,user,region=sys.argv[1:]; port_int=int(port); token=boto3.client("rds", region_name=region).generate_db_auth_token(DBHostname=host, Port=port_int, DBUsername=user); sys.stdout.write(token)' "${HOST}" "${PORT}" "${USER}" "${REGION}")"
       if [ -z "${PGPASSWORD}" ]; then
         echo "failed to generate IAM auth token" >&2
         exit 1


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Updating the pginto script to account for IAM auth as well.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options
Updated for our testing cluster and validated that this works.

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add IAM auth support to pginto so you can connect to AWS RDS/Aurora using temporary IAM tokens instead of stored passwords. Automatically detects AWS region and enforces SSL when IAM is used.

- **New Features**
  - Toggle IAM auth with USE_IAM_AUTH=true.
  - Auto-detect AWS region from env (AWS_REGION/AWS_DEFAULT_REGION/AWS_REGION_NAME) or RDS hostname.
  - Generate RDS IAM token via boto3 and set PGPASSWORD.
  - Default PGSSLMODE=require when IAM auth is enabled.

- **Migration**
  - Set USE_IAM_AUTH=true.
  - Ensure python or python3 and boto3 are available in the container.
  - Set AWS_REGION, AWS_DEFAULT_REGION, or AWS_REGION_NAME (or use an RDS hostname that includes the region).

<sup>Written for commit a120c16c1e5195ec851dd8445853d65c58d8b023. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







