### PR TITLE
chore: [Running GitHub actions for #6517]

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -94,19 +94,8 @@ export const NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK =
 export const NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY =
   process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
-// Add support for custom URL protocols in markdown links
-export const ALLOWED_URL_PROTOCOLS = [
-  "http:",
-  "https:",
-  "mailto:",
-  "tel:",
-  "slack:",
-  "vscode:",
-  "file:",
-  "sms:",
-  "spotify:",
-  "zoommtg:",
-];
+// Restrict markdown links to safe protocols
+export const ALLOWED_URL_PROTOCOLS = ["http:", "https:", "mailto:"] as const;
 
 export const MAX_CHARACTERS_PERSONA_DESCRIPTION = 5000000;
 export const MAX_STARTER_MESSAGES = 4;

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -11,28 +11,33 @@ export const truncateString = (str: string, maxLength: number) => {
 };
 
 /**
- * Custom URL transformer function for ReactMarkdown
- * Allows specific protocols to be used in markdown links
- * We use this with the urlTransform prop in ReactMarkdown
+ * Custom URL transformer function for ReactMarkdown.
+ * Only allows a small, safe set of protocols and strips everything else.
+ * Returning null removes the href attribute entirely.
  */
-export function transformLinkUri(href: string) {
-  if (!href) return href;
+export function transformLinkUri(href: string): string | null {
+  if (!href) return null;
 
-  const url = href.trim();
+  const trimmedHref = href.trim();
+  if (!trimmedHref) return null;
+
   try {
-    const parsedUrl = new URL(url);
-    if (
-      ALLOWED_URL_PROTOCOLS.some((protocol) =>
-        parsedUrl.protocol.startsWith(protocol)
-      )
-    ) {
-      return url;
+    const parsedUrl = new URL(trimmedHref);
+    const protocol = parsedUrl.protocol.toLowerCase();
+
+    if (ALLOWED_URL_PROTOCOLS.some((allowed) => allowed === protocol)) {
+      return trimmedHref;
     }
+
+    return null;
   } catch {
-    // If it's not a valid URL with protocol, return the original href
-    return href;
+    // Allow relative URLs, but drop anything that looks like a protocol-prefixed link
+    if (/^[a-zA-Z][a-zA-Z\d+.-]*:\S*/.test(trimmedHref)) {
+      return null;
+    }
+
+    return trimmedHref;
   }
-  return href;
 }
 
 export function isSubset(parent: string[], child: string[]): boolean {


### PR DESCRIPTION
Automated mirror of PR #6517 so private CI can run.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened markdown link handling to block unsafe protocols in user content. Only http, https, and mailto are allowed; others are stripped to reduce XSS risk.

- **Bug Fixes**
  - Restricted ALLOWED_URL_PROTOCOLS to ["http:", "https:", "mailto:"].
  - Updated transformLinkUri to trim input, lowercase the protocol, return null for disallowed protocols, allow relative URLs, and block protocol-like strings.

<sup>Written for commit b9b70bc87e0785cacc3ceecf34b40b28942cdd24. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

