### PR TITLE
fix(migration): new chat history downgrade

### DIFF
--- a/backend/alembic/versions/a852cbe15577_new_chat_history.py
+++ b/backend/alembic/versions/a852cbe15577_new_chat_history.py
@@ -253,24 +253,18 @@ def downgrade() -> None:
     op.create_unique_constraint("uq_tool_call_message_id", "tool_call", ["message_id"])
 
     # Reverse ChatMessage changes
+    # Note: research_answer_purpose and research_type were originally String columns,
+    # not Enum types (see migrations 5ae8240accb3 and f8a9b2c3d4e5)
     op.add_column(
         "chat_message",
-        sa.Column(
-            "research_answer_purpose",
-            sa.Enum("INTRO", "DEEP_DIVE", name="researchanswerpurpose"),
-            nullable=True,
-        ),
+        sa.Column("research_answer_purpose", sa.String(), nullable=True),
     )
     op.add_column(
         "chat_message", sa.Column("research_plan", postgresql.JSONB(), nullable=True)
     )
     op.add_column(
         "chat_message",
-        sa.Column(
-            "research_type",
-            sa.Enum("SIMPLE", "DEEP", name="researchtype"),
-            nullable=True,
-        ),
+        sa.Column("research_type", sa.String(), nullable=True),
     )
     op.add_column(
         "chat_message",


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the new chat history migration downgrade by restoring research_answer_purpose and research_type as String columns instead of Enums. This matches the original schema and prevents type mismatches during rollback.

<sup>Written for commit ab3577941fb79d49a30759106bfd07d78b807b1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

