### PR TITLE
chore(gemini): FE updates for Gemini

### DIFF
--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -6,6 +6,7 @@ export enum LLMProviderName {
   OLLAMA_CHAT = "ollama_chat",
   AZURE = "azure",
   OPENROUTER = "openrouter",
+  GOOGLE_GENAI = "google_genai",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
 }

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -39,6 +39,7 @@ export const getProviderIcon = (
     llama: MetaIcon,
     ollama_chat: OllamaIcon,
     gemini: GeminiIcon,
+    google_genai: GeminiIcon,
     deepseek: DeepseekIcon,
     claude: AnthropicIcon,
     anthropic: AnthropicIcon,

--- a/web/src/components/embedding/interfaces.tsx
+++ b/web/src/components/embedding/interfaces.tsx
@@ -262,7 +262,7 @@ export const AVAILABLE_CLOUD_PROVIDERS: CloudEmbeddingProvider[] = [
     icon: GoogleIcon,
     docsLink: "https://docs.onyx.app/admin/advanced_configs/search_configs",
     description:
-      "Offers a wide range of AI services including language and vision models",
+      "Gemini (Google Gen AI) offers a wide range of language and vision models",
     apiLink: "https://console.cloud.google.com/apis/credentials",
     costslink: "https://cloud.google.com/vertex-ai/pricing",
     embedding_models: [

--- a/web/src/refresh-components/onboarding/components/LLMFormikEffects.tsx
+++ b/web/src/refresh-components/onboarding/components/LLMFormikEffects.tsx
@@ -93,6 +93,7 @@ const LLMFormikEffects = ({
         if (isEmpty(values.api_key) || isEmpty(values.api_base))
           shouldReset = true;
         break;
+      case LLMProviderName.GOOGLE_GENAI:
       case LLMProviderName.VERTEX_AI:
         if (isEmpty(values?.custom_config?.vertex_credentials))
           shouldReset = true;

--- a/web/src/refresh-components/onboarding/components/llmValidationSchema.ts
+++ b/web/src/refresh-components/onboarding/components/llmValidationSchema.ts
@@ -87,6 +87,7 @@ export const getValidationSchema = (
           ),
       });
 
+    case "google_genai":
     case "vertex_ai":
       return Yup.object().shape({
         ...baseSchema,

--- a/web/src/refresh-components/onboarding/constants.tsx
+++ b/web/src/refresh-components/onboarding/constants.tsx
@@ -97,6 +97,7 @@ export const PROVIDER_ICON_MAP: Record<
   [LLMProviderName.ANTHROPIC]: SvgClaude,
   [LLMProviderName.BEDROCK]: SvgAws,
   [LLMProviderName.AZURE]: AzureIcon,
+  [LLMProviderName.GOOGLE_GENAI]: GeminiIcon,
   [LLMProviderName.VERTEX_AI]: GeminiIcon,
   [LLMProviderName.OPENAI]: SvgOpenai,
   [LLMProviderName.OLLAMA_CHAT]: SvgOllama,
@@ -156,9 +157,9 @@ export const MODAL_CONTENT_MAP: Record<string, any> = {
         "This model will be used by Onyx by default for Ollama.",
     },
   },
-  [LLMProviderName.VERTEX_AI]: {
+  [LLMProviderName.GOOGLE_GENAI]: {
     description:
-      "Connect to Google Cloud Vertex AI and set up your Gemini models.",
+      "Connect to Google Gemini (Google Gen AI) and set up your Gemini models.",
     display_name: "Gemini",
     field_metadata: {
       vertex_credentials: (
@@ -167,7 +168,25 @@ export const MODAL_CONTENT_MAP: Record<string, any> = {
           <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
             API key
           </InlineExternalLink>
-          {" from Google Cloud Vertex AI to access your models."}
+          {" from Google Cloud to access your models."}
+        </>
+      ),
+      default_model_name:
+        "This model will be used by Onyx by default for Gemini.",
+    },
+  },
+  [LLMProviderName.VERTEX_AI]: {
+    description:
+      "Connect to Google Gemini (formerly Vertex AI) and set up your Gemini models.",
+    display_name: "Gemini",
+    field_metadata: {
+      vertex_credentials: (
+        <>
+          {"Paste your "}
+          <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
+            API key
+          </InlineExternalLink>
+          {" from Google Cloud to access your models."}
         </>
       ),
       default_model_name:
@@ -285,6 +304,7 @@ export const PROVIDER_TAB_CONFIG: Record<string, ProviderTabConfig> = {
 };
 
 export const PROVIDER_SKIP_FIELDS: Record<string, string[]> = {
+  [LLMProviderName.GOOGLE_GENAI]: ["vertex_location"],
   [LLMProviderName.VERTEX_AI]: ["vertex_location"],
 };
 

--- a/web/tests/e2e/chat/onboarding_flow.spec.ts
+++ b/web/tests/e2e/chat/onboarding_flow.spec.ts
@@ -155,7 +155,7 @@ test.describe("First user onboarding flow", () => {
       { title: "Claude", subtitle: "Anthropic" },
       { title: "Azure OpenAI", subtitle: "Microsoft Azure Cloud" },
       { title: "Amazon Bedrock", subtitle: "AWS" },
-      { title: "Gemini", subtitle: "Google Cloud Vertex AI" },
+      { title: "Gemini", subtitle: "Google Gen AI" },
       { title: "OpenRouter", subtitle: "OpenRouter" },
       { title: "Ollama", subtitle: "Ollama" },
       { title: "Custom LLM Provider", subtitle: "LiteLLM Compatible APIs" },


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Purely FE changes in order to migrate to new naming scheme

Link to deprecation information: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/deprecations/genai-vertexai-sdk

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Pulled up locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the FE naming from “Vertex AI” to “Google Gen AI/Gemini” while keeping Vertex AI support for compatibility.

- **Refactors**
  - Add LLMProviderName.GOOGLE_GENAI and map to the Gemini icon.
  - Treat GOOGLE_GENAI like VERTEX_AI in form reset logic and Yup validation.
  - Update onboarding and embedding copy to use “Google Gen AI (Gemini)”; revise subtitles and descriptions.
  - Skip vertex_location for GOOGLE_GENAI in onboarding config.
  - Update onboarding E2E test to expect “Google Gen AI” subtitle for Gemini.

<sup>Written for commit fa5027c8bb77680bb6b01b5d4f7380a8c5e0be1d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

