### PR TITLE
fix: eager load persona in slack channel config

### DIFF
--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
@@ -269,7 +270,9 @@ def fetch_slack_channel_config_for_channel_or_default(
     # attempt to find channel-specific config first
     if channel_name is not None:
         sc_config = db_session.scalar(
-            select(SlackChannelConfig).where(
+            select(SlackChannelConfig)
+            .options(joinedload(SlackChannelConfig.persona))
+            .where(
                 SlackChannelConfig.slack_bot_id == slack_bot_id,
                 SlackChannelConfig.channel_config["channel_name"].astext
                 == channel_name,
@@ -283,7 +286,9 @@ def fetch_slack_channel_config_for_channel_or_default(
 
     # if none found, see if there is a default
     default_sc = db_session.scalar(
-        select(SlackChannelConfig).where(
+        select(SlackChannelConfig)
+        .options(joinedload(SlackChannelConfig.persona))
+        .where(
             SlackChannelConfig.slack_bot_id == slack_bot_id,
             SlackChannelConfig.is_default == True,  # noqa: E712
         )

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -142,12 +142,14 @@ def handle_regular_answer(
     # This way slack flow always has a persona
     persona = slack_channel_config.persona
     if not persona:
+        logger.warning("No persona found for channel config, using default persona")
         with get_session_with_current_tenant() as db_session:
             persona = get_persona_by_id(DEFAULT_PERSONA_ID, user, db_session)
             document_set_names = [
                 document_set.name for document_set in persona.document_sets
             ]
     else:
+        logger.info(f"Using persona {persona.name} for channel config")
         document_set_names = [
             document_set.name for document_set in persona.document_sets
         ]

--- a/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
+++ b/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 os.environ["MODEL_SERVER_HOST"] = "disabled"
 os.environ["MODEL_SERVER_PORT"] = "9000"
 
+from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 from slack_sdk.errors import SlackApiError
 
@@ -760,3 +761,76 @@ def test_multiple_missing_scopes_resilience(
     # Should still return available channels
     assert len(result) == 1, f"Expected 1 channel, got {len(result)}"
     assert result["C1234567890"]["name"] == "general"
+
+
+def test_slack_channel_config_eager_loads_persona(db_session: Session) -> None:
+    """Test that fetch_slack_channel_config_for_channel_or_default eagerly loads persona.
+
+    This prevents lazy loading failures when the session context changes later
+    in the request handling flow (e.g., in handle_regular_answer).
+    """
+    from onyx.db.slack_channel_config import (
+        fetch_slack_channel_config_for_channel_or_default,
+    )
+
+    unique_id = str(uuid4())[:8]
+
+    # Create a persona (using same fields as _create_test_persona_with_slack_config)
+    persona = Persona(
+        name=f"test_eager_load_persona_{unique_id}",
+        description="Test persona for eager loading test",
+        chunks_above=0,
+        chunks_below=0,
+        llm_relevance_filter=True,
+        llm_filter_extraction=True,
+        recency_bias=RecencyBiasSetting.AUTO,
+        system_prompt="You are a helpful assistant.",
+        task_prompt="Answer the user's question.",
+    )
+    db_session.add(persona)
+    db_session.flush()
+
+    # Create a slack bot
+    slack_bot = SlackBot(
+        name=f"Test Bot {unique_id}",
+        bot_token=f"xoxb-test-{unique_id}",
+        app_token=f"xapp-test-{unique_id}",
+        enabled=True,
+    )
+    db_session.add(slack_bot)
+    db_session.flush()
+
+    # Create slack channel config with persona
+    channel_name = f"test-channel-{unique_id}"
+    slack_channel_config = SlackChannelConfig(
+        slack_bot_id=slack_bot.id,
+        persona_id=persona.id,
+        channel_config={"channel_name": channel_name, "disabled": False},
+        enable_auto_filters=False,
+        is_default=False,
+    )
+    db_session.add(slack_channel_config)
+    db_session.commit()
+
+    # Fetch the config using the function under test
+    fetched_config = fetch_slack_channel_config_for_channel_or_default(
+        db_session=db_session,
+        slack_bot_id=slack_bot.id,
+        channel_name=channel_name,
+    )
+
+    assert fetched_config is not None, "Should find the channel config"
+
+    # Check that persona relationship is already loaded (not pending lazy load)
+    insp = inspect(fetched_config)
+    assert insp is not None, "Should be able to inspect the config"
+    assert "persona" not in insp.unloaded, (
+        "Persona should be eagerly loaded, not pending lazy load. "
+        "This is required to prevent fallback to default persona when "
+        "session context changes in handle_regular_answer."
+    )
+
+    # Verify the persona is correct
+    assert fetched_config.persona is not None, "Persona should not be None"
+    assert fetched_config.persona.id == persona.id, "Should load the correct persona"
+    assert fetched_config.persona.name == persona.name


### PR DESCRIPTION
## Description

Fix Slack bot falling back to default assistant instead of using the configured persona. See thread: https://onyx-dot-app.slack.com/archives/C056265VB1N/p1763721492214309

**Root Cause**: The persona relationship on SlackChannelConfig uses lazy loading. When `handle_regular_answer` accesses slack_channel_config.persona, the SQLAlchemy session context may have changed, causing the lazy load to fail silently and return None. This triggers the fallback to `DEFAULT_PERSONA_ID` (the default "Assistant"), which doesn't have the custom tools configured on the user's intended persona.

**Fix**: Add joinedload(SlackChannelConfig.persona) to eagerly load the persona relationship in fetch_slack_channel_config_for_channel_or_default, ensuring the persona is loaded in the same query and eliminating dependency on lazy loading.

Additional: Added info/warning logs to track which assistant is being resolved for Slack messages, making future debugging easier.

## How Has This Been Tested?
  - Unit tests
  - Manual testing with Slack bot to verify correct persona is loaded
  - Verified logs show correct assistant resolution without fallback warnings
  
## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Slack bot using the wrong assistant by eagerly loading the channel’s configured persona. Prevents fallback to the default assistant and restores persona-specific tools.

- **Bug Fixes**
  - Eagerly load SlackChannelConfig.persona via joinedload in fetch_slack_channel_config_for_channel_or_default.
  - Add info/warning logs in handle_regular_answer to trace which persona is used.

<sup>Written for commit c7f9b4adb9639a81d9da7fec4e6947921264ee98. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



