### PR TITLE
chore(deployment): check if tagged correctly

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -83,6 +83,51 @@ jobs:
             echo "sanitized-tag=$SANITIZED_TAG"
           } >> "$GITHUB_OUTPUT"
 
+  check-version-tag:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && github.event_name != 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # ratchet:astral-sh/setup-uv@v7.1.4
+        with:
+          # NOTE: This isn't caching much and zizmor suggests this could be poisoned, so disable.
+          enable-cache: false
+
+      - name: Install release-tag package
+        run: |
+          uv venv
+          uv pip install release-tag
+
+      - name: Validate tag is versioned correctly
+        run: |
+          uv run --no-sync tag --check
+
+  notify-slack-on-tag-check-failure:
+    needs:
+      - check-version-tag
+    if: always() && needs.check-version-tag.result == 'failure' && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Send Slack notification
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          failed-jobs: "• check-version-tag"
+          title: "🚨 Version Tag Check Failed"
+          ref-name: ${{ github.ref_name }}
+
   build-web-amd64:
     needs: determine-builds
     if: needs.determine-builds.outputs.build-web == 'true'

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -368,6 +368,7 @@ referencing==0.36.2
     #   jsonschema-specifications
 regex==2025.11.3
     # via tiktoken
+release-tag==0.4.3
 reorder-python-imports-black==3.14.0
 requests==2.32.5
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ dev = [
     "types-retry==0.9.9.3",
     "types-setuptools==68.0.0.3",
     "ipykernel==6.29.5",
+    "release-tag>=0.4.3",
 ]
 
 # Enterprise Edition features

--- a/uv.lock
+++ b/uv.lock
@@ -3595,6 +3595,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-dotenv" },
     { name = "pytest-xdist" },
+    { name = "release-tag" },
     { name = "reorder-python-imports-black" },
     { name = "ruff" },
     { name = "types-beautifulsoup4" },
@@ -3762,6 +3763,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-dotenv", specifier = "==0.5.2" },
     { name = "pytest-xdist", specifier = "==3.6.1" },
+    { name = "release-tag", specifier = ">=0.4.3" },
     { name = "reorder-python-imports-black", specifier = "==3.14.0" },
     { name = "ruff", specifier = "==0.12.0" },
     { name = "types-beautifulsoup4", specifier = "==4.12.0.3" },
@@ -5314,6 +5316,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/59/9b/7c29be7903c318488983e7d97abcf8ebd3830e4c956c4c540005fcfb0462/regex-2025.11.3-cp312-cp312-win32.whl", hash = "sha256:3839967cf4dc4b985e1570fd8d91078f0c519f30491c60f9ac42a8db039be204", size = 266194, upload-time = "2025-11-03T21:31:51.53Z" },
     { url = "https://files.pythonhosted.org/packages/1a/67/3b92df89f179d7c367be654ab5626ae311cb28f7d5c237b6bb976cd5fbbb/regex-2025.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:e721d1b46e25c481dc5ded6f4b3f66c897c58d2e8cfdf77bbced84339108b0b9", size = 277069, upload-time = "2025-11-03T21:31:53.151Z" },
     { url = "https://files.pythonhosted.org/packages/d7/55/85ba4c066fe5094d35b249c3ce8df0ba623cfd35afb22d6764f23a52a1c5/regex-2025.11.3-cp312-cp312-win_arm64.whl", hash = "sha256:64350685ff08b1d3a6fff33f45a9ca183dc1d58bbfe4981604e70ec9801bbc26", size = 270330, upload-time = "2025-11-03T21:31:54.514Z" },
+]
+
+[[package]]
+name = "release-tag"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/18/c1d17d973f73f0aa7e2c45f852839ab909756e1bd9727d03babe400fcef0/release_tag-0.4.3-py3-none-any.whl", hash = "sha256:4206f4fa97df930c8176bfee4d3976a7385150ed14b317bd6bae7101ac8b66dd", size = 1181112, upload-time = "2025-12-03T00:18:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c7/ecc443953840ac313856b2181f55eb8d34fa2c733cdd1edd0bcceee0938d/release_tag-0.4.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a347a9ad3d2af16e5367e52b451fbc88a0b7b666850758e8f9a601554a8fb13", size = 1170517, upload-time = "2025-12-03T00:18:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/2f6ffa0d87c792364ca9958433fe088c8acc3d096ac9734040049c6ad506/release_tag-0.4.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2d1603aa37d8e4f5df63676bbfddc802fbc108a744ba28288ad25c997981c164", size = 1101663, upload-time = "2025-12-03T00:18:15.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ed/9e4ebe400fc52e38dda6e6a45d9da9decd4535ab15e170b8d9b229a66730/release_tag-0.4.3-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6db7b81a198e3ba6a87496a554684912c13f9297ea8db8600a80f4f971709d37", size = 1079322, upload-time = "2025-12-03T00:18:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/64/9e0ce6119e091ef9211fa82b9593f564eeec8bdd86eff6a97fe6e2fcb20f/release_tag-0.4.3-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d79a9cf191dd2c29e1b3a35453fa364b08a7aadd15aeb2c556a7661c6cf4d5ad", size = 1181129, upload-time = "2025-12-03T00:18:15.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/09/d96acf18f0773b6355080a568ba48931faa9dbe91ab1abefc6f8c4df04a8/release_tag-0.4.3-py3-none-win_amd64.whl", hash = "sha256:3958b880375f2241d0cc2b9882363bf54b1d4d7ca8ffc6eecc63ab92f23307f0", size = 1260773, upload-time = "2025-12-03T00:18:14.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/da/ecb6346df1ffb0752fe213e25062f802c10df2948717f0d5f9816c2df914/release_tag-0.4.3-py3-none-win_arm64.whl", hash = "sha256:7d5b08000e6e398d46f05a50139031046348fba6d47909f01e468bb7600c19df", size = 1142155, upload-time = "2025-12-03T00:18:20.647Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a step to the deployment pipeline to assert the git tag is correct. That is to say, the previous stable tag is an ancestor, the version bump is continuous, and no larger tag is an ancestor.

**valid**
```
zxczxc - (v0.0.3)
asdasd - (v0.0.2)
qweqwe - (v0.0.1)
```

**valid**
```
foobar - (v0.0.3-cloud)
zxczxc - (v0.0.3)
asdasd - (v0.0.2)
qweqwe - (v0.0.1)
```

**invalid**
```
zxczxc - (v0.0.2)
asdasd - (v0.0.3)
qweqwe - (v0.0.1)
```

**invalid**
```
zxczxc - (v0.0.4)
asdasd - (v0.0.2)
qweqwe - (v0.0.1)
```
etc.

Generally, any tag generated with `uv run tag` would be an acceptable tag.

This is currently non-blocking but posts to #monitor-deployments on failure. We can change this if there's interest.

## How Has This Been Tested?



## Additional Options

- [x] [Optional] Override Linear Check




































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tag validation step to the deployment workflow to catch mis-tagged releases early, and sends a Slack alert if the check fails.

- **New Features**
  - Adds check-version-tag job to deployment.yml.
  - Installs release-tag and runs uv run --no-sync tag --check to verify tag ancestry and continuous version bump.
  - Adds a Slack notification job that alerts on tag check failure.

- **Dependencies**
  - Adds release-tag >=0.4.3 to dev dependencies.

<sup>Written for commit bf8b594a14ec5cc0e965296300be6967f00dcd07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



































