### PR TITLE
chore: [Running GitHub actions for #5782]

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -152,8 +152,6 @@ def validate_active_indexing_attempts(
     """
     logger.info("Validating active indexing attempts")
 
-    heartbeat_timeout_seconds = HEARTBEAT_TIMEOUT_SECONDS
-
     with get_session_with_current_tenant() as db_session:
 
         # Find all active indexing attempts
@@ -170,6 +168,9 @@ def validate_active_indexing_attempts(
 
         for attempt in active_attempts:
             lock_beat.reacquire()
+
+            # Initialize timeout for each attempt to prevent state pollution
+            heartbeat_timeout_seconds = HEARTBEAT_TIMEOUT_SECONDS
 
             # Double-check the attempt still exists and has the same status
             fresh_attempt = get_index_attempt(db_session, attempt.id)


### PR DESCRIPTION
Automated mirror of PR #5782 so private CI can run.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reinitializes the heartbeat timeout per indexing attempt to stop timeout state leaking between attempts. This restores timely detection of stalled jobs and reduces wasted worker time.

- **Bug Fixes**
  - Initialize heartbeat_timeout_seconds inside the validation loop (after lock_beat.reacquire()) so each attempt uses its own timeout.
  - Prevents a 12h timeout from carrying over; stalled attempts now time out at the intended 30m threshold.

<sup>Written for commit ad1f6b5f14683cd555dfc6fe7d2e368d6b2cb2a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

