### PR TITLE
feat(cleanup): No Bastion Setup

### DIFF
--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -1,0 +1,80 @@
+# Quick Start: Tenant Cleanup Without Bastion
+
+## TL;DR - The Commands You Need
+
+```bash
+# Navigate to backend directory
+cd onyx/backend
+
+# Step 1: Generate CSV of tenants to clean (5-10 min)
+PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_analyze_tenants.py
+
+# Step 2: Mark connectors for deletion (1-2 min)
+PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py \
+  --csv gated_tenants_no_query_3mo_*.csv \
+  --force \
+  --concurrency 16
+
+# ⏰ WAIT 6+ hours for background deletion to complete
+
+# Step 3: Final cleanup (1-2 min)
+PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py \
+  --csv gated_tenants_no_query_3mo_*.csv \
+  --force
+```
+
+## What Changed?
+
+Instead of the original scripts that require bastion access:
+- `analyze_current_tenants.py` → `no_bastion_analyze_tenants.py`
+- `mark_connectors_for_deletion.py` → `no_bastion_mark_connectors.py`
+- `cleanup_tenants.py` → `no_bastion_cleanup_tenants.py`
+
+**No environment variables needed!** All queries run directly from pods.
+
+## What You Need
+
+✅ `kubectl` access to your cluster
+✅ Running `celery-worker-user-file-processing` pods
+✅ Permission to exec into pods
+
+❌ No bastion host required
+❌ No SSH keys required
+❌ No environment variables required
+
+## Test Your Setup
+
+```bash
+# Check if you can find worker pods
+kubectl get po | grep celery-worker-user-file-processing | grep Running
+
+# If you see pods, you're ready to go!
+```
+
+## Important Notes
+
+1. **Step 2 triggers background deletion** - the actual document deletion happens asynchronously via Celery workers
+2. **You MUST wait** between Step 2 and Step 3 for deletion to complete (can take 6+ hours)
+3. **Monitor deletion progress** with: `kubectl logs -f <celery-worker-pod>`
+4. **All scripts verify tenant status** - they'll refuse to process active (non-GATED_ACCESS) tenants
+
+## Files Generated
+
+- `gated_tenants_no_query_3mo_YYYYMMDD_HHMMSS.csv` - List of tenants to clean
+- `cleaned_tenants.csv` - Successfully cleaned tenants with timestamps
+
+## Safety First
+
+The scripts include multiple safety checks:
+- ✅ Verifies tenant status before any operation
+- ✅ Checks documents are deleted before dropping schemas
+- ✅ Prompts for confirmation on dangerous operations (unless `--force`)
+- ✅ Records all successful operations in real-time
+
+## Need More Details?
+
+See [NO_BASTION_README.md](./NO_BASTION_README.md) for:
+- Detailed explanations of each step
+- Troubleshooting guide
+- How it works under the hood
+- Performance characteristics

--- a/backend/scripts/tenant_cleanup/check_no_bastion_setup.py
+++ b/backend/scripts/tenant_cleanup/check_no_bastion_setup.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Verification script to check if your environment is ready for no-bastion tenant cleanup.
+
+Usage:
+    python scripts/tenant_cleanup/check_no_bastion_setup.py
+"""
+
+import subprocess
+import sys
+
+
+def print_header(text: str) -> None:
+    """Print a formatted header."""
+    print(f"\n{'=' * 80}")
+    print(f"  {text}")
+    print(f"{'=' * 80}\n")
+
+
+def check_kubectl_access() -> bool:
+    """Check if kubectl is installed and can access the cluster."""
+    print("Checking kubectl access...")
+
+    try:
+        result = subprocess.run(
+            ["kubectl", "version", "--client", "--short"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode == 0:
+            print(f"✅ kubectl is installed: {result.stdout.strip()}")
+
+            # Try to access cluster
+            result = subprocess.run(
+                ["kubectl", "get", "ns"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode == 0:
+                print("✅ kubectl can access the cluster")
+                return True
+            else:
+                print("❌ kubectl cannot access the cluster")
+                print(f"   Error: {result.stderr}")
+                return False
+        else:
+            print("❌ kubectl is not installed or not in PATH")
+            return False
+
+    except FileNotFoundError:
+        print("❌ kubectl is not installed")
+        return False
+    except subprocess.TimeoutExpired:
+        print("❌ kubectl command timed out")
+        return False
+    except Exception as e:
+        print(f"❌ Error checking kubectl: {e}")
+        return False
+
+
+def check_worker_pods() -> tuple[bool, list[str]]:
+    """Check if worker pods are running."""
+    print("\nChecking for worker pods...")
+
+    try:
+        result = subprocess.run(
+            ["kubectl", "get", "po"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+
+        lines = result.stdout.strip().split("\n")
+        worker_pods = []
+
+        for line in lines[1:]:  # Skip header
+            if "celery-worker-user-file-processing" in line and "Running" in line:
+                pod_name = line.split()[0]
+                worker_pods.append(pod_name)
+
+        if worker_pods:
+            print(f"✅ Found {len(worker_pods)} running worker pod(s):")
+            for pod in worker_pods[:3]:  # Show first 3
+                print(f"   - {pod}")
+            if len(worker_pods) > 3:
+                print(f"   ... and {len(worker_pods) - 3} more")
+            return True, worker_pods
+        else:
+            print("❌ No running celery-worker-user-file-processing pods found")
+            print("   Available pods:")
+            for line in lines[1:6]:  # Show first 5 pods
+                print(f"   {line}")
+            return False, []
+
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Error getting pods: {e}")
+        return False, []
+    except Exception as e:
+        print(f"❌ Error checking worker pods: {e}")
+        return False, []
+
+
+def check_pod_exec_permission(pod_name: str) -> bool:
+    """Check if we can exec into a pod."""
+    print("\nChecking pod exec permissions...")
+
+    try:
+        result = subprocess.run(
+            ["kubectl", "exec", pod_name, "--", "echo", "test"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        if result.returncode == 0 and "test" in result.stdout:
+            print(f"✅ Can exec into pod: {pod_name}")
+            return True
+        else:
+            print(f"❌ Cannot exec into pod: {pod_name}")
+            print(f"   Error: {result.stderr}")
+            return False
+
+    except subprocess.TimeoutExpired:
+        print(f"❌ Exec command timed out for pod: {pod_name}")
+        return False
+    except Exception as e:
+        print(f"❌ Error checking exec permission: {e}")
+        return False
+
+
+def check_pod_db_access(pod_name: str) -> dict:
+    """Check if pod has database environment variables."""
+    print("\nChecking database access from pod...")
+
+    checks = {
+        "control_plane": False,
+        "data_plane": False,
+    }
+
+    try:
+        # Check for control plane DB env vars
+        result = subprocess.run(
+            ["kubectl", "exec", pod_name, "--", "env"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        if result.returncode == 0:
+            env_output = result.stdout
+
+            # Check control plane access
+            if any(
+                var in env_output
+                for var in [
+                    "POSTGRES_CONTROL_URI",
+                    "POSTGRES_CONTROL_HOST",
+                ]
+            ):
+                print("✅ Pod has control plane database environment variables")
+                checks["control_plane"] = True
+            else:
+                print(
+                    "⚠️  Pod may not have control plane database environment variables"
+                )
+                print("   (This might be okay if they're dynamically loaded)")
+
+            # Check data plane access
+            if any(
+                var in env_output
+                for var in ["POSTGRES_URI", "POSTGRES_HOST", "DATABASE_URL"]
+            ):
+                print("✅ Pod has data plane database environment variables")
+                checks["data_plane"] = True
+            else:
+                print("❌ Pod does not have data plane database environment variables")
+
+        return checks
+
+    except Exception as e:
+        print(f"❌ Error checking database access: {e}")
+        return checks
+
+
+def check_required_scripts() -> bool:
+    """Check if the required on_pod_scripts exist."""
+    print("\nChecking for required scripts...")
+
+    from pathlib import Path
+
+    script_dir = Path(__file__).parent
+    required_scripts = [
+        "on_pod_scripts/understand_tenants.py",
+        "on_pod_scripts/execute_connector_deletion.py",
+        "on_pod_scripts/check_documents_deleted.py",
+        "on_pod_scripts/cleanup_tenant_schema.py",
+        "on_pod_scripts/get_tenant_index_name.py",
+        "on_pod_scripts/get_tenant_users.py",
+    ]
+
+    all_exist = True
+    for script in required_scripts:
+        script_path = script_dir / script
+        if script_path.exists():
+            print(f"✅ {script}")
+        else:
+            print(f"❌ {script} - NOT FOUND")
+            all_exist = False
+
+    return all_exist
+
+
+def main() -> None:
+    print_header("No-Bastion Tenant Cleanup - Setup Verification")
+
+    all_checks_passed = True
+
+    # 1. Check kubectl access
+    if not check_kubectl_access():
+        all_checks_passed = False
+
+    # 2. Check for worker pods
+    has_pods, worker_pods = check_worker_pods()
+    if not has_pods:
+        all_checks_passed = False
+        print("\n⚠️  Cannot proceed without running worker pods")
+        print_header("SETUP VERIFICATION FAILED")
+        sys.exit(1)
+
+    # Use first worker pod for remaining checks
+    test_pod = worker_pods[0]
+
+    # 3. Check exec permissions
+    if not check_pod_exec_permission(test_pod):
+        all_checks_passed = False
+
+    # 4. Check database access
+    db_checks = check_pod_db_access(test_pod)
+    if not db_checks["data_plane"]:
+        all_checks_passed = False
+
+    # 5. Check required scripts
+    if not check_required_scripts():
+        all_checks_passed = False
+
+    # Summary
+    print_header("VERIFICATION SUMMARY")
+
+    if all_checks_passed and db_checks["control_plane"]:
+        print("✅ ALL CHECKS PASSED!")
+        print("\nYou're ready to run tenant cleanup without bastion access.")
+        print("\nNext steps:")
+        print("1. Read QUICK_START_NO_BASTION.md for commands")
+        print(
+            "2. Run: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_analyze_tenants.py"
+        )
+        sys.exit(0)
+    elif all_checks_passed:
+        print("⚠️  MOSTLY READY (with warnings)")
+        print("\nYou can proceed, but control plane access may need verification.")
+        print("Try running Step 1 and see if it works.")
+        print("\nNext steps:")
+        print(
+            "1. Run: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_analyze_tenants.py"
+        )
+        print("2. If it fails with DB errors, check pod environment variables")
+        sys.exit(0)
+    else:
+        print("❌ SETUP VERIFICATION FAILED")
+        print("\nPlease fix the issues above before proceeding.")
+        print("\nCommon fixes:")
+        print("- Install kubectl: https://kubernetes.io/docs/tasks/tools/")
+        print("- Configure cluster access: kubectl config use-context <context>")
+        print("- Check pod status: kubectl get po")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/tenant_cleanup/no_bastion_analyze_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_analyze_tenants.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""
+Tenant analysis script that works WITHOUT bastion access.
+Control plane and data plane are in SEPARATE clusters.
+
+Usage:
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_analyze_tenants.py \
+        [--skip-cache] \
+        [--data-plane-context <context>] \
+        [--control-plane-context <context>]
+"""
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_background_pod
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_worker_pod
+
+
+def collect_tenant_data(
+    pod_name: str, context: str | None = None
+) -> list[dict[str, Any]]:
+    """Run the understand_tenants script on the data plane pod."""
+    print(f"\nCollecting tenant data from data plane pod {pod_name}...")
+
+    # Get the path to the understand_tenants script
+    script_dir = Path(__file__).parent
+    understand_tenants_script = script_dir / "on_pod_scripts" / "understand_tenants.py"
+
+    if not understand_tenants_script.exists():
+        raise FileNotFoundError(
+            f"understand_tenants.py not found at {understand_tenants_script}"
+        )
+
+    # Copy script to pod
+    print("Copying script to pod...")
+    cmd_cp = [
+        "kubectl",
+        "cp",
+        str(understand_tenants_script),
+        f"{pod_name}:/tmp/understand_tenants.py",
+    ]
+    if context:
+        cmd_cp.extend(["--context", context])
+
+    subprocess.run(cmd_cp, check=True, capture_output=True)
+
+    # Execute script on pod
+    print("Executing script on pod (this may take a while)...")
+    cmd_exec = ["kubectl", "exec", pod_name]
+    if context:
+        cmd_exec.extend(["--context", context])
+    cmd_exec.extend(["--", "python", "/tmp/understand_tenants.py"])
+
+    result = subprocess.run(cmd_exec, capture_output=True, text=True, check=True)
+
+    # Show progress messages from stderr
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    # Parse JSON from stdout
+    try:
+        tenant_data = json.loads(result.stdout)
+        print(f"Successfully collected data for {len(tenant_data)} tenants")
+        return tenant_data
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON output: {e}", file=sys.stderr)
+        print(f"stdout: {result.stdout[:500]}", file=sys.stderr)
+        raise
+
+
+def collect_control_plane_data_from_pod(
+    pod_name: str, context: str | None = None
+) -> list[dict[str, Any]]:
+    """Collect control plane data by running a query on a control plane pod."""
+    print(f"\nCollecting control plane data from pod {pod_name}...")
+
+    # Create a script to query the control plane database
+    query_script = """
+import json
+import os
+from sqlalchemy import create_engine, text
+
+# Try to get database URL from various environment patterns
+control_db_url = None
+
+# Pattern 1: POSTGRES_CONTROL_* variables
+if os.environ.get("POSTGRES_CONTROL_HOST"):
+    host = os.environ.get("POSTGRES_CONTROL_HOST")
+    port = os.environ.get("POSTGRES_CONTROL_PORT", "5432")
+    db = os.environ.get("POSTGRES_CONTROL_DB", "control")
+    user = os.environ.get("POSTGRES_CONTROL_USER", "postgres")
+    password = os.environ.get("POSTGRES_CONTROL_PASSWORD", "")
+    if password:
+        control_db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+# Pattern 2: Standard POSTGRES_* variables (in control plane cluster)
+if not control_db_url and os.environ.get("POSTGRES_HOST"):
+    host = os.environ.get("POSTGRES_HOST")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    db = os.environ.get("POSTGRES_DB", "danswer")
+    user = os.environ.get("POSTGRES_USER", "postgres")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+    if password:
+        control_db_url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+if not control_db_url:
+    raise ValueError("Cannot determine control plane database connection")
+
+engine = create_engine(control_db_url)
+
+with engine.connect() as conn:
+    result = conn.execute(
+        text(
+            "SELECT tenant_id, stripe_customer_id, created_at, active_seats, "
+            "creator_email, referral_source, application_status FROM tenant"
+        )
+    )
+    rows = [dict(row._mapping) for row in result]
+    print(json.dumps(rows, default=str))
+"""
+
+    # Write the script to a temp file
+    script_path = "/tmp/query_control_plane.py"
+
+    print("  Creating control plane query script on pod...")
+    cmd_write = ["kubectl", "exec", pod_name]
+    if context:
+        cmd_write.extend(["--context", context])
+    cmd_write.extend(
+        ["--", "bash", "-c", f"cat > {script_path} << 'EOF'\n{query_script}\nEOF"]
+    )
+
+    subprocess.run(cmd_write, check=True, capture_output=True)
+
+    # Execute the script on the pod
+    print("  Executing control plane query on pod...")
+    cmd_exec = ["kubectl", "exec", pod_name]
+    if context:
+        cmd_exec.extend(["--context", context])
+    cmd_exec.extend(["--", "python", script_path])
+
+    result = subprocess.run(cmd_exec, capture_output=True, text=True, check=True)
+
+    # Parse JSON output
+    try:
+        control_plane_data = json.loads(result.stdout)
+        print(
+            f"✓ Successfully collected {len(control_plane_data)} tenant records from control plane"
+        )
+        return control_plane_data
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON output: {e}", file=sys.stderr)
+        print(f"stdout: {result.stdout[:500]}", file=sys.stderr)
+        raise
+
+
+def analyze_tenants(
+    tenants: list[dict[str, Any]], control_plane_data: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Analyze tenant activity data and return gated tenants with no query in last 3 months."""
+
+    print(f"\n{'=' * 80}")
+    print(f"TENANT ANALYSIS REPORT - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"{'=' * 80}")
+    print(f"Total tenants analyzed: {len(tenants)}\n")
+
+    # Create a lookup dict for control plane data by tenant_id
+    control_plane_lookup = {}
+    for row in control_plane_data:
+        tenant_id = row.get("tenant_id")
+        tenant_status = row.get("application_status")
+        if tenant_id:
+            control_plane_lookup[tenant_id] = tenant_status
+
+    # Calculate cutoff dates
+    one_month_cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+    three_month_cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+
+    # Categorize tenants into 4 groups
+    gated_no_query_3_months = []  # GATED_ACCESS + no query in last 3 months
+    gated_query_1_3_months = []  # GATED_ACCESS + query between 1-3 months
+    gated_query_1_month = []  # GATED_ACCESS + query in last 1 month
+    everyone_else = []  # All other tenants
+
+    for tenant in tenants:
+        tenant_id = tenant.get("tenant_id")
+        last_query_time = tenant.get("last_query_time")
+        tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
+
+        is_gated = tenant_status == "GATED_ACCESS"
+
+        # Parse last query time
+        if last_query_time:
+            query_time = datetime.fromisoformat(last_query_time.replace("Z", "+00:00"))
+        else:
+            query_time = None
+
+        # Categorize
+        if is_gated:
+            if query_time is None or query_time <= three_month_cutoff:
+                gated_no_query_3_months.append(tenant)
+            elif query_time <= one_month_cutoff:
+                gated_query_1_3_months.append(tenant)
+            else:  # query_time > one_month_cutoff
+                gated_query_1_month.append(tenant)
+        else:
+            everyone_else.append(tenant)
+
+    # Calculate document counts for each group
+    gated_no_query_docs = sum(
+        t.get("num_documents", 0) for t in gated_no_query_3_months
+    )
+    gated_1_3_month_docs = sum(
+        t.get("num_documents", 0) for t in gated_query_1_3_months
+    )
+    gated_1_month_docs = sum(t.get("num_documents", 0) for t in gated_query_1_month)
+    everyone_else_docs = sum(t.get("num_documents", 0) for t in everyone_else)
+
+    print("=" * 80)
+    print("TENANT CATEGORIZATION BY GATED ACCESS STATUS AND ACTIVITY")
+    print("=" * 80)
+
+    print("\n1. GATED_ACCESS + No query in last 3 months:")
+    print(f"   Count: {len(gated_no_query_3_months):,}")
+    print(f"   Total documents: {gated_no_query_docs:,}")
+    print(
+        f"   Avg documents per tenant: {gated_no_query_docs / len(gated_no_query_3_months) if gated_no_query_3_months else 0:.2f}"
+    )
+
+    print("\n2. GATED_ACCESS + Query between 1-3 months ago:")
+    print(f"   Count: {len(gated_query_1_3_months):,}")
+    print(f"   Total documents: {gated_1_3_month_docs:,}")
+    print(
+        f"   Avg documents per tenant: {gated_1_3_month_docs / len(gated_query_1_3_months) if gated_query_1_3_months else 0:.2f}"
+    )
+
+    print("\n3. GATED_ACCESS + Query in last 1 month:")
+    print(f"   Count: {len(gated_query_1_month):,}")
+    print(f"   Total documents: {gated_1_month_docs:,}")
+    print(
+        f"   Avg documents per tenant: {gated_1_month_docs / len(gated_query_1_month) if gated_query_1_month else 0:.2f}"
+    )
+
+    print("\n4. Everyone else (non-GATED_ACCESS):")
+    print(f"   Count: {len(everyone_else):,}")
+    print(f"   Total documents: {everyone_else_docs:,}")
+    print(
+        f"   Avg documents per tenant: {everyone_else_docs / len(everyone_else) if everyone_else else 0:.2f}"
+    )
+
+    total_docs = (
+        gated_no_query_docs
+        + gated_1_3_month_docs
+        + gated_1_month_docs
+        + everyone_else_docs
+    )
+    print(f"\nTotal documents across all tenants: {total_docs:,}")
+
+    # Top 100 tenants by document count
+    print("\n" + "=" * 80)
+    print("TOP 100 TENANTS BY DOCUMENT COUNT")
+    print("=" * 80)
+
+    # Sort all tenants by document count
+    sorted_tenants = sorted(
+        tenants, key=lambda t: t.get("num_documents", 0), reverse=True
+    )
+
+    top_100 = sorted_tenants[:100]
+
+    print(
+        f"\n{'Rank':<6} {'Tenant ID':<45} {'Documents':>12} {'Users':>8} {'Last Query':<12} {'Group'}"
+    )
+    print("-" * 130)
+
+    for idx, tenant in enumerate(top_100, 1):
+        tenant_id = tenant.get("tenant_id", "Unknown")
+        num_docs = tenant.get("num_documents", 0)
+        num_users = tenant.get("num_users", 0)
+        last_query = tenant.get("last_query_time", "Never")
+        tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
+
+        # Format the last query time
+        if last_query and last_query != "Never":
+            try:
+                query_dt = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
+                last_query_str = query_dt.strftime("%Y-%m-%d")
+            except Exception:
+                last_query_str = last_query[:10] if len(last_query) > 10 else last_query
+        else:
+            last_query_str = "Never"
+
+        # Determine group
+        if tenant_status == "GATED_ACCESS":
+            if last_query and last_query != "Never":
+                query_time = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
+                if query_time <= three_month_cutoff:
+                    group = "Gated - No query (3mo)"
+                elif query_time <= one_month_cutoff:
+                    group = "Gated - Query (1-3mo)"
+                else:
+                    group = "Gated - Query (1mo)"
+            else:
+                group = "Gated - No query (3mo)"
+        else:
+            group = f"Other ({tenant_status})"
+
+        print(
+            f"{idx:<6} {tenant_id:<45} {num_docs:>12,} {num_users:>8} {last_query_str:<12} {group}"
+        )
+
+    # Summary stats for top 100
+    top_100_docs = sum(t.get("num_documents", 0) for t in top_100)
+
+    print("\n" + "-" * 110)
+    print(f"Top 100 total documents: {top_100_docs:,}")
+    print(
+        f"Percentage of all documents: {(top_100_docs / total_docs * 100) if total_docs > 0 else 0:.2f}%"
+    )
+
+    # Additional insights
+    print("\n" + "=" * 80)
+    print("ADDITIONAL INSIGHTS")
+    print("=" * 80)
+
+    # Tenants with no documents
+    no_docs = [t for t in tenants if t.get("num_documents", 0) == 0]
+    print(
+        f"\nTenants with 0 documents: {len(no_docs):,} ({len(no_docs) / len(tenants) * 100:.2f}%)"
+    )
+
+    # Tenants with no users
+    no_users = [t for t in tenants if t.get("num_users", 0) == 0]
+    print(
+        f"Tenants with 0 users: {len(no_users):,} ({len(no_users) / len(tenants) * 100:.2f}%)"
+    )
+
+    # Document distribution quartiles
+    doc_counts = sorted([t.get("num_documents", 0) for t in tenants])
+    if doc_counts:
+        print("\nDocument count distribution:")
+        print(f"  Median: {doc_counts[len(doc_counts) // 2]:,}")
+        print(f"  75th percentile: {doc_counts[int(len(doc_counts) * 0.75)]:,}")
+        print(f"  90th percentile: {doc_counts[int(len(doc_counts) * 0.90)]:,}")
+        print(f"  95th percentile: {doc_counts[int(len(doc_counts) * 0.95)]:,}")
+        print(f"  99th percentile: {doc_counts[int(len(doc_counts) * 0.99)]:,}")
+        print(f"  Max: {doc_counts[-1]:,}")
+
+    return gated_no_query_3_months
+
+
+def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Find the most recent tenant data file if it's less than 7 days old."""
+    current_dir = Path.cwd()
+    tenant_data_files = list(current_dir.glob("tenant_data_*.json"))
+
+    if not tenant_data_files:
+        return None, None
+
+    # Sort by modification time, most recent first
+    tenant_data_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    most_recent = tenant_data_files[0]
+
+    # Check if file is less than 7 days old
+    file_age = datetime.now().timestamp() - most_recent.stat().st_mtime
+    seven_days_in_seconds = 7 * 24 * 60 * 60
+
+    if file_age < seven_days_in_seconds:
+        file_age_days = file_age / (24 * 60 * 60)
+        print(
+            f"\n✓ Found recent tenant data: {most_recent.name} (age: {file_age_days:.1f} days)"
+        )
+
+        with open(most_recent, "r") as f:
+            tenant_data = json.load(f)
+
+        return tenant_data, str(most_recent)
+
+    return None, None
+
+
+def main() -> None:
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Analyze tenant data WITHOUT bastion access - control plane and data plane are separate clusters"
+    )
+    parser.add_argument(
+        "--skip-cache",
+        action="store_true",
+        help="Skip cached tenant data and collect fresh data from pod",
+    )
+    parser.add_argument(
+        "--data-plane-context",
+        type=str,
+        help="Kubectl context for data plane cluster (optional)",
+    )
+    parser.add_argument(
+        "--control-plane-context",
+        type=str,
+        help="Kubectl context for control plane cluster (optional)",
+    )
+    args = parser.parse_args()
+
+    try:
+        # Step 1: Check for recent tenant data (< 7 days old) unless --skip-cache is set
+        tenant_data = None
+        cached_file = None
+
+        if not args.skip_cache:
+            tenant_data, cached_file = find_recent_tenant_data()
+
+        if tenant_data:
+            print(f"Using cached tenant data from: {cached_file}")
+            print(f"Total tenants in cache: {len(tenant_data)}")
+        else:
+            if args.skip_cache:
+                print("\n⚠ Skipping cache (--skip-cache flag set)")
+
+            # Find data plane worker pod
+            print("\n" + "=" * 80)
+            print("CONNECTING TO DATA PLANE CLUSTER")
+            print("=" * 80)
+            data_plane_pod = find_worker_pod(args.data_plane_context)
+
+            # Collect tenant data from data plane
+            tenant_data = collect_tenant_data(data_plane_pod, args.data_plane_context)
+
+            # Save raw data to file with timestamp
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_file = f"tenant_data_{timestamp}.json"
+            with open(output_file, "w") as f:
+                json.dump(tenant_data, f, indent=2, default=str)
+            print(f"\n✓ Raw data saved to: {output_file}")
+
+        # Step 2: Collect control plane data from control plane cluster
+        print("\n" + "=" * 80)
+        print("CONNECTING TO CONTROL PLANE CLUSTER")
+        print("=" * 80)
+        control_plane_pod = find_background_pod(args.control_plane_context)
+        control_plane_data = collect_control_plane_data_from_pod(
+            control_plane_pod, args.control_plane_context
+        )
+
+        # Step 3: Analyze the data and get gated tenants without recent queries
+        gated_no_query_3_months = analyze_tenants(tenant_data, control_plane_data)
+
+        # Step 4: Export to CSV (sorted by num_documents descending)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        csv_file = f"gated_tenants_no_query_3mo_{timestamp}.csv"
+
+        # Sort by num_documents in descending order
+        sorted_tenants = sorted(
+            gated_no_query_3_months,
+            key=lambda t: t.get("num_documents", 0),
+            reverse=True,
+        )
+
+        with open(csv_file, "w", newline="", encoding="utf-8") as csvfile:
+            fieldnames = [
+                "tenant_id",
+                "num_documents",
+                "num_users",
+                "last_query_time",
+                "days_since_last_query",
+            ]
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+
+            now = datetime.now(timezone.utc)
+            for tenant in sorted_tenants:
+                # Calculate days since last query
+                last_query_time = tenant.get("last_query_time")
+                if last_query_time:
+                    try:
+                        query_dt = datetime.fromisoformat(
+                            last_query_time.replace("Z", "+00:00")
+                        )
+                        days_since = str((now - query_dt).days)
+                    except Exception:
+                        days_since = "N/A"
+                else:
+                    days_since = "Never"
+
+                writer.writerow(
+                    {
+                        "tenant_id": tenant.get("tenant_id", ""),
+                        "num_documents": tenant.get("num_documents", 0),
+                        "num_users": tenant.get("num_users", 0),
+                        "last_query_time": last_query_time or "Never",
+                        "days_since_last_query": days_since,
+                    }
+                )
+
+        print(f"\n✓ CSV exported to: {csv_file}")
+        print(
+            f"  Total gated tenants with no query in last 3 months: {len(gated_no_query_3_months)}"
+        )
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command: {e}", file=sys.stderr)
+        if e.stderr:
+            print(f"stderr: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -1,0 +1,870 @@
+#!/usr/bin/env python3
+"""
+Tenant cleanup script that works WITHOUT bastion access.
+All queries run directly from pods.
+Supports two-cluster architecture (data plane and control plane in separate clusters).
+
+Usage:
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py <tenant_id> [--force]
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> [--force]
+
+    With explicit contexts:
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> \
+        --data-plane-context <context> --control-plane-context <context> [--force]
+"""
+
+import csv
+import json
+import signal
+import subprocess
+import sys
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import confirm_step
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import execute_control_plane_delete
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_background_pod
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_worker_pod
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import get_tenant_status
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import read_tenant_ids_from_csv
+
+# Global lock for thread-safe operations
+_print_lock: Lock = Lock()
+_csv_lock: Lock = Lock()
+
+
+def signal_handler(signum: int, frame: object) -> None:
+    """Handle termination signals by killing active subprocess."""
+    sys.exit(1)
+
+
+def setup_scripts_on_pod(pod_name: str, context: str | None = None) -> None:
+    """Copy all required scripts to the pod once at the beginning.
+
+    Args:
+        pod_name: Pod to copy scripts to
+        context: Optional kubectl context
+    """
+    print("Setting up scripts on pod (one-time operation)...")
+
+    script_dir = Path(__file__).parent
+    scripts_to_copy = [
+        (
+            "on_pod_scripts/check_documents_deleted.py",
+            "/tmp/check_documents_deleted.py",
+        ),
+        ("on_pod_scripts/cleanup_tenant_schema.py", "/tmp/cleanup_tenant_schema.py"),
+        ("on_pod_scripts/get_tenant_users.py", "/tmp/get_tenant_users.py"),
+        ("on_pod_scripts/get_tenant_index_name.py", "/tmp/get_tenant_index_name.py"),
+    ]
+
+    for local_path, remote_path in scripts_to_copy:
+        local_file = script_dir / local_path
+        if not local_file.exists():
+            raise FileNotFoundError(f"Script not found: {local_file}")
+
+        cmd_cp = ["kubectl", "cp"]
+        if context:
+            cmd_cp.extend(["--context", context])
+        cmd_cp.extend([str(local_file), f"{pod_name}:{remote_path}"])
+
+        subprocess.run(cmd_cp, check=True, capture_output=True)
+
+    print("✓ All scripts copied to pod")
+
+
+def get_tenant_index_name(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> str:
+    """Get the default index name for the given tenant by running script on pod.
+
+    Args:
+        pod_name: Data plane pod to execute on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for data plane cluster
+    """
+    print(f"Getting default index name for tenant: {tenant_id}")
+
+    # Get the path to the script
+    script_dir = Path(__file__).parent
+    index_name_script = script_dir / "on_pod_scripts" / "get_tenant_index_name.py"
+
+    if not index_name_script.exists():
+        raise FileNotFoundError(
+            f"get_tenant_index_name.py not found at {index_name_script}"
+        )
+
+    try:
+        # Copy script to pod
+        print("  Copying script to pod...")
+        cmd_cp = ["kubectl", "cp"]
+        if context:
+            cmd_cp.extend(["--context", context])
+        cmd_cp.extend(
+            [
+                str(index_name_script),
+                f"{pod_name}:/tmp/get_tenant_index_name.py",
+            ]
+        )
+
+        subprocess.run(
+            cmd_cp,
+            check=True,
+            capture_output=True,
+        )
+
+        # Execute script on pod
+        print("  Executing script on pod...")
+        cmd_exec = ["kubectl", "exec"]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(
+            [
+                pod_name,
+                "--",
+                "python",
+                "/tmp/get_tenant_index_name.py",
+                tenant_id,
+            ]
+        )
+
+        result = subprocess.run(
+            cmd_exec,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Show progress messages from stderr
+        if result.stderr:
+            print(f"  {result.stderr}", end="")
+
+        # Parse JSON result from stdout
+        result_data = json.loads(result.stdout)
+        status = result_data.get("status")
+
+        if status == "success":
+            index_name = result_data.get("index_name")
+            print(f"✓ Found index name: {index_name}")
+            return index_name
+        else:
+            message = result_data.get("message", "Unknown error")
+            raise RuntimeError(f"Failed to get index name: {message}")
+
+    except subprocess.CalledProcessError as e:
+        print(
+            f"✗ Failed to get index name for tenant {tenant_id}: {e}", file=sys.stderr
+        )
+        if e.stderr:
+            print(f"  Error details: {e.stderr}", file=sys.stderr)
+        raise
+    except Exception as e:
+        print(
+            f"✗ Failed to get index name for tenant {tenant_id}: {e}", file=sys.stderr
+        )
+        raise
+
+
+def get_tenant_users(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> list[str]:
+    """Get list of user emails from the tenant's data plane schema.
+
+    Args:
+        pod_name: Data plane pod to execute on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for data plane cluster
+    """
+    # Script is already on pod from setup_scripts_on_pod()
+    try:
+        # Execute script on pod
+        cmd_exec = ["kubectl", "exec"]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(
+            [
+                pod_name,
+                "--",
+                "python",
+                "/tmp/get_tenant_users.py",
+                tenant_id,
+            ]
+        )
+
+        result = subprocess.run(
+            cmd_exec,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Show progress messages from stderr
+        if result.stderr:
+            print(f"  {result.stderr}", end="")
+
+        # Parse JSON result from stdout
+        result_data = json.loads(result.stdout)
+        status = result_data.get("status")
+
+        if status == "success":
+            users = result_data.get("users", [])
+            if users:
+                print(f"✓ Found {len(users)} user(s):")
+                for email in users:
+                    print(f"    - {email}")
+            else:
+                print("  No users found in tenant")
+            return users
+        else:
+            message = result_data.get("message", "Unknown error")
+            print(f"⚠ Could not fetch users: {message}")
+            return []
+
+    except subprocess.CalledProcessError as e:
+        print(f"⚠ Failed to get users for tenant {tenant_id}: {e}")
+        if e.stderr:
+            print(f"  Error details: {e.stderr}")
+        return []
+    except Exception as e:
+        print(f"⚠ Failed to get users for tenant {tenant_id}: {e}")
+        return []
+
+
+def check_documents_deleted(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> None:
+    """Check if all documents and connector credential pairs have been deleted.
+
+    Args:
+        pod_name: Data plane pod to execute on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for data plane cluster
+    """
+    # Script is already on pod from setup_scripts_on_pod()
+    try:
+        # Execute script on pod
+        cmd_exec = ["kubectl", "exec"]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(
+            [
+                pod_name,
+                "--",
+                "python",
+                "/tmp/check_documents_deleted.py",
+                tenant_id,
+            ]
+        )
+
+        result = subprocess.run(
+            cmd_exec,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Show progress messages from stderr
+        if result.stderr:
+            print(f"  {result.stderr}", end="")
+
+        # Parse JSON result from stdout
+        result_data = json.loads(result.stdout)
+        status = result_data.get("status")
+
+        if status == "success":
+            message = result_data.get("message")
+            print(f"✓ {message}")
+        elif status == "not_found":
+            message = result_data.get("message", "Schema not found")
+            print(f"⚠ {message}")
+        else:
+            message = result_data.get("message", "Unknown error")
+            cc_count = result_data.get("connector_credential_pair_count", 0)
+            doc_count = result_data.get("document_count", 0)
+            error_details = f"{message}"
+            if cc_count > 0 or doc_count > 0:
+                error_details += f"\n  ConnectorCredentialPairs: {cc_count}\n  Documents: {doc_count}"
+            raise RuntimeError(error_details)
+
+    except subprocess.CalledProcessError as e:
+        print(
+            f"✗ Failed to check documents for tenant {tenant_id}: {e}",
+            file=sys.stderr,
+        )
+        if e.stderr:
+            print(f"  Error details: {e.stderr}", file=sys.stderr)
+        raise
+    except Exception as e:
+        print(
+            f"✗ Failed to check documents for tenant {tenant_id}: {e}",
+            file=sys.stderr,
+        )
+        raise
+
+
+def drop_data_plane_schema(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> None:
+    """Drop the PostgreSQL schema for the given tenant by running script on pod.
+
+    Args:
+        pod_name: Data plane pod to execute on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for data plane cluster
+    """
+    # Script is already on pod from setup_scripts_on_pod()
+    try:
+        # Execute script on pod
+        cmd_exec = ["kubectl", "exec"]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(
+            [
+                pod_name,
+                "--",
+                "python",
+                "/tmp/cleanup_tenant_schema.py",
+                tenant_id,
+            ]
+        )
+
+        result = subprocess.run(
+            cmd_exec,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Show progress messages from stderr
+        if result.stderr:
+            print(f"  {result.stderr}", end="")
+
+        # Parse JSON result from stdout
+        result_data = json.loads(result.stdout)
+        status = result_data.get("status")
+        message = result_data.get("message")
+
+        if status == "success":
+            print(f"✓ {message}")
+        elif status == "not_found":
+            print(f"⚠ {message}")
+        else:
+            print(f"✗ {message}", file=sys.stderr)
+            raise RuntimeError(message)
+
+    except subprocess.CalledProcessError as e:
+        print(f"✗ Failed to drop schema for tenant {tenant_id}: {e}", file=sys.stderr)
+        if e.stderr:
+            print(f"  Error details: {e.stderr}", file=sys.stderr)
+        raise
+    except Exception as e:
+        print(f"✗ Failed to drop schema for tenant {tenant_id}: {e}", file=sys.stderr)
+        raise
+
+
+def cleanup_control_plane(
+    pod_name: str, tenant_id: str, context: str | None = None, force: bool = False
+) -> None:
+    """Clean up control plane data via pod queries.
+
+    Args:
+        pod_name: Control plane pod to execute on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for control plane cluster
+        force: Skip confirmations if True
+    """
+    print(f"Cleaning up control plane data for tenant: {tenant_id}")
+
+    # Delete in order respecting foreign key constraints
+    delete_queries = [
+        (
+            "tenant_notification",
+            f"DELETE FROM tenant_notification WHERE tenant_id = '{tenant_id}'",
+        ),
+        ("tenant_config", f"DELETE FROM tenant_config WHERE tenant_id = '{tenant_id}'"),
+        ("subscription", f"DELETE FROM subscription WHERE tenant_id = '{tenant_id}'"),
+        ("tenant", f"DELETE FROM tenant WHERE tenant_id = '{tenant_id}'"),
+    ]
+
+    try:
+        for table_name, query in delete_queries:
+            print(f"  Deleting from {table_name}...")
+
+            if not confirm_step(f"Delete from {table_name}?", force):
+                print(f"  Skipping deletion from {table_name}")
+                continue
+
+            execute_control_plane_delete(pod_name, query, context)
+
+        print(f"✓ Successfully cleaned up control plane data for tenant: {tenant_id}")
+
+    except Exception as e:
+        print(
+            f"✗ Failed to clean up control plane for tenant {tenant_id}: {e}",
+            file=sys.stderr,
+        )
+        raise
+
+
+def cleanup_tenant(
+    tenant_id: str,
+    data_plane_pod: str,
+    control_plane_pod: str,
+    data_plane_context: str | None = None,
+    control_plane_context: str | None = None,
+    force: bool = False,
+) -> bool:
+    """Main cleanup function that orchestrates all cleanup steps.
+
+    Args:
+        tenant_id: Tenant ID to process
+        data_plane_pod: Data plane pod for schema operations
+        control_plane_pod: Control plane pod for tenant record operations
+        data_plane_context: Optional kubectl context for data plane cluster
+        control_plane_context: Optional kubectl context for control plane cluster
+        force: Skip confirmations if True
+    """
+    print(f"Starting cleanup for tenant: {tenant_id}")
+
+    # Check tenant status first (from control plane)
+    print(f"\n{'=' * 80}")
+    try:
+        tenant_status = get_tenant_status(
+            control_plane_pod, tenant_id, control_plane_context
+        )
+
+        # If tenant is not GATED_ACCESS, require explicit confirmation even in force mode
+        if tenant_status and tenant_status != "GATED_ACCESS":
+            print(
+                f"\n⚠️  WARNING: Tenant status is '{tenant_status}', not 'GATED_ACCESS'!"
+            )
+            print(
+                "This tenant may be active and should not be deleted without careful review."
+            )
+            print(f"{'=' * 80}\n")
+
+            if force:
+                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+                return False
+
+            # Always ask for confirmation if not gated
+            response = input(
+                "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
+            )
+            if response.lower() != "yes":
+                print("Cleanup aborted - tenant is not GATED_ACCESS")
+                return False
+        elif tenant_status == "GATED_ACCESS":
+            print("✓ Tenant status is GATED_ACCESS - safe to proceed with cleanup")
+        elif tenant_status is None:
+            print("⚠️  WARNING: Could not determine tenant status!")
+
+            if force:
+                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+                return False
+
+            response = input("Continue anyway? Type 'yes' to confirm: ")
+            if response.lower() != "yes":
+                print("Cleanup aborted - could not verify tenant status")
+                return False
+    except Exception as e:
+        print(f"⚠️  WARNING: Failed to check tenant status: {e}")
+
+        if force:
+            print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+            return False
+
+        response = input("Continue anyway? Type 'yes' to confirm: ")
+        if response.lower() != "yes":
+            print("Cleanup aborted - could not verify tenant status")
+            return False
+    print(f"{'=' * 80}\n")
+
+    # Fetch tenant users for informational purposes (non-blocking) from data plane
+    if not force:
+        print(f"\n{'=' * 80}")
+        try:
+            get_tenant_users(data_plane_pod, tenant_id, data_plane_context)
+        except Exception as e:
+            print(f"⚠ Could not fetch tenant users: {e}")
+        print(f"{'=' * 80}\n")
+
+    # Step 1: Make sure all documents are deleted (data plane)
+    print(f"\n{'=' * 80}")
+    print("Step 1/3: Checking for remaining ConnectorCredentialPairs and Documents")
+    print(f"{'=' * 80}")
+    try:
+        check_documents_deleted(data_plane_pod, tenant_id, data_plane_context)
+    except Exception as e:
+        print(f"✗ Document check failed: {e}", file=sys.stderr)
+        print(
+            "\nPlease ensure all ConnectorCredentialPairs and Documents are deleted before running cleanup."
+        )
+        print(
+            "You may need to mark connectors for deletion and wait for cleanup to complete."
+        )
+        return False
+    print(f"{'=' * 80}\n")
+
+    # Step 2: Drop data plane schema
+    if confirm_step(
+        f"Step 2/3: Drop data plane schema '{tenant_id}' (CASCADE - will delete all tables, functions, etc.)",
+        force,
+    ):
+        try:
+            drop_data_plane_schema(data_plane_pod, tenant_id, data_plane_context)
+        except Exception as e:
+            print(f"✗ Failed at schema cleanup step: {e}", file=sys.stderr)
+            if not force:
+                response = input("Continue with control plane cleanup? (y/n): ")
+                if response.lower() != "y":
+                    print("Cleanup aborted by user")
+                    return False
+            else:
+                print("[FORCE MODE] Continuing despite schema cleanup failure")
+    else:
+        print("Step 2 skipped by user")
+
+    # Step 3: Clean up control plane
+    if confirm_step(
+        "Step 3/3: Delete control plane records (tenant_notification, tenant_config, subscription, tenant)",
+        force,
+    ):
+        try:
+            cleanup_control_plane(
+                control_plane_pod, tenant_id, control_plane_context, force
+            )
+        except Exception as e:
+            print(f"✗ Failed at control plane cleanup step: {e}", file=sys.stderr)
+            if not force:
+                print("Control plane cleanup failed")
+            else:
+                print("[FORCE MODE] Control plane cleanup failed but continuing")
+    else:
+        print("Step 3 skipped by user")
+        return False
+
+    print(f"\n{'=' * 80}")
+    print(f"✓ Cleanup completed for tenant: {tenant_id}")
+    print(f"{'=' * 80}")
+    return True
+
+
+def main() -> None:
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    if len(sys.argv) < 2:
+        print(
+            "Usage: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py <tenant_id> [--force]"
+        )
+        print(
+            "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> [--force]"
+        )
+        print("\nTwo-cluster architecture (with explicit contexts):")
+        print(
+            "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> \\"
+        )
+        print(
+            "           --data-plane-context <context> --control-plane-context <context> [--force]"
+        )
+        print("\nThis version runs ALL operations from pods (no bastion required)")
+        print("\nArguments:")
+        print(
+            "  tenant_id                  The tenant ID to clean up (required if not using --csv)"
+        )
+        print(
+            "  --csv PATH                 Path to CSV file containing tenant IDs to clean up"
+        )
+        print("  --force                    Skip all confirmation prompts (optional)")
+        print(
+            "  --concurrency N            Process N tenants concurrently (default: 1)"
+        )
+        print(
+            "  --data-plane-context CTX   Kubectl context for data plane cluster (optional)"
+        )
+        print(
+            "  --control-plane-context CTX Kubectl context for control plane cluster (optional)"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    force = "--force" in sys.argv
+    tenant_ids = []
+
+    # Parse concurrency
+    concurrency: int = 1
+    if "--concurrency" in sys.argv:
+        try:
+            concurrency_index = sys.argv.index("--concurrency")
+            if concurrency_index + 1 >= len(sys.argv):
+                print("Error: --concurrency flag requires a number", file=sys.stderr)
+                sys.exit(1)
+            concurrency = int(sys.argv[concurrency_index + 1])
+            if concurrency < 1:
+                print("Error: concurrency must be at least 1", file=sys.stderr)
+                sys.exit(1)
+        except ValueError:
+            print("Error: --concurrency value must be an integer", file=sys.stderr)
+            sys.exit(1)
+
+    # Validate: concurrency > 1 requires --force
+    if concurrency > 1 and not force:
+        print(
+            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Parse contexts
+    data_plane_context: str | None = None
+    control_plane_context: str | None = None
+
+    if "--data-plane-context" in sys.argv:
+        try:
+            idx = sys.argv.index("--data-plane-context")
+            if idx + 1 >= len(sys.argv):
+                print(
+                    "Error: --data-plane-context requires a context name",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            data_plane_context = sys.argv[idx + 1]
+        except ValueError:
+            pass
+
+    if "--control-plane-context" in sys.argv:
+        try:
+            idx = sys.argv.index("--control-plane-context")
+            if idx + 1 >= len(sys.argv):
+                print(
+                    "Error: --control-plane-context requires a context name",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            control_plane_context = sys.argv[idx + 1]
+        except ValueError:
+            pass
+
+    # Check for CSV mode
+    if "--csv" in sys.argv:
+        try:
+            csv_index = sys.argv.index("--csv")
+            if csv_index + 1 >= len(sys.argv):
+                print("Error: --csv flag requires a file path", file=sys.stderr)
+                sys.exit(1)
+
+            csv_path = sys.argv[csv_index + 1]
+            tenant_ids = read_tenant_ids_from_csv(csv_path)
+
+            if not tenant_ids:
+                print("Error: No tenant IDs found in CSV file", file=sys.stderr)
+                sys.exit(1)
+
+            print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
+
+        except Exception as e:
+            print(f"Error reading CSV file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Single tenant mode
+        tenant_ids = [sys.argv[1]]
+
+    # Initial confirmation (unless --force is used)
+    if not force:
+        print(f"\n{'=' * 80}")
+        print("TENANT CLEANUP - NO BASTION VERSION")
+        print(f"{'=' * 80}")
+        if len(tenant_ids) == 1:
+            print(f"Tenant ID: {tenant_ids[0]}")
+        else:
+            print(f"Number of tenants: {len(tenant_ids)}")
+            print(f"Tenant IDs: {', '.join(tenant_ids[:5])}")
+            if len(tenant_ids) > 5:
+                print(f"            ... and {len(tenant_ids) - 5} more")
+
+        print("\nThis will:")
+        print("  1. Check for remaining documents and connector credential pairs")
+        print("  2. Drop the data plane PostgreSQL schema (CASCADE)")
+        print("  3. Clean up control plane data (all via pod queries)")
+        print(f"\n{'=' * 80}")
+        print("WARNING: This operation is IRREVERSIBLE!")
+        print(f"{'=' * 80}\n")
+
+        response = input("Are you sure you want to proceed? Type 'yes' to confirm: ")
+
+        if response.lower() != "yes":
+            print("Cleanup aborted by user")
+            sys.exit(0)
+    else:
+        print(
+            f"⚠ FORCE MODE: Running cleanup for {len(tenant_ids)} tenant(s) without confirmations"
+        )
+
+    # Find pods in both clusters before processing
+    try:
+        print("Finding data plane worker pod...")
+        data_plane_pod = find_worker_pod(data_plane_context)
+        print(f"✓ Using data plane worker pod: {data_plane_pod}")
+
+        print("Finding control plane pod...")
+        control_plane_pod = find_background_pod(control_plane_context)
+        print(f"✓ Using control plane pod: {control_plane_pod}\n")
+
+        # Copy all scripts to data plane pod once
+        setup_scripts_on_pod(data_plane_pod, data_plane_context)
+        print()
+    except Exception as e:
+        print(f"✗ Failed to find required pods or setup scripts: {e}", file=sys.stderr)
+        print("Cannot proceed with cleanup")
+        sys.exit(1)
+
+    # Run cleanup for each tenant
+    failed_tenants = []
+    successful_tenants = []
+    skipped_tenants = []
+
+    # Open CSV file for writing successful cleanups in real-time
+    csv_output_path = "cleaned_tenants.csv"
+    with open(csv_output_path, "w", newline="") as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(["tenant_id", "cleaned_at"])
+        csv_file.flush()
+
+        print(f"Writing successful cleanups to: {csv_output_path}\n")
+
+        if concurrency == 1:
+            # Sequential processing
+            for idx, tenant_id in enumerate(tenant_ids, 1):
+                if len(tenant_ids) > 1:
+                    print(f"\n{'=' * 80}")
+                    print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
+                    print(f"{'=' * 80}")
+
+                try:
+                    was_cleaned = cleanup_tenant(
+                        tenant_id,
+                        data_plane_pod,
+                        control_plane_pod,
+                        data_plane_context,
+                        control_plane_context,
+                        force,
+                    )
+
+                    if was_cleaned:
+                        successful_tenants.append(tenant_id)
+
+                        # Write to CSV immediately after successful cleanup
+                        timestamp = datetime.utcnow().isoformat()
+                        csv_writer.writerow([tenant_id, timestamp])
+                        csv_file.flush()
+                        print(f"✓ Recorded cleanup in {csv_output_path}")
+                    else:
+                        skipped_tenants.append(tenant_id)
+                        print(f"⚠ Tenant {tenant_id} was skipped (not recorded in CSV)")
+
+                except Exception as e:
+                    print(
+                        f"✗ Cleanup failed for tenant {tenant_id}: {e}", file=sys.stderr
+                    )
+                    failed_tenants.append((tenant_id, str(e)))
+
+                    # If not in force mode and there are more tenants, ask if we should continue
+                    if not force and idx < len(tenant_ids):
+                        response = input(
+                            f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
+                        )
+                        if response.lower() != "y":
+                            print("Cleanup aborted by user")
+                            break
+        else:
+            # Parallel processing
+            print(
+                f"Processing {len(tenant_ids)} tenant(s) with concurrency={concurrency}\n"
+            )
+
+            def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
+                """Process a single tenant. Returns (tenant_id, was_cleaned, error_message)."""
+                try:
+                    was_cleaned = cleanup_tenant(
+                        tenant_id,
+                        data_plane_pod,
+                        control_plane_pod,
+                        data_plane_context,
+                        control_plane_context,
+                        force,
+                    )
+                    return (tenant_id, was_cleaned, None)
+                except Exception as e:
+                    return (tenant_id, False, str(e))
+
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                # Submit all tasks
+                future_to_tenant = {
+                    executor.submit(process_tenant, tenant_id): tenant_id
+                    for tenant_id in tenant_ids
+                }
+
+                # Process results as they complete
+                completed = 0
+                for future in as_completed(future_to_tenant):
+                    completed += 1
+                    tenant_id, was_cleaned, error = future.result()
+
+                    if error:
+                        with _print_lock:
+                            print(
+                                f"[{completed}/{len(tenant_ids)}] ✗ Failed: {tenant_id}: {error}",
+                                file=sys.stderr,
+                            )
+                        failed_tenants.append((tenant_id, error))
+                    elif was_cleaned:
+                        with _csv_lock:
+                            timestamp = datetime.utcnow().isoformat()
+                            csv_writer.writerow([tenant_id, timestamp])
+                            csv_file.flush()
+                        successful_tenants.append(tenant_id)
+                        with _print_lock:
+                            print(
+                                f"[{completed}/{len(tenant_ids)}] ✓ Cleaned: {tenant_id}"
+                            )
+                    else:
+                        skipped_tenants.append(tenant_id)
+                        with _print_lock:
+                            print(
+                                f"[{completed}/{len(tenant_ids)}] ⊘ Skipped: {tenant_id}"
+                            )
+
+    # Print summary
+    if len(tenant_ids) > 1:
+        print(f"\n{'=' * 80}")
+        print("CLEANUP SUMMARY")
+        print(f"{'=' * 80}")
+        print(f"Total tenants: {len(tenant_ids)}")
+        print(f"Successful: {len(successful_tenants)}")
+        print(f"Skipped: {len(skipped_tenants)}")
+        print(f"Failed: {len(failed_tenants)}")
+        print(f"\nSuccessfully cleaned tenants written to: {csv_output_path}")
+
+        if skipped_tenants:
+            print(f"\nSkipped tenants ({len(skipped_tenants)}):")
+            for tenant_id in skipped_tenants:
+                print(f"  - {tenant_id}")
+
+        if failed_tenants:
+            print(f"\nFailed tenants ({len(failed_tenants)}):")
+            for tenant_id, error in failed_tenants:
+                print(f"  - {tenant_id}: {error}")
+
+        print(f"{'=' * 80}")
+
+        if failed_tenants:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
@@ -1,0 +1,318 @@
+"""
+Cleanup utilities that work WITHOUT bastion access.
+Control plane and data plane are in SEPARATE clusters.
+"""
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_worker_pod(context: str | None = None) -> str:
+    """Find a user file processing worker pod using kubectl.
+
+    Args:
+        context: Optional kubectl context to use
+    """
+    print(
+        f"Finding user file processing worker pod{f' in context {context}' if context else ''}..."
+    )
+
+    cmd = ["kubectl", "get", "po"]
+    if context:
+        cmd.extend(["--context", context])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    # Parse output and find user file processing worker pod
+    lines = result.stdout.strip().split("\n")
+    lines = lines[1:]  # Skip header
+
+    import random
+
+    random.shuffle(lines)
+
+    for line in lines:
+        if "celery-worker-user-file-processing" in line and "Running" in line:
+            pod_name = line.split()[0]
+            print(f"Found pod: {pod_name}")
+            return pod_name
+
+    raise RuntimeError("No running user file processing worker pod found")
+
+
+def find_background_pod(context: str | None = None) -> str:
+    """Find a background/api-server pod for control plane operations.
+
+    Args:
+        context: Optional kubectl context to use
+    """
+    print(f"Finding background/api pod{f' in context {context}' if context else ''}...")
+
+    cmd = ["kubectl", "get", "po"]
+    if context:
+        cmd.extend(["--context", context])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    # Parse output and find suitable pod
+    lines = result.stdout.strip().split("\n")
+    lines = lines[1:]  # Skip header
+
+    import random
+
+    random.shuffle(lines)
+
+    # Try to find api-server, background worker, or any celery worker
+    for line in lines:
+        if (
+            any(
+                name in line
+                for name in [
+                    "api-server",
+                    "celery-worker-light",
+                    "celery-worker-primary",
+                    "background",
+                ]
+            )
+            and "Running" in line
+        ):
+            pod_name = line.split()[0]
+            print(f"Found pod: {pod_name}")
+            return pod_name
+
+    raise RuntimeError("No suitable background pod found for control plane operations")
+
+
+def confirm_step(message: str, force: bool = False) -> bool:
+    """Ask for confirmation before executing a step.
+
+    Args:
+        message: The confirmation message to display
+        force: If True, skip confirmation and return True
+
+    Returns:
+        True if user confirms or force is True, False otherwise
+    """
+    if force:
+        print(f"[FORCE MODE] Skipping confirmation: {message}")
+        return True
+
+    print(f"\n{message}")
+    response = input("Proceed? (y/n): ")
+    return response.lower() == "y"
+
+
+def execute_control_plane_query_from_pod(
+    pod_name: str, query: str, context: str | None = None
+) -> dict:
+    """Execute a SQL query against control plane database from within a pod.
+
+    Args:
+        pod_name: The Kubernetes pod name to execute from
+        query: The SQL query to execute
+        context: Optional kubectl context for control plane cluster
+
+    Returns:
+        Dict with 'success' bool, 'stdout' str, and optional 'error' str
+    """
+    # Create a Python script to run the query
+    # This script tries multiple environment variable patterns
+    query_script = f'''
+import os
+from sqlalchemy import create_engine, text
+
+# Try to get control plane database URL from various environment patterns
+control_db_url = None
+
+# Pattern 1: POSTGRES_CONTROL_* variables
+if os.environ.get("POSTGRES_CONTROL_HOST"):
+    host = os.environ.get("POSTGRES_CONTROL_HOST")
+    port = os.environ.get("POSTGRES_CONTROL_PORT", "5432")
+    db = os.environ.get("POSTGRES_CONTROL_DB", "control")
+    user = os.environ.get("POSTGRES_CONTROL_USER", "postgres")
+    password = os.environ.get("POSTGRES_CONTROL_PASSWORD", "")
+    if password:
+        control_db_url = f"postgresql://{{user}}:{{password}}@{{host}}:{{port}}/{{db}}"
+
+# Pattern 2: Standard POSTGRES_* variables (might point to control plane in this cluster)
+if not control_db_url and os.environ.get("POSTGRES_HOST"):
+    host = os.environ.get("POSTGRES_HOST")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    db = os.environ.get("POSTGRES_DB", "danswer")
+    user = os.environ.get("POSTGRES_USER", "postgres")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+    if password:
+        control_db_url = f"postgresql://{{user}}:{{password}}@{{host}}:{{port}}/{{db}}"
+
+# Pattern 3: Direct URI
+if not control_db_url:
+    control_db_url = os.environ.get("DATABASE_URL") or os.environ.get("POSTGRES_URI")
+
+if not control_db_url:
+    raise ValueError("Cannot determine control plane database connection. No suitable environment variables found.")
+
+engine = create_engine(control_db_url)
+
+with engine.connect() as conn:
+    result = conn.execute(text("""{query}"""))
+
+    # Check if this is a SELECT query
+    if result.returns_rows:
+        rows = [dict(row._mapping) for row in result]
+        import json
+        print(json.dumps(rows, default=str))
+    else:
+        # For INSERT/UPDATE/DELETE, print rowcount
+        print(f"{{result.rowcount}} rows affected")
+
+    conn.commit()
+'''
+
+    # Write the script to a temp file on the pod
+    script_path = "/tmp/control_plane_query.py"
+
+    try:
+        cmd_write = ["kubectl", "exec", pod_name]
+        if context:
+            cmd_write.extend(["--context", context])
+        cmd_write.extend(
+            [
+                "--",
+                "bash",
+                "-c",
+                f"cat > {script_path} << 'EOFQUERY'\n{query_script}\nEOFQUERY",
+            ]
+        )
+
+        subprocess.run(
+            cmd_write,
+            check=True,
+            capture_output=True,
+        )
+
+        # Execute the script
+        cmd_exec = ["kubectl", "exec", pod_name]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(["--", "python", script_path])
+
+        result = subprocess.run(
+            cmd_exec,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        return {
+            "success": True,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip() if result.stderr else "",
+        }
+
+    except subprocess.CalledProcessError as e:
+        return {
+            "success": False,
+            "stdout": e.stdout if e.stdout else "",
+            "error": e.stderr if e.stderr else str(e),
+        }
+
+
+def get_tenant_status(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> str | None:
+    """
+    Get tenant status from control plane database via pod.
+
+    Args:
+        pod_name: The pod to execute the query from
+        tenant_id: The tenant ID to look up
+        context: Optional kubectl context for control plane cluster
+
+    Returns:
+        Tenant status string (e.g., 'GATED_ACCESS', 'ACTIVE') or None if not found
+    """
+    print(f"Fetching tenant status for tenant: {tenant_id}")
+
+    query = f"SELECT application_status FROM tenant WHERE tenant_id = '{tenant_id}'"
+
+    result = execute_control_plane_query_from_pod(pod_name, query, context)
+
+    if not result["success"]:
+        print(
+            f"✗ Failed to get tenant status for {tenant_id}: {result.get('error', 'Unknown error')}",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        # Parse JSON output
+        rows = json.loads(result["stdout"])
+
+        if rows and len(rows) > 0:
+            status = rows[0].get("application_status")
+            if status:
+                print(f"✓ Tenant status: {status}")
+                return status
+
+        print("⚠ Tenant not found in control plane")
+        return None
+
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        print(f"✗ Failed to parse tenant status: {e}", file=sys.stderr)
+        return None
+
+
+def execute_control_plane_delete(
+    pod_name: str, query: str, context: str | None = None
+) -> bool:
+    """Execute a DELETE query against control plane database from pod.
+
+    Args:
+        pod_name: The pod to execute the query from
+        query: The DELETE query to execute
+        context: Optional kubectl context for control plane cluster
+
+    Returns:
+        True if successful, False otherwise
+    """
+    result = execute_control_plane_query_from_pod(pod_name, query, context)
+
+    if result["success"]:
+        print(f"    {result['stdout']}")
+        return True
+    else:
+        print(f"    Error: {result.get('error', 'Unknown error')}", file=sys.stderr)
+        return False
+
+
+def read_tenant_ids_from_csv(csv_path: str) -> list[str]:
+    """Read tenant IDs from CSV file.
+
+    Args:
+        csv_path: Path to CSV file
+
+    Returns:
+        List of tenant IDs
+    """
+    if not Path(csv_path).exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    tenant_ids = []
+    with open(csv_path, "r", newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+
+        # Check if tenant_id column exists
+        if not reader.fieldnames or "tenant_id" not in reader.fieldnames:
+            raise ValueError(
+                f"CSV file must have a 'tenant_id' column. Found columns: {reader.fieldnames}"
+            )
+
+        for row in reader:
+            tenant_id = row.get("tenant_id", "").strip()
+            if tenant_id:
+                tenant_ids.append(tenant_id)
+
+    return tenant_ids

--- a/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""
+Mark connectors for deletion script that works WITHOUT bastion access.
+All queries run directly from pods.
+Supports two-cluster architecture (data plane and control plane in separate clusters).
+
+Usage:
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py <tenant_id> [--force]
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py --csv <csv_file_path> [--force] [--concurrency N]
+
+    With explicit contexts:
+    PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py --csv <csv_file_path> \
+        --data-plane-context <context> --control-plane-context <context> [--force] [--concurrency N]
+"""
+
+import subprocess
+import sys
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import confirm_step
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_background_pod
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import find_worker_pod
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import get_tenant_status
+from scripts.tenant_cleanup.no_bastion_cleanup_utils import read_tenant_ids_from_csv
+
+# Global lock for thread-safe printing
+_print_lock: Lock = Lock()
+
+
+def safe_print(*args: Any, **kwargs: Any) -> None:
+    """Thread-safe print function."""
+    with _print_lock:
+        print(*args, **kwargs)
+
+
+def run_connector_deletion(
+    pod_name: str, tenant_id: str, context: str | None = None
+) -> None:
+    """Mark all connector credential pairs for deletion.
+
+    Args:
+        pod_name: Data plane pod to execute deletion on
+        tenant_id: Tenant ID to process
+        context: Optional kubectl context for data plane cluster
+    """
+    safe_print("  Marking all connector credential pairs for deletion...")
+
+    # Get the path to the script
+    script_dir = Path(__file__).parent
+    mark_deletion_script = (
+        script_dir / "on_pod_scripts" / "execute_connector_deletion.py"
+    )
+
+    if not mark_deletion_script.exists():
+        raise FileNotFoundError(
+            f"execute_connector_deletion.py not found at {mark_deletion_script}"
+        )
+
+    try:
+        # Copy script to pod
+        cmd_cp = ["kubectl", "cp"]
+        if context:
+            cmd_cp.extend(["--context", context])
+        cmd_cp.extend(
+            [
+                str(mark_deletion_script),
+                f"{pod_name}:/tmp/execute_connector_deletion.py",
+            ]
+        )
+
+        subprocess.run(
+            cmd_cp,
+            check=True,
+            capture_output=True,
+        )
+
+        # Execute script on pod
+        cmd_exec = ["kubectl", "exec"]
+        if context:
+            cmd_exec.extend(["--context", context])
+        cmd_exec.extend(
+            [
+                pod_name,
+                "--",
+                "python",
+                "/tmp/execute_connector_deletion.py",
+                tenant_id,
+                "--all",
+            ]
+        )
+
+        result = subprocess.run(cmd_exec)
+
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr)
+
+    except subprocess.CalledProcessError as e:
+        safe_print(
+            f"  ✗ Failed to mark all connector credential pairs for deletion: {e}",
+            file=sys.stderr,
+        )
+        if e.stderr:
+            safe_print(f"    Error details: {e.stderr}", file=sys.stderr)
+        raise
+    except Exception as e:
+        safe_print(
+            f"  ✗ Failed to mark all connector credential pairs for deletion: {e}",
+            file=sys.stderr,
+        )
+        raise
+
+
+def mark_tenant_connectors_for_deletion(
+    tenant_id: str,
+    data_plane_pod: str,
+    control_plane_pod: str,
+    data_plane_context: str | None = None,
+    control_plane_context: str | None = None,
+    force: bool = False,
+) -> None:
+    """Main function to mark all connectors for a tenant for deletion.
+
+    Args:
+        tenant_id: Tenant ID to process
+        data_plane_pod: Data plane pod for connector operations
+        control_plane_pod: Control plane pod for status checks
+        data_plane_context: Optional kubectl context for data plane cluster
+        control_plane_context: Optional kubectl context for control plane cluster
+        force: Skip confirmations if True
+    """
+    safe_print(f"Processing connectors for tenant: {tenant_id}")
+
+    # Check tenant status first (from control plane)
+    safe_print(f"\n{'=' * 80}")
+    try:
+        tenant_status = get_tenant_status(
+            control_plane_pod, tenant_id, control_plane_context
+        )
+
+        # If tenant is not GATED_ACCESS, require explicit confirmation even in force mode
+        if tenant_status and tenant_status != "GATED_ACCESS":
+            safe_print(
+                f"\n⚠️  WARNING: Tenant status is '{tenant_status}', not 'GATED_ACCESS'!"
+            )
+            safe_print(
+                "This tenant may be active and should not have connectors deleted without careful review."
+            )
+            safe_print(f"{'=' * 80}\n")
+
+            # Always ask for confirmation if not gated, even in force mode
+            if not force:
+                response = input(
+                    "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
+                )
+                if response.lower() != "yes":
+                    safe_print("Operation aborted - tenant is not GATED_ACCESS")
+                    raise RuntimeError(f"Tenant {tenant_id} is not GATED_ACCESS")
+            else:
+                raise RuntimeError(f"Tenant {tenant_id} is not GATED_ACCESS")
+        elif tenant_status == "GATED_ACCESS":
+            safe_print("✓ Tenant status is GATED_ACCESS - safe to proceed")
+        elif tenant_status is None:
+            safe_print("⚠️  WARNING: Could not determine tenant status!")
+            if not force:
+                response = input("Continue anyway? Type 'yes' to confirm: ")
+                if response.lower() != "yes":
+                    safe_print("Operation aborted - could not verify tenant status")
+                    raise RuntimeError(
+                        f"Could not verify tenant status for {tenant_id}"
+                    )
+            else:
+                raise RuntimeError(f"Could not verify tenant status for {tenant_id}")
+    except Exception as e:
+        safe_print(f"⚠️  WARNING: Failed to check tenant status: {e}")
+        if not force:
+            response = input("Continue anyway? Type 'yes' to confirm: ")
+            if response.lower() != "yes":
+                safe_print("Operation aborted - could not verify tenant status")
+                raise
+        else:
+            raise RuntimeError(f"Failed to check tenant status for {tenant_id}")
+    safe_print(f"{'=' * 80}\n")
+
+    # Confirm before proceeding (only in non-force mode)
+    if not confirm_step(
+        f"Mark all connector credential pairs for deletion for tenant {tenant_id}?",
+        force,
+    ):
+        safe_print("Operation cancelled by user")
+        raise ValueError("Operation cancelled by user")
+
+    run_connector_deletion(data_plane_pod, tenant_id, data_plane_context)
+
+    # Print summary
+    safe_print(
+        f"✓ Marked all connector credential pairs for deletion for tenant {tenant_id}"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(
+            "Usage: PYTHONPATH=. python scripts/tenant_cleanup/"
+            "no_bastion_mark_connectors.py <tenant_id> [--force] [--concurrency N]"
+        )
+        print(
+            "       PYTHONPATH=. python scripts/tenant_cleanup/"
+            "no_bastion_mark_connectors.py --csv <csv_file_path> "
+            "[--force] [--concurrency N]"
+        )
+        print("\nTwo-cluster architecture (with explicit contexts):")
+        print(
+            "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py --csv <csv_file_path> \\"
+        )
+        print(
+            "           --data-plane-context <context> --control-plane-context <context> [--force] [--concurrency N]"
+        )
+        print("\nThis version runs ALL operations from pods (no bastion required)")
+        print("\nArguments:")
+        print(
+            "  tenant_id                  The tenant ID to process (required if not using --csv)"
+        )
+        print(
+            "  --csv PATH                 Path to CSV file containing tenant IDs to process"
+        )
+        print("  --force                    Skip all confirmation prompts (optional)")
+        print(
+            "  --concurrency N            Process N tenants concurrently (default: 1)"
+        )
+        print(
+            "  --data-plane-context CTX   Kubectl context for data plane cluster (optional)"
+        )
+        print(
+            "  --control-plane-context CTX Kubectl context for control plane cluster (optional)"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    force = "--force" in sys.argv
+    tenant_ids: list[str] = []
+
+    # Parse contexts
+    data_plane_context: str | None = None
+    control_plane_context: str | None = None
+
+    if "--data-plane-context" in sys.argv:
+        try:
+            idx = sys.argv.index("--data-plane-context")
+            if idx + 1 >= len(sys.argv):
+                print(
+                    "Error: --data-plane-context requires a context name",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            data_plane_context = sys.argv[idx + 1]
+        except ValueError:
+            pass
+
+    if "--control-plane-context" in sys.argv:
+        try:
+            idx = sys.argv.index("--control-plane-context")
+            if idx + 1 >= len(sys.argv):
+                print(
+                    "Error: --control-plane-context requires a context name",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            control_plane_context = sys.argv[idx + 1]
+        except ValueError:
+            pass
+
+    # Parse concurrency
+    concurrency: int = 1
+    if "--concurrency" in sys.argv:
+        try:
+            concurrency_index = sys.argv.index("--concurrency")
+            if concurrency_index + 1 >= len(sys.argv):
+                print("Error: --concurrency flag requires a number", file=sys.stderr)
+                sys.exit(1)
+            concurrency = int(sys.argv[concurrency_index + 1])
+            if concurrency < 1:
+                print("Error: concurrency must be at least 1", file=sys.stderr)
+                sys.exit(1)
+        except ValueError:
+            print("Error: --concurrency value must be an integer", file=sys.stderr)
+            sys.exit(1)
+
+    # Validate: concurrency > 1 requires --force
+    if concurrency > 1 and not force:
+        print(
+            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Check for CSV mode
+    if "--csv" in sys.argv:
+        try:
+            csv_index: int = sys.argv.index("--csv")
+            if csv_index + 1 >= len(sys.argv):
+                print("Error: --csv flag requires a file path", file=sys.stderr)
+                sys.exit(1)
+
+            csv_path: str = sys.argv[csv_index + 1]
+            tenant_ids = read_tenant_ids_from_csv(csv_path)
+
+            if not tenant_ids:
+                print("Error: No tenant IDs found in CSV file", file=sys.stderr)
+                sys.exit(1)
+
+            print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
+
+        except Exception as e:
+            print(f"Error reading CSV file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Single tenant mode
+        tenant_ids = [sys.argv[1]]
+
+    # Find pods in both clusters before processing
+    try:
+        print("Finding data plane worker pod...")
+        data_plane_pod: str = find_worker_pod(data_plane_context)
+        print(f"✓ Using data plane worker pod: {data_plane_pod}")
+
+        print("Finding control plane pod...")
+        control_plane_pod: str = find_background_pod(control_plane_context)
+        print(f"✓ Using control plane pod: {control_plane_pod}")
+    except Exception as e:
+        print(f"✗ Failed to find required pods: {e}", file=sys.stderr)
+        print("Cannot proceed with marking connectors for deletion")
+        sys.exit(1)
+
+    # Initial confirmation (unless --force is used)
+    if not force:
+        print(f"\n{'=' * 80}")
+        print("MARK CONNECTORS FOR DELETION - NO BASTION VERSION")
+        print(f"{'=' * 80}")
+        if len(tenant_ids) == 1:
+            print(f"Tenant ID: {tenant_ids[0]}")
+        else:
+            print(f"Number of tenants: {len(tenant_ids)}")
+            print(f"Tenant IDs: {', '.join(tenant_ids[:5])}")
+            if len(tenant_ids) > 5:
+                print(f"            ... and {len(tenant_ids) - 5} more")
+
+        print(
+            f"Mode: {'FORCE (no confirmations)' if force else 'Interactive (will ask for confirmation at each step)'}"
+        )
+        print(f"Concurrency: {concurrency} tenant(s) at a time")
+        print("\nThis will:")
+        print("  1. Fetch all connector credential pairs for each tenant")
+        print("  2. Cancel any scheduled indexing attempts for each connector")
+        print("  3. Mark each connector credential pair status as DELETING")
+        print("  4. Trigger the connector deletion task")
+        print(f"\n{'=' * 80}")
+        print("WARNING: This will mark connectors for deletion!")
+        print("The actual deletion will be performed by the background celery worker.")
+        print(f"{'=' * 80}\n")
+
+        response = input("Are you sure you want to proceed? Type 'yes' to confirm: ")
+
+        if response.lower() != "yes":
+            print("Operation aborted by user")
+            sys.exit(0)
+    else:
+        if len(tenant_ids) == 1:
+            print(
+                f"⚠ FORCE MODE: Marking connectors for deletion for {tenant_ids[0]} without confirmations"
+            )
+        else:
+            print(
+                f"⚠ FORCE MODE: Marking connectors for deletion for {len(tenant_ids)} tenants "
+                f"(concurrency: {concurrency}) without confirmations"
+            )
+
+    # Process tenants (in parallel if concurrency > 1)
+    failed_tenants: list[tuple[str, str]] = []
+    successful_tenants: list[str] = []
+
+    if concurrency == 1:
+        # Sequential processing
+        for idx, tenant_id in enumerate(tenant_ids, 1):
+            if len(tenant_ids) > 1:
+                print(f"\n{'=' * 80}")
+                print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
+                print(f"{'=' * 80}")
+
+            try:
+                mark_tenant_connectors_for_deletion(
+                    tenant_id,
+                    data_plane_pod,
+                    control_plane_pod,
+                    data_plane_context,
+                    control_plane_context,
+                    force,
+                )
+                successful_tenants.append(tenant_id)
+            except Exception as e:
+                print(
+                    f"✗ Failed to process tenant {tenant_id}: {e}",
+                    file=sys.stderr,
+                )
+                failed_tenants.append((tenant_id, str(e)))
+
+                # If not in force mode and there are more tenants, ask if we should continue
+                if not force and idx < len(tenant_ids):
+                    response = input(
+                        f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
+                    )
+                    if response.lower() != "y":
+                        print("Operation aborted by user")
+                        break
+    else:
+        # Parallel processing
+        print(
+            f"\nProcessing {len(tenant_ids)} tenant(s) with concurrency={concurrency}"
+        )
+
+        def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
+            """Process a single tenant. Returns (tenant_id, success, error_message)."""
+            try:
+                mark_tenant_connectors_for_deletion(
+                    tenant_id,
+                    data_plane_pod,
+                    control_plane_pod,
+                    data_plane_context,
+                    control_plane_context,
+                    force,
+                )
+                return (tenant_id, True, None)
+            except Exception as e:
+                return (tenant_id, False, str(e))
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            # Submit all tasks
+            future_to_tenant = {
+                executor.submit(process_tenant, tenant_id): tenant_id
+                for tenant_id in tenant_ids
+            }
+
+            # Process results as they complete
+            completed: int = 0
+            for future in as_completed(future_to_tenant):
+                completed += 1
+                tenant_id, success, error = future.result()
+
+                if success:
+                    successful_tenants.append(tenant_id)
+                    safe_print(
+                        f"[{completed}/{len(tenant_ids)}] ✓ Successfully processed {tenant_id}"
+                    )
+                else:
+                    failed_tenants.append((tenant_id, error or "Unknown error"))
+                    safe_print(
+                        f"[{completed}/{len(tenant_ids)}] ✗ Failed to process {tenant_id}: {error}",
+                        file=sys.stderr,
+                    )
+
+    # Print summary if multiple tenants
+    if len(tenant_ids) > 1:
+        print(f"\n{'=' * 80}")
+        print("OPERATION SUMMARY")
+        print(f"{'=' * 80}")
+        print(f"Total tenants: {len(tenant_ids)}")
+        print(f"Successful: {len(successful_tenants)}")
+        print(f"Failed: {len(failed_tenants)}")
+
+        if failed_tenants:
+            print("\nFailed tenants:")
+            for tenant_id, error in failed_tenants:
+                print(f"  - {tenant_id}: {error}")
+
+        print(f"{'=' * 80}")
+
+        if failed_tenants:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Doing the same cleanup script without a bastion connection now.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran myself and got it to work so that we don't need to have a Bastion Connection

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-bastion tenant cleanup flow that runs entirely inside Kubernetes pods, supporting separate data/control plane clusters with built-in safety checks and simple quick-start commands.

- **New Features**
  - Tenant analysis from data-plane pods: generates gated_tenants_no_query_3mo_*.csv for tenants with no queries in 3+ months.
  - Connector deletion marking from pods with optional concurrency and force mode.
  - Final cleanup from pods: verifies documents are gone, drops tenant schema, and deletes control-plane records; writes successes to cleaned_tenants.csv.
  - Setup verification script to check kubectl access, running worker pods, pod exec permissions, and required on-pod scripts.
  - Support for two clusters via --data-plane-context and --control-plane-context; no bastion or env vars needed.
  - Quick start guide with the exact commands and timing guidance.

- **Migration**
  - Ensure kubectl access and running celery-worker-user-file-processing pods; run check_no_bastion_setup.py first.
  - Run analyze → mark connectors → wait 6+ hours → cleanup; monitor progress via pod logs.
  - Use --force for non-interactive runs and to enable --concurrency.
  - No bastion, SSH keys, or environment variables required; all actions are executed via kubectl exec.

<sup>Written for commit 51ef5d9dfed6200d09aaaf3ca9db914186011173. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



