### PR TITLE
fix: Fix failing type checks in message feedback tests

### DIFF
--- a/web/tests/e2e/chat/message_feedback.spec.ts
+++ b/web/tests/e2e/chat/message_feedback.spec.ts
@@ -79,7 +79,7 @@ test.describe("Message feedback thumbs controls", () => {
       likeButton.click(),
     ]);
     expect(removeFeedbackRequests).toHaveLength(1);
-    expect(removeFeedbackRequests?.[0]?.query.chat_message_id).toBe(
+    expect(removeFeedbackRequests[0]?.query.chat_message_id).toBe(
       String(likedRequest?.chat_message_id)
     );
 


### PR DESCRIPTION
## Description

Type checks were failing for this file. Just a bunch of `?`s were thrown in to fix the `possibly undefined` errors.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing type checks in the chat message feedback e2e test by adding optional chaining around request fields. This resolves “possibly undefined” errors and keeps the test behavior unchanged.

<sup>Written for commit 7d9400381e295b006ee1f1b512e7b0a707ddd07f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



