### PR TITLE
chore: add fe type checking to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,10 @@ repos:
         entry: python3 backend/scripts/check_lazy_imports.py
         language: system
         files: ^backend/(?!\.venv/).*\.py$
+
+      - id: typescript-check
+        name: TypeScript type check
+        entry: bash -c 'cd web && npm run types:check'
+        language: system
+        pass_filenames: false
+        files: ^web/.*\.(ts|tsx)$


### PR DESCRIPTION
## Description

run type checking on pre-commit. only runs if `web/**/*.ts` or  `web/**/*.tsx` files are changed in the commit

## How Has This Been Tested?


made a change to a file i knew would fail
```
nikolas@Nikolass-MacBook-Pro web % commit
Enter Commit Message: test change
mypy.................................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
Lint GitHub Actions workflow files...................(no files to check)Skipped
black................................................(no files to check)Skipped
Reorder python imports...............................(no files to check)Skipped
autoflake............................................(no files to check)Skipped
ruff.................................................(no files to check)Skipped
prettier.................................................................Passed
ripsecrets...............................................................Passed
terraform fmt........................................(no files to check)Skipped
Check lazy imports...................................(no files to check)Skipped
TypeScript type check....................................................Failed
- hook id: typescript-check
- exit code: 2

> web@1.0.0-dev types:check
> tsc --noEmit

tests/e2e/chat/message_feedback.spec.ts:74:12 - error TS18048: 'likedRequest' is possibly 'undefined'.

74     expect(likedRequest.is_positive).toBe(true);
              ~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:75:12 - error TS18048: 'likedRequest' is possibly 'undefined'.

75     expect(likedRequest.chat_message_id).toBeTruthy();
              ~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:83:12 - error TS2532: Object is possibly 'undefined'.

83     expect(removeFeedbackRequests[0].query.chat_message_id).toBe(
              ~~~~~~~~~~~~~~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:84:14 - error TS18048: 'likedRequest' is possibly 'undefined'.

84       String(likedRequest.chat_message_id)
                ~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:104:12 - error TS18048: 'dislikedRequest' is possibly 'undefined'.

104     expect(dislikedRequest.is_positive).toBe(false);
               ~~~~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:105:12 - error TS18048: 'dislikedRequest' is possibly 'undefined'.

105     expect(dislikedRequest.feedback_text).toContain("missed some details");
               ~~~~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:106:12 - error TS18048: 'dislikedRequest' is possibly 'undefined'.

106     expect(dislikedRequest.chat_message_id).toBe(likedRequest.chat_message_id);
               ~~~~~~~~~~~~~~~

tests/e2e/chat/message_feedback.spec.ts:106:50 - error TS18048: 'likedRequest' is possibly 'undefined'.

106     expect(dislikedRequest.chat_message_id).toBe(likedRequest.chat_message_id);
                                                     ~~~~~~~~~~~~


Found 8 errors in the same file, starting at: tests/e2e/chat/message_feedback.spec.ts:74


```


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TypeScript type checking to pre-commit for the web code. The hook runs npm run types:check (tsc --noEmit) only when web/**/*.ts or web/**/*.tsx files change, blocking commits with type errors.

<sup>Written for commit 571e8769f4e989b1e432b9a67c3bc7a394ec1d74. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

