### PR TITLE
chore(tool): call output fix

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -694,6 +694,9 @@ def run_llm_step(
 
     # Note: Content (AgentResponseDelta) doesn't need an explicit end packet - OverallStop handles it
     # Tool calls are handled by tool execution code and emit their own packets (e.g., SectionEnd)
+    if LOG_ONYX_MODEL_INTERACTIONS:
+        logger.debug(f"Accumulated reasoning: {accumulated_reasoning}")
+        logger.debug(f"Accumulated answer: {accumulated_answer}")
 
     if tool_calls:
         tool_calls_str = "\n".join(


### PR DESCRIPTION
## Description

Properly trace tool calls as the output of an LLM span (just modifies data sent to trace -- doesn't modify prod functionality)

## How Has This Been Tested?

Tested locally

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assistant output when tool calls are present by attaching tool_calls to the message and only sending plain text when no tool calls exist. Ensures function calls and arguments are delivered correctly downstream.

- **Bug Fixes**
  - Build assistant message with tool_calls via a new _extract_tool_call_kickoffs helper.
  - Preserve accumulated answer as content when available; use None when empty.
  - Safely parse tool call arguments; log JSON errors and fall back to {}.

<sup>Written for commit a33110f8e0d8c3723ee2c281640901f6e703d79a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





