### PR TITLE
chore(pre-commit): disable mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,12 @@ repos:
     rev: d30b4298e4fb63ce8609e29acdbcf4c9018a483c
     hooks:
       - id: uv-sync
-      - id: uv-run
-        name: mypy
-        args: ["mypy"]
-        pass_filenames: true
-        files: ^backend/.*\.py$
+      # NOTE: This takes ~6s on a single, large module which is prohibitively slow.
+      # - id: uv-run
+      #   name: mypy
+      #   args: ["mypy"]
+      #   pass_filenames: true
+      #   files: ^backend/.*\.py$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
## Description

See also, https://onyx-company.slack.com/archives/C0771QKDBPE/p1764467081310029

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the mypy pre-commit hook to speed up local commits. It was taking ~6s on a single large module, slowing down the workflow.

<sup>Written for commit 93b3a7c574939116d49534cfc657b5eab75eed3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

