### PR TITLE
chore: Removing Retrievaldoc

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -538,14 +538,6 @@ class SavedSearchDocWithContent(SavedSearchDoc):
     content: str
 
 
-class RetrievalDocs(BaseModel):
-    top_documents: list[SavedSearchDoc]
-
-
-class SearchResponse(RetrievalDocs):
-    llm_indices: list[int]
-
-
 class RetrievalMetricsContainer(BaseModel):
     search_type: SearchType
     metrics: list[ChunkMetric]  # This contains the scores for retrieval as well

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -81,9 +81,7 @@ def _build_citation_list(chat_message_detail: ChatMessageDetail) -> list[Citatio
         return []
     else:
         top_documents = (
-            chat_message_detail.context_docs.top_documents
-            if chat_message_detail.context_docs
-            else []
+            chat_message_detail.context_docs if chat_message_detail.context_docs else []
         )
         citation_list = _convert_document_ids_to_citation_info(
             citation_dict, top_documents
@@ -255,7 +253,7 @@ def handle_publish_ephemeral_message_button(
         if chat_message_detail.context_docs:
             top_documents: list[SearchDoc] = [
                 SearchDoc.from_saved_search_doc(doc)
-                for doc in chat_message_detail.context_docs.top_documents
+                for doc in chat_message_detail.context_docs
             ]
         else:
             top_documents = []

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -20,7 +20,7 @@ from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import ChunkContext
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.models import RetrievalDetails
-from onyx.context.search.models import RetrievalDocs
+from onyx.context.search.models import SavedSearchDoc
 from onyx.context.search.models import SavedSearchDocWithContent
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import Tag
@@ -229,15 +229,6 @@ class SubQueryDetail(BaseModel):
     doc_ids: list[int] | None = None
 
 
-class SubQuestionDetail(BaseModel):
-    level: int
-    level_question_num: int
-    question: str
-    answer: str
-    sub_queries: list[SubQueryDetail] | None = None
-    context_docs: RetrievalDocs | None = None
-
-
 class ChatMessageDetail(BaseModel):
     chat_session_id: UUID | None = None
     message_id: int
@@ -246,7 +237,7 @@ class ChatMessageDetail(BaseModel):
     message: str
     reasoning_tokens: str | None = None
     message_type: MessageType
-    context_docs: RetrievalDocs | None = None
+    context_docs: list[SavedSearchDoc] | None = None
     # Dict mapping citation number to document_id
     citations: dict[int, str] | None = None
     time_sent: datetime


### PR DESCRIPTION
## Description

Removal of some dead classes

## How Has This Been Tested?

Local works

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the RetrievalDocs and SearchResponse models and flattened chat message context docs to a simple list for easier handling. Cleaned up unused code and updated Slack handlers to match.

- **Refactors**
  - Deleted RetrievalDocs, SearchResponse, and SubQuestionDetail.
  - Changed ChatMessageDetail.context_docs to list[SavedSearchDoc].
  - Removed get_retrieval_docs_from_search_docs, get_doc_query_identifiers_from_model, and attach_files_to_chat_message.
  - Updated DB translation and Slack button handlers to use the list directly.

- **Migration**
  - Use chat_message_detail.context_docs as a list; remove ".top_documents" access.
  - Replace RetrievalDocs types with list[SavedSearchDoc] and remove SubQuestionDetail references.

<sup>Written for commit 3cec13d0a0fadf9981c044e3f10be76512828c3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

