### PR TITLE
fix(persona): Fix sorting logic

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -705,14 +705,17 @@ def update_all_personas_display_priority(
     display_priority_map: dict[int, int],
     db_session: Session,
 ) -> None:
-    """Updates the display priority of all lives Personas"""
+    """Updates the display priority of Personas in the provided map."""
     personas = get_personas(db_session=db_session)
     available_persona_ids = {persona.id for persona in personas}
-    if available_persona_ids != set(display_priority_map.keys()):
+    provided_persona_ids = set(display_priority_map.keys())
+    invalid_persona_ids = provided_persona_ids - available_persona_ids
+    if invalid_persona_ids:
         raise ValueError("Invalid persona IDs provided")
 
     for persona in personas:
-        persona.display_priority = display_priority_map[persona.id]
+        if persona.id in display_priority_map:
+            persona.display_priority = display_priority_map[persona.id]
     db_session.commit()
 
 

--- a/backend/tests/unit/onyx/db/test_persona_display_priority.py
+++ b/backend/tests/unit/onyx/db/test_persona_display_priority.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.db.persona import update_all_personas_display_priority
+
+
+def _persona(persona_id: int, display_priority: int) -> SimpleNamespace:
+    return SimpleNamespace(id=persona_id, display_priority=display_priority)
+
+
+def test_update_display_priority_updates_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persona_a = _persona(1, 5)
+    persona_b = _persona(2, 6)
+    db_session = MagicMock()
+    monkeypatch.setattr(
+        "onyx.db.persona.get_personas", lambda db_session: [persona_a, persona_b]
+    )
+
+    update_all_personas_display_priority({1: 0}, db_session)
+
+    assert persona_a.display_priority == 0
+    assert persona_b.display_priority == 6
+    db_session.commit.assert_called_once_with()
+
+
+def test_update_display_priority_invalid_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    persona_a = _persona(1, 5)
+    db_session = MagicMock()
+    monkeypatch.setattr("onyx.db.persona.get_personas", lambda db_session: [persona_a])
+
+    with pytest.raises(ValueError):
+        update_all_personas_display_priority({1: 0, 99: 1}, db_session)
+
+    db_session.commit.assert_not_called()


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Fixing the persona endpoint to ensure that we don't fail on IDs especially with skipping default and built in personas which it was not doing before. This restores the functionality so that we can do proper persona organization.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Locally tested and also added a new unit test

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix display priority updates for personas to allow partial updates and validate IDs. This prevents sorting failures when default/built-in personas are excluded and restores correct persona ordering.

- **Bug Fixes**
  - update_all_personas_display_priority now updates only provided IDs; others are untouched.
  - Unknown persona IDs are rejected with a ValueError; unit tests added for subset updates and invalid IDs.

<sup>Written for commit d3072500abc1852738be8b8d07d7f435fa547856. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

