### PR TITLE
chore(mypy): un-ignore braintrust missing import

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,10 +14,6 @@ module = "alembic.versions.*"
 disable_error_code = ["var-annotated"]
 
 [[tool.mypy.overrides]]
-module = "braintrust_langchain.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "alembic_tenants.versions.*"
 disable_error_code = ["var-annotated"]
 


### PR DESCRIPTION
## Description

I am trying to understand why I can't repro https://github.com/onyx-dot-app/onyx/actions/runs/19917283213/job/57099086908?pr=6587 locally. I don't think this is related, but something I noticed which we may no longer need and should remove if we can.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the mypy ignore_missing_imports override for braintrust_langchain.* to surface real import and typing issues. This tightens type checks in CI and ensures the dependency is correctly installed or stubbed.

<sup>Written for commit 98d07c3d27ca2ab7beefc6360079c8597eb98bf2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

