### PR TITLE
fix(web search ui): make font sizes consistent

### DIFF
--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -218,9 +218,9 @@ const ProviderSetupModal = memo(
                   />
                 </FormField.Control>
                 {optionalField.description && (
-                  <div className="text-text-03 ml-0.5">
+                  <Text secondaryBody text03 className="ml-0.5">
                     {optionalField.description}
-                  </div>
+                  </Text>
                 )}
               </FormField>
             )}
@@ -321,9 +321,9 @@ const ProviderSetupModal = memo(
                   />
                 </FormField.Control>
                 {optionalField.description && (
-                  <div className="text-text-03 ml-0.5">
+                  <Text secondaryBody text03 className="ml-0.5">
                     {optionalField.description}
-                  </div>
+                  </Text>
                 )}
               </FormField>
             )}


### PR DESCRIPTION
After:
<img width="526" height="413" alt="Screenshot 2025-12-04 at 11 51 14 AM" src="https://github.com/user-attachments/assets/f4d247e8-7901-42ee-830f-2df95d3a0502" />

Before:
<img width="1052" height="826" alt="image" src="https://github.com/user-attachments/assets/ddac023c-9801-491c-b39b-fc29a8544d09" />

## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made explainer text in the Web Search configuration modal consistent by using the shared Text component instead of a styled div. This fixes mismatched font sizes for optional field descriptions.

<sup>Written for commit 2ed9a76ad35a0420b2ddfe1ad02bdc09b3c38823. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

