### PR TITLE
feat(tracing): Update the traces

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from typing import Any
 from typing import cast
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -790,8 +791,20 @@ def run_llm_loop(
     token_counter: Callable[[str], int],
     db_session: Session,
     forced_tool_id: int | None = None,
+    chat_session_id: UUID | None = None,
+    user_id: UUID | None = None,
 ) -> None:
-    with trace("run_llm_loop", metadata={"tenant_id": get_current_tenant_id()}):
+    trace_metadata: dict[str, Any] = {"tenant_id": get_current_tenant_id()}
+    if chat_session_id:
+        trace_metadata["chat_session_id"] = str(chat_session_id)
+    if user_id:
+        trace_metadata["user_id"] = str(user_id)
+
+    with trace(
+        "run_llm_loop",
+        group_id=str(chat_session_id) if chat_session_id else None,
+        metadata=trace_metadata,
+    ):
         # Fix some LiteLLM issues,
         from onyx.llm.litellm_singleton.config import (
             initialize_litellm,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -505,6 +505,8 @@ def stream_chat_message_objects(
             forced_tool_id=(
                 new_msg_req.forced_tool_ids[0] if new_msg_req.forced_tool_ids else None
             ),
+            chat_session_id=chat_session_id,
+            user_id=user_id,
         )
 
         # Determine if stopped by user

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -71,6 +71,15 @@ class BraintrustTracingProcessor(TracingProcessor):
     def on_trace_start(self, trace: Trace) -> None:
         trace_meta = trace.export() or {}
         metadata = trace_meta.get("metadata") or {}
+        if isinstance(metadata, dict):
+            metadata = dict(metadata)
+        else:
+            metadata = {"metadata": metadata}
+
+        group_id = trace_meta.get("group_id")
+        if group_id:
+            metadata.setdefault("group_id", group_id)
+            metadata.setdefault("session_id", group_id)
 
         current_context = braintrust.current_span()
         if current_context != NOOP_SPAN:

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -283,4 +283,5 @@ class TraceImpl(Trace):
             "id": self.trace_id,
             "workflow_name": self.name,
             "metadata": self.metadata,
+            "group_id": self.group_id,
         }


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update tracing to group events by chat session and include user/session metadata. Integrates Langfuse attributes and captures input/output and token usage for better observability.

- **New Features**
  - Group traces by chat_session_id via group_id; export group_id and set session_id from it.
  - run_llm_loop now accepts chat_session_id and user_id and adds them to trace metadata.
  - OpenInference processor applies Langfuse trace/span/generation attributes (input, output, model params, token usage).
  - Normalize and augment metadata; Braintrust now receives group_id and session_id.
  - Root spans record first input and last output and set OK status.

<sup>Written for commit 1623cee44defe0560695586eb8bdfe9eaab879cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

