### PR TITLE
chore(slack): add better typing + move some logs from debug to info

### DIFF
--- a/backend/onyx/context/search/federated/models.py
+++ b/backend/onyx/context/search/federated/models.py
@@ -1,6 +1,18 @@
 from datetime import datetime
+from typing import TypedDict
 
 from pydantic import BaseModel
+
+from onyx.onyxbot.slack.models import ChannelType
+
+
+class ChannelMetadata(TypedDict):
+    """Type definition for cached channel metadata."""
+
+    name: str
+    type: ChannelType
+    is_private: bool
+    is_member: bool
 
 
 class SlackMessage(BaseModel):

--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -16,12 +16,11 @@ from onyx.configs.app_configs import ENABLE_CONTEXTUAL_RAG
 from onyx.configs.chat_configs import DOC_TIME_DECAY
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import TextSection
+from onyx.context.search.federated.models import ChannelMetadata
 from onyx.context.search.federated.models import SlackMessage
 from onyx.context.search.federated.slack_search_utils import ALL_CHANNEL_TYPES
 from onyx.context.search.federated.slack_search_utils import build_channel_query_filter
 from onyx.context.search.federated.slack_search_utils import build_slack_queries
-from onyx.context.search.federated.slack_search_utils import ChannelMetadata
-from onyx.context.search.federated.slack_search_utils import ChannelTypeString
 from onyx.context.search.federated.slack_search_utils import get_channel_type
 from onyx.context.search.federated.slack_search_utils import (
     get_channel_type_for_missing_scope,
@@ -92,7 +91,7 @@ def fetch_and_cache_channel_metadata(
                 filtered: dict[str, ChannelMetadata] = {
                     k: v
                     for k, v in cached_data.items()
-                    if v.get("type") != ChannelTypeString.PRIVATE_CHANNEL.value
+                    if v.get("type") != ChannelType.PRIVATE_CHANNEL.value
                 }
                 logger.debug(f"Filtered to {len(filtered)} channels (exclude private)")
                 return filtered
@@ -135,7 +134,7 @@ def fetch_and_cache_channel_metadata(
 
                     # Determine channel type
                     channel_type_enum = get_channel_type(channel_info=ch)
-                    channel_type = ChannelTypeString(channel_type_enum.value)
+                    channel_type = ChannelType(channel_type_enum.value)
 
                     channel_metadata[channel_id] = {
                         "name": ch.get("name", ""),
@@ -353,7 +352,7 @@ def _extract_channel_data_from_entities(
                 if meta["name"]
                 and (
                     parsed_entities.include_private_channels
-                    or meta.get("type") != ChannelTypeString.PRIVATE_CHANNEL.value
+                    or meta.get("type") != ChannelType.PRIVATE_CHANNEL.value
                 )
             ]
     except ValidationError:

--- a/backend/onyx/context/search/federated/slack_search_utils.py
+++ b/backend/onyx/context/search/federated/slack_search_utils.py
@@ -4,14 +4,13 @@ import re
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
-from enum import Enum
 from typing import Any
-from typing import TypedDict
 
 from langchain_core.messages import HumanMessage
 from pydantic import ValidationError
 
 from onyx.configs.app_configs import MAX_SLACK_QUERY_EXPANSIONS
+from onyx.context.search.federated.models import ChannelMetadata
 from onyx.context.search.models import ChunkIndexRequest
 from onyx.federated_connectors.slack.models import SlackEntities
 from onyx.llm.interfaces import LLM
@@ -35,44 +34,25 @@ WORD_PUNCTUATION = ".,!?;:\"'#"
 
 RECENCY_KEYWORDS = ["recent", "latest", "newest", "last"]
 
-
-class ChannelTypeString(str, Enum):
-    """String representations of Slack channel types."""
-
-    IM = "im"
-    MPIM = "mpim"
-    PRIVATE_CHANNEL = "private_channel"
-    PUBLIC_CHANNEL = "public_channel"
-
-
-class ChannelMetadata(TypedDict):
-    """Type definition for cached channel metadata."""
-
-    name: str
-    type: ChannelTypeString
-    is_private: bool
-    is_member: bool
-
-
 # All Slack channel types for fetching metadata
 ALL_CHANNEL_TYPES = [
-    ChannelTypeString.PUBLIC_CHANNEL.value,
-    ChannelTypeString.IM.value,
-    ChannelTypeString.MPIM.value,
-    ChannelTypeString.PRIVATE_CHANNEL.value,
+    ChannelType.PUBLIC_CHANNEL.value,
+    ChannelType.IM.value,
+    ChannelType.MPIM.value,
+    ChannelType.PRIVATE_CHANNEL.value,
 ]
 
 # Map Slack API scopes to their corresponding channel types
 # This is used for graceful degradation when scopes are missing
 SCOPE_TO_CHANNEL_TYPE_MAP = {
-    "mpim:read": ChannelTypeString.MPIM.value,
-    "mpim:history": ChannelTypeString.MPIM.value,
-    "im:read": ChannelTypeString.IM.value,
-    "im:history": ChannelTypeString.IM.value,
-    "groups:read": ChannelTypeString.PRIVATE_CHANNEL.value,
-    "groups:history": ChannelTypeString.PRIVATE_CHANNEL.value,
-    "channels:read": ChannelTypeString.PUBLIC_CHANNEL.value,
-    "channels:history": ChannelTypeString.PUBLIC_CHANNEL.value,
+    "mpim:read": ChannelType.MPIM.value,
+    "mpim:history": ChannelType.MPIM.value,
+    "im:read": ChannelType.IM.value,
+    "im:history": ChannelType.IM.value,
+    "groups:read": ChannelType.PRIVATE_CHANNEL.value,
+    "groups:history": ChannelType.PRIVATE_CHANNEL.value,
+    "channels:read": ChannelType.PUBLIC_CHANNEL.value,
+    "channels:history": ChannelType.PUBLIC_CHANNEL.value,
 }
 
 
@@ -371,11 +351,11 @@ def get_channel_type(
         ch_meta = channel_metadata.get(channel_id)
         if ch_meta:
             type_str = ch_meta.get("type")
-            if type_str == ChannelTypeString.IM.value:
+            if type_str == ChannelType.IM.value:
                 return ChannelType.IM
-            elif type_str == ChannelTypeString.MPIM.value:
+            elif type_str == ChannelType.MPIM.value:
                 return ChannelType.MPIM
-            elif type_str == ChannelTypeString.PRIVATE_CHANNEL.value:
+            elif type_str == ChannelType.PRIVATE_CHANNEL.value:
                 return ChannelType.PRIVATE_CHANNEL
             return ChannelType.PUBLIC_CHANNEL
 


### PR DESCRIPTION
## Description

 Follow-up to #6588 addressing review comments from @Weves:

  1. Added proper typing for channel_metadata_dict parameter - Created ChannelMetadata TypedDict with strongly-typed fields:
    - name: str
    - type: ChannelTypeString (enum instead of raw string)
    - is_private: bool
    - is_member: bool
  2. Updated function signatures to use the new typed dict:
    - fetch_and_cache_channel_metadata() - return type
    - _extract_channel_data_from_entities() - parameter type
    - _should_skip_channel() - parameter type
    - query_slack() - parameter type
    - get_channel_type() - parameter type
  3. Reverted log levels for two useful log statements back to logger.info:
    - "Final query to slack: {final_query}"
    - "Slack search found {len(matches)} messages"

## How Has This Been Tested?

triggered some slack bot queries. all is gucci

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Slack search typing by centralizing ChannelMetadata in models and replacing ChannelTypeString with Slack’s ChannelType enum. Promoted key search logs to info for better observability.

- **Refactors**
  - Moved ChannelMetadata TypedDict to federated/models.py and updated function signatures to use it.
  - Replaced ChannelTypeString with ChannelType and updated channel type lists/maps.
  - Changed “Final query to slack” and “Slack search found … messages” logs to info.

<sup>Written for commit a8385a466fdc8be34f5585ec2dd58b128ccc5463. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







