### PR TITLE
fix: pass tools in responses api format for openai models

### DIFF
--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -92,9 +92,13 @@ def _convert_tools_to_responses_api_format(tools: list[dict]) -> list[dict]:
     for tool in tools:
         if tool.get("type") == "function" and "function" in tool:
             func = tool["function"]
+            name = func.get("name")
+            if not name:
+                logger.warning("Skipping tool with missing name in function definition")
+                continue
             converted_tool = {
                 "type": "function",
-                "name": func.get("name"),
+                "name": name,
                 "description": func.get("description", ""),
                 "parameters": func.get("parameters", {}),
             }


### PR DESCRIPTION
## Description

Added `_convert_tools_to_responses_api_format()`, converting tools from the OpenAI Chat Completions API format to the Responses API format when using an OpenAI model

The stream_options.include_usage parameter is now conditionally excluded when using the Responses API b/c the Responses API doesn't support it

## How Has This Been Tested?

Before these changes, attempting to send a message to an OpenAI model in an Onyx session locally caused a 400 bad request error with the message "Missing required parameter: 'tools[0].name'". Now, it executes the prompt processing flow correctly and returns a satisfactory result.

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert tool payloads to the OpenAI Responses API format when using OpenAI/Azure models, fixing 400 errors and allowing prompts to run correctly.

- **Bug Fixes**
  - Added a helper to convert tools from Chat Completions format to Responses format and preserve the strict flag.
  - Auto-apply converted tools when the Responses API is used.
  - Skip stream_options.include_usage for Responses API (not supported).
  - Resolves “Missing required parameter: 'tools[0].name'” errors.

<sup>Written for commit dc198ce1fb3faf629c7087cd4a5ce851b65b6ff0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





