### PR TITLE
feat(license): Add license infrastructure for billing system (Phase 1)

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_license_table.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_license_table.py
@@ -1,0 +1,49 @@
+"""add license table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 87c52ec39f84
+Create Date: 2025-12-04 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "87c52ec39f84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "license",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("license_data", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # Singleton pattern - only ever one row in this table
+    op.create_index(
+        "idx_license_singleton",
+        "license",
+        [sa.text("(true)")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_license_singleton", table_name="license")
+    op.drop_table("license")

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -1,0 +1,263 @@
+"""Database and cache operations for the license table."""
+
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ee.onyx.server.license.models import LicenseMetadata
+from ee.onyx.server.license.models import LicensePayload
+from ee.onyx.server.license.models import LicenseSource
+from onyx.db.models import License
+from onyx.db.models import User
+from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.redis_pool import get_redis_replica_client
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+LICENSE_METADATA_KEY = "license:metadata"
+LICENSE_CACHE_TTL_SECONDS = 86400  # 24 hours
+
+
+# -----------------------------------------------------------------------------
+# Database CRUD Operations
+# -----------------------------------------------------------------------------
+
+
+def get_license(db_session: Session) -> License | None:
+    """
+    Get the current license (singleton pattern - only one row).
+
+    Args:
+        db_session: Database session
+
+    Returns:
+        License object if exists, None otherwise
+    """
+    return db_session.execute(select(License)).scalars().first()
+
+
+def upsert_license(db_session: Session, license_data: str) -> License:
+    """
+    Insert or update the license (singleton pattern).
+
+    Args:
+        db_session: Database session
+        license_data: Base64-encoded signed license blob
+
+    Returns:
+        The created or updated License object
+    """
+    existing = get_license(db_session)
+
+    if existing:
+        existing.license_data = license_data
+        db_session.commit()
+        db_session.refresh(existing)
+        logger.info("License updated")
+        return existing
+
+    new_license = License(license_data=license_data)
+    db_session.add(new_license)
+    db_session.commit()
+    db_session.refresh(new_license)
+    logger.info("License created")
+    return new_license
+
+
+def delete_license(db_session: Session) -> bool:
+    """
+    Delete the current license.
+
+    Args:
+        db_session: Database session
+
+    Returns:
+        True if deleted, False if no license existed
+    """
+    existing = get_license(db_session)
+    if existing:
+        db_session.delete(existing)
+        db_session.commit()
+        logger.info("License deleted")
+        return True
+    return False
+
+
+# -----------------------------------------------------------------------------
+# Seat Counting
+# -----------------------------------------------------------------------------
+
+
+def get_used_seats(tenant_id: str | None = None) -> int:
+    """Get current seat usage."""
+    if MULTI_TENANT:
+        from ee.onyx.server.tenants.user_mapping import get_tenant_count
+
+        return get_tenant_count(tenant_id or get_current_tenant_id())
+    else:
+        # Self-hosted: count all active users
+        from onyx.db.engine.sql_engine import get_session_with_current_tenant
+
+        with get_session_with_current_tenant() as db_session:
+            result = db_session.execute(
+                select(func.count()).select_from(User).where(User.is_active)  # type: ignore
+            )
+            return result.scalar() or 0
+
+
+# -----------------------------------------------------------------------------
+# Redis Cache Operations
+# -----------------------------------------------------------------------------
+
+
+def get_cached_license_metadata(tenant_id: str | None = None) -> LicenseMetadata | None:
+    """
+    Get license metadata from Redis cache.
+
+    Args:
+        tenant_id: Tenant ID (for multi-tenant deployments)
+
+    Returns:
+        LicenseMetadata if cached, None otherwise
+    """
+    tenant = tenant_id or get_current_tenant_id()
+    redis_client = get_redis_replica_client(tenant_id=tenant)
+
+    cached = redis_client.get(LICENSE_METADATA_KEY)
+    if cached:
+        try:
+            cached_str: str
+            if isinstance(cached, bytes):
+                cached_str = cached.decode("utf-8")
+            else:
+                cached_str = str(cached)
+            return LicenseMetadata.model_validate_json(cached_str)
+        except Exception as e:
+            logger.warning(f"Failed to parse cached license metadata: {e}")
+            return None
+    return None
+
+
+def invalidate_license_cache(tenant_id: str | None = None) -> None:
+    """
+    Invalidate the license cache.
+
+    Args:
+        tenant_id: Tenant ID (for multi-tenant deployments)
+    """
+    tenant = tenant_id or get_current_tenant_id()
+    redis_client = get_redis_client(tenant_id=tenant)
+    redis_client.delete(LICENSE_METADATA_KEY)
+    logger.info("License cache invalidated")
+
+
+def update_license_cache(
+    payload: LicensePayload,
+    source: LicenseSource | None = None,
+    grace_period_end: datetime | None = None,
+    tenant_id: str | None = None,
+) -> LicenseMetadata:
+    """
+    Update the Redis cache with license metadata.
+
+    Args:
+        payload: Verified license payload
+        source: How the license was obtained
+        grace_period_end: Optional grace period end time
+        tenant_id: Tenant ID (for multi-tenant deployments)
+
+    Returns:
+        The cached LicenseMetadata
+    """
+    from ee.onyx.utils.license import get_license_status
+
+    tenant = tenant_id or get_current_tenant_id()
+    redis_client = get_redis_client(tenant_id=tenant)
+
+    used_seats = get_used_seats(tenant)
+    status = get_license_status(payload, grace_period_end)
+
+    metadata = LicenseMetadata(
+        tenant_id=payload.tenant_id,
+        organization_name=payload.organization_name,
+        seats=payload.seats,
+        used_seats=used_seats,
+        plan_type=payload.plan_type,
+        issued_at=payload.issued_at,
+        expires_at=payload.expires_at,
+        grace_period_end=grace_period_end,
+        status=status.value,
+        source=source,
+        stripe_subscription_id=payload.stripe_subscription_id,
+    )
+
+    redis_client.setex(
+        LICENSE_METADATA_KEY,
+        LICENSE_CACHE_TTL_SECONDS,
+        metadata.model_dump_json(),
+    )
+
+    logger.info(f"License cache updated: {metadata.seats} seats, status={status.value}")
+    return metadata
+
+
+def refresh_license_cache(
+    db_session: Session,
+    tenant_id: str | None = None,
+) -> LicenseMetadata | None:
+    """
+    Refresh the license cache from the database.
+
+    Args:
+        db_session: Database session
+        tenant_id: Tenant ID (for multi-tenant deployments)
+
+    Returns:
+        LicenseMetadata if license exists, None otherwise
+    """
+    from ee.onyx.utils.license import verify_license_signature
+
+    license_record = get_license(db_session)
+    if not license_record:
+        invalidate_license_cache(tenant_id)
+        return None
+
+    try:
+        payload = verify_license_signature(license_record.license_data)
+        return update_license_cache(
+            payload,
+            source=LicenseSource.AUTO_FETCH,
+            tenant_id=tenant_id,
+        )
+    except ValueError as e:
+        logger.error(f"Failed to verify license during cache refresh: {e}")
+        invalidate_license_cache(tenant_id)
+        return None
+
+
+def get_license_metadata(
+    db_session: Session,
+    tenant_id: str | None = None,
+) -> LicenseMetadata | None:
+    """
+    Get license metadata, using cache if available.
+
+    Args:
+        db_session: Database session
+        tenant_id: Tenant ID (for multi-tenant deployments)
+
+    Returns:
+        LicenseMetadata if license exists, None otherwise
+    """
+    # Try cache first
+    cached = get_cached_license_metadata(tenant_id)
+    if cached:
+        return cached
+
+    # Refresh from database
+    return refresh_license_cache(db_session, tenant_id)

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -14,6 +14,7 @@ from ee.onyx.server.enterprise_settings.api import (
     basic_router as enterprise_settings_router,
 )
 from ee.onyx.server.evals.api import router as evals_router
+from ee.onyx.server.license.api import router as license_router
 from ee.onyx.server.manage.standard_answer import router as standard_answer_router
 from ee.onyx.server.middleware.tenant_tracking import (
     add_api_server_tenant_id_middleware,
@@ -139,6 +140,8 @@ def get_application() -> FastAPI:
     )
     include_router_with_global_prefix_prepended(application, enterprise_settings_router)
     include_router_with_global_prefix_prepended(application, usage_export_router)
+    # License management
+    include_router_with_global_prefix_prepended(application, license_router)
 
     if MULTI_TENANT:
         # Tenant management

--- a/backend/ee/onyx/server/license/api.py
+++ b/backend/ee/onyx/server/license/api.py
@@ -1,0 +1,202 @@
+"""License API endpoints."""
+
+import requests
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import File
+from fastapi import HTTPException
+from fastapi import UploadFile
+from sqlalchemy.orm import Session
+
+from ee.onyx.auth.users import current_admin_user
+from ee.onyx.db.license import delete_license as db_delete_license
+from ee.onyx.db.license import get_license_metadata
+from ee.onyx.db.license import invalidate_license_cache
+from ee.onyx.db.license import refresh_license_cache
+from ee.onyx.db.license import update_license_cache
+from ee.onyx.db.license import upsert_license
+from ee.onyx.server.license.models import LicenseResponse
+from ee.onyx.server.license.models import LicenseSource
+from ee.onyx.server.license.models import LicenseStatusResponse
+from ee.onyx.server.license.models import LicenseUploadResponse
+from ee.onyx.server.license.models import SeatUsageResponse
+from ee.onyx.server.tenants.access import generate_data_plane_token
+from ee.onyx.utils.license import verify_license_signature
+from onyx.auth.users import User
+from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.db.engine.sql_engine import get_session
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/license")
+
+
+@router.get("")
+async def get_license_status(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> LicenseStatusResponse:
+    """Get current license status and seat usage."""
+    metadata = get_license_metadata(db_session)
+
+    if not metadata:
+        return LicenseStatusResponse(has_license=False)
+
+    return LicenseStatusResponse(
+        has_license=True,
+        seats=metadata.seats,
+        used_seats=metadata.used_seats,
+        plan_type=metadata.plan_type,
+        issued_at=metadata.issued_at,
+        expires_at=metadata.expires_at,
+        grace_period_end=metadata.grace_period_end,
+        status=metadata.status,
+        source=metadata.source,
+    )
+
+
+@router.get("/seats")
+async def get_seat_usage(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> SeatUsageResponse:
+    """Get detailed seat usage information."""
+    metadata = get_license_metadata(db_session)
+
+    if not metadata:
+        return SeatUsageResponse(
+            total_seats=0,
+            used_seats=0,
+            available_seats=0,
+        )
+
+    return SeatUsageResponse(
+        total_seats=metadata.seats,
+        used_seats=metadata.used_seats,
+        available_seats=max(0, metadata.seats - metadata.used_seats),
+    )
+
+
+@router.post("/fetch")
+async def fetch_license(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> LicenseResponse:
+    """
+    Fetch license from control plane.
+    Used after Stripe checkout completion to retrieve the new license.
+    """
+    tenant_id = get_current_tenant_id()
+
+    try:
+        token = generate_data_plane_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        url = f"{CONTROL_PLANE_API_BASE_URL}/license/{tenant_id}"
+        response = requests.get(url, headers=headers, timeout=10)
+
+        if not response.ok:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail="Failed to fetch license from control plane",
+            )
+
+        data = response.json()
+        license_data = data.get("license")
+        if not license_data:
+            raise HTTPException(status_code=404, detail="No license found")
+
+        payload = verify_license_signature(license_data)
+        upsert_license(db_session, license_data)
+        update_license_cache(payload, source=LicenseSource.AUTO_FETCH)
+
+        return LicenseResponse(success=True, license=payload)
+
+    except ValueError as e:
+        logger.error(f"License verification failed: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except requests.RequestException as e:
+        logger.exception("Failed to fetch license from control plane")
+        raise HTTPException(status_code=502, detail=str(e))
+
+
+@router.post("/upload")
+async def upload_license(
+    license_file: UploadFile = File(...),
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> LicenseUploadResponse:
+    """
+    Upload a license file manually.
+    Used for air-gapped deployments where control plane is not accessible.
+    """
+    try:
+        content = await license_file.read()
+        license_data = content.decode("utf-8").strip()
+        payload = verify_license_signature(license_data)
+
+        tenant_id = get_current_tenant_id()
+        if payload.tenant_id != tenant_id:
+            raise HTTPException(
+                status_code=400,
+                detail=f"License tenant ID mismatch. Expected {tenant_id}, got {payload.tenant_id}",
+            )
+
+        upsert_license(db_session, license_data)
+        update_license_cache(payload, source=LicenseSource.MANUAL_UPLOAD)
+
+        return LicenseUploadResponse(
+            success=True,
+            message=f"License uploaded successfully. {payload.seats} seats, expires {payload.expires_at.date()}",
+        )
+
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid license file format")
+
+
+@router.post("/refresh")
+async def refresh_license_cache_endpoint(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> LicenseStatusResponse:
+    """
+    Force refresh the license cache from the database.
+    Useful after manual database changes or to verify license validity.
+    """
+    metadata = refresh_license_cache(db_session)
+
+    if not metadata:
+        return LicenseStatusResponse(has_license=False)
+
+    return LicenseStatusResponse(
+        has_license=True,
+        seats=metadata.seats,
+        used_seats=metadata.used_seats,
+        plan_type=metadata.plan_type,
+        issued_at=metadata.issued_at,
+        expires_at=metadata.expires_at,
+        grace_period_end=metadata.grace_period_end,
+        status=metadata.status,
+        source=metadata.source,
+    )
+
+
+@router.delete("")
+async def delete_license(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> dict[str, bool]:
+    """
+    Delete the current license.
+    Admin only - removes license and invalidates cache.
+    """
+    deleted = db_delete_license(db_session)
+    invalidate_license_cache()
+
+    return {"deleted": deleted}

--- a/backend/ee/onyx/server/license/models.py
+++ b/backend/ee/onyx/server/license/models.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class PlanType(str, Enum):
+    MONTHLY = "monthly"
+    ANNUAL = "annual"
+
+
+class LicenseSource(str, Enum):
+    AUTO_FETCH = "auto_fetch"
+    MANUAL_UPLOAD = "manual_upload"
+
+
+class LicensePayload(BaseModel):
+    """The payload portion of a signed license."""
+
+    version: str
+    tenant_id: str
+    organization_name: str | None = None
+    issued_at: datetime
+    expires_at: datetime
+    seats: int
+    plan_type: PlanType
+    billing_cycle: str | None = None
+    grace_period_days: int = 30
+    stripe_subscription_id: str | None = None
+    stripe_customer_id: str | None = None
+
+
+class LicenseData(BaseModel):
+    """Full signed license structure."""
+
+    payload: LicensePayload
+    signature: str
+
+
+class LicenseMetadata(BaseModel):
+    """Cached license metadata stored in Redis."""
+
+    tenant_id: str
+    organization_name: str | None = None
+    seats: int
+    used_seats: int
+    plan_type: PlanType
+    issued_at: datetime
+    expires_at: datetime
+    grace_period_end: datetime | None = None
+    status: str
+    source: LicenseSource | None = None
+    stripe_subscription_id: str | None = None
+
+
+class LicenseStatusResponse(BaseModel):
+    """Response for license status API."""
+
+    has_license: bool
+    seats: int = 0
+    used_seats: int = 0
+    plan_type: PlanType | None = None
+    issued_at: datetime | None = None
+    expires_at: datetime | None = None
+    grace_period_end: datetime | None = None
+    status: str | None = None
+    source: LicenseSource | None = None
+
+
+class LicenseResponse(BaseModel):
+    """Response after license fetch/upload."""
+
+    success: bool
+    message: str | None = None
+    license: LicensePayload | None = None
+
+
+class LicenseUploadResponse(BaseModel):
+    """Response after license upload."""
+
+    success: bool
+    message: str | None = None
+
+
+class SeatUsageResponse(BaseModel):
+    """Response for seat usage API."""
+
+    total_seats: int
+    used_seats: int
+    available_seats: int

--- a/backend/ee/onyx/utils/license.py
+++ b/backend/ee/onyx/utils/license.py
@@ -1,0 +1,127 @@
+"""RSA-4096 license signature verification utilities."""
+
+import base64
+import json
+from datetime import datetime
+from datetime import timezone
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+from ee.onyx.server.license.models import LicenseData
+from ee.onyx.server.license.models import LicensePayload
+from onyx.server.settings.models import ApplicationStatus
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# RSA-4096 Public Key for license verification
+# This key is generated on the control plane and embedded here
+# Replace with actual public key when generated
+PUBLIC_KEY_PEM = """-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0PLACEHOLDER0000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000000000000000000000000000000000000000AQAB
+-----END PUBLIC KEY-----"""
+
+
+def _get_public_key() -> RSAPublicKey:
+    """Load the embedded public key."""
+    key = serialization.load_pem_public_key(PUBLIC_KEY_PEM.encode())
+    if not isinstance(key, RSAPublicKey):
+        raise ValueError("Expected RSA public key")
+    return key
+
+
+def verify_license_signature(license_data: str) -> LicensePayload:
+    """
+    Verify RSA-4096 signature and return payload if valid.
+
+    Args:
+        license_data: Base64-encoded JSON containing payload and signature
+
+    Returns:
+        LicensePayload if signature is valid
+
+    Raises:
+        ValueError: If license data is invalid or signature verification fails
+    """
+    try:
+        # Decode the license data
+        decoded = json.loads(base64.b64decode(license_data))
+        license_obj = LicenseData(**decoded)
+
+        payload_json = json.dumps(
+            license_obj.payload.model_dump(mode="json"), sort_keys=True
+        )
+        signature_bytes = base64.b64decode(license_obj.signature)
+
+        # Verify signature
+        public_key = _get_public_key()
+        public_key.verify(
+            signature_bytes,
+            payload_json.encode(),
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+
+        return license_obj.payload
+
+    except InvalidSignature:
+        logger.error("License signature verification failed")
+        raise ValueError("Invalid license signature")
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode license JSON: {e}")
+        raise ValueError("Invalid license format: not valid JSON")
+    except Exception as e:
+        logger.error(f"License verification error: {e}")
+        raise ValueError(f"License verification failed: {str(e)}")
+
+
+def get_license_status(
+    payload: LicensePayload,
+    grace_period_end: datetime | None = None,
+) -> ApplicationStatus:
+    """
+    Determine current license status based on expiry.
+
+    Args:
+        payload: The verified license payload
+        grace_period_end: Optional grace period end datetime
+
+    Returns:
+        ApplicationStatus indicating current license state
+    """
+    now = datetime.now(timezone.utc)
+
+    # Check if grace period has expired
+    if grace_period_end and now > grace_period_end:
+        return ApplicationStatus.GATED_ACCESS
+
+    # Check if license has expired
+    if now > payload.expires_at:
+        if grace_period_end and now <= grace_period_end:
+            return ApplicationStatus.GRACE_PERIOD
+        return ApplicationStatus.GATED_ACCESS
+
+    # License is valid
+    return ApplicationStatus.ACTIVE
+
+
+def is_license_valid(payload: LicensePayload) -> bool:
+    """Check if a license is currently valid (not expired)."""
+    now = datetime.now(timezone.utc)
+    return now <= payload.expires_at

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3911,3 +3911,18 @@ class ExternalGroupPermissionSyncAttempt(Base):
 
     def is_finished(self) -> bool:
         return self.status.is_terminal()
+
+
+class License(Base):
+    """Stores the signed license blob (singleton pattern - only one row)."""
+
+    __tablename__ = "license"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    license_data: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -15,9 +15,10 @@ class PageType(str, Enum):
 
 
 class ApplicationStatus(str, Enum):
-    PAYMENT_REMINDER = "payment_reminder"
-    GATED_ACCESS = "gated_access"
     ACTIVE = "active"
+    PAYMENT_REMINDER = "payment_reminder"
+    GRACE_PERIOD = "grace_period"
+    GATED_ACCESS = "gated_access"
 
 
 class Notification(BaseModel):

--- a/backend/tests/unit/ee/onyx/db/test_license.py
+++ b/backend/tests/unit/ee/onyx/db/test_license.py
@@ -1,0 +1,102 @@
+"""Tests for license database CRUD operations."""
+
+from unittest.mock import MagicMock
+
+from ee.onyx.db.license import delete_license
+from ee.onyx.db.license import get_license
+from ee.onyx.db.license import upsert_license
+from onyx.db.models import License
+
+
+class TestGetLicense:
+    """Tests for get_license function."""
+
+    def test_get_existing_license(self) -> None:
+        """Test getting an existing license."""
+        mock_session = MagicMock()
+        mock_license = License(id=1, license_data="test_data")
+
+        # Mock the query chain
+        mock_session.execute.return_value.scalars.return_value.first.return_value = (
+            mock_license
+        )
+
+        result = get_license(mock_session)
+
+        assert result is not None
+        assert result.license_data == "test_data"
+        mock_session.execute.assert_called_once()
+
+    def test_get_no_license(self) -> None:
+        """Test getting when no license exists."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.first.return_value = None
+
+        result = get_license(mock_session)
+
+        assert result is None
+
+
+class TestUpsertLicense:
+    """Tests for upsert_license function."""
+
+    def test_insert_new_license(self) -> None:
+        """Test inserting a new license when none exists."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.first.return_value = None
+
+        upsert_license(mock_session, "new_license_data")
+
+        # Verify add was called with a License object
+        mock_session.add.assert_called_once()
+        added_license = mock_session.add.call_args[0][0]
+        assert isinstance(added_license, License)
+        assert added_license.license_data == "new_license_data"
+
+        mock_session.commit.assert_called_once()
+        mock_session.refresh.assert_called_once()
+
+    def test_update_existing_license(self) -> None:
+        """Test updating an existing license."""
+        mock_session = MagicMock()
+        existing_license = License(id=1, license_data="old_data")
+        mock_session.execute.return_value.scalars.return_value.first.return_value = (
+            existing_license
+        )
+
+        upsert_license(mock_session, "updated_license_data")
+
+        # Verify the existing license was updated
+        assert existing_license.license_data == "updated_license_data"
+        mock_session.add.assert_not_called()  # Should not add new
+        mock_session.commit.assert_called_once()
+        mock_session.refresh.assert_called_once_with(existing_license)
+
+
+class TestDeleteLicense:
+    """Tests for delete_license function."""
+
+    def test_delete_existing_license(self) -> None:
+        """Test deleting an existing license."""
+        mock_session = MagicMock()
+        existing_license = License(id=1, license_data="test_data")
+        mock_session.execute.return_value.scalars.return_value.first.return_value = (
+            existing_license
+        )
+
+        result = delete_license(mock_session)
+
+        assert result is True
+        mock_session.delete.assert_called_once_with(existing_license)
+        mock_session.commit.assert_called_once()
+
+    def test_delete_no_license(self) -> None:
+        """Test deleting when no license exists."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalars.return_value.first.return_value = None
+
+        result = delete_license(mock_session)
+
+        assert result is False
+        mock_session.delete.assert_not_called()
+        mock_session.commit.assert_not_called()

--- a/backend/tests/unit/ee/onyx/utils/test_license_utils.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_utils.py
@@ -1,0 +1,256 @@
+"""Tests for license signature verification utilities."""
+
+import base64
+import json
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from ee.onyx.server.license.models import LicensePayload
+from ee.onyx.server.license.models import PlanType
+from ee.onyx.utils.license import get_license_status
+from ee.onyx.utils.license import is_license_valid
+from ee.onyx.utils.license import verify_license_signature
+from onyx.server.settings.models import ApplicationStatus
+
+
+def generate_test_key_pair() -> tuple[rsa.RSAPrivateKey, rsa.RSAPublicKey]:
+    """Generate a test RSA key pair."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,  # Use smaller key for faster tests
+    )
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def create_signed_license(
+    private_key: rsa.RSAPrivateKey,
+    payload: LicensePayload,
+) -> str:
+    """Create a signed license for testing."""
+    payload_json = json.dumps(payload.model_dump(mode="json"), sort_keys=True)
+    signature = private_key.sign(
+        payload_json.encode(),
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+
+    license_data = {
+        "payload": payload.model_dump(mode="json"),
+        "signature": base64.b64encode(signature).decode(),
+    }
+
+    return base64.b64encode(json.dumps(license_data).encode()).decode()
+
+
+class TestVerifyLicenseSignature:
+    """Tests for verify_license_signature function."""
+
+    def test_valid_signature(self) -> None:
+        """Test that a valid signature passes verification."""
+        private_key, public_key = generate_test_key_pair()
+
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        license_data = create_signed_license(private_key, payload)
+
+        # Patch the public key in the validator module
+        public_key_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+
+        with patch("ee.onyx.utils.license.PUBLIC_KEY_PEM", public_key_pem):
+            result = verify_license_signature(license_data)
+
+        assert result.tenant_id == "tenant_123"
+        assert result.seats == 50
+        assert result.plan_type == PlanType.MONTHLY
+
+    def test_invalid_signature(self) -> None:
+        """Test that an invalid signature fails verification."""
+        private_key, public_key = generate_test_key_pair()
+        _, different_public_key = generate_test_key_pair()
+
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        license_data = create_signed_license(private_key, payload)
+
+        # Use a different public key
+        different_public_key_pem = different_public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+
+        with patch(
+            "ee.onyx.utils.license.PUBLIC_KEY_PEM",
+            different_public_key_pem,
+        ):
+            with pytest.raises(ValueError, match="Invalid license signature"):
+                verify_license_signature(license_data)
+
+    def test_tampered_payload(self) -> None:
+        """Test that a tampered payload fails verification."""
+        private_key, public_key = generate_test_key_pair()
+
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=datetime(2025, 12, 31, tzinfo=timezone.utc),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        # Create valid signature
+        payload_json = json.dumps(payload.model_dump(mode="json"), sort_keys=True)
+        signature = private_key.sign(
+            payload_json.encode(),
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+
+        # Tamper with the payload (change seats)
+        tampered_payload = payload.model_dump(mode="json")
+        tampered_payload["seats"] = 1000  # Changed!
+
+        license_data = {
+            "payload": tampered_payload,
+            "signature": base64.b64encode(signature).decode(),
+        }
+
+        encoded_license = base64.b64encode(json.dumps(license_data).encode()).decode()
+
+        public_key_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+
+        with patch("ee.onyx.utils.license.PUBLIC_KEY_PEM", public_key_pem):
+            with pytest.raises(ValueError, match="Invalid license signature"):
+                verify_license_signature(encoded_license)
+
+    def test_invalid_base64(self) -> None:
+        """Test that invalid base64 fails."""
+        with pytest.raises(ValueError):
+            verify_license_signature("not-valid-base64!!!")
+
+    def test_invalid_json(self) -> None:
+        """Test that invalid JSON fails."""
+        invalid_data = base64.b64encode(b"not json").decode()
+        with pytest.raises(ValueError):
+            verify_license_signature(invalid_data)
+
+
+class TestGetLicenseStatus:
+    """Tests for get_license_status function."""
+
+    def test_active_license(self) -> None:
+        """Test status for an active license."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=30),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        status = get_license_status(payload)
+        assert status == ApplicationStatus.ACTIVE
+
+    def test_expired_license_no_grace(self) -> None:
+        """Test status for an expired license without grace period."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=60),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        status = get_license_status(payload)
+        assert status == ApplicationStatus.GATED_ACCESS
+
+    def test_expired_license_within_grace(self) -> None:
+        """Test status for an expired license within grace period."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=60),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        grace_end = datetime.now(timezone.utc) + timedelta(days=29)
+        status = get_license_status(payload, grace_period_end=grace_end)
+        assert status == ApplicationStatus.GRACE_PERIOD
+
+    def test_grace_period_expired(self) -> None:
+        """Test status when grace period has expired."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=90),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=31),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        grace_end = datetime.now(timezone.utc) - timedelta(days=1)
+        status = get_license_status(payload, grace_period_end=grace_end)
+        assert status == ApplicationStatus.GATED_ACCESS
+
+
+class TestIsLicenseValid:
+    """Tests for is_license_valid function."""
+
+    def test_valid_license(self) -> None:
+        """Test that an unexpired license is valid."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=30),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        assert is_license_valid(payload) is True
+
+    def test_expired_license(self) -> None:
+        """Test that an expired license is invalid."""
+        payload = LicensePayload(
+            version="1.0",
+            tenant_id="tenant_123",
+            issued_at=datetime.now(timezone.utc) - timedelta(days=60),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            seats=50,
+            plan_type=PlanType.MONTHLY,
+        )
+
+        assert is_license_valid(payload) is False


### PR DESCRIPTION
## Description

Full plan: https://linear.app/danswer/document/billing-and-licensing-system-implementation-plan-e1cba3c449ca

Data plane infrastructure for cryptographic license verification and storage.

### Architecture

```
┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│  Control Plane  │────▶│   Data Plane    │────▶│     Redis       │
│ (signs license) │     │ (verifies sig)  │     │   (caches)      │
└─────────────────┘     └─────────────────┘     └─────────────────┘
                               │
                               ▼
                        ┌─────────────────┐
                        │   PostgreSQL    │
                        │ (license table) │
                        └─────────────────┘
```

### License Format

A license is a base64-encoded JSON containing a payload and RSA-4096 signature:

```python
class LicensePayload(BaseModel):
    version: str
    tenant_id: str
    organization_name: str | None
    issued_at: datetime
    expires_at: datetime
    seats: int
    plan_type: PlanType  # monthly | annual
    grace_period_days: int = 30
    stripe_subscription_id: str | None
    stripe_customer_id: str | None

class LicenseData(BaseModel):
    payload: LicensePayload
    signature: str  # base64-encoded RSA signature
```

### Database

Single `license` table using singleton pattern (only one row, enforced by unique index):

```sql
CREATE TABLE license (
    id INTEGER PRIMARY KEY,
    license_data TEXT NOT NULL,
    created_at TIMESTAMP WITH TIME ZONE,
    updated_at TIMESTAMP WITH TIME ZONE
);

CREATE UNIQUE INDEX idx_license_singleton ON license ((true));
```

### Redis Cache

License metadata cached for 24 hours to avoid repeated DB + crypto verification:

```python
class LicenseMetadata(BaseModel):
    tenant_id: str
    seats: int
    used_seats: int  # computed on cache refresh
    plan_type: PlanType
    expires_at: datetime
    status: str  # ACTIVE | GRACE_PERIOD | GATED_ACCESS
    source: LicenseSource  # auto_fetch | manual_upload
```

### API Endpoints

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/license` | GET | Get current license status |
| `/license/seats` | GET | Get seat usage details |
| `/license/fetch` | POST | Pull license from control plane |
| `/license/upload` | POST | Manual file upload (air-gapped) |
| `/license/refresh` | POST | Force cache refresh |
| `/license` | DELETE | Remove license |

### Status States

| Status | Meaning |
|--------|---------|
| `ACTIVE` | License valid, not expired |
| `GRACE_PERIOD` | Expired but within grace period (default 30 days) |
| `GATED_ACCESS` | Expired and grace period ended |

### Seat Counting

- **Multi-tenant**: Uses `get_tenant_count()` for the tenant
- **Self-hosted**: Counts active users in the `User` table



Control plane implementation (Phase 1.1) is up next 

## How Has This Been Tested?

unit tests

## Additional Options

- [x] [Optional] Override Linear Check
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 1 adds the data-plane license system: a singleton license store, RSA signature verification, Redis-cached metadata, and admin APIs for status, seats, fetch, upload, refresh, and delete. Enables seat tracking, grace-period handling, and control-plane auto-fetch after Stripe checkout.

- **New Features**
  - Alembic migration and License SQLAlchemy model (singleton row).
  - Admin endpoints: GET /license, GET /license/seats, POST /license/fetch, POST /license/upload, POST /license/refresh, DELETE /license.
  - RSA-4096 license signature verification (public key placeholder).
  - Redis cache for license metadata (24h TTL) with seat usage and status.
  - Added GRACE_PERIOD to ApplicationStatus.

- **Migration**
  - Run Alembic upgrade to create the license table.
  - Ensure Redis is configured per tenant.
  - Use POST /license/fetch after Stripe checkout, or POST /license/upload for air-gapped.
  - Optionally call POST /license/refresh to rebuild cache from DB.

<sup>Written for commit a4ee81ed9dbc270dce769c1bc9af149d8f3f1147. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















