### PR TITLE
chore(devtools): QOL improvements for cherry-pick script

### DIFF
--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -31,6 +31,9 @@ func NewRootCommand() *cobra.Command {
 			} else {
 				log.SetLevel(log.InfoLevel)
 			}
+			log.SetFormatter(&log.TextFormatter{
+				DisableTimestamp: true,
+			})
 		},
 		Version: fmt.Sprintf("%s\ncommit %s", Version, Commit),
 	}


### PR DESCRIPTION
## Description

- Clean up some logging.
- Make git stdout only stream when `--debug` is set.
- Add `--dry-run`
- Add a prompt to ensure the release branch detection is correct
  - Allow prompt to be skipped with `--yes`
- Accept multiple commits

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the cherry-pick CLI to support multiple commits, add dry-run and confirmation, and clean up logging for a safer, clearer workflow. This makes hotfix cherry-picks easier and less error-prone.

- **New Features**
  - Cherry-pick one or more commits in order.
  - Add --dry-run to skip pushing and PR creation.
  - Prompt to confirm auto-detected release; skip with --yes.
  - Allow multiple --release values.

- **Refactors**
  - Cleaner logging: hide git stdout unless --debug; disable timestamps.
  - Safer branch operations using git switch and quiet/prune fetch.
  - Improved PR title/body generation for multi-commit cherry-picks.

<sup>Written for commit 7518453b9d0a90c366af3ec026691e09d3bda00f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





