### PR TITLE
fix: add reciprocal rank score for web search docs based on ordering

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/utils.py
+++ b/backend/onyx/tools/tool_implementations/web_search/utils.py
@@ -15,8 +15,12 @@ def truncate_search_result_content(content: str, max_chars: int = 20000) -> str:
 
 def inference_section_from_internet_page_scrape(
     result: WebContent,
+    rank: int = 0,
 ) -> InferenceSection:
     truncated_content = truncate_search_result_content(result.full_content)
+    # Calculate score using reciprocal rank to preserve ordering
+    score = 1.0 / (rank + 1)
+
     inference_chunk = InferenceChunk(
         chunk_id=0,
         blurb=result.title,
@@ -29,9 +33,7 @@ def inference_section_from_internet_page_scrape(
         title=result.title,
         boost=1,
         recency_bias=1.0,
-        # TODO, this is not a great system for this, and can cause the results to be out of order
-        # when saving and loading from the db, Postgres doesn't maintain the order.
-        score=0,
+        score=score,
         hidden=False,
         metadata={},
         match_highlights=[truncated_content],
@@ -49,7 +51,11 @@ def inference_section_from_internet_page_scrape(
 
 def inference_section_from_internet_search_result(
     result: WebSearchResult,
+    rank: int = 0,
 ) -> InferenceSection:
+    # Calculate score using reciprocal rank to preserve ordering
+    score = 1.0 / (rank + 1)
+
     chunk = InferenceChunk(
         chunk_id=0,
         blurb=result.snippet,
@@ -62,8 +68,7 @@ def inference_section_from_internet_search_result(
         title=result.title,
         boost=1,
         recency_bias=1.0,
-        # TODO, this is not a great system for this, and can cause the results to be out of order
-        score=0,
+        score=score,
         hidden=False,
         metadata={},
         match_highlights=[result.snippet],

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -188,10 +188,10 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
         if not all_search_results:
             raise RuntimeError("No search results found.")
 
-        # Convert search results to InferenceSections
+        # Convert search results to InferenceSections with rank-based scoring
         inference_sections = [
-            inference_section_from_internet_search_result(result)
-            for result in all_search_results
+            inference_section_from_internet_search_result(result, rank=i)
+            for i, result in enumerate(all_search_results)
         ]
 
         # Convert to SearchDocs


### PR DESCRIPTION
## Description

All web search tool returns documents in order of most relevance, so we assign a score based on this ordering and store that in the db, so that documents are returned in a consistent order

Addresses https://linear.app/danswer/issue/DAN-3136/web-search-docs-ordering

## How Has This Been Tested?

Need to figure out good way to test this

## Additional Options

- [ ] [Optional] Override Linear Check
