### PR TITLE
fix: litellm w/ azure reasoning mode (#6612)

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -910,21 +910,31 @@ def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     """
 
     # NOTE: not using the OPENAI_PROVIDER_NAME constant here due to circular import issues
-    if model_provider != "openai":
+    if model_provider != "openai" and model_provider != "litellm_proxy":
         return False
 
+    model_map = get_model_map()
+
+    def _check_if_model_name_is_openai_provider(model_name: str) -> bool:
+        return (
+            model_name in model_map
+            and model_map[model_name].get("litellm_provider") == "openai"
+        )
+
     try:
-        model_map = get_model_map()
+
         # Check if any model exists in litellm's registry with openai prefix
         # If it's registered as "openai/model-name", it's a real OpenAI model
         if f"openai/{model_name}" in model_map:
             return True
 
-        if (
-            model_name in model_map
-            and model_map[model_name].get("litellm_provider") == "openai"
-        ):
+        if _check_if_model_name_is_openai_provider(model_name):
             return True
+
+        if model_name.startswith("azure/"):
+            model_name_with_azure_removed = "/".join(model_name.split("/")[1:])
+            if _check_if_model_name_is_openai_provider(model_name_with_azure_removed):
+                return True
 
         return False
 

--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -128,3 +128,13 @@ class TestIsTrueOpenAIModel:
         model_map = get_model_map()
         if "openai/gpt-3.5-turbo-instruct" in model_map:
             assert is_true_openai_model("openai", "gpt-3.5-turbo-instruct") is True
+
+    def test_azure_openai_model_through_litellm_proxy(self) -> None:
+        """Test that Azure OpenAI models are correctly identified."""
+        assert is_true_openai_model("litellm_proxy", "gpt-4") is True
+        assert is_true_openai_model("litellm_proxy", "gpt-5") is True
+        assert is_true_openai_model("litellm_proxy", "gpt-5.1") is True
+
+        assert is_true_openai_model("litellm_proxy", "azure/gpt-4") is True
+        assert is_true_openai_model("litellm_proxy", "azure/gpt-5") is True
+        assert is_true_openai_model("litellm_proxy", "azure/gpt-5.1") is True


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI model detection when using LiteLLM proxy and Azure-prefixed models, enabling Azure reasoning mode via LiteLLM. Updates the detection logic to correctly treat Azure OpenAI models as true OpenAI models.

- **Bug Fixes**
  - Recognize "litellm_proxy" as a valid provider in is_true_openai_model.
  - Handle "azure/<model>" names by checking their underlying OpenAI mapping.
  - Added unit tests for litellm_proxy and azure model names (gpt-4, gpt-5, gpt-5.1).

<sup>Written for commit f8ac971f05822bd5dd91edee13188516e5bce3a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

