### PR TITLE
fix: only re-index active connectors

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -818,7 +818,8 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
             if secondary_search_settings:
                 # For ACTIVE_ONLY, we skip paused connectors
                 include_paused = (
-                    secondary_search_settings.switchover_type != SwitchoverType.ACTIVE_ONLY
+                    secondary_search_settings.switchover_type
+                    != SwitchoverType.ACTIVE_ONLY
                 )
                 standard_cc_pair_ids = (
                     fetch_indexable_standard_connector_credential_pair_ids(


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure re-indexing only targets active connectors when switchover_type is ACTIVE_ONLY, skipping paused connectors. Paused connectors are included for other switchover types to preserve expected behavior.

- **Bug Fixes**
  - Updated check_for_indexing to exclude paused connector-credential pairs when switchover_type is ACTIVE_ONLY by setting active_cc_pairs_only accordingly.

<sup>Written for commit 52382ca8e29cca5eda8bc6a9c7d4cd54f98a35f0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







