### PR TITLE
fix: add default-groups=all

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,9 @@ dev = [
     "hatchling==1.28.0",
 ]
 
+[tool.uv]
+default-groups = "all"
+
 [tool.uv.workspace]
 members = ["backend", "tools/ods"]
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set uv’s default dependency groups to “all” in pyproject.toml so all groups install by default. This prevents missing dev/tool dependencies during setup across the workspace.

<sup>Written for commit b446233e5d9826a29260d447e13ffac11ea1afab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

