### PR TITLE
fix: hitting endpoint with undefined persona

### DIFF
--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -1044,6 +1044,8 @@ export function useChatController({
 
   // fetch # of allowed document tokens for the selected Persona
   useEffect(() => {
+    if (!liveAssistant?.id) return; // avoid calling with undefined persona id
+
     async function fetchMaxTokens() {
       const response = await fetch(
         `/api/chat/max-selected-document-tokens?persona_id=${liveAssistant?.id}`


### PR DESCRIPTION
## Description

unnecessary call to fetch max tokens before assistant id is set (race condition)

## How Has This Been Tested?

n/a, strictly an improvement

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented max-tokens API calls when no assistant is selected. Adds an early return in useChatController so the fetch runs only when liveAssistant.id exists, avoiding race-condition requests with an undefined persona id.

<sup>Written for commit 5b39e854682c9b6675abf595f19cf46287ad0e79. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

