### PR TITLE
fix(sharepoint): set tenant domain for client secret auth

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1258,22 +1258,21 @@ class SharepointConnector(
             return token
 
         self._graph_client = GraphClient(_acquire_token_for_graph)
-        if auth_method == SharepointAuthMethod.CERTIFICATE.value:
-            org = self.graph_client.organization.get().execute_query()
-            if not org or len(org) == 0:
-                raise ConnectorValidationError("No organization found")
 
-            tenant_info: Organization = org[
-                0
-            ]  # Access first item directly from collection
-            if not tenant_info.verified_domains:
-                raise ConnectorValidationError("No verified domains found for tenant")
+        org = self.graph_client.organization.get().execute_query()
+        if not org or len(org) == 0:
+            raise ConnectorValidationError("No organization found")
 
-            sp_tenant_domain = tenant_info.verified_domains[0].name
-            if not sp_tenant_domain:
-                raise ConnectorValidationError("No verified domains found for tenant")
-            # remove the .onmicrosoft.com part
-            self.sp_tenant_domain = sp_tenant_domain.split(".")[0]
+        tenant_info: Organization = org[0]
+        if not tenant_info.verified_domains:
+            raise ConnectorValidationError("No verified domains found for tenant")
+
+        sp_tenant_domain = tenant_info.verified_domains[0].name
+        if not sp_tenant_domain:
+            raise ConnectorValidationError("No verified domains found for tenant")
+        # remove the .onmicrosoft.com part
+        self.sp_tenant_domain = sp_tenant_domain.split(".")[0]
+
         return None
 
     def _create_document_failure(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
@@ -1,0 +1,153 @@
+"""Unit tests for SharePoint connector load_credentials method."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.connectors.sharepoint.connector import SharepointConnector
+
+
+class MockVerifiedDomain:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class MockOrganization:
+    def __init__(self, verified_domains: list[MockVerifiedDomain]) -> None:
+        self.verified_domains = verified_domains
+
+
+class MockOrganizationQuery:
+    def __init__(self, organizations: list[MockOrganization]) -> None:
+        self._organizations = organizations
+
+    def get(self) -> MockOrganizationQuery:
+        return self
+
+    def execute_query(self) -> list[MockOrganization]:
+        return self._organizations
+
+
+class MockGraphClient:
+    def __init__(self, organizations: list[MockOrganization]) -> None:
+        self.organization = MockOrganizationQuery(organizations)
+
+
+def _create_mock_msal_app() -> MagicMock:
+    """Create a mock MSAL ConfidentialClientApplication."""
+    mock_app = MagicMock()
+    mock_app.acquire_token_for_client.return_value = {
+        "access_token": "fake_token",
+        "token_type": "Bearer",
+    }
+    return mock_app
+
+
+@pytest.fixture
+def client_secret_credentials() -> dict[str, Any]:
+    """Credentials for client secret authentication."""
+    return {
+        "authentication_method": "client_secret",
+        "sp_client_id": "test-client-id",
+        "sp_client_secret": "test-client-secret",
+        "sp_directory_id": "test-directory-id",
+    }
+
+
+@pytest.fixture
+def certificate_credentials() -> dict[str, Any]:
+    """Credentials for certificate authentication."""
+    return {
+        "authentication_method": "certificate",
+        "sp_client_id": "test-client-id",
+        "sp_directory_id": "test-directory-id",
+        "sp_private_key": "dGVzdA==",  # base64("test")
+        "sp_certificate_password": "test-password",
+    }
+
+
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+def test_load_credentials_client_secret_sets_tenant_domain(
+    mock_msal_class: MagicMock,
+    mock_graph_client_class: MagicMock,
+    client_secret_credentials: dict[str, Any],
+) -> None:
+    """Test that load_credentials sets sp_tenant_domain when using client secret auth."""
+    # Setup mocks
+    mock_msal_class.return_value = _create_mock_msal_app()
+
+    mock_org = MockOrganization([MockVerifiedDomain("contoso.onmicrosoft.com")])
+    mock_graph_client = MockGraphClient([mock_org])
+    mock_graph_client_class.return_value = mock_graph_client
+
+    # Create connector and load credentials
+    connector = SharepointConnector()
+    connector.load_credentials(client_secret_credentials)
+
+    # Verify msal_app is set
+    assert connector.msal_app is not None
+
+    # Verify sp_tenant_domain is set (should be "contoso" - the part before the first dot)
+    assert connector.sp_tenant_domain == "contoso"
+
+
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+@patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
+def test_load_credentials_certificate_sets_tenant_domain(
+    mock_load_cert: MagicMock,
+    mock_msal_class: MagicMock,
+    mock_graph_client_class: MagicMock,
+    certificate_credentials: dict[str, Any],
+) -> None:
+    """Test that load_credentials sets sp_tenant_domain when using certificate auth."""
+    # Setup mocks
+    mock_cert_data = MagicMock()
+    mock_cert_data.model_dump.return_value = {
+        "private_key": "key",
+        "thumbprint": "thumb",
+    }
+    mock_load_cert.return_value = mock_cert_data
+
+    mock_msal_class.return_value = _create_mock_msal_app()
+
+    mock_org = MockOrganization([MockVerifiedDomain("fabrikam.onmicrosoft.com")])
+    mock_graph_client = MockGraphClient([mock_org])
+    mock_graph_client_class.return_value = mock_graph_client
+
+    # Create connector and load credentials
+    connector = SharepointConnector()
+    connector.load_credentials(certificate_credentials)
+
+    # Verify msal_app is set
+    assert connector.msal_app is not None
+
+    # Verify sp_tenant_domain is set (should be "fabrikam" - the part before the first dot)
+    assert connector.sp_tenant_domain == "fabrikam"
+
+
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+def test_load_credentials_tenant_domain_extracted_correctly(
+    mock_msal_class: MagicMock,
+    mock_graph_client_class: MagicMock,
+    client_secret_credentials: dict[str, Any],
+) -> None:
+    """Test that tenant domain is extracted correctly from verified domain name."""
+    mock_msal_class.return_value = _create_mock_msal_app()
+
+    # Test with a more complex domain name
+    mock_org = MockOrganization([MockVerifiedDomain("my-company.sharepoint.com")])
+    mock_graph_client = MockGraphClient([mock_org])
+    mock_graph_client_class.return_value = mock_graph_client
+
+    connector = SharepointConnector()
+    connector.load_credentials(client_secret_credentials)
+
+    # Should extract only the first part before the dot
+    assert connector.sp_tenant_domain == "my-company"


### PR DESCRIPTION
## Description

The `sp_tenant_domain` was only being set when using certificate authentication, causing permissions sync to fail with "MSAL app or tenant domain is not set" error for connectors using client secret auth when "Auto Sync Permissions" is enabled.

This PR moves the tenant domain fetching logic outside the certificate-only block so it runs for all authentication methods.

  Why it's needed for all auth methods:
  - Graph API uses https://graph.microsoft.com/.default (works without tenant domain)
  - SharePoint REST API uses https://{tenant}.sharepoint.com/.default (needs tenant domain)
  - Permissions sync uses the SharePoint REST API via ClientContext, so it needs the tenant domain regardless of how you authenticated

## How Has This Been Tested?

- Added unit tests for `load_credentials` that verify `sp_tenant_domain` is set for both CLIENT_SECRET and CERTIFICATE auth methods
- All 3 new tests pass

## Additional Options

- [x] [Optional] Override Linear Check









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint permission sync for client secret auth by always setting the tenant domain during credential loading. Applies tenant domain lookup for all auth methods to unblock Auto Sync Permissions.

- **Bug Fixes**
  - SharePoint: fetch and set sp_tenant_domain for client secret and certificate flows; added unit tests covering both paths and domain extraction.

<sup>Written for commit c53b731e312261085b1124cfa58850dd62163b62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









