### PR TITLE
chore(vscode): migrate install python reqs to uv

### DIFF
--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -554,10 +554,10 @@
       "name": "Install Python Requirements",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "bash",
+      "runtimeExecutable": "uv",
       "runtimeArgs": [
-        "-c",
-        "pip install -r backend/requirements/default.txt && pip install -r backend/requirements/dev.txt && pip install -r backend/requirements/ee.txt && pip install -r backend/requirements/model_server.txt"
+        "sync",
+        "--all-extras"
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",


### PR DESCRIPTION
## Description

I missed a `pip` usage in a hidden directory.

## How Has This Been Tested?

<img width="2880" height="1920" alt="20251205_16h11m25s_grim" src="https://github.com/user-attachments/assets/68dd5400-7e2d-421a-bef3-bb6df8f6a288" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the VSCode “Install Python Requirements” launch task from pip via bash to uv sync --all-extras. This removes the hidden pip usage, aligns with our uv-managed environment, and installs all extras deterministically.

<sup>Written for commit 3628a1108bacc11d59e2f922d99524c871d1915d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

