### PR TITLE
fix(ui): Search Settings Active Only

### DIFF
--- a/web/src/app/admin/configuration/search/UpgradingPage.tsx
+++ b/web/src/app/admin/configuration/search/UpgradingPage.tsx
@@ -22,12 +22,8 @@ import { Connector } from "@/lib/connectors/connectors";
 import { FailedReIndexAttempts } from "@/components/embedding/FailedReIndexAttempts";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { useConnectorIndexingStatusWithPagination } from "@/lib/hooks";
-<<<<<<< HEAD
 import { SvgX } from "@opal/icons";
-import { ConnectorCredentialPairStatus } from "../../connector/[ccPairId]/types";
-=======
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
->>>>>>> 817bede39 (addressing comments)
 
 export default function UpgradingPage({
   futureEmbeddingModel,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show re-indexing progress only for active connectors when switchover type is “active_only,” and display a clear message when all connectors are paused and not blocking the switchover.

- **Bug Fixes**
  - Filter out paused connector pairs from the re-indexing table in “active_only” mode.
  - Base sorting and visibility on filtered statuses; show an empty-state message when no active connectors are blocking.

<sup>Written for commit ce4e63c668d3902efb713b806c4e04531efde038. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







