### PR TITLE
chore(devtools): upgrade onyx-devtools 0.0.2->0.0.3

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -260,7 +260,7 @@ numpy==1.26.4
     #   pandas-stubs
     #   shapely
     #   voyageai
-onyx-devtools==0.0.2
+onyx-devtools==0.0.3
     # via onyx
 openai==2.6.1
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ dev = [
     "ipykernel==6.29.5",
     "release-tag==0.4.3",
     "zizmor==1.18.0",
-    "onyx-devtools==0.0.2",
+    "onyx-devtools==0.0.3",
     "manygo==0.2.0",
     "hatchling==1.28.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3572,7 +3572,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==1.26.4" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.0.2" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.0.3" },
     { name = "openai", specifier = "==2.6.1" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
     { name = "openpyxl", marker = "extra == 'backend'", specifier = "==3.0.10" },
@@ -3674,16 +3674,11 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.0.2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/84/8d97c856aee8677413beb48f6a2a98ac2e98b4c53b03a2b26794041c3044/onyx_devtools-0.0.2-py3-none-any.whl", hash = "sha256:50ab24322ab6e2a4b4b02d4f92dcd4871755daac3b23ce19a7024de1f39ea458", size = 1156648, upload-time = "2025-12-05T01:29:26.34Z" },
-    { url = "https://files.pythonhosted.org/packages/26/07/d42b4a8310c90ae51d30b561e22d0cbd06523f6e39c07373fdc8dbe0a320/onyx_devtools-0.0.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:99384c97d9ff5b02dd072d353f5d314531f791c432e014f7a6d75f1bb3817d23", size = 1146427, upload-time = "2025-12-05T01:30:08.391Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/8e/6e22b3c96d493f97f5a14c1a56d8141845c8b3b6d25674c0ae775cae937d/onyx_devtools-0.0.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2ab6e00c1697269d4b350f22f4de0a253d05d4ae07c9e67b9759a258712c3668", size = 1080355, upload-time = "2025-12-05T01:29:22.483Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/77/9c300ee47d55e99a7beb70aae983c783d2f78219069213c24ad091e7b201/onyx_devtools-0.0.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:924e1f76b590c27c31fcf7d1de4d12bc6d9095c2935ea22d612ca325fa092210", size = 1058229, upload-time = "2025-12-05T01:30:04.6Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/10/10f2690a576d627648c64c7449b9cbab8fcd11ba8125c80981230a1ddb63/onyx_devtools-0.0.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:2fbca1c370e08759c2354e766aadfdfc8b5fe61936641400f4120817d2239026", size = 1156668, upload-time = "2025-12-05T01:29:24.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/4d634ff14402364f6730061417f0b8f7c3e8dc03ef47326233cad0ec9b54/onyx_devtools-0.0.2-py3-none-win_amd64.whl", hash = "sha256:e5dfe7b83d731c6af3afc3c14781de2e5258863edd763ce8ae4217936fb613be", size = 1237537, upload-time = "2025-12-05T01:29:27.566Z" },
-    { url = "https://files.pythonhosted.org/packages/56/71/974d966b6849a2feaf855b58beb03071f8ae1a532af911f2047169a4f80a/onyx_devtools-0.0.2-py3-none-win_arm64.whl", hash = "sha256:601364ff43f68b3e7ca05324897ed64b9df8b130bb9dfe935e46c207043ee162", size = 1122945, upload-time = "2025-12-05T01:29:27.5Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/fb6c6d374e032cb788db494b41db21cf5b75d354231657845320c03d1c4f/onyx_devtools-0.0.3-py3-none-any.whl", hash = "sha256:055c2cb166d8531802d5ff9ac86e21b67c8a83fccba6474788a324036fb11801", size = 1203090, upload-time = "2025-12-06T17:55:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/07/a37f20e342c2db40beda222eb4b9b621bf0f2bebdf399b4810dbf0ce8d16/onyx_devtools-0.0.3-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c5eb14880db6b18b964e109da960e2f29b1f5480333a7e3913e67caef2927263", size = 1100677, upload-time = "2025-12-06T17:55:24.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Pulls in https://github.com/onyx-dot-app/onyx/pull/6661

## How Has This Been Tested?

```
uv sync --all-extras
ods --version
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded onyx-devtools from 0.0.2 to 0.0.3 to pull in the latest dev tooling fixes from upstream. Dev-only change aligned with the ODS 0.0.3 branch; no runtime impact.

- **Dependencies**
  - Bumped onyx-devtools in pyproject.toml and backend/requirements/dev.txt.
  - Regenerated uv.lock to reflect the new version.

<sup>Written for commit aef85e3b85b76bce4c8367a42ce74e4b9bc6b90e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

