### PR TITLE
chore: only pause after repeated failure on cloud

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -447,10 +447,11 @@ def set_cc_pair_repeated_error_state(
     values: dict = {"in_repeated_error_state": in_repeated_error_state}
 
     # When entering repeated error state, also pause the connector
-    # to prevent continued indexing retry attempts.
+    # to prevent continued indexing retry attempts burning through embedding credits.
     # However, don't pause if there's an active manual indexing trigger,
     # which indicates the user wants to retry immediately.
-    # Only pause for cloud deployments - self-hosted users manage their own connectors.
+    # NOTE: only for Cloud, since most self-hosted users use self-hosted embedding
+    # models. Also, they are more prone to repeated failures -> eventual success.
     if in_repeated_error_state and AUTH_TYPE == AuthType.CLOUD:
         cc_pair = get_connector_credential_pair_from_id(
             db_session=db_session,

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -6,14 +6,11 @@ import httpx
 from onyx.background.celery.tasks.docprocessing.utils import (
     NUM_REPEAT_ERRORS_BEFORE_REPEATED_ERROR_STATE,
 )
-from onyx.configs.app_configs import AUTH_TYPE
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
@@ -124,12 +121,13 @@ def test_repeated_error_state_detection_and_recovery(
             )
             assert cc_pair_obj is not None
             if cc_pair_obj.in_repeated_error_state:
-                # Pausing only happens for cloud deployments
-                if AUTH_TYPE == AuthType.CLOUD:
-                    assert cc_pair_obj.status == ConnectorCredentialPairStatus.PAUSED, (
-                        f"Expected status to be PAUSED when in repeated error state, "
-                        f"but got {cc_pair_obj.status}"
-                    )
+                # Pausing only happens for cloud deployments and the IT don't run with
+                # that auth type :(
+                # if AUTH_TYPE == AuthType.CLOUD:
+                #     assert cc_pair_obj.status == ConnectorCredentialPairStatus.PAUSED, (
+                #         f"Expected status to be PAUSED when in repeated error state, "
+                #         f"but got {cc_pair_obj.status}"
+                #     )
                 break
 
         if time.monotonic() - start_time > 30:


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only pause connectors after repeated indexing failures on cloud. Self-hosted deployments no longer auto-pause; integration tests now skip pause assertions since they don’t run with cloud auth.

<sup>Written for commit faaad1c2f10220e1d45f840d7aaf15d51546169d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



