### PR TITLE
chore(gha): replace pre-commit with prek

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Description

[Prek](https://prek.j178.dev/) is a fast, modern drop-in replacement for pre-commit. (It's what I use locally.)

Also replaces the runs-on runner with `ubuntu-latest` since we aren't using any runs-on specific features and it's cheaper, more than 1cpu, and x64 instead of arm. 

Also upgrades the other actions in the workflow, but should be fine.

## How Has This Been Tested?

Captured by existing, `prek run --all-files` locally

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced pre-commit with prek in the PR quality workflow to speed up checks. Also moved the runner to ubuntu-latest and updated action versions for stability and lower cost.

- **Refactors**
  - Swapped pre-commit/action for j178/prek-action (prek 0.2.21) with PR diff args.
  - Changed runner to ubuntu-latest (x64, more CPU, cheaper).

- **Dependencies**
  - Upgraded actions/setup-node to v6.
  - Updated the pinned SHA for actions/checkout (v6).

<sup>Written for commit 5bb16a32fedc9dd04e883e60f75007bcce8701d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



