### PR TITLE
fix(users): Add Race Condition Handling (#6639)

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -56,6 +56,7 @@ from httpx_oauth.oauth2 import OAuth2Token
 from pydantic import BaseModel
 from sqlalchemy import nulls_last
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
@@ -339,6 +340,39 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         user_create, safe=safe, request=request
                     )  # type: ignore
                     user_created = True
+                except IntegrityError as error:
+                    # Race condition: another request created the same user after the
+                    # pre-insert existence check but before our commit.
+                    await self.user_db.session.rollback()
+                    logger.warning(
+                        "IntegrityError while creating user %s, assuming duplicate: %s",
+                        user_create.email,
+                        str(error),
+                    )
+                    try:
+                        user = await self.get_by_email(user_create.email)
+                    except exceptions.UserNotExists:
+                        # Unexpected integrity error, surface it for handling upstream.
+                        raise error
+
+                    if MULTI_TENANT:
+                        user_by_session = await db_session.get(User, user.id)
+                        if user_by_session:
+                            user = user_by_session
+
+                    if (
+                        user.role.is_web_login()
+                        or not isinstance(user_create, UserCreate)
+                        or not user_create.role.is_web_login()
+                    ):
+                        raise exceptions.UserAlreadyExists()
+
+                    user_update = UserUpdateWithRole(
+                        password=user_create.password,
+                        is_verified=user_create.is_verified,
+                        role=user_create.role,
+                    )
+                    user = await self.update(user_update, user)
                 except exceptions.UserAlreadyExists:
                     user = await self.get_by_email(user_create.email)
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle race conditions during user creation by catching IntegrityError, reconciling with the existing user, and updating web-login users when appropriate. Prevents intermittent 500s and duplicate records in concurrent signups, including multi-tenant setups.

- **Bug Fixes**
  - Catch IntegrityError on create, rollback the session, and log.
  - Fetch existing user by email; in multi-tenant mode, refresh via session.
  - For web-login users, update password, verification, and role; otherwise raise UserAlreadyExists.
  - Stabilizes concurrent signup flows and avoids duplicate inserts.

<sup>Written for commit 80dd2ad8c1981ed0737026c2bf9c1292254e92c6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

