### PR TITLE
fix(multi-tenant): User Management cleanup

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -356,6 +356,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         raise error
 
                     if MULTI_TENANT:
+                        db_session.expire_all()
                         user_by_session = await db_session.get(User, user.id)
                         if user_by_session:
                             user = user_by_session


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire the DB session during multi-tenant user creation to reload the user from the database and prevent stale data in User Management. This ensures the returned user reflects the correct tenant state.

- **Bug Fixes**
  - Call db_session.expire_all() before db_session.get(User, user.id) when MULTI_TENANT is enabled to avoid stale session reads.

<sup>Written for commit 3f7b1824a7eadc4b337f59e62dbc58294de1c39b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

