### PR TITLE
fix: Fix mask

### DIFF
--- a/web/src/refresh-components/OverflowDiv.tsx
+++ b/web/src/refresh-components/OverflowDiv.tsx
@@ -5,13 +5,17 @@ import { cn } from "@/lib/utils";
 
 export interface VerticalShadowScrollerProps
   extends React.HtmlHTMLAttributes<HTMLDivElement> {
+  // Mask related
   disableMask?: boolean;
+  backgroundColor?: string;
   height?: string;
 }
 
 export default function OverflowDiv({
   disableMask,
+  backgroundColor = "var(--background-tint-02)",
   height: minHeight = "2rem",
+
   className,
   ...rest
 }: VerticalShadowScrollerProps) {
@@ -22,7 +26,12 @@ export default function OverflowDiv({
         <div style={{ minHeight }} />
       </div>
       {!disableMask && (
-        <div className="absolute bottom-0 left-0 right-0 border-t border-border z-[20] pointer-events-none" />
+        <div
+          className="absolute bottom-0 left-0 right-0 h-[3rem] z-[20] pointer-events-none"
+          style={{
+            background: `linear-gradient(to bottom, transparent, ${backgroundColor})`,
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Previous clean up removed mask. This PR adds it back.

## Screenshots

Broken one (in main currently):
<img width="484" height="2154" alt="image" src="https://github.com/user-attachments/assets/681e1e55-6a3d-43a6-9182-85a0ba3b2917" />

Reverted and fixed version:
<img width="482" height="2162" alt="image" src="https://github.com/user-attachments/assets/9c16deb7-410b-42fc-8350-4ec764fd328b" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the bottom gradient mask in OverflowDiv to smoothly fade overflowing content and remove the hard cutoff. Replaced the old border with a 3rem linear-gradient and added a customizable background color.

- **Bug Fixes**
  - Gradient overlay uses a 3rem height with linear-gradient for a smooth fade.
  - Added backgroundColor prop (default: var(--background-tint-02)); disableMask still supported.

<sup>Written for commit cf506430c5e0ccae538e9f16ed5eb12a0286f38f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

