### PR TITLE
feat: allow updating embedding API key

### DIFF
--- a/web/src/app/admin/embeddings/EmbeddingModelSelectionForm.tsx
+++ b/web/src/app/admin/embeddings/EmbeddingModelSelectionForm.tsx
@@ -7,6 +7,9 @@ import {
   CloudEmbeddingProvider,
   CloudEmbeddingModel,
   AVAILABLE_MODELS,
+  AVAILABLE_CLOUD_PROVIDERS,
+  LITELLM_CLOUD_PROVIDER,
+  AZURE_CLOUD_PROVIDER,
   HostedEmbeddingModel,
   EmbeddingProvider,
 } from "@/components/embedding/interfaces";
@@ -24,6 +27,7 @@ import {
   EMBEDDING_PROVIDERS_ADMIN_URL,
 } from "@/app/admin/configuration/llm/constants";
 import { AdvancedSearchConfiguration } from "@/app/admin/embeddings/interfaces";
+import Button from "@/refresh-components/buttons/Button";
 
 export interface EmbeddingDetails {
   api_key?: string;
@@ -272,6 +276,30 @@ export default function EmbeddingModelSelection({
               }
             />
           </button>
+          {currentEmbeddingModel?.provider_type && (
+            <div className="mt-2">
+              <Button
+                secondary
+                onClick={() => {
+                  const allProviders = [
+                    ...AVAILABLE_CLOUD_PROVIDERS,
+                    LITELLM_CLOUD_PROVIDER,
+                    AZURE_CLOUD_PROVIDER,
+                  ];
+                  const provider = allProviders.find(
+                    (p) =>
+                      p.provider_type === currentEmbeddingModel.provider_type
+                  );
+                  if (!provider) {
+                    return;
+                  }
+                  setChangeCredentialsProvider(provider);
+                }}
+              >
+                Update API key
+              </Button>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
@@ -159,6 +159,9 @@ export default function ChangeCredentialsModal({
         );
       }
 
+      // Refresh cached provider details so the rest of the form sees the new key without forcing a re-index
+      await mutate(EMBEDDING_PROVIDERS_ADMIN_URL);
+
       onConfirm();
     } catch (error) {
       setTestError(


### PR DESCRIPTION


## Description

The flow in the mostly-defunct to-be-reworked Search Settings page for changing your embedding model did not allow users to update their API key, which was pretty annoying to deal with. This change won't matter for many users for long but probably still worth merging to help self-deployed folks rotate keys

<img width="1232" height="794" alt="Screenshot 2025-12-12 at 3 22 05 PM" src="https://github.com/user-attachments/assets/71095e7f-ec53-4258-9d28-a3a7543b222a" />

## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Optional] Override Linear Check
