### PR TITLE
fix(users): User Groups Race Condition

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -363,7 +363,7 @@ def _check_user_group_is_modifiable(user_group: UserGroup) -> None:
 
 def _add_user__user_group_relationships__no_commit(
     db_session: Session, user_group_id: int, user_ids: list[UUID]
-) -> list[User__UserGroup]:
+) -> None:
     """NOTE: does not commit the transaction.
 
     This function is idempotent - it will skip users who are already in the group
@@ -371,7 +371,7 @@ def _add_user__user_group_relationships__no_commit(
     Uses ON CONFLICT DO NOTHING to keep inserts atomic under concurrency.
     """
     if not user_ids:
-        return []
+        return
 
     insert_stmt = (
         insert(User__UserGroup)
@@ -386,15 +386,6 @@ def _add_user__user_group_relationships__no_commit(
         )
     )
     db_session.execute(insert_stmt)
-
-    return list(
-        db_session.scalars(
-            select(User__UserGroup).where(
-                User__UserGroup.user_group_id == user_group_id,
-                User__UserGroup.user_id.in_(user_ids),
-            )
-        ).all()
-    )
 
 
 def _add_user_group__cc_pair_relationships__no_commit(


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Ensuring that we protect this API endpoint with proper checks

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate key errors when adding users to groups by making membership inserts idempotent with ON CONFLICT DO NOTHING. This removes the race condition and stabilizes concurrent adds and re-syncs.

- **Bug Fixes**
  - Use atomic bulk insert via PostgreSQL ON CONFLICT DO NOTHING to avoid duplicate-key races.
  - Simplify helper to perform idempotent inserts and return None.

<sup>Written for commit bf5b9bfaa7a9da039d272ca70bd1ca556b9ebf88. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













