### PR TITLE
feat: adding auto-authentication-users and token rate limit per user groups

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -48,6 +48,9 @@ DISABLED_GEN_AI_MSG = (
     "You can still use Onyx as a search engine."
 )
 
+TIER_LIMIT_ERROR_MESSAGE = "Token budget exceeded for your User Tier. Upgrade to Pro for more."
+RATE_LIMIT_ERROR_MESSAGE = "🚫 **Rate Limit Exceeded**\n\nYou have used your daily token allowance. Please upgrade to Pro for more."
+
 #####
 # Version Pattern Configs
 #####

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -59,6 +59,7 @@ PUBLIC_ENDPOINT_SPECS = [
     # anonymous user on cloud
     ("/tenants/anonymous-user", {"POST"}),
     ("/metrics", {"GET"}),  # added by prometheus_fastapi_instrumentator
+    ("/manage/auth/login-with-token", {"GET"}),
 ]
 
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -25,7 +25,7 @@ from onyx.utils.variable_functionality import fetch_versioned_implementation
 logger = setup_logger()
 
 
-TOKEN_BUDGET_UNIT = 1_000
+TOKEN_BUDGET_UNIT = 1 # 1 Token = 1 Token. (Simplified from 1,000)
 
 
 def check_token_rate_limits(
@@ -42,8 +42,10 @@ def check_token_rate_limits(
     return versioned_rate_limit_strategy(user)
 
 
-def _check_token_rate_limits(_: User | None) -> None:
+def _check_token_rate_limits(user: User | None) -> None:
     _user_is_rate_limited_by_global()
+    if user:
+        _user_is_rate_limited_by_user_groups(str(user.id))
 
 
 """
@@ -66,6 +68,50 @@ def _user_is_rate_limited_by_global() -> None:
                     status_code=429,
                     detail="Token budget exceeded for organization. Try again later.",
                 )
+
+
+
+
+def _user_is_rate_limited_by_user_groups(user_id: str) -> None:
+     with get_session_with_current_tenant() as db_session:
+         # Import here to avoid circulars if any
+         from onyx.db.token_limit import fetch_token_rate_limits_for_user_groups
+         from onyx.configs.constants import TIER_LIMIT_ERROR_MESSAGE
+
+         group_limits = fetch_token_rate_limits_for_user_groups(db_session, user_id)
+        
+         if group_limits:
+              cutoff_time = _get_cutoff_time(group_limits)
+              # Reuse global usage fetcher (it groups by minute for ALL chats, which is what we want for total usage)
+              # Wait, _fetch_global_usage fetches ALL messages in the system?
+              # No, strictly speaking we need usage FOR THIS USER.
+              # _fetch_global_usage -> join ChatSession. 
+              # We need to filter by user_id!
+              user_usage = _fetch_user_usage(cutoff_time, user_id, db_session)
+              
+              if _is_rate_limited(group_limits, user_usage):
+                  raise HTTPException(
+                     status_code=429,
+                     detail=TIER_LIMIT_ERROR_MESSAGE,
+                 )
+
+def _fetch_user_usage(
+    cutoff_time: datetime, user_id: str, db_session: Session
+) -> Sequence[tuple[datetime, int]]:
+    result = db_session.execute(
+        select(
+            func.date_trunc("minute", ChatMessage.time_sent),
+            func.sum(ChatMessage.token_count),
+        )
+        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
+        .filter(
+            ChatMessage.time_sent >= cutoff_time,
+            ChatSession.user_id == user_id 
+        )
+        .group_by(func.date_trunc("minute", ChatMessage.time_sent))
+    ).all()
+
+    return [(row[0], row[1]) for row in result]
 
 
 def _fetch_global_usage(

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -60,8 +60,8 @@ services:
     # DEV: To expose ports, either:
     # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
     # 2. Uncomment the ports below
-    # ports:
-    #   - "8080:8080"
+    ports:
+      - "8080:8080"
     environment:
       # Auth Settings
       - AUTH_TYPE=${AUTH_TYPE:-basic}
@@ -83,7 +83,9 @@ services:
         max-size: "50m"
         max-file: "6"
     # Optional, only for debugging purposes
+    # Optional, only for debugging purposes
     volumes:
+      - ../../backend:/app
       - api_server_logs:/var/log/onyx
 
   background:
@@ -294,8 +296,8 @@ services:
     # DEV: To expose ports, either:
     # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
     # 2. Uncomment the ports below
-    # ports:
-    #   - "5432:5432"
+    ports:
+      - "5435:5432"
     volumes:
       - db_volume:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin-generated login tokens for one-click user authentication and enforces per-user-group token rate limits with clear streaming errors in chat. Also exposes API (8080) and Postgres (5435) ports to simplify local dev.

- **New Features**
  - Admin can generate single-use login tokens and auto-login users via /manage/auth/login-with-token; sets auth cookie and redirects to WEB_DOMAIN; route is whitelisted.
  - Rate limiting checks global and user-group limits; usage counted per user; token unit is 1; returns clear messages (tier and rate limit) and streams limit errors to the chat UI.
  - Docker Compose: API port 8080 and Postgres port 5435 exposed; backend volume mounted for easier debugging.

<sup>Written for commit 02d00cabd1036cb12cdfa131743e554d1e6f94ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

