### PR TITLE
chore: ignore plans dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ node_modules
 
 # MCP configs
 .playwright-mcp
+
+# plans
+plans/


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added plans/ to .gitignore to prevent committing local plan files. This keeps generated or WIP plans out of version control.

<sup>Written for commit 398b751f01a81d682d61cbb9003b5d5cbd94b204. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

