### PR TITLE
fix: remove unnecessary chat display tabindex

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -626,8 +626,8 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
         >
           {({ getRootProps }) => (
             <div
-              className="h-full w-full flex flex-col items-center"
-              {...getRootProps()}
+              className="h-full w-full flex flex-col items-center outline-none"
+              {...getRootProps({ tabIndex: -1 })}
             >
               {/* ProjectUI */}
               {!!currentProjectId && projectPanelVisible && (


### PR DESCRIPTION
## Description

This element is inheriting a `tabIndex` of `0` causing it to be focusable which in turn causes an `outline`,

<img width="2880" height="1920" alt="20251214_17h36m33s_grim" src="https://github.com/user-attachments/assets/c74ba1a4-d9f4-4ede-8553-e63c1d608b5a" />

## How Has This Been Tested?



## Additional Options

- [x] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent unwanted focus ring in the Chat page by making the chat display container non-focusable and disabling its outline. Set tabIndex to -1 and apply outline: none so it no longer inherits focus or shows an outline during navigation.

<sup>Written for commit c27acb040c6224a3dd9c8d102c9c44da1f814850. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







