### PR TITLE
fix: chat page overflow on small screens

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -626,7 +626,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
         >
           {({ getRootProps }) => (
             <div
-              className="h-full w-full flex flex-col items-center outline-none"
+              className="h-full w-full p-4 flex flex-col items-center outline-none"
               {...getRootProps({ tabIndex: -1 })}
             >
               {/* ProjectUI */}

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -416,7 +416,7 @@ const ChatInputBar = React.memo(
         <div
           id="onyx-chat-input"
           className={cn(
-            "max-w-full w-[50rem] flex flex-col shadow-01 bg-background-neutral-00 rounded-16",
+            "max-w-full w-[min(50rem,100%)] flex flex-col shadow-01 bg-background-neutral-00 rounded-16",
             disabled && "opacity-50 cursor-not-allowed pointer-events-none"
           )}
           aria-disabled={disabled}


### PR DESCRIPTION
## Description

~~This expands the grid container horizontally to~~ allow the textinput to be sized the smaller of either `50rem` or `100%`, ensuring it is contained within the window on smaller screens.  

**before**
<img width="1296" height="1820" alt="20251215_19h18m54s_grim" src="https://github.com/user-attachments/assets/3e17e034-ba99-49ad-b0e7-c735dd2ad50a" />

**after**
<img width="1296" height="1820" alt="20251215_19h19m06s_grim" src="https://github.com/user-attachments/assets/84c6d8b7-11a7-4d6a-a6a2-0d7c454bc3ff" />

## How Has This Been Tested?


## Additional Options

- [x] Override Linear Check










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat page overflow on small screens by limiting the chat input width to min(50rem, 100%) and adding padding to the chat page container so content stays within the viewport.

- **Bug Fixes**
  - Added p-4 to the chat page container.
  - Set chat input width to w-[min(50rem,100%)].

<sup>Written for commit fe0fedbd889c1e4b15caeb9dcb5f22fb0a3a1b58. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









