### PR TITLE
fix: mypy

### DIFF
--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -1,7 +1,7 @@
 import os
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
-from collections.abc import Generator
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -13,11 +13,9 @@ from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
-
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
     rl_requests,
 )
-
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import UnexpectedValidationError
@@ -36,6 +34,7 @@ _CODA_CALL_TIMEOUT = 30
 _CODA_BASE_URL = "https://coda.io/apis/v1"
 
 logger = setup_logger()
+
 
 class CodaClientRequestFailedError(ConnectionError):
     def __init__(self, message: str, status_code: int):
@@ -90,13 +89,15 @@ class CodaRow(BaseModel):
 
 class CodaApiClient:
     def __init__(
-        self, 
-        bearer_token: str, 
+        self,
+        bearer_token: str,
     ) -> None:
         self.bearer_token = bearer_token
-        self.base_url = os.environ.get("CODA_BASE_URL", _CODA_BASE_URL)  
-    
-    def get(self, endpoint: str, params: Optional[dict[str, str]] = None) -> dict[str, Any]:
+        self.base_url = os.environ.get("CODA_BASE_URL", _CODA_BASE_URL)
+
+    def get(
+        self, endpoint: str, params: Optional[dict[str, str]] = None
+    ) -> dict[str, Any]:
         url = self._build_url(endpoint)
         headers = self._build_headers()
 
@@ -120,14 +121,14 @@ class CodaApiClient:
 
     def _build_headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.bearer_token}"}
-    
+
     def _build_url(self, endpoint: str) -> str:
         return self.base_url.rstrip("/") + "/" + endpoint.lstrip("/")
 
 
 class CodaConnector(LoadConnector, PollConnector):
     def __init__(
-        self, 
+        self,
         batch_size: int = INDEX_BATCH_SIZE,
         index_page_content: bool = True,
         workspace_id: str | None = None,
@@ -135,18 +136,20 @@ class CodaConnector(LoadConnector, PollConnector):
         self.batch_size = batch_size
         self.index_page_content = index_page_content
         self.workspace_id = workspace_id
-        self.coda_client: CodaApiClient | None = None
+        self._coda_client: CodaApiClient | None = None
 
-    
+    @property
+    def coda_client(self) -> CodaApiClient:
+        if self._coda_client is None:
+            raise ConnectorMissingCredentialError("Coda")
+        return self._coda_client
 
-    @retry(tries=3, delay=1, backoff=2) 
+    @retry(tries=3, delay=1, backoff=2)
     def _get_doc(self, doc_id: str) -> CodaDoc:
         """Fetch a specific Coda document by its ID."""
         logger.debug(f"Fetching Coda doc with ID: {doc_id}")
         try:
-            response = self.coda_client.get(
-                f"docs/{doc_id}"
-            )
+            response = self.coda_client.get(f"docs/{doc_id}")
         except CodaClientRequestFailedError as e:
             if e.status_code == 404:
                 raise ConnectorValidationError(f"Failed to fetch doc: {doc_id}") from e
@@ -162,17 +165,15 @@ class CodaConnector(LoadConnector, PollConnector):
             workspace_id=response["workspace"]["id"],
             workspace_name=response["workspace"]["name"],
             folder_id=response["folder"]["id"] if response.get("folder") else None,
-            folder_name=response["folder"]["name"] if response.get("folder") else None
+            folder_name=response["folder"]["name"] if response.get("folder") else None,
         )
 
-    @retry(tries=3, delay=1, backoff=2) 
+    @retry(tries=3, delay=1, backoff=2)
     def _get_page(self, doc_id: str, page_id: str) -> CodaPage:
         """Fetch a specific page from a Coda document."""
         logger.debug(f"Fetching Coda page with ID: {page_id}")
         try:
-            response = self.coda_client.get(
-                f"docs/{doc_id}/pages/{page_id}"
-            )
+            response = self.coda_client.get(f"docs/{doc_id}/pages/{page_id}")
         except CodaClientRequestFailedError as e:
             if e.status_code == 404:
                 raise ConnectorValidationError(
@@ -188,17 +189,15 @@ class CodaConnector(LoadConnector, PollConnector):
             name=response["name"],
             content_type=response["contentType"],
             created_at=response["createdAt"],
-            updated_at=response["updatedAt"]
+            updated_at=response["updatedAt"],
         )
 
-    @retry(tries=3, delay=1, backoff=2) 
+    @retry(tries=3, delay=1, backoff=2)
     def _get_table(self, doc_id: str, table_id: str) -> CodaTable:
         """Fetch a specific table from a Coda document."""
         logger.debug(f"Fetching Coda table with ID: {table_id}")
         try:
-            response = self.coda_client.get(
-                f"docs/{doc_id}/tables/{table_id}"
-            )
+            response = self.coda_client.get(f"docs/{doc_id}/tables/{table_id}")
         except CodaClientRequestFailedError as e:
             if e.status_code == 404:
                 raise ConnectorValidationError(
@@ -213,10 +212,10 @@ class CodaConnector(LoadConnector, PollConnector):
             browser_link=response["browserLink"],
             created_at=response["createdAt"],
             updated_at=response["updatedAt"],
-            doc_id=doc_id
+            doc_id=doc_id,
         )
-    
-    @retry(tries=3, delay=1, backoff=2) 
+
+    @retry(tries=3, delay=1, backoff=2)
     def _get_row(self, doc_id: str, table_id: str, row_id: str) -> CodaRow:
         """Fetch a specific row from a Coda table."""
         logger.debug(f"Fetching Coda row with ID: {row_id}")
@@ -245,14 +244,12 @@ class CodaConnector(LoadConnector, PollConnector):
             updated_at=response["updatedAt"],
             values=values,
             table_id=table_id,
-            doc_id=doc_id
+            doc_id=doc_id,
         )
-    
+
     @retry(tries=3, delay=1, backoff=2)
     def _list_all_docs(
-        self,
-        endpoint: str = "docs",
-        params: Optional[Dict[str, str]] = None
+        self, endpoint: str = "docs", params: Optional[Dict[str, str]] = None
     ) -> List[CodaDoc]:
         """List all Coda documents in the workspace."""
         logger.debug("Listing documents in Coda")
@@ -260,7 +257,7 @@ class CodaConnector(LoadConnector, PollConnector):
         all_docs: List[CodaDoc] = []
         next_page_token: str | None = None
         params = params or {}
-        
+
         if self.workspace_id:
             params["workspaceId"] = self.workspace_id
 
@@ -288,7 +285,7 @@ class CodaConnector(LoadConnector, PollConnector):
                     workspace_id=item["workspace"]["id"],
                     workspace_name=item["workspace"]["name"],
                     folder_id=item["folder"]["id"] if item.get("folder") else None,
-                    folder_name=item["folder"]["name"] if item.get("folder") else None
+                    folder_name=item["folder"]["name"] if item.get("folder") else None,
                 )
                 all_docs.append(doc)
 
@@ -298,7 +295,7 @@ class CodaConnector(LoadConnector, PollConnector):
 
         logger.debug(f"Found {len(all_docs)} docs")
         return all_docs
-    
+
     @retry(tries=3, delay=1, backoff=2)
     def _list_pages_in_doc(self, doc_id: str) -> List[CodaPage]:
         """List all pages in a Coda document."""
@@ -325,7 +322,7 @@ class CodaConnector(LoadConnector, PollConnector):
 
             items = response.get("items", [])
             for item in items:
-                #can be removed if we don't care to skip hidden pages
+                # can be removed if we don't care to skip hidden pages
                 if item.get("isHidden", False):
                     continue
 
@@ -356,11 +353,11 @@ class CodaConnector(LoadConnector, PollConnector):
         content_parts = []
         next_page_token: str | None = None
         params: Dict[str, str] = {}
-        
+
         while True:
             if next_page_token:
                 params["pageToken"] = next_page_token
-            
+
             try:
                 response = self.coda_client.get(
                     f"docs/{doc_id}/pages/{page_id}/content", params=params
@@ -370,23 +367,23 @@ class CodaConnector(LoadConnector, PollConnector):
                     logger.debug(f"No content available for page {page_id}")
                     return ""
                 raise
-            
+
             items = response.get("items", [])
-            
+
             for item in items:
                 item_content = item.get("itemContent", {})
-                
+
                 content_text = item_content.get("content", "")
                 if content_text:
                     content_parts.append(content_text)
-            
+
             next_page_token = response.get("nextPageToken")
             if not next_page_token:
                 break
-        
+
         return "\n\n".join(content_parts)
 
-    @retry(tries=3, delay=1, backoff=2) 
+    @retry(tries=3, delay=1, backoff=2)
     def _list_tables(self, doc_id: str) -> List[CodaTable]:
         """List all tables in a Coda document."""
         logger.debug(f"Listing tables in Coda doc with ID: {doc_id}")
@@ -419,7 +416,7 @@ class CodaConnector(LoadConnector, PollConnector):
                         name=item["name"],
                         created_at=item["createdAt"],
                         updated_at=item["updatedAt"],
-                        doc_id=doc_id
+                        doc_id=doc_id,
                     )
                 )
 
@@ -429,8 +426,8 @@ class CodaConnector(LoadConnector, PollConnector):
 
         logger.debug(f"Found {len(tables)} tables in doc {doc_id}")
         return tables
-    
-    @retry(tries=3, delay=1, backoff=2) 
+
+    @retry(tries=3, delay=1, backoff=2)
     def _list_rows_and_values(self, doc_id: str, table_id: str) -> List[CodaRow]:
         """List all rows and their values in a table."""
         logger.debug(f"Listing rows in Coda table: {table_id} in Coda doc: {doc_id}")
@@ -483,22 +480,14 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def _convert_page_to_document(self, page: CodaPage, content: str = "") -> Document:
         """Convert a page into a Document."""
-        page_updated = (
-            datetime.fromisoformat(page.updated_at)
-            .astimezone(timezone.utc)
-        )
-        
+        page_updated = datetime.fromisoformat(page.updated_at).astimezone(timezone.utc)
+
         text_parts = [page.name, page.browser_link]
         if content:
             text_parts.append(content)
-        
-        sections = [
-            TextSection(
-                link=page.browser_link,
-                text="\n\n".join(text_parts)
-            )
-        ]
-        
+
+        sections = [TextSection(link=page.browser_link, text="\n\n".join(text_parts))]
+
         return Document(
             id=f"coda-page-{page.doc_id}-{page.id}",
             sections=cast(list[TextSection | ImageSection], sections),
@@ -516,37 +505,28 @@ class CodaConnector(LoadConnector, PollConnector):
         self, table: CodaTable, rows: List[CodaRow]
     ) -> Document:
         """Convert a table and its rows into a single Document with multiple sections (one per row)."""
-        table_updated = (
-            datetime.fromisoformat(table.updated_at)
-            .astimezone(timezone.utc)
+        table_updated = datetime.fromisoformat(table.updated_at).astimezone(
+            timezone.utc
         )
-        
+
         sections: List[TextSection] = []
         for row in rows:
             content_text = " ".join(
                 str(v) if not isinstance(v, list) else " ".join(map(str, v))
                 for v in row.values.values()
             )
-            
+
             row_name = row.name or f"Row {row.index or row.id}"
             text = f"{row_name}: {content_text}" if content_text else row_name
-            
-            sections.append(
-                TextSection(
-                    link=row.browser_link,
-                    text=text
-                )
-            )
-        
+
+            sections.append(TextSection(link=row.browser_link, text=text))
+
         # If no rows, create a single section for the table itself
         if not sections:
             sections = [
-                TextSection(
-                    link=table.browser_link,
-                    text=f"Table: {table.name}"
-                )
+                TextSection(link=table.browser_link, text=f"Table: {table.name}")
             ]
-        
+
         return Document(
             id=f"coda-table-{table.doc_id}-{table.id}",
             sections=cast(list[TextSection | ImageSection], sections),
@@ -562,12 +542,10 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         """Load and validate Coda credentials."""
-        self.coda_client = CodaApiClient(
-            bearer_token=credentials["coda_bearer_token"]
-        )
+        self._coda_client = CodaApiClient(bearer_token=credentials["coda_bearer_token"])
 
         try:
-            self.coda_client.get("docs", params={"limit": "1"})
+            self._coda_client.get("docs", params={"limit": "1"})
         except CodaClientRequestFailedError as e:
             if e.status_code == 401:
                 raise ConnectorMissingCredentialError("Invalid Coda API token")
@@ -577,16 +555,14 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def load_from_state(self) -> GenerateDocumentsOutput:
         """Load all documents from Coda workspace."""
-        if self.coda_client is None:
-            raise ConnectorMissingCredentialError("Coda")
 
         def _iter_documents() -> Generator[Document, None, None]:
             docs = self._list_all_docs()
             logger.info(f"Found {len(docs)} Coda docs to process")
-            
+
             for doc in docs:
                 logger.debug(f"Processing doc: {doc.name} ({doc.id})")
-                
+
                 try:
                     pages = self._list_pages_in_doc(doc.id)
                     for page in pages:
@@ -595,11 +571,13 @@ class CodaConnector(LoadConnector, PollConnector):
                             try:
                                 content = self._fetch_page_content(doc.id, page.id)
                             except Exception as e:
-                                logger.warning(f"Failed to fetch content for page {page.id}: {e}")
+                                logger.warning(
+                                    f"Failed to fetch content for page {page.id}: {e}"
+                                )
                         yield self._convert_page_to_document(page, content)
                 except ConnectorValidationError as e:
                     logger.warning(f"Failed to list pages for doc {doc.id}: {e}")
-                
+
                 try:
                     tables = self._list_tables(doc.id)
                     for table in tables:
@@ -607,7 +585,9 @@ class CodaConnector(LoadConnector, PollConnector):
                             rows = self._list_rows_and_values(doc.id, table.id)
                             yield self._convert_table_with_rows_to_document(table, rows)
                         except ConnectorValidationError as e:
-                            logger.warning(f"Failed to list rows for table {table.id}: {e}")
+                            logger.warning(
+                                f"Failed to list rows for table {table.id}: {e}"
+                            )
                             yield self._convert_table_with_rows_to_document(table, [])
                 except ConnectorValidationError as e:
                     logger.warning(f"Failed to list tables for doc {doc.id}: {e}")
@@ -621,18 +601,18 @@ class CodaConnector(LoadConnector, PollConnector):
         Polls the Coda API for documents updated between start and end timestamps.
         We refer to page and table update times to determine if they need to be re-indexed.
         """
-        if self.coda_client is None:
-            raise ConnectorMissingCredentialError("Coda")
 
         def _iter_documents() -> Generator[Document, None, None]:
             docs = self._list_all_docs()
-            logger.info(f"Polling {len(docs)} Coda docs for updates between {start} and {end}")
-            
+            logger.info(
+                f"Polling {len(docs)} Coda docs for updates between {start} and {end}"
+            )
+
             for doc in docs:
                 try:
                     pages = self._list_pages_in_doc(doc.id)
                     for page in pages:
-                        page_timestamp = ( 
+                        page_timestamp = (
                             datetime.fromisoformat(page.updated_at)
                             .astimezone(timezone.utc)
                             .timestamp()
@@ -649,7 +629,7 @@ class CodaConnector(LoadConnector, PollConnector):
                             yield self._convert_page_to_document(page, content)
                 except ConnectorValidationError as e:
                     logger.warning(f"Failed to list pages for doc {doc.id}: {e}")
-                
+
                 try:
                     tables = self._list_tables(doc.id)
                     for table in tables:
@@ -658,10 +638,10 @@ class CodaConnector(LoadConnector, PollConnector):
                             .astimezone(timezone.utc)
                             .timestamp()
                         )
-                        
+
                         try:
                             rows = self._list_rows_and_values(doc.id, table.id)
-                            
+
                             table_or_rows_updated = start < table_timestamp <= end
                             if not table_or_rows_updated:
                                 for row in rows:
@@ -673,15 +653,21 @@ class CodaConnector(LoadConnector, PollConnector):
                                     if start < row_timestamp <= end:
                                         table_or_rows_updated = True
                                         break
-                            
+
                             if table_or_rows_updated:
-                                yield self._convert_table_with_rows_to_document(table, rows)
-                        
+                                yield self._convert_table_with_rows_to_document(
+                                    table, rows
+                                )
+
                         except ConnectorValidationError as e:
-                            logger.warning(f"Failed to list rows for table {table.id}: {e}")
+                            logger.warning(
+                                f"Failed to list rows for table {table.id}: {e}"
+                            )
                             if table_timestamp > start and table_timestamp <= end:
-                                yield self._convert_table_with_rows_to_document(table, [])
-                
+                                yield self._convert_table_with_rows_to_document(
+                                    table, []
+                                )
+
                 except ConnectorValidationError as e:
                     logger.warning(f"Failed to list tables for doc {doc.id}: {e}")
 
@@ -689,18 +675,17 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def validate_connector_settings(self) -> None:
         """Validates the Coda connector settings calling the 'whoami' endpoint."""
-        if self.coda_client is None:
-            raise ConnectorMissingCredentialError("Coda")
-        
         try:
             response = self.coda_client.get("whoami")
-            logger.info(f"Coda connector validated for user: {response.get('name', 'Unknown')}")
-            
+            logger.info(
+                f"Coda connector validated for user: {response.get('name', 'Unknown')}"
+            )
+
             if self.workspace_id:
                 params = {"workspaceId": self.workspace_id, "limit": "1"}
                 self.coda_client.get("docs", params=params)
                 logger.info(f"Validated access to workspace: {self.workspace_id}")
-                
+
         except CodaClientRequestFailedError as e:
             if e.status_code == 401:
                 raise CredentialExpiredError(
@@ -724,4 +709,3 @@ class CodaConnector(LoadConnector, PollConnector):
             raise UnexpectedValidationError(
                 f"Unexpected error during Coda settings validation: {exc}"
             )
-

--- a/backend/tests/daily/connectors/coda/test_coda_connector.py
+++ b/backend/tests/daily/connectors/coda/test_coda_connector.py
@@ -1,30 +1,31 @@
 import os
 import time
 from collections.abc import Generator
+from typing import Any
 
 import pytest
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.coda.connector import CodaConnector
-from onyx.connectors.models import Document
 from onyx.connectors.exceptions import CredentialInvalidError
+from onyx.connectors.models import Document
 
 
 @pytest.fixture
-def coda_credentials():
+def coda_credentials() -> dict[str, str]:
     """Fixture to get and validate Coda credentials."""
     bearer_token = os.environ.get("CODA_BEARER_TOKEN")
-    
+
     if not bearer_token:
         pytest.skip("CODA_BEARER_TOKEN not set")
-    
+
     return {
         "coda_bearer_token": bearer_token,
     }
 
 
 @pytest.fixture
-def connector(coda_credentials):
+def connector(coda_credentials: dict[str, str]) -> CodaConnector:
     """Fixture to create and authenticate connector."""
     conn = CodaConnector(batch_size=5, index_page_content=True)
     conn.load_credentials(coda_credentials)
@@ -32,33 +33,35 @@ def connector(coda_credentials):
 
 
 @pytest.fixture
-def workspace_scoped_connector(coda_credentials):
+def workspace_scoped_connector(coda_credentials: dict[str, str]) -> CodaConnector:
     """Fixture to create connector scoped to a specific workspace (if CODA_WORKSPACE_ID is set)."""
     workspace_id = os.environ.get("CODA_WORKSPACE_ID")
     if not workspace_id:
         pytest.skip("CODA_WORKSPACE_ID not set - skipping workspace-scoped tests")
-    
-    conn = CodaConnector(batch_size=5, index_page_content=True, workspace_id=workspace_id)
+
+    conn = CodaConnector(
+        batch_size=5, index_page_content=True, workspace_id=workspace_id
+    )
     conn.load_credentials(coda_credentials)
     return conn
 
 
 @pytest.fixture
-def reference_data(connector):
+def reference_data(connector: CodaConnector) -> dict[str, Any]:
     """Fixture to fetch reference data from API for validation."""
     all_docs = connector._list_all_docs()
-    
+
     if not all_docs:
         pytest.skip("No docs found in Coda workspace")
-    
+
     expected_page_count = 0
     expected_table_count = 0
     pages_by_doc = {}
     tables_by_doc = {}
-    
+
     for doc in all_docs:
         doc_id = doc.id
-        
+
         try:
             pages = connector._list_pages_in_doc(doc_id)
             pages_by_doc[doc_id] = pages
@@ -66,7 +69,7 @@ def reference_data(connector):
         except Exception as e:
             print(f"Warning: Could not fetch pages for doc {doc_id}: {e}")
             pages_by_doc[doc_id] = []
-        
+
         try:
             tables = connector._list_tables(doc_id)
             tables_by_doc[doc_id] = tables
@@ -74,12 +77,12 @@ def reference_data(connector):
         except Exception as e:
             print(f"Warning: Could not fetch tables for doc {doc_id}: {e}")
             tables_by_doc[doc_id] = []
-    
+
     total_expected_documents = expected_page_count + expected_table_count
-    
+
     if total_expected_documents == 0:
         pytest.skip("No pages or tables found in Coda workspace")
-    
+
     return {
         "docs": all_docs,
         "total_pages": expected_page_count,
@@ -92,59 +95,69 @@ def reference_data(connector):
 
 class TestCodaConnectorValidation:
     """Test suite for connector validation and credential handling."""
-    
-    def test_validate_connector_settings_success(self, connector):
+
+    def test_validate_connector_settings_success(
+        self, connector: CodaConnector
+    ) -> None:
         """Test that validate_connector_settings succeeds with valid credentials."""
         # Should not raise any exceptions
         connector.validate_connector_settings()
-    
-    def test_validate_workspace_scoped_connector(self, workspace_scoped_connector):
+
+    def test_validate_workspace_scoped_connector(
+        self, workspace_scoped_connector: CodaConnector
+    ) -> None:
         """Test that workspace-scoped connector validates successfully."""
         workspace_scoped_connector.validate_connector_settings()
-    
-    def test_load_credentials_invalid_token(self):
+
+    def test_load_credentials_invalid_token(self) -> None:
         """Test that invalid credentials are rejected."""
         conn = CodaConnector()
-        
-        with pytest.raises(CredentialInvalidError):  
-            conn.load_credentials({
-                "coda_bearer_token": "invalid_token_12345",
-            })
+
+        with pytest.raises(CredentialInvalidError):
+            conn.load_credentials(
+                {
+                    "coda_bearer_token": "invalid_token_12345",
+                }
+            )
 
 
 class TestLoadFromState:
     """Test suite for load_from_state functionality."""
-    
-    def test_returns_generator(self, connector):
+
+    def test_returns_generator(self, connector: CodaConnector) -> None:
         """Test that load_from_state returns a generator."""
         gen = connector.load_from_state()
         assert isinstance(gen, Generator), "load_from_state should return a Generator"
-    
-    def test_batch_sizes_respect_config(self, connector, reference_data):
+
+    def test_batch_sizes_respect_config(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that batches respect the configured batch_size."""
         batch_size = connector.batch_size
         gen = connector.load_from_state()
-        
+
         batch_sizes = []
         for batch in gen:
             batch_sizes.append(len(batch))
             assert (
                 len(batch) <= batch_size
             ), f"Batch size {len(batch)} exceeds configured {batch_size}"
-        
+
         for i, size in enumerate(batch_sizes[:-1]):
             assert (
                 size == batch_size
             ), f"Non-final batch {i} has size {size}, expected {batch_size}"
-        
+
         # Last batch may be smaller or equal
         if batch_sizes:
             assert batch_sizes[-1] <= batch_size
-    
-    def test_document_count_matches_expected(self, connector, reference_data):
+
+    def test_document_count_matches_expected(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that total documents match expected pages + tables."""
         gen = connector.load_from_state()
-        
+
         total_documents = sum(len(batch) for batch in gen)
         expected_count = reference_data["total_documents"]
 
@@ -154,38 +167,56 @@ class TestLoadFromState:
             f"{reference_data['total_tables']} tables) "
             f"but got {total_documents}"
         )
-    
-    def test_document_required_fields(self, connector, reference_data):
+
+    def test_document_required_fields(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that all documents have required fields with valid values."""
         gen = connector.load_from_state()
-        
+
         for batch in gen:
             for doc in batch:
                 assert isinstance(doc, Document)
-                
+
                 assert doc.id is not None, "Document ID should not be None"
-                assert doc.id.startswith("coda-"), "Document ID should start with 'coda-'"
-                assert doc.source == DocumentSource.CODA, "Document source should be CODA"
-                assert doc.semantic_identifier is not None, "Semantic identifier should not be None"
-                assert doc.doc_updated_at is not None, "doc_updated_at should not be None"
-                
-                assert len(doc.sections) > 0, "Document should have at least one section"
+                assert doc.id.startswith(
+                    "coda-"
+                ), "Document ID should start with 'coda-'"
+                assert (
+                    doc.source == DocumentSource.CODA
+                ), "Document source should be CODA"
+                assert (
+                    doc.semantic_identifier is not None
+                ), "Semantic identifier should not be None"
+                assert (
+                    doc.doc_updated_at is not None
+                ), "doc_updated_at should not be None"
+
+                assert (
+                    len(doc.sections) > 0
+                ), "Document should have at least one section"
                 for section in doc.sections:
                     assert section.text is not None, "Section text should not be None"
                     assert len(section.text) > 0, "Section text should not be empty"
                     assert section.link is not None, "Section link should not be None"
-                    assert section.link.startswith("https://"), "Section link should be a valid URL"
-                
+                    assert section.link.startswith(
+                        "https://"
+                    ), "Section link should be a valid URL"
+
                 assert "doc_id" in doc.metadata, "Metadata should contain doc_id"
-                assert "browser_link" in doc.metadata, "Metadata should contain browser_link"
-    
-    def test_document_types(self, connector, reference_data):
+                assert (
+                    "browser_link" in doc.metadata
+                ), "Metadata should contain browser_link"
+
+    def test_document_types(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that both page and table documents are generated correctly."""
         gen = connector.load_from_state()
-        
+
         page_docs = []
         table_docs = []
-        
+
         for batch in gen:
             for doc in batch:
                 if "coda-page-" in doc.id:
@@ -194,77 +225,93 @@ class TestLoadFromState:
                 elif "coda-table-" in doc.id:
                     table_docs.append(doc)
                     assert "row_count" in doc.metadata
-        
+
         # Verify we found both types (if both exist in the workspace)
         if reference_data["total_pages"] > 0:
             assert len(page_docs) > 0, "Should have found page documents"
-        
+
         if reference_data["total_tables"] > 0:
             assert len(table_docs) > 0, "Should have found table documents"
-        
+
         # Verify counts match
-        assert len(page_docs) == reference_data["total_pages"], \
-            f"Expected {reference_data['total_pages']} page documents, got {len(page_docs)}"
-        assert len(table_docs) == reference_data["total_tables"], \
-            f"Expected {reference_data['total_tables']} table documents, got {len(table_docs)}"
-    
-    def test_no_duplicate_documents(self, connector, reference_data):
+        assert (
+            len(page_docs) == reference_data["total_pages"]
+        ), f"Expected {reference_data['total_pages']} page documents, got {len(page_docs)}"
+        assert (
+            len(table_docs) == reference_data["total_tables"]
+        ), f"Expected {reference_data['total_tables']} table documents, got {len(table_docs)}"
+
+    def test_no_duplicate_documents(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that no documents are yielded twice."""
         gen = connector.load_from_state()
-        
+
         document_ids = []
         for batch in gen:
             for doc in batch:
                 document_ids.append(doc.id)
-        
+
         unique_ids = set(document_ids)
         assert len(document_ids) == len(
             unique_ids
         ), f"Found {len(document_ids) - len(unique_ids)} duplicate documents"
-    
-    def test_all_docs_processed(self, connector, reference_data):
+
+    def test_all_docs_processed(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that content from all docs are included."""
         gen = connector.load_from_state()
-        
+
         processed_doc_ids = set()
         for batch in gen:
             for doc in batch:
                 doc_id = doc.metadata.get("doc_id")
                 processed_doc_ids.add(doc_id)
-        
+
         expected_doc_ids = {doc.id for doc in reference_data["docs"]}
-        
+
         expected_doc_ids_with_content = {
-            doc_id for doc_id in expected_doc_ids
-            if len(reference_data["pages_by_doc"].get(doc_id, [])) > 0 or
-               len(reference_data["tables_by_doc"].get(doc_id, [])) > 0
+            doc_id
+            for doc_id in expected_doc_ids
+            if len(reference_data["pages_by_doc"].get(doc_id, [])) > 0
+            or len(reference_data["tables_by_doc"].get(doc_id, [])) > 0
         }
-        
-        assert processed_doc_ids == expected_doc_ids_with_content, \
-            f"Not all docs with content were processed. Expected {expected_doc_ids_with_content}, got {processed_doc_ids}"
-    
-    def test_document_content_not_empty(self, connector, reference_data):
+
+        assert (
+            processed_doc_ids == expected_doc_ids_with_content
+        ), f"Not all docs with content were processed. Expected {expected_doc_ids_with_content}, got {processed_doc_ids}"
+
+    def test_document_content_not_empty(
+        self, connector: CodaConnector, reference_data: dict[str, Any]
+    ) -> None:
         """Test that all documents have meaningful content."""
         gen = connector.load_from_state()
-        
+
         for batch in gen:
             for doc in batch:
-                assert doc.semantic_identifier, "Semantic identifier should not be empty"
-                assert len(doc.semantic_identifier) > 0, "Semantic identifier should have content"
-                
-                total_text_length = sum(len(section.text) for section in doc.sections)
+                assert (
+                    doc.semantic_identifier
+                ), "Semantic identifier should not be empty"
+                assert (
+                    len(doc.semantic_identifier) > 0
+                ), "Semantic identifier should have content"
+
+                total_text_length = sum(
+                    len(section.text or "") for section in doc.sections
+                )
                 assert total_text_length > 0, f"Document {doc.id} has no content"
-    
-    def test_page_content_indexing(self, coda_credentials):
+
+    def test_page_content_indexing(self, coda_credentials: dict[str, str]) -> None:
         """Test that index_page_content flag works correctly."""
         # page indexing disabled
         conn_no_content = CodaConnector(batch_size=5, index_page_content=False)
         conn_no_content.load_credentials(coda_credentials)
-        
+
         # page indexing enabled
         conn_with_content = CodaConnector(batch_size=5, index_page_content=True)
         conn_with_content.load_credentials(coda_credentials)
-        
+
         docs_no_content = []
         for batch in conn_no_content.load_from_state():
             for doc in batch:
@@ -273,7 +320,7 @@ class TestLoadFromState:
                     break
             if docs_no_content:
                 break
-        
+
         docs_with_content = []
         for batch in conn_with_content.load_from_state():
             for doc in batch:
@@ -282,119 +329,143 @@ class TestLoadFromState:
                     break
             if docs_with_content:
                 break
-        
+
         if docs_no_content and docs_with_content:
-            no_content_length = sum(len(s.text) for s in docs_no_content[0].sections)
-            with_content_length = sum(len(s.text) for s in docs_with_content[0].sections)
-            
-            assert with_content_length >= no_content_length, \
-                "Content-indexed page should have at least as much text as non-indexed"
+            no_content_length = sum(
+                len(s.text or "") for s in docs_no_content[0].sections
+            )
+            with_content_length = sum(
+                len(s.text or "") for s in docs_with_content[0].sections
+            )
+
+            assert (
+                with_content_length >= no_content_length
+            ), "Content-indexed page should have at least as much text as non-indexed"
 
 
 class TestPollSource:
     """Test suite for poll_source functionality."""
-    
-    def test_poll_source_returns_generator(self, connector):
+
+    def test_poll_source_returns_generator(self, connector: CodaConnector) -> None:
         """Test that poll_source returns a generator."""
         current_time = time.time()
         start_time = current_time - 86400  # 24 hours
-        
+
         gen = connector.poll_source(start_time, current_time)
         assert isinstance(gen, Generator), "poll_source should return a Generator"
-    
-    def test_poll_source_recent_updates(self, connector):
+
+    def test_poll_source_recent_updates(self, connector: CodaConnector) -> None:
         """Test polling for recently updated documents."""
         current_time = time.time()
         start_time = current_time - (86400 * 30)
-        
+
         gen = connector.poll_source(start_time, current_time)
-        
+
         documents = []
         for batch in gen:
             documents.extend(batch)
-        
+
         # All returned documents should be updated within the time range
         for doc in documents:
+            assert doc.doc_updated_at is not None, "doc_updated_at should not be None"
             doc_timestamp = doc.doc_updated_at.timestamp()
-            assert start_time < doc_timestamp <= current_time, \
-                f"Document {doc.id} updated at {doc_timestamp} is outside range [{start_time}, {current_time}]"
-    
-    def test_poll_source_no_updates_in_range(self, connector):
+            assert (
+                start_time < doc_timestamp <= current_time
+            ), f"Document {doc.id} updated at {doc_timestamp} is outside range [{start_time}, {current_time}]"
+
+    def test_poll_source_no_updates_in_range(self, connector: CodaConnector) -> None:
         """Test polling with a time range that has no updates."""
         end_time = time.time() - (86400 * 365)  # 1 year ago
         start_time = end_time - 86400  # 1 day before that
-        
+
         gen = connector.poll_source(start_time, end_time)
-        
+
         documents = []
         for batch in gen:
             documents.extend(batch)
-        
+
         # Should return no documents (unless workspace is very old)
         print(f"Found {len(documents)} documents updated over a year ago")
         assert len(documents) == 0
-    
-    def test_poll_source_batch_sizes(self, connector):
+
+    def test_poll_source_batch_sizes(self, connector: CodaConnector) -> None:
         """Test that poll_source respects batch sizes."""
         current_time = time.time()
         start_time = current_time - (86400 * 30)
-        
+
         batch_size = connector.batch_size
         gen = connector.poll_source(start_time, current_time)
-        
+
         for batch in gen:
-            assert len(batch) <= batch_size, \
-                f"Batch size {len(batch)} exceeds configured {batch_size}"
+            assert (
+                len(batch) <= batch_size
+            ), f"Batch size {len(batch)} exceeds configured {batch_size}"
 
 
 class TestWorkspaceScoping:
     """Test suite for workspace_id scoping functionality."""
-    
-    def test_workspace_scoped_loads_subset(self, connector, workspace_scoped_connector, reference_data):
+
+    def test_workspace_scoped_loads_subset(
+        self,
+        connector: CodaConnector,
+        workspace_scoped_connector: CodaConnector,
+        reference_data: dict[str, Any],
+    ) -> None:
         """Test that workspace-scoped connector loads a subset of documents."""
         all_docs = []
         for batch in connector.load_from_state():
             all_docs.extend(batch)
-        
+
         scoped_docs = []
         for batch in workspace_scoped_connector.load_from_state():
             scoped_docs.extend(batch)
-        
+
         # Scoped should be <= all docs
-        assert len(scoped_docs) <= len(all_docs), \
-            "Workspace-scoped connector should return same or fewer documents"
-        
+        assert len(scoped_docs) <= len(
+            all_docs
+        ), "Workspace-scoped connector should return same or fewer documents"
+
         workspace_id = workspace_scoped_connector.workspace_id
         for doc in scoped_docs:
             doc_id = doc.metadata.get("doc_id")
+            assert isinstance(doc_id, str), "doc_id should be a string"
             coda_doc = workspace_scoped_connector._get_doc(doc_id)
-            assert coda_doc.workspace_id == workspace_id, \
-                f"Document {doc_id} has workspace {coda_doc.workspace_id}, expected {workspace_id}"
+            assert (
+                coda_doc.workspace_id == workspace_id
+            ), f"Document {doc_id} has workspace {coda_doc.workspace_id}, expected {workspace_id}"
 
 
 class TestErrorHandling:
     """Test suite for error handling and edge cases."""
-    
-    def test_handles_missing_page_content_gracefully(self, connector):
+
+    def test_handles_missing_page_content_gracefully(
+        self, connector: CodaConnector
+    ) -> None:
         """Test that connector handles pages without accessible content."""
         gen = connector.load_from_state()
-        
+
         documents = []
         for batch in gen:
             documents.extend(batch)
-        
-        assert len(documents) > 0, "Should yield documents even if some content is inaccessible"
-    
-    def test_handles_empty_tables_gracefully(self, connector):
+
+        assert (
+            len(documents) > 0
+        ), "Should yield documents even if some content is inaccessible"
+
+    def test_handles_empty_tables_gracefully(self, connector: CodaConnector) -> None:
         """Test that connector handles tables with no rows."""
         gen = connector.load_from_state()
-        
+
         for batch in gen:
             for doc in batch:
                 if "coda-table-" in doc.id:
-                    assert len(doc.sections) > 0, "Empty table should still have a section"
+                    assert (
+                        len(doc.sections) > 0
+                    ), "Empty table should still have a section"
                     if doc.metadata.get("row_count") == "0":
-                        assert len(doc.sections) == 1, "Empty table should have exactly one section"
+                        assert (
+                            len(doc.sections) == 1
+                        ), "Empty table should have exactly one section"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mypy errors in the Coda connector by tightening types, introducing a validated Coda client property, and simplifying date/content handling. Tests were updated with typed fixtures and stronger assertions to prevent regressions.

- **Refactors**
  - Replaced public coda_client with a private _coda_client and a @property that enforces credentials.
  - Added precise type hints and return types across connector and tests.
  - Simplified datetime conversions and content assembly.
  - Standardized pagination params and URL/header building.

- **Bug Fixes**
  - Avoids None client access by raising a clear credential error early.
  - Handles missing page content and empty tables without failing.
  - Ensures batch generators consistently respect batch_size.

<sup>Written for commit b7345408c7855883a46c7d618cedd60114bace08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

