### PR TITLE
feat: Deep Research Clarification Stage

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -103,15 +103,17 @@ def construct_message_history(
     custom_agent_prompt: ChatMessageSimple | None,
     simple_chat_history: list[ChatMessageSimple],
     reminder_message: ChatMessageSimple | None,
-    project_files: ExtractedProjectFiles,
+    project_files: ExtractedProjectFiles | None,
     available_tokens: int,
+    last_n_user_messages: int | None = None,
 ) -> list[ChatMessageSimple]:
     history_token_budget = available_tokens
     history_token_budget -= system_prompt.token_count
     history_token_budget -= (
         custom_agent_prompt.token_count if custom_agent_prompt else 0
     )
-    history_token_budget -= project_files.total_token_count
+    if project_files:
+        history_token_budget -= project_files.total_token_count
     history_token_budget -= reminder_message.token_count if reminder_message else 0
 
     if history_token_budget < 0:
@@ -122,7 +124,7 @@ def construct_message_history(
         result = [system_prompt]
         if custom_agent_prompt:
             result.append(custom_agent_prompt)
-        if project_files.project_file_texts:
+        if project_files and project_files.project_file_texts:
             project_message = _create_project_files_message(
                 project_files, token_counter=None
             )
@@ -130,6 +132,26 @@ def construct_message_history(
         if reminder_message:
             result.append(reminder_message)
         return result
+
+    # If last_n_user_messages is set, filter history to only include the last n user messages
+    if last_n_user_messages is not None:
+        # Find all user message indices
+        user_msg_indices = [
+            i
+            for i, msg in enumerate(simple_chat_history)
+            if msg.message_type == MessageType.USER
+        ]
+
+        if not user_msg_indices:
+            raise ValueError("No user message found in simple_chat_history")
+
+        # If we have more than n user messages, keep only the last n
+        if len(user_msg_indices) > last_n_user_messages:
+            # Find the index of the n-th user message from the end
+            # For example, if last_n_user_messages=2, we want the 2nd-to-last user message
+            nth_user_msg_index = user_msg_indices[-(last_n_user_messages)]
+            # Keep everything from that user message onwards
+            simple_chat_history = simple_chat_history[nth_user_msg_index:]
 
     # Find the last USER message in the history
     # The history may contain tool calls and responses after the last user message
@@ -178,7 +200,7 @@ def construct_message_history(
             break
 
     # Attach project images to the last user message
-    if project_files.project_image_files:
+    if project_files and project_files.project_image_files:
         existing_images = last_user_message.image_files or []
         last_user_message = ChatMessageSimple(
             message=last_user_message.message,
@@ -200,7 +222,7 @@ def construct_message_history(
         result.append(custom_agent_prompt)
 
     # 3. Add project files message (inserted before last user message)
-    if project_files.project_file_texts:
+    if project_files and project_files.project_file_texts:
         project_message = _create_project_files_message(
             project_files, token_counter=None
         )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -491,6 +491,9 @@ def stream_chat_message_objects(
         # Note: DB session is not thread safe but nothing else uses it and the
         # reference is passed directly so it's ok.
         if os.environ.get("ENABLE_DEEP_RESEARCH_LOOP"):  # Dev only feature flag for now
+            if extracted_project_files:
+                raise RuntimeError("Deep research is not supported for projects")
+
             yield from run_chat_llm_with_state_containers(
                 run_deep_research_llm_loop,
                 is_connected=check_is_connected,

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -1,15 +1,29 @@
 from collections.abc import Callable
+from typing import cast
 
 from sqlalchemy.orm import Session
 
 from onyx.chat.chat_state import ChatStateContainer
+from onyx.chat.citation_processor import DynamicCitationProcessor
 from onyx.chat.emitter import Emitter
+from onyx.chat.llm_loop import construct_message_history
+from onyx.chat.llm_step import run_llm_step
 from onyx.chat.models import ChatMessageSimple
+from onyx.chat.models import LlmStepResult
+from onyx.configs.constants import MessageType
+from onyx.deep_research.dr_mock_tools import get_clarification_tool_definitions
 from onyx.llm.interfaces import LLM
+from onyx.llm.models import ToolChoiceOptions
+from onyx.prompts.deep_research.orchestration_layer import CLARIFICATION_PROMPT
+from onyx.prompts.prompt_utils import get_current_llm_day_time
+from onyx.server.query_and_chat.streaming_models import OverallStop
+from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.tool import Tool
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+MAX_MESSAGES_FOR_CLARIFICATION = 5
 
 
 def run_deep_research_llm_loop(
@@ -21,8 +35,70 @@ def run_deep_research_llm_loop(
     llm: LLM,
     token_counter: Callable[[str], int],
     db_session: Session,
+    skip_clarification: bool = False,
 ) -> None:
+    # Here for lazy load LiteLLM
+    from onyx.llm.litellm_singleton.config import initialize_litellm
+
     if llm.config.max_input_tokens < 25000:
         raise RuntimeError(
             "Cannot run Deep Research with an LLM that has less than 25,000 max input tokens"
         )
+
+    initialize_litellm()
+
+    available_tokens = llm.config.max_input_tokens
+    current_tool_call_index = 0
+
+    llm_step_result: LlmStepResult | None = None
+
+    if not skip_clarification:
+        clarification_prompt = CLARIFICATION_PROMPT.format(get_current_llm_day_time())
+        system_prompt = ChatMessageSimple(
+            message=clarification_prompt,
+            token_count=300,  # Skips the exact token count but has enough leeway
+            message_type=MessageType.SYSTEM,
+        )
+
+        truncated_message_history = construct_message_history(
+            system_prompt=system_prompt,
+            custom_agent_prompt=None,
+            simple_chat_history=simple_chat_history,
+            reminder_message=None,
+            project_files=None,
+            available_tokens=available_tokens,
+            last_n_user_messages=MAX_MESSAGES_FOR_CLARIFICATION,
+        )
+
+        step_generator = run_llm_step(
+            history=truncated_message_history,
+            tool_definitions=get_clarification_tool_definitions(),
+            tool_choice=ToolChoiceOptions.AUTO,
+            llm=llm,
+            turn_index=current_tool_call_index,
+            # No citations in this step, it should just pass through all
+            # tokens directly so initialized as an empty citation processor
+            citation_processor=DynamicCitationProcessor(),
+            state_container=state_container,
+            final_documents=None,
+        )
+
+        # Consume the generator, emitting packets and capturing the final result
+        while True:
+            try:
+                packet = next(step_generator)
+                emitter.emit(packet)
+            except StopIteration as e:
+                llm_step_result, current_tool_call_index = e.value
+                break
+
+        # Type narrowing: generator always returns a result, so this can't be None
+        llm_step_result = cast(LlmStepResult, llm_step_result)
+
+        if not llm_step_result.tool_calls:
+            emitter.emit(
+                Packet(turn_index=current_tool_call_index, obj=OverallStop(type="stop"))
+            )
+
+            # If a clarification is asked, we need to end this turn and wait on user input
+            return

--- a/backend/onyx/deep_research/dr_mock_tools.py
+++ b/backend/onyx/deep_research/dr_mock_tools.py
@@ -1,0 +1,18 @@
+GENERATE_PLAN_TOOL_NAME = "generate_plan"
+
+
+def get_clarification_tool_definitions() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": GENERATE_PLAN_TOOL_NAME,
+                "description": "No clarification needed, generate a research plan for the user's query.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        }
+    ]


### PR DESCRIPTION
## Description

Initial clarification stage code, no-op

## How Has This Been Tested?

No live paths touched

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the initial clarification stage to the Deep Research flow. The model can ask for clarification before generating a plan; if it does, we end the turn and wait for user input.

- **New Features**
  - Clarification step using a dedicated system prompt and AUTO tool choice.
  - Mock tool definitions with generate_plan to proceed when no clarification is needed.
  - Emits OverallStop and pauses the turn when clarification is requested; gated by ENABLE_DEEP_RESEARCH_LOOP.

- **Refactors**
  - construct_message_history supports None project_files and a last_n_user_messages cap (MAX_MESSAGES_FOR_CLARIFICATION=5).
  - Safer handling of project file texts/images when absent.
  - Deep Research is blocked for projects and raises a clear error.

<sup>Written for commit baf10d6d4d352dc62872f88676b9ae57f4845c3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

