### PR TITLE
fix(projects): don't disable internal search when no project files are uploaded

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -397,13 +397,11 @@ def stream_chat_message_objects(
         # (which means it can use search)
         # However if in a project and there are more files than can fit in the context,
         # it should use the search tool with the project filter on
+        # If no files are uploaded, search should remain enabled
         disable_internal_search = bool(
             chat_session.project_id
             and persona.id is DEFAULT_PERSONA_ID
-            and (
-                extracted_project_files.project_file_texts
-                or not extracted_project_files.project_as_filter
-            )
+            and extracted_project_files.project_file_texts
         )
 
         emitter = get_default_emitter()


### PR DESCRIPTION
## Description

- When using Projects as a chat organization feature, there are no uploaded files
- In addition, if using the default assistant, internal search is disabled in this configuration
- Internal search should be disabled only if project files exist and they fit within llm context window.
-- Whether or not the search should be scoped to the project filter should not dictate the tool status.


## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures internal search stays enabled when a project has no uploaded files, preventing unnecessary search disabling in empty projects. Updates the logic so search is only disabled when project files are present and the default persona is used.

- **Bug Fixes**
  - Adjusted disable_internal_search condition in stream_chat_message_objects to check only for project_file_texts.

<sup>Written for commit ff6728cf794ff4c3e1556330ab7aff91449cb00e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



