### PR TITLE
chore: disable coda tests temporarily until we fully configure

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -170,7 +170,7 @@ jobs:
             file_processing:
               - 'backend/onyx/file_processing/**'
 
-      - name: Run Tests (excluding HubSpot, Salesforce, and GitHub)
+      - name: Run Tests (excluding HubSpot, Salesforce, GitHub, and Coda)
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         run: |
           py.test \
@@ -183,7 +183,8 @@ jobs:
             backend/tests/daily/connectors \
             --ignore backend/tests/daily/connectors/hubspot \
             --ignore backend/tests/daily/connectors/salesforce \
-            --ignore backend/tests/daily/connectors/github
+            --ignore backend/tests/daily/connectors/github \
+            --ignore backend/tests/daily/connectors/coda
 
       - name: Run HubSpot Connector Tests
         if: ${{ github.event_name == 'schedule' || steps.changes.outputs.hubspot == 'true' || steps.changes.outputs.file_processing == 'true' }}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disable Coda connector tests in the PR Python workflow to prevent failures until the connector is fully configured. Updates the test step name and adds an ignore for backend/tests/daily/connectors/coda in py.test.

<sup>Written for commit 92ce24d8022ab711fb73d83b4a0fcaaff717e704. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

