### PR TITLE
fix(table): rectify table model

### DIFF
--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -552,9 +552,7 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         """Load and validate Coda credentials."""
-        self._coda_client = CodaApiClient(
-            bearer_token="de790189-1ca1-4917-b36d-32d7cf0d032c"
-        )
+        self._coda_client = CodaApiClient(bearer_token=credentials["coda_bearer_token"])
 
         try:
             self._coda_client.get("docs", params={"limit": "1"})


### PR DESCRIPTION
## Description

Issue: #6738

Update CodaTable model to match API. Connector is still sub-par when benchmarking with TempTabQA against my connector #6504.  Currently working on an easy setup to benchmark table processing connectors




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Coda connector’s table model with the Coda API by introducing a table reference type and fetching full table details when building documents. Fixes table metadata and ID handling, and ensures a table-only document is emitted if row retrieval fails.

- **Refactors**
  - Added CodaTableReference (id, name, browser_link); _list_tables now returns references.
  - Fetch full table via _get_table(doc_id, table_id) to use accurate updated_at and metadata.
  - Document IDs and metadata now use doc_id and tableReference fields; row_count included.
  - Graceful fallback when rows fail: emit a table-only document.

- **Bug Fixes**
  - Removed hardcoded bearer token from credentials.

<sup>Written for commit fb619dc0b8fc84f278d91b2652ceb74c021a873b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



