### PR TITLE
feat: add slash commands for navigation and tool toggling

### DIFF
--- a/web/src/app/chat/components/input/keyboardHandlers.ts
+++ b/web/src/app/chat/components/input/keyboardHandlers.ts
@@ -1,0 +1,118 @@
+import { SlashCommand } from "@/app/chat/components/slash-commands/types";
+import { InputPrompt } from "@/app/chat/interfaces";
+
+/**
+ * Keyboard handler for slash command menu navigation
+ *
+ * Handles arrow keys for navigation, Enter/Tab for selection, and Escape to dismiss
+ * @returns true if event was handled and should not propagate
+ */
+export function handleSlashCommandKeyDown(
+  e: React.KeyboardEvent,
+  options: {
+    filteredSlashCommands: SlashCommand[];
+    slashMenuIndex: number;
+    setSlashMenuIndex: (index: number | ((prev: number) => number)) => void;
+    onSelectCommand: (command: SlashCommand) => void;
+    onEscape: () => void;
+  }
+): boolean {
+  const {
+    filteredSlashCommands,
+    slashMenuIndex,
+    setSlashMenuIndex,
+    onSelectCommand,
+    onEscape,
+  } = options;
+
+  if (filteredSlashCommands.length === 0) return false;
+
+  switch (e.key) {
+    case "ArrowDown":
+      e.preventDefault();
+      setSlashMenuIndex((idx) =>
+        Math.min(idx + 1, filteredSlashCommands.length - 1)
+      );
+      return true;
+
+    case "ArrowUp":
+      e.preventDefault();
+      setSlashMenuIndex((idx) => Math.max(idx - 1, 0));
+      return true;
+
+    case "Tab":
+    case "Enter": {
+      e.preventDefault();
+      const selectedCommand = filteredSlashCommands[slashMenuIndex];
+      if (selectedCommand) {
+        onSelectCommand(selectedCommand);
+      }
+      return true;
+    }
+
+    case "Escape":
+      e.preventDefault();
+      onEscape();
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Keyboard handler for input prompts menu navigation
+ *
+ * Handles arrow keys for navigation, Enter/Tab for selection
+ * The last index triggers "Create new prompt" action
+ * @returns true if event was handled and should not propagate
+ */
+export function handleInputPromptsKeyDown(
+  e: React.KeyboardEvent,
+  options: {
+    filteredPrompts: InputPrompt[];
+    tabbingIconIndex: number;
+    setTabbingIconIndex: (index: number | ((prev: number) => number)) => void;
+    onSelectPrompt: (prompt: InputPrompt) => void;
+    onCreateNew: () => void;
+  }
+): boolean {
+  const {
+    filteredPrompts,
+    tabbingIconIndex,
+    setTabbingIconIndex,
+    onSelectPrompt,
+    onCreateNew,
+  } = options;
+
+  switch (e.key) {
+    case "Tab":
+    case "Enter": {
+      e.preventDefault();
+      // Last index is the "Create new prompt" option
+      if (tabbingIconIndex === filteredPrompts.length) {
+        onCreateNew();
+      } else {
+        const selectedPrompt =
+          filteredPrompts[tabbingIconIndex >= 0 ? tabbingIconIndex : 0];
+        if (selectedPrompt) {
+          onSelectPrompt(selectedPrompt);
+        }
+      }
+      return true;
+    }
+
+    case "ArrowDown":
+      e.preventDefault();
+      setTabbingIconIndex((idx) => Math.min(idx + 1, filteredPrompts.length));
+      return true;
+
+    case "ArrowUp":
+      e.preventDefault();
+      setTabbingIconIndex((idx) => Math.max(idx - 1, 0));
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/web/src/app/chat/components/slash-commands/SlashCommandMenu.tsx
+++ b/web/src/app/chat/components/slash-commands/SlashCommandMenu.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import React, { useRef, useEffect, useMemo, useState } from "react";
+import {
+  SlashCommand,
+  SlashCommandType,
+} from "@/app/chat/components/slash-commands/types";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import { PopoverMenu } from "@/components/ui/popover";
+import SvgBubbleText from "@/icons/bubble-text";
+import SvgArrowRight from "@/icons/arrow-right";
+import SvgPlug from "@/icons/plug";
+import SvgChevronRight from "@/icons/chevron-right";
+import SvgChevronDown from "@/icons/chevron-down";
+import Text from "@/refresh-components/texts/Text";
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (command: SlashCommand) => void;
+}
+
+const GROUP_LABELS: Record<SlashCommandType, string> = {
+  prompt: "Prompts",
+  navigation: "Navigation",
+  tool: "Tools",
+};
+
+const GROUP_ICONS: Record<SlashCommandType, React.ReactNode> = {
+  prompt: <SvgBubbleText size={14} />,
+  navigation: <SvgArrowRight size={14} />,
+  tool: <SvgPlug size={14} />,
+};
+
+const GROUP_ORDER: SlashCommandType[] = ["tool", "navigation", "prompt"];
+
+export default function SlashCommandMenu({
+  commands,
+  selectedIndex,
+  onSelect,
+}: SlashCommandMenuProps) {
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Track which groups are expanded (default to all expanded)
+  const [expandedGroups, setExpandedGroups] = useState<Set<SlashCommandType>>(
+    new Set(GROUP_ORDER)
+  );
+
+  // Group commands by type
+  const groupedCommands = useMemo(() => {
+    const groups = commands.reduce(
+      (acc, cmd) => {
+        if (!acc[cmd.type]) {
+          acc[cmd.type] = [];
+        }
+        acc[cmd.type].push(cmd);
+        return acc;
+      },
+      {} as Record<SlashCommandType, SlashCommand[]>
+    );
+
+    // Return groups in the defined order
+    return GROUP_ORDER.filter((type) => groups[type]?.length > 0).map(
+      (type) => ({
+        type,
+        label: GROUP_LABELS[type],
+        commands: groups[type],
+      })
+    );
+  }, [commands]);
+
+  useEffect(() => {
+    const selectedItem = itemRefs.current[selectedIndex];
+    if (selectedItem) {
+      selectedItem.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [selectedIndex]);
+
+  const toggleGroup = (type: SlashCommandType) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  };
+
+  if (commands.length === 0) return null;
+
+  let flatIndex = 0;
+
+  return (
+    <div className="absolute left-0 top-0 transform -translate-y-full mb-1">
+      <div className="bg-background-neutral-00 p-1.5 rounded-12 border shadow-md max-h-[500px] overflow-hidden w-[280px] flex flex-col gap-2">
+        {/* Title */}
+        <Text secondaryBody text03 className="px-2">
+          Commands
+        </Text>
+
+        {/* Scrollable content */}
+        <PopoverMenu
+          scrollContainerRef={scrollContainerRef}
+          medium
+          className="!w-full"
+        >
+          {groupedCommands.map((group, groupIdx) => {
+            const isExpanded = expandedGroups.has(group.type);
+
+            return (
+              <div key={group.type}>
+                {/* Group header - collapsible */}
+                {groupedCommands.length > 1 && (
+                  <button
+                    onClick={() => toggleGroup(group.type)}
+                    className="w-full px-1.5 py-1 flex items-center gap-1.5 text-xs font-medium text-text-03 rounded-08 hover:bg-background-tint-02 transition-colors"
+                  >
+                    <div className="flex items-center justify-center size-5 shrink-0">
+                      {GROUP_ICONS[group.type]}
+                    </div>
+                    <span className="flex-1 text-left">{group.label}</span>
+                    <div className="flex items-center justify-center size-6 shrink-0">
+                      {isExpanded ? (
+                        <SvgChevronDown className="h-4 w-4 stroke-text-04" />
+                      ) : (
+                        <SvgChevronRight className="h-4 w-4 stroke-text-04" />
+                      )}
+                    </div>
+                  </button>
+                )}
+
+                {/* Group commands - only show when expanded */}
+                {isExpanded && (
+                  <>
+                    {group.commands.map((command) => {
+                      const currentIndex = flatIndex++;
+                      const isNewPromptCommand =
+                        command.command === "/new-prompt";
+
+                      return (
+                        <div
+                          key={command.command}
+                          ref={(el) => {
+                            itemRefs.current[currentIndex] = el;
+                          }}
+                        >
+                          {isNewPromptCommand ? (
+                            <div className="mt-2">
+                              <button
+                                onClick={() => onSelect(command)}
+                                className="px-2 py-1 flex items-center gap-1.5 text-xs font-medium text-text-03 bg-background-neutral-01 hover:bg-background-neutral-02 rounded-08 border border-border-01 transition-colors"
+                              >
+                                <span className="text-sm">+</span>
+                                <span>New prompt</span>
+                              </button>
+                            </div>
+                          ) : (
+                            <div className="[&_p]:text-left">
+                              <LineItem
+                                selected={selectedIndex === currentIndex}
+                                emphasized={selectedIndex === currentIndex}
+                                description={command.description}
+                                onClick={() => onSelect(command)}
+                              >
+                                {command.command}
+                              </LineItem>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </>
+                )}
+
+                {/* Divider between groups (except after last group) */}
+                {groupIdx < groupedCommands.length - 1 && (
+                  <div className="my-1 border-t border-border-01" />
+                )}
+              </div>
+            );
+          })}
+        </PopoverMenu>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/chat/components/slash-commands/commands/navigationCommands.ts
+++ b/web/src/app/chat/components/slash-commands/commands/navigationCommands.ts
@@ -1,0 +1,91 @@
+import { SlashCommand } from "@/app/chat/components/slash-commands/types";
+
+export const navigationCommands: SlashCommand[] = [
+  {
+    command: "/new-chat",
+    description: "Start a new chat session",
+    type: "navigation",
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.startNewChat();
+    },
+  },
+  {
+    command: "/create-agent",
+    description: "Create a new AI assistant",
+    type: "navigation",
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/assistants/new");
+    },
+  },
+  {
+    command: "/agents",
+    description: "Browse available AI assistants",
+    type: "navigation",
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/chat/agents");
+    },
+  },
+  {
+    command: "/add-connector",
+    description: "Connect a new data source",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/add-connector");
+    },
+  },
+  {
+    command: "/connectors",
+    description: "View and manage data connectors",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/indexing/status");
+    },
+  },
+  {
+    command: "/settings",
+    description: "Open workspace settings",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/settings");
+    },
+  },
+  {
+    command: "/users",
+    description: "Manage workspace users",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/users");
+    },
+  },
+  {
+    command: "/document-sets",
+    description: "Manage document collections",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/documents/sets");
+    },
+  },
+  {
+    command: "/llm-config",
+    description: "Configure LLM providers",
+    type: "navigation",
+    adminOnly: true,
+    execute: (ctx) => {
+      ctx.clearInput();
+      ctx.navigate("/admin/configuration/llm");
+    },
+  },
+];

--- a/web/src/app/chat/components/slash-commands/commands/promptCommands.ts
+++ b/web/src/app/chat/components/slash-commands/commands/promptCommands.ts
@@ -1,0 +1,56 @@
+import { InputPrompt } from "@/app/chat/interfaces";
+import { SlashCommand } from "@/app/chat/components/slash-commands/types";
+
+/**
+ * Converts an InputPrompt to a slash command format
+ */
+function toSlashCommand(promptName: string): string {
+  return (
+    "/" +
+    promptName
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .replace(/[\s_]+/g, "-")
+      .replace(/[^a-zA-Z0-9-]/g, "")
+      .toLowerCase()
+  );
+}
+
+/**
+ * Generates slash commands from input prompts
+ * Each prompt becomes a command that inserts its content when selected
+ */
+export function generatePromptCommands(
+  inputPrompts: InputPrompt[]
+): SlashCommand[] {
+  return inputPrompts
+    .filter((prompt) => prompt.active)
+    .map((prompt) => ({
+      command: toSlashCommand(prompt.prompt),
+      description:
+        prompt.content
+          ?.trim()
+          .replace(/\n/g, " ") // Replace newlines with spaces
+          .slice(0, 80) || "Insert prompt", // Reduced to 80 chars for better single-line display
+      type: "prompt" as const,
+      promptContent: prompt.content,
+      execute: (ctx) => {
+        // Insert the prompt content into the input
+        ctx.clearInput();
+        if (ctx.setMessage) {
+          ctx.setMessage(prompt.content || "");
+        }
+      },
+    }));
+}
+
+/**
+ * Special command to create a new prompt
+ */
+export const createPromptCommand: SlashCommand = {
+  command: "/new-prompt",
+  description: "Create a new prompt shortcut",
+  type: "prompt",
+  execute: (ctx) => {
+    ctx.navigate("/chat/input-prompts");
+  },
+};

--- a/web/src/app/chat/components/slash-commands/commands/toolCommands.ts
+++ b/web/src/app/chat/components/slash-commands/commands/toolCommands.ts
@@ -1,0 +1,58 @@
+import { ToolSnapshot } from "@/lib/tools/interfaces";
+import {
+  SlashCommand,
+  CommandContext,
+} from "@/app/chat/components/slash-commands/types";
+
+function toSlashCommand(name: string): string {
+  return (
+    "/" +
+    name
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .replace(/[\s_]+/g, "-")
+      .replace(/[^a-zA-Z0-9-]/g, "")
+      .toLowerCase()
+  );
+}
+
+// Static tool commands that are always available
+const staticToolCommands: SlashCommand[] = [
+  {
+    command: "/upload",
+    description: "Upload files to chat",
+    type: "tool" as const,
+    execute: (ctx: CommandContext) => {
+      ctx.clearInput();
+      ctx.triggerFileUpload?.();
+    },
+  },
+];
+
+export function generateToolCommands(
+  tools: ToolSnapshot[],
+  disabledToolIds: number[] = []
+): SlashCommand[] {
+  const dynamicCommands = tools
+    .filter((tool) => {
+      if (!tool.chat_selectable) return false;
+      if (tool.mcp_server_id) return false;
+      // Don't show commands for disabled tools - user must enable via normal UI
+      if (disabledToolIds.includes(tool.id)) return false;
+      return true;
+    })
+    .map((tool) => {
+      const displayName = tool.display_name || tool.name;
+      return {
+        command: toSlashCommand(displayName),
+        description: `Use ${displayName}`,
+        type: "tool" as const,
+        toolId: tool.id,
+        execute: (ctx: CommandContext) => {
+          ctx.toggleForcedTool(tool.id);
+          ctx.clearInput();
+        },
+      };
+    });
+
+  return [...staticToolCommands, ...dynamicCommands];
+}

--- a/web/src/app/chat/components/slash-commands/types.ts
+++ b/web/src/app/chat/components/slash-commands/types.ts
@@ -1,0 +1,22 @@
+export type SlashCommandType = "prompt" | "navigation" | "tool";
+
+export interface SlashCommand {
+  command: string;
+  description: string;
+  type: SlashCommandType;
+  hidden?: boolean;
+  adminOnly?: boolean;
+  toolId?: number;
+  promptContent?: string; // For prompt commands - the content to insert
+  execute: (context: CommandContext) => void | Promise<void>;
+}
+
+export interface CommandContext {
+  clearInput: () => void;
+  startNewChat: () => void;
+  navigate: (path: string) => void;
+  isAdmin: boolean;
+  toggleForcedTool: (toolId: number) => void;
+  setMessage?: (message: string) => void; // For prompt commands to set input content
+  triggerFileUpload?: () => void; // For triggering file upload dialog
+}

--- a/web/src/app/chat/hooks/useSlashCommands.ts
+++ b/web/src/app/chat/hooks/useSlashCommands.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import {
+  SlashCommand,
+  CommandContext,
+} from "@/app/chat/components/slash-commands/types";
+import { navigationCommands } from "@/app/chat/components/slash-commands/commands/navigationCommands";
+import { generateToolCommands } from "@/app/chat/components/slash-commands/commands/toolCommands";
+import {
+  generatePromptCommands,
+  createPromptCommand,
+} from "@/app/chat/components/slash-commands/commands/promptCommands";
+import { ToolSnapshot } from "@/lib/tools/interfaces";
+import { InputPrompt } from "@/app/chat/interfaces";
+
+interface UseSlashCommandsOptions {
+  isAdmin?: boolean;
+  tools?: ToolSnapshot[];
+  disabledToolIds?: number[];
+  inputPrompts?: InputPrompt[];
+  shortcutsEnabled?: boolean;
+}
+
+/**
+ * Hook for managing slash commands in chat input
+ *
+ * Combines navigation commands, tool toggle commands, and prompt shortcuts into a unified menu.
+ *
+ * @param options.isAdmin - Whether the current user is an admin (for admin-only commands)
+ * @param options.tools - Available tools for the current assistant
+ * @param options.disabledToolIds - Tool IDs that are disabled for the current assistant
+ * @param options.inputPrompts - User's saved prompt shortcuts
+ * @param options.shortcutsEnabled - Whether prompt shortcuts feature is enabled
+ */
+export function useSlashCommands(options: UseSlashCommandsOptions = {}) {
+  const {
+    isAdmin = false,
+    tools = [],
+    disabledToolIds = [],
+    inputPrompts = [],
+    shortcutsEnabled = false,
+  } = options;
+
+  const allCommands = useMemo(() => {
+    const toolCommands = generateToolCommands(tools, disabledToolIds);
+    const promptCommands =
+      shortcutsEnabled && inputPrompts.length > 0
+        ? generatePromptCommands(inputPrompts)
+        : [];
+
+    // Add "create new prompt" command if shortcuts are enabled
+    const createCommand = shortcutsEnabled ? [createPromptCommand] : [];
+
+    return [
+      ...toolCommands,
+      ...navigationCommands,
+      ...promptCommands,
+      ...createCommand,
+    ];
+  }, [tools, disabledToolIds, inputPrompts, shortcutsEnabled]);
+
+  const getFilteredCommands = useCallback(
+    (input: string): SlashCommand[] => {
+      const trimmed = input.trim().toLowerCase();
+      if (!trimmed.startsWith("/")) return [];
+
+      return allCommands.filter((cmd) => {
+        if (!cmd.command.toLowerCase().startsWith(trimmed)) return false;
+        if (cmd.adminOnly && !isAdmin) return false;
+        if (cmd.hidden && cmd.command.toLowerCase() !== trimmed) return false;
+        return true;
+      });
+    },
+    [allCommands, isAdmin]
+  );
+
+  const executeCommand = useCallback(
+    (message: string, context: CommandContext): SlashCommand | undefined => {
+      const trimmed = message.trim().toLowerCase();
+      const command = allCommands.find(
+        (cmd) => cmd.command.toLowerCase() === trimmed
+      );
+
+      if (!command) return undefined;
+      if (command.adminOnly && !isAdmin) return undefined;
+
+      command.execute(context);
+      return command;
+    },
+    [allCommands, isAdmin]
+  );
+
+  const isSlashCommand = useCallback(
+    (message: string): boolean => {
+      const trimmed = message.trim().toLowerCase();
+      return allCommands.some(
+        (cmd) =>
+          cmd.command.toLowerCase() === trimmed && (!cmd.adminOnly || isAdmin)
+      );
+    },
+    [allCommands, isAdmin]
+  );
+
+  return {
+    executeCommand,
+    isSlashCommand,
+    getFilteredCommands,
+  };
+}


### PR DESCRIPTION
## Description

Add a slash command system to the chat input with a unified, collapsible menu. Users can type "/" to see available commands organized in three groups:

**Tools**:
- `/upload` - Open file picker to upload files
- Tool toggle commands: dynamically generated from assistant's available tools (e.g., `/web-search`, `/internal-search`, `/image-generation`, etc.)

**Navigation**:
- `/new-chat`, `/agents`, `/create-agent`
- Admin-only: `/settings`, `/connectors`, `/users`, `/document-sets`, `/llm-config`, `/add-connector`

**Prompts** :
- Prompt shortcuts: dynamically generated from saved prompts
- `/new-prompt` - Create a new prompt shortcut

## How Has This Been Tested?

Manual testing

Non-admin
<img src="https://github.com/user-attachments/assets/6794c60e-3cc5-454e-97d5-1d4b2d2320f5" width="500" />

Admin
<img src="https://github.com/user-attachments/assets/b552ac3a-be4c-4925-97e7-5cb17a5e73fe" width="500" />

E2E flow with tool calling + prompts
<video src="https://github.com/user-attachments/assets/d5969885-decd-4359-8647-8c13e22342e1" width="500" controls></video>


## Additional Options

- [x] Override Linear Check





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds slash commands to the chat input for quick navigation, tool toggling, and prompt shortcuts. Type “/” to open a grouped menu and run commands without sending a chat message.

- **New Features**
  - Menu appears on “/”; Arrow keys navigate; Tab/Enter select; Esc cancels. Groups are collapsible: Tools, Navigation, Prompts.
  - Navigation: /new-chat, /agents, /create-agent; admin-only: /settings, /connectors, /users, /document-sets, /llm-config, /add-connector.
  - Tools: commands generated from the assistant’s tools; disabled tools omitted; selection toggles forced tools; added /upload to open the file picker.
  - Prompts: commands generated from saved prompts; selection inserts content; added /new-prompt to create a prompt. The slash menu replaces the old prompt shortcuts UI.

<sup>Written for commit 1845069415e6057ccb176d4c3cc7406f43bcc67c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





