### PR TITLE
chore(deployment): run check-version-tag in debug mode

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Validate tag is versioned correctly
         run: |
-          uv run --no-sync --with release-tag tag --check
+          uv run --no-sync --with release-tag tag --check --debug
 
   notify-slack-on-tag-check-failure:
     needs:


### PR DESCRIPTION
## Description

`tag --check` works locally as expected, so not sure why [this](https://github.com/onyx-dot-app/onyx/actions/runs/20251569302/job/58144497428) is failing. This should help investigate.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the version tag check in debug mode during deployment to get detailed logs and help diagnose the CI failure. Adds the --debug flag to the release-tag tag --check step.

<sup>Written for commit 342cef748b31a55ec5aa350ff9e28b58ab82b7ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

