### PR TITLE
fix(llms): destructure fetched_model_configurations

### DIFF
--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -284,6 +284,7 @@ export function LLMProviderUpdateForm({
         const {
           selected_model_names: visibleModels,
           model_configurations: modelConfigurations,
+          fetched_model_configurations,
           target_uri,
           _modelListUpdated,
           ...rest


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Destructures fetched_model_configurations in LLMProviderUpdateForm so it doesn’t get bundled into the rest payload. This reduces the request body size for provider updates and prevents oversized requests.

<sup>Written for commit 723aa0dd4cda760d15647b241ae33e17189e006a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

