### PR TITLE
feat(new vector db interface): Plug in hybrid_retrieval for Vespa

### DIFF
--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -967,10 +967,13 @@ class VespaIndex(DocumentIndex):
             large_chunks_enabled=self.large_chunks_enabled,
             httpx_client=self.httpx_client,
         )
-        assert (
+        if not (
             ranking_profile_type == QueryExpansionType.KEYWORD
             or ranking_profile_type == QueryExpansionType.SEMANTIC
-        )
+        ):
+            raise ValueError(
+                f"Bug: Received invalid ranking profile type: {ranking_profile_type}"
+            )
         query_type = (
             QueryType.KEYWORD
             if ranking_profile_type == QueryExpansionType.KEYWORD

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -234,7 +234,9 @@ class VespaDocumentIndex(DocumentIndex):
             )
         self._multitenant = tenant_state.multitenant
         if self._multitenant:
-            assert self._tenant_id, "Must supply a tenant id if in multitenant mode."
+            assert (
+                self._tenant_id
+            ), "Bug: Must supply a tenant id if in multitenant mode."
 
     def verify_and_create_index_if_necessary(
         self, embedding_dim: int, embedding_precision: EmbeddingPrecision


### PR DESCRIPTION
## Description
This PR plugs in VespaDocumentIndex's hybrid_retrieval method implemented in #6750 into the hotpath.

## How Has This Been Tested?
Indexed a couple large txt docs locally and was able to fetch them as sources in a query.

## Additional Options

- [x] [Optional] Override Linear Check





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched hybrid search to a new VespaDocumentIndex that implements a generic DocumentIndex API. Results now return clean chunk content and we ensure enough hits are fetched for proper reranking.

- **New Features**
  - Added DocumentIndex interfaces and data models (indexing, updates, deletion, hybrid/id/random retrieval).
  - Implemented VespaDocumentIndex with hybrid search, batched indexing and deletes, multitenant support, and chunk cleanup.
  - Introduced QueryType and constants (RERANK_COUNT, RECENCY_BIAS_MULTIPLIER) to align targetHits with schema rerank-count and stabilize recency weighting.

- **Refactors**
  - Delegated vespa/index.py hybrid_retrieval to VespaDocumentIndex and mapped QueryExpansionType to QueryType.
  - Require tenant id in multitenant mode.
  - Small cleanups: HTTPX client context usage, batch generator naming, docstrings, and TODO markers for unused code.

<sup>Written for commit 4dd53600f3ca91d9c2fd321d0a36001254d1e5f1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




