### PR TITLE
chore: gpt 5.2 model naming

### DIFF
--- a/backend/onyx/llm/model_metadata_enrichments.json
+++ b/backend/onyx/llm/model_metadata_enrichments.json
@@ -2621,6 +2621,28 @@
     "model_vendor": "openai",
     "model_version": "2025-10-06"
   },
+  "gpt-5.2-pro-2025-12-11": {
+    "display_name": "GPT-5.2 Pro",
+    "model_vendor": "openai",
+    "model_version": "2025-12-11"
+  },
+  "gpt-5.2-pro": {
+    "display_name": "GPT-5.2 Pro",
+    "model_vendor": "openai"
+  },
+  "gpt-5.2-chat-latest": {
+    "display_name": "GPT 5.2 Chat",
+    "model_vendor": "openai"
+  },
+  "gpt-5.2-2025-12-11": {
+    "display_name": "GPT 5.2",
+    "model_vendor": "openai",
+    "model_version": "2025-12-11"
+  },
+  "gpt-5.2": {
+    "display_name": "GPT 5.2",
+    "model_vendor": "openai"
+  },
   "gpt-5.1": {
     "display_name": "GPT 5.1",
     "model_vendor": "openai"


### PR DESCRIPTION
## Description

metadata to make gpt-5.2 models nice in the UI

## How Has This Been Tested?

in UI

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added display names and vendor/version metadata for OpenAI GPT-5.2 models so the UI shows clear, friendly names.
Covers gpt-5.2, gpt-5.2-2025-12-11, gpt-5.2-pro, gpt-5.2-pro-2025-12-11, and gpt-5.2-chat-latest.

<sup>Written for commit b4a8637489be416f83fdaef6058a4abdbebb9e6f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

