### PR TITLE
fix: llm popover scroll

### DIFF
--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -118,12 +118,11 @@ export function PopoverMenu({
 
   return (
     <div className="flex flex-col gap-1 max-h-[20rem]">
-      {/* Scrollable area with shadows */}
-      <div className="relative flex-1 min-h-0">
+      <div className="relative">
         <div
           ref={containerRef}
           className={cn(
-            "flex flex-col gap-1 h-full overflow-y-scroll",
+            "flex flex-col gap-1 overflow-y-auto h-[20rem]",
             sizeClasses[size],
             className
           )}

--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -365,7 +365,7 @@ export default function LLMPopover({
           {/* Model List with Vendor Groups */}
           <PopoverMenu
             scrollContainerRef={scrollContainerRef}
-            className="w-full min-h-[20rem]"
+            className="w-full"
           >
             {isLoadingProviders
               ? [


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

![2025-12-15 21 03 48](https://github.com/user-attachments/assets/b31e0b4f-8378-4302-9103-2210436b9d5d)


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix scroll in the LLM model popover by making the menu a single, fixed-height (20rem) scroll container. Prevents double scrollbars and clipping so the model list is fully accessible.

<sup>Written for commit f16b346fa716e7853873e4945f3397e89d83f30f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

