### PR TITLE
fix(llms): only save model configs for active/usable LLMs

### DIFF
--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -121,8 +121,9 @@ export function CustomLLMProviderUpdateForm({
 
         // build final payload
         const finalValues = { ...values };
-        finalValues.model_configurations = finalValues.model_configurations.map(
-          (modelConfiguration) => ({
+        // Filter out models that are not default, fast default, or visible
+        finalValues.model_configurations = finalValues.model_configurations
+          .map((modelConfiguration) => ({
             ...modelConfiguration,
             max_input_tokens:
               modelConfiguration.max_input_tokens === null ||
@@ -130,8 +131,13 @@ export function CustomLLMProviderUpdateForm({
                 ? null
                 : modelConfiguration.max_input_tokens,
             supports_image_input: false, // doesn't matter, not used
-          })
-        );
+          }))
+          .filter(
+            (modelConfiguration) =>
+              modelConfiguration.name === values.default_model_name ||
+              modelConfiguration.name === values.fast_default_model_name ||
+              modelConfiguration.is_visible
+          );
         finalValues.api_key_changed = values.api_key !== initialValues.api_key;
 
         if (values.model_configurations.length === 0) {

--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -312,13 +312,11 @@ export function LLMProviderUpdateForm({
         }
 
         // Create the final payload with proper typing
-        const finalValues = {
-          ...rest,
-          api_base: finalApiBase,
-          api_version: finalApiVersion,
-          deployment_name: finalDeploymentName,
-          api_key_changed: values.api_key !== initialValues.api_key,
-          model_configurations: getCurrentModelConfigurations(values).map(
+        // Filter out models that are not default, fast default, or visible
+        const filteredModelConfigurations = getCurrentModelConfigurations(
+          values
+        )
+          .map(
             (modelConfiguration): ModelConfiguration => ({
               name: modelConfiguration.name,
               is_visible: visibleModels.includes(modelConfiguration.name),
@@ -326,7 +324,21 @@ export function LLMProviderUpdateForm({
               supports_image_input: modelConfiguration.supports_image_input,
               display_name: modelConfiguration.display_name,
             })
-          ),
+          )
+          .filter(
+            (modelConfiguration) =>
+              modelConfiguration.name === rest.default_model_name ||
+              modelConfiguration.name === rest.fast_default_model_name ||
+              modelConfiguration.is_visible
+          );
+
+        const finalValues = {
+          ...rest,
+          api_base: finalApiBase,
+          api_version: finalApiVersion,
+          deployment_name: finalDeploymentName,
+          api_key_changed: values.api_key !== initialValues.api_key,
+          model_configurations: filteredModelConfigurations,
         };
 
         // test the configuration


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Save only active model configurations (default, fast default, or visible) when updating LLM providers. This trims payloads and prevents persisting hidden or unused models.

- **Bug Fixes**
  - Filter model_configurations to default_model_name, fast_default_model_name, or is_visible in both LLMProviderUpdateForm and CustomLLMProviderUpdateForm.
  - Normalize max_input_tokens to null when unset; keep display_name and visibility; set supports_image_input to false for custom providers.
  - Preserve api_key_changed detection and existing API base/version/deployment handling.

<sup>Written for commit 6d3afcc0f7325121bfcb9219b3dd1de9ae312028. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

