### PR TITLE
chore(deployment): fetch-depth: 0 for check-version-tag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # ratchet:astral-sh/setup-uv@v7.1.4
@@ -101,7 +102,7 @@ jobs:
 
       - name: Validate tag is versioned correctly
         run: |
-          uv run --no-sync --with release-tag tag --check --debug
+          uv run --no-sync --with release-tag tag --check
 
   notify-slack-on-tag-check-failure:
     needs:


### PR DESCRIPTION
## Description

Github Actions checkout with [--depth=1](https://github.com/onyx-dot-app/onyx/actions/runs/20259032275/job/58166897513#step:2:68) by default, but we need the missing history to check ancestry.

Fixes: https://github.com/onyx-dot-app/onyx/actions/runs/20259032275/job/58166897513

## How Has This Been Tested?

Initialized a repo locally replacing the fetch command with `git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*` and confirmed `tag --check` was happy,

```
mkdir -p onyx && \
  cd onyx && \
  git init && \
  git remote add origin https://github.com/onyx-dot-app/onyx && \
  git -c protocol.version=2 fetch --prune --no-recurse-submodules origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*' && \
  git checkout --progress --force refs/tags/v2.6.0-beta.4 && \
  uv run --with release-tag tag --check
```

## Additional Options

- [x] Override Linear Check
