### PR TITLE
chore(gha): use `ods openapi` in CI

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -40,24 +40,10 @@ jobs:
             backend/requirements/model_server.txt
             backend/requirements/ee.txt
 
-      - name: Generate OpenAPI schema
-        shell: bash
-        working-directory: backend
-        env:
-          PYTHONPATH: "."
-        run: |
-          python scripts/onyx_openapi_schema.py --filename generated/openapi.json
-
-      - name: Generate OpenAPI Python client
+      - name: Generate OpenAPI schema and Python client
         shell: bash
         run: |
-          uv run openapi-generator-cli generate \
-            -i backend/generated/openapi.json \
-            -g python \
-            -o backend/generated/onyx_openapi_client \
-            --package-name onyx_openapi_client \
-            --skip-validate-spec \
-            --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
+          ods openapi all
 
       - name: Cache mypy cache
         if: ${{ vars.DISABLE_MYPY_CACHE != 'true' }}


### PR DESCRIPTION
## Description

See also, [chore(devtools): ods openapi to generate schema and client #6748](https://github.com/onyx-dot-app/onyx/pull/6748)

## How Has This Been Tested?

Expecting a non-functional change; captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI to generate the OpenAPI schema and Python client using `ods openapi all`, replacing the custom script and `openapi-generator` steps. This simplifies the workflow, aligns with local tooling, and has no functional impact.

<sup>Written for commit 19b46f41e9c40142f92039707128cdd2ae717da3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

