### PR TITLE
chore(hygiene): rm unused secrets

### DIFF
--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -26,9 +26,6 @@ jobs:
     env:
       PYTHONPATH: ./backend
       REDIS_CLOUD_PYTEST_PASSWORD: ${{ secrets.REDIS_CLOUD_PYTEST_PASSWORD }}
-      SF_USERNAME: ${{ secrets.SF_USERNAME }}
-      SF_PASSWORD: ${{ secrets.SF_PASSWORD }}
-      SF_SECURITY_TOKEN: ${{ secrets.SF_SECURITY_TOKEN }}
       DISABLE_TELEMETRY: "true"
 
     steps:


### PR DESCRIPTION
## Description


## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused Salesforce secrets from the pr-python-tests GitHub Actions workflow to reduce risk and simplify the environment. No functional changes; tests still run with Redis credentials as before.

<sup>Written for commit 13c8eb4943a837b28db9d4750bb4a84eeb3c7332. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

