### PR TITLE
fix(web search): clamp google pse max results to api max

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/clients/google_pse_client.py
+++ b/backend/onyx/tools/tool_implementations/web_search/clients/google_pse_client.py
@@ -28,7 +28,7 @@ class GooglePSEClient(WebSearchProvider):
     ) -> None:
         self._api_key = api_key
         self._search_engine_id = search_engine_id
-        self._num_results = num_results
+        self._num_results = min(num_results, 10)  # Google API max is 10
         self._timeout_seconds = timeout_seconds
 
     @retry_builder(tries=3, delay=1, backoff=2)


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp Google PSE search results to a maximum of 10 to match the API limit. This prevents invalid requests and avoids errors from over-limit values.

<sup>Written for commit c61e178ddc6bf850d4fa910ef145eb4c36de4919. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

