### PR TITLE
fix(llm): fix custom provider detection and model filtering

### DIFF
--- a/web/src/app/admin/configuration/llm/ConfiguredLLMProviderDisplay.tsx
+++ b/web/src/app/admin/configuration/llm/ConfiguredLLMProviderDisplay.tsx
@@ -9,7 +9,7 @@ import { mutate } from "swr";
 import { Badge } from "@/components/ui/badge";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
-import { cn, isSubset } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import SvgSettings from "@/icons/settings";
 
 function LLMProviderUpdateModal({


### PR DESCRIPTION
## Description

- Remove broken isSubset check that was causing well-known providers to be treated as custom
- Provider is now only considered custom if provider field doesn't match a well-known descriptor

## How Has This Been Tested?

local testing -> the known provider list appears 

## Additional Options

- [x] [Optional] Override Linear Check
