### PR TITLE
chore(gha): run connector tests when uv.lock changes

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -161,14 +161,18 @@ jobs:
             hubspot:
               - 'backend/onyx/connectors/hubspot/**'
               - 'backend/tests/daily/connectors/hubspot/**'
+              - 'uv.lock'
             salesforce:
               - 'backend/onyx/connectors/salesforce/**'
               - 'backend/tests/daily/connectors/salesforce/**'
+              - 'uv.lock'
             github:
               - 'backend/onyx/connectors/github/**'
               - 'backend/tests/daily/connectors/github/**'
+              - 'uv.lock'
             file_processing:
               - 'backend/onyx/file_processing/**'
+              - 'uv.lock'
 
       - name: Run Tests (excluding HubSpot, Salesforce, GitHub, and Coda)
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"


### PR DESCRIPTION
## Description

To catch issues like [fix(hubspot): api client and urllib conflict](https://github.com/onyx-dot-app/onyx/pull/6765)

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run connector tests when uv.lock changes to catch dependency conflicts early. Adds uv.lock to the path filters for HubSpot, Salesforce, GitHub, and file_processing in the PR workflow so CI runs when the lockfile updates.

<sup>Written for commit fda2d47071adf108cabd3580426a53f1f8129517. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

