### PR TITLE
fix(helm): Redis Operator Name

### DIFF
--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   VESPA_HOST: {{ .Values.vespa.name }}.{{ .Values.vespa.service.name }}.{{ .Release.Namespace }}.svc.cluster.local
   {{- end }}
   {{- if .Values.redis.enabled }}
-  REDIS_HOST: {{ .Release.Name }}-redis-master
+  REDIS_HOST: {{ .Values.redis.redisStandalone.name | default .Release.Name }}-master
   {{- end }}
   MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-inference-model-service"
   INDEXING_MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-indexing-model-service"

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -792,7 +792,6 @@ celery_worker_docfetching:
 redis:
   enabled: true
   redisStandalone:
-    name: "onyx-redis"
     image: quay.io/opstree/redis
     tag: v7.0.15
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Addressing an issue from our users

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran helm template to ensure it works with our deployment templates that are already in the codebase.

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated REDIS_HOST to use the redisStandalone name from values (fallback to the release name) with a -master suffix to match the Redis Operator and avoid name conflicts. Bumped the Helm chart version to 0.4.16.

<sup>Written for commit ec85c3f8826ad86df42cf93ca6462f664bc5e546. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



