### PR TITLE
fix: scrollable container height for popover.tsx

### DIFF
--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -117,12 +117,12 @@ export function PopoverMenu({
   const size = small ? "small" : medium ? "medium" : "small";
 
   return (
-    <div className="flex flex-col gap-1 max-h-[20rem]">
+    <div className="flex flex-col gap-1">
       <div className="relative">
         <div
           ref={containerRef}
           className={cn(
-            "flex flex-col gap-1 overflow-y-auto h-[20rem]",
+            "flex flex-col gap-1 overflow-y-auto max-h-[20rem]",
             sizeClasses[size],
             className
           )}


### PR DESCRIPTION
## Description

![2025-12-16 11 47 06](https://github.com/user-attachments/assets/a516fe10-5bf8-43c1-be5b-97f9121cc1b1)

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed PopoverMenu scrolling by capping the inner container at 20rem (max-h) and removing the outer max height. The popover now fits its content and only scrolls when it exceeds 20rem.

<sup>Written for commit 9b19433794b47e0b81518ea0c9e782d45ca4b170. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

