### PR TITLE
fix: confluence params

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -581,14 +581,12 @@ class OnyxConfluence:
             try:
                 # Only pass params if they're not already in the URL to avoid duplicate
                 # params accumulating. Confluence's _links.next already includes these.
-                params = (
-                    {
-                        "body-format": "atlas_doc_format",
-                        "expand": "body.atlas_doc_format",
-                    }
-                    if "body-format=" not in url_suffix
-                    else None
-                )
+                params = {}
+                if "body-format=" not in url_suffix:
+                    params["body-format"] = "atlas_doc_format"
+                if "expand=" not in url_suffix:
+                    params["expand"] = "body.atlas_doc_format"
+
                 raw_response = self.get(
                     path=url_suffix,
                     advanced_mode=True,


### PR DESCRIPTION
## Description

Fixes:

```
Traceback (most recent call last):
  File "/app/onyx/background/indexing/run_docfetching.py", line 1128, in connector_document_extraction
    for document_batch, failure, next_checkpoint in connector_runner.run(
  File "/app/onyx/connectors/connector_runner.py", line 154, in run
    for document, failure, next_checkpoint in CheckpointOutputWrapper[CT]()(
  File "/app/onyx/connectors/connector_runner.py", line 77, in __call__
    for document_or_failure in _inner_wrapper(checkpoint_connector_generator):
  File "/app/onyx/connectors/connector_runner.py", line 74, in _inner_wrapper
    self.next_checkpoint = yield from checkpoint_connector_generator
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/confluence/connector.py", line 553, in _fetch_document_batches
    attachment_docs, attachment_failures = self._fetch_page_attachments(
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/confluence/connector.py", line 390, in _fetch_page_attachments
    for attachment in self.confluence_client.paginated_cql_retrieval(
  File "/app/onyx/connectors/confluence/onyx_confluence.py", line 728, in paginated_cql_retrieval
    yield from self._paginate_url(cql_url, limit)
  File "/app/onyx/connectors/confluence/onyx_confluence.py", line 595, in _paginate_url
    raw_response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error:  for url: https://confluence.X.net/rest/api/content/search?expand=version%2Cspace%2Cmetadata.labels&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&expand=body.atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&body-format=atlas_doc_format&limit=200&start=25200&cql=type%3Dattachment%20and%20container%3D%2764784896%27%20and%20lastmodified%20%3C%3D%20%272025-12-14%2007%3A59%27%20order%20by%20lastmodified%20asc&body-format=atlas_doc_format&expand=body.atlas_doc_format
```

## How Has This Been Tested?

👀 

## Additional Options

- [x] [Optional] Override Linear Check
