### PR TITLE
fix: main chat page w/ overridden app name

### DIFF
--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -43,7 +43,7 @@ export default function Logo({ folded, size, className }: LogoProps) {
         )}
         <Text
           headingH3
-          className={cn("line-clamp-1 truncate", folded && "invisible")}
+          className={cn("line-clamp-1 truncate", folded && "hidden")}
           nowrap
         >
           {settings.enterpriseSettings?.application_name}
@@ -53,10 +53,7 @@ export default function Logo({ folded, size, className }: LogoProps) {
         <Text
           secondaryBody
           text03
-          className={cn(
-            "ml-[33px] line-clamp-1 truncate",
-            folded && "invisible"
-          )}
+          className={cn("ml-[33px] line-clamp-1 truncate", folded && "hidden")}
           nowrap
         >
           Powered by Onyx


### PR DESCRIPTION
## Description

Before:
<img width="1340" height="464" alt="Screenshot 2025-12-16 at 12 33 46 PM" src="https://github.com/user-attachments/assets/7788a64b-531c-49ac-a2f1-05e0b5bdc4b6" />

## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed header spacing on the main chat page when an enterprise app name is set. The logo text now fully hides in the folded state to remove blank space and prevent misalignment.

- **Bug Fixes**
  - Replace "invisible" with "hidden" for the app name and "Powered by Onyx" in Logo.tsx when folded.

<sup>Written for commit cf7b1980eb2c2b3848790b97ae5c42039704dc86. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

