### PR TITLE
fix(style): increase tooltip z-index

### DIFF
--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         side={side}
         className={cn(
-          "z-[3000] rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-[30000] rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           width,
           className
         )}


### PR DESCRIPTION
## Description

The dropdown has a z-index of `30,000` which was greater than the tooltip, so increase the tooltip's to match.

**before**
<img width="1107" height="2085" alt="20251216_13h16m11s_grim" src="https://github.com/user-attachments/assets/872629dd-9a21-4db6-ad78-c6651ec10ad7" />

**after**
<img width="1107" height="2085" alt="20251216_13h15m26s_grim" src="https://github.com/user-attachments/assets/c71b3596-0969-4004-a235-0fab9bfe7749" />

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase tooltip z-index from 3,000 to 30,000 so tooltips render above the dropdown. Fixes tooltips being hidden behind dropdowns.

<sup>Written for commit d0fd4278bf6b677683da29edd009887169bb7162. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

