### PR TITLE
chore(style): fix chat page scrollbar after padding change

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -626,7 +626,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
         >
           {({ getRootProps }) => (
             <div
-              className="h-full w-full p-4 flex flex-col items-center outline-none"
+              className="h-full w-full flex flex-col items-center outline-none"
               {...getRootProps({ tabIndex: -1 })}
             >
               {/* ProjectUI */}
@@ -666,7 +666,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
               {/* ChatInputBar container */}
               <div
                 ref={inputRef}
-                className="max-w-[50rem] w-full pointer-events-auto flex flex-col justify-center items-center"
+                className="max-w-[50rem] w-full pointer-events-auto flex flex-col px-4 justify-center items-center"
               >
                 {(showOnboarding ||
                   (user?.role !== UserRole.ADMIN &&


### PR DESCRIPTION
## Description

The padding added in https://github.com/onyx-dot-app/onyx/pull/6723/files#diff-8d1768d2ca4931ea25d6a1e94aca5b90c80e7f5acae53d74a607794521ec0737R629 caused the scrollbar to be padded which is incorrect. Also, this needlessly added padding to the top (which is already applied via the header component) and bottom (which is being applied by a dynamic div from the chatbar(?) component) which was incorrect.

**before**
<img width="1227" height="2085" alt="20251216_13h51m43s_grim" src="https://github.com/user-attachments/assets/b985c9b1-6919-4c6b-b8a5-09bbb41d588d" />


**after**
<img width="1227" height="2085" alt="20251216_13h53m24s_grim" src="https://github.com/user-attachments/assets/d86a7a1e-24e7-4ba5-8405-b38bdb8f196d" />


## How Has This Been Tested?

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed page-level padding on ChatPage to fix the padded scrollbar and avoid duplicate top/bottom spacing. Added px-4 to the ChatInputBar to keep horizontal spacing without affecting scroll behavior.

<sup>Written for commit 3d052f358b714f5af230db3552ede82066f6eb08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

