### PR TITLE
fix: attach user credentials to assistant requests

### DIFF
--- a/web/src/app/admin/assistants/lib.ts
+++ b/web/src/app/admin/assistants/lib.ts
@@ -145,6 +145,7 @@ export async function createPersona(
     body: JSON.stringify(
       buildPersonaUpsertRequest(personaUpsertParams, fileId, null)
     ),
+    credentials: "include",
   });
 
   return createPersonaResponse;
@@ -170,6 +171,7 @@ export async function updatePersona(
     body: JSON.stringify(
       buildPersonaUpsertRequest(personaUpsertParams, fileId, null)
     ),
+    credentials: "include",
   });
 
   return updatePersonaResponse;
@@ -178,6 +180,7 @@ export async function updatePersona(
 export function deletePersona(personaId: number) {
   return fetch(`/api/persona/${personaId}`, {
     method: "DELETE",
+    credentials: "include",
   });
 }
 
@@ -237,6 +240,7 @@ export async function togglePersonaDefault(
     body: JSON.stringify({
       is_default_persona: !isDefault,
     }),
+    credentials: "include",
   });
   return response;
 }
@@ -253,6 +257,7 @@ export async function togglePersonaVisibility(
     body: JSON.stringify({
       is_visible: !isVisible,
     }),
+    credentials: "include",
   });
   return response;
 }


### PR DESCRIPTION
## Description

Prevents 403s when nginx does not attach the credentials by default. See thread: https://onyx-company.slack.com/archives/C0832RVRVG8/p1765921354025699

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send user credentials with all admin persona requests so cookies are included. This fixes unauthorized errors across image uploads, persona create/update/delete, and default/visibility toggles.

<sup>Written for commit 8ead7a8568ccbd2a9db9a771ee390d894acee79d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



