### PR TITLE
chore: bump fallback max token limit to 32k

### DIFF
--- a/backend/onyx/configs/model_configs.py
+++ b/backend/onyx/configs/model_configs.py
@@ -65,9 +65,10 @@ GEN_AI_NUM_RESERVED_OUTPUT_TOKENS = int(
     os.environ.get("GEN_AI_NUM_RESERVED_OUTPUT_TOKENS") or 1024
 )
 
-# Typically, GenAI models nowadays are at least 4K tokens
+# Fallback token limit for models where the max context is unknown
+# Set conservatively at 32K to handle most modern models
 GEN_AI_MODEL_FALLBACK_MAX_TOKENS = int(
-    os.environ.get("GEN_AI_MODEL_FALLBACK_MAX_TOKENS") or 4096
+    os.environ.get("GEN_AI_MODEL_FALLBACK_MAX_TOKENS") or 32000
 )
 
 # This is used when computing how much context space is available for documents

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -571,7 +571,7 @@ def fetch_model_configurations_for_provider(
     """Fetch model configurations for a static provider (OpenAI, Anthropic, Vertex AI).
 
     Looks up max_input_tokens from LiteLLM's model_cost. If not found, stores None
-    and the runtime will use the fallback (4096).
+    and the runtime will use the fallback (32000).
 
     Models in the curated visible lists (OPENAI_VISIBLE_MODEL_NAMES, etc.) are
     marked as is_visible=True by default.

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -514,11 +514,11 @@ def get_max_input_tokens_from_llm_provider(
     1. Use max_input_tokens from model_configuration (populated from source APIs
        like OpenRouter, Ollama, or our Bedrock mapping)
     2. Look up in litellm.model_cost dictionary
-    3. Fall back to GEN_AI_MODEL_FALLBACK_MAX_TOKENS (4096)
+    3. Fall back to GEN_AI_MODEL_FALLBACK_MAX_TOKENS (32000)
 
     Most dynamic providers (OpenRouter, Ollama) provide context_length via their
     APIs. Bedrock doesn't expose this, so we parse from model ID suffix (:200k)
-    or use BEDROCK_MODEL_TOKEN_LIMITS mapping. The 4096 fallback is only hit for
+    or use BEDROCK_MODEL_TOKEN_LIMITS mapping. The 32000 fallback is only hit for
     unknown models not in any of these sources.
     """
     max_input_tokens = None
@@ -545,7 +545,7 @@ def get_bedrock_token_limit(model_id: str) -> int:
     1. Parse from model ID suffix (e.g., ":200k" → 200000)
     2. Check LiteLLM's model_cost dictionary
     3. Fall back to our hardcoded BEDROCK_MODEL_TOKEN_LIMITS mapping
-    4. Default to 4096 if not found anywhere
+    4. Default to 32000 if not found anywhere
     """
     from onyx.llm.constants import BEDROCK_MODEL_TOKEN_LIMITS
 

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -301,7 +301,7 @@ class BedrockModelsRequest(BaseModel):
 class BedrockFinalModelResponse(BaseModel):
     name: str  # Model ID (e.g., "anthropic.claude-3-5-sonnet-20241022-v2:0")
     display_name: str  # Human-readable name from AWS (e.g., "Claude 3.5 Sonnet v2")
-    max_input_tokens: int  # From LiteLLM, our mapping, or default 4096
+    max_input_tokens: int  # From LiteLLM, our mapping, or default 32000
     supports_image_input: bool
 
 

--- a/backend/tests/unit/onyx/llm/test_bedrock_token_limit.py
+++ b/backend/tests/unit/onyx/llm/test_bedrock_token_limit.py
@@ -94,8 +94,8 @@ class TestGetBedrockTokenLimit:
         """Test default fallback for unknown models."""
         with patch("onyx.llm.utils.get_model_map", return_value={}):
             result = get_bedrock_token_limit("unknown.model-v1:0")
-            # Should fall back to GEN_AI_MODEL_FALLBACK_MAX_TOKENS (4096)
-            assert result == 4096
+            # Should fall back to GEN_AI_MODEL_FALLBACK_MAX_TOKENS (32000)
+            assert result == 32000
 
     def test_cross_region_model_id(self) -> None:
         """Test cross-region model ID (us.anthropic.claude-...)."""


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default fallback max input token limit from 4,096 to 32,000 for models with unknown context size to reduce truncation and align with modern models. Updates config, provider comments, utils, server response, and unit tests to use 32k as the default.

- **Migration**
  - No action needed. Override via GEN_AI_MODEL_FALLBACK_MAX_TOKENS if desired.

<sup>Written for commit dcb058769a8882fb933f8f9dbf8bcb2c5d0399d3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

