### PR TITLE
fix(tool): default tool descriptions assistant -> agent

### DIFF
--- a/backend/alembic/versions/a01bf2971c5d_update_default_tool_descriptions.py
+++ b/backend/alembic/versions/a01bf2971c5d_update_default_tool_descriptions.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "a01bf2971c5d"
-down_revision = "87c52ec39f84"
+down_revision = "18b5b2524446"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Description

Updated default tool descriptions to use “agent” terminology and clarify when each action is used. Covers Search, Web Search, Image Generation, Knowledge Graph, and Okta Profile tools.

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated default tool descriptions to use “agent” terminology and clarify when each action is used. Covers Search, Web Search, Image Generation, Knowledge Graph, and Okta Profile tools.

- **Migration**
  - Alembic migration updates tool.description for: SearchTool, ImageGenerationTool, WebSearchTool, KnowledgeGraphTool, OktaProfileTool.
  - No schema changes; downgrade is a no-op.

<sup>Written for commit ca31b0d3b2c99fed35c053a4bdbb79e188a6d002. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







