### PR TITLE
refactor: Add new z-indexing file

### DIFF
--- a/web/src/app/css/z-index.css
+++ b/web/src/app/css/z-index.css
@@ -1,0 +1,49 @@
+:root {
+  /* Base layers */
+  --z-base: 0;
+  --z-content: 1;
+  --z-sticky: 10;
+
+  /* Floating buttons */
+  --z-floating-scroll-down-button: 500;
+
+  /* Interactive overlays */
+  --z-modal-overlay: 900;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-popover: 1200;
+  --z-tooltip: 1300;
+}
+
+/* Base layers */
+.z-base {
+  z-index: var(--z-base);
+}
+.z-content {
+  z-index: var(--z-content);
+}
+.z-sticky {
+  z-index: var(--z-sticky);
+}
+
+/* Floating buttons */
+.z-floating-scroll-down-button {
+  z-index: var(--z-floating-scroll-down-button);
+}
+
+/* Interactive overlays */
+.z-modal-overlay {
+  z-index: var(--z-modal-overlay);
+}
+.z-modal {
+  z-index: var(--z-modal);
+}
+.z-toast {
+  z-index: var(--z-toast);
+}
+.z-popover {
+  z-index: var(--z-popover);
+}
+.z-tooltip {
+  z-index: var(--z-tooltip);
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -5,6 +5,7 @@
 @import "css/inputs.css";
 @import "css/line-item.css";
 @import "css/switch.css";
+@import "css/z-index.css";
 
 @tailwind base;
 @tailwind components;

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         side={side}
         className={cn(
-          "z-[30000] rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-tooltip rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           width,
           className
         )}

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -190,7 +190,7 @@ const ChatUI = React.forwardRef(
     return (
       <div className="flex flex-col flex-1 w-full relative overflow-hidden">
         {aboveHorizon && (
-          <div className="absolute bottom-0 z-[1000000] left-1/2 -translate-x-1/2">
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 z-floating-scroll-down-button">
             <IconButton icon={SvgChevronDown} onClick={scrollToBottom} />
 
             <Spacer />


### PR DESCRIPTION
## Description

This PR introduces a new "z-indexing" file which aims to consolidate all z-indexes into one central location.

Addresses: https://linear.app/danswer/issue/DAN-3164/refactor-all-z-indexing-to-use-a-centralized-css-file-instead.

## Notes

This PR does *not* introduce any new UI changes; no screenshots were provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized all z-index values in a new CSS file and replaced hardcoded z-indexes with utility classes for consistent layering. No UI changes; addresses Linear DAN-3164.

- **Refactors**
  - Added z-index.css with CSS variables and utility classes for base layers, sticky, floating button, and overlays (modal, toast, popover, tooltip).
  - Imported z-index.css in globals.css.
  - Replaced inline z-index values in TooltipContent and ChatUI with z-tooltip and z-floating-scroll-down-button.

<sup>Written for commit 457417762adac0428e95e74b4cfd43f04437a301. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

