### PR TITLE
fix: horrible typo in README

### DIFF
--- a/backend/onyx/db/README.md
+++ b/backend/onyx/db/README.md
@@ -1,7 +1,7 @@
 An explanation of how the history of messages, tool calls, and docs are stored in the database:
 
 Messages are grouped by a chat session, a tree structured is used to allow edits and for the
-user to switch between branches. Each ChatMessage is either a user message of an assistant message.
+user to switch between branches. Each ChatMessage is either a user message or an assistant message.
 It should always alternate between the two, System messages, custom agent prompt injections, and
 reminder messages are injected dynamically after the chat session is loaded into memory. The user
 and assistant messages are stored in pairs, though it is ok if the user message is stored and the


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a grammar error in backend/onyx/db/README.md, clarifying that a ChatMessage is either a user message or an assistant message. This improves readability of the database docs.

<sup>Written for commit c436b61a7ab57747ef46b715415967f8d38952dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

