### PR TITLE
fix(devtools): restart_containers.sh should source venv before running alembic

### DIFF
--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -508,7 +508,6 @@
       ],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
-      "stopOnEntry": true,
       "presentation": {
         "group": "3"
       }

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -55,13 +55,20 @@ else
     docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin minio/minio server /data --console-address ":9001"
 fi
 
-# Ensure alembic runs in the correct directory
+# Ensure alembic runs in the correct directory (backend/)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PARENT_DIR"
 
 # Give Postgres a second to start
 sleep 1
+
+# Alembic should be configured in the virtualenv for this repo
+if [[ -f "../.venv/bin/activate" ]]; then
+    source ../.venv/bin/activate
+else
+    echo "Warning: Python virtual environment not found at .venv/bin/activate; alembic may not work."
+fi
 
 # Run Alembic upgrade
 echo "Running Alembic migration..."


### PR DESCRIPTION
## Description

There is an issue where the first invocation of Clear and Restart External Volumes and Containers fails because the venv is not up so alembic cannot be found. Currently the script assumes the venv is already up, which is not a guarantee when running it via Clear and Restart External Volumes and Containers because vs code/cursor take a second or two to actually start the venv in a new terminal session, and that even assumes the developer has the activateEnvironment option enabled. With this PR the script should work standalone.

Also Clear and Restart External Volumes and Containers does not need `"stopOnEntry": true,` I'm not sure why that was there.

## How Has This Been Tested?

Ran Clear and Restart External Volumes and Containers myself and say no venv issues.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make restart_containers.sh activate the project's .venv before running Alembic, and warn if the venv is missing, so the first run of “Clear and Restart External Volumes and Containers” works reliably. Remove stopOnEntry from the VS Code launch config to avoid pausing on start.

<sup>Written for commit 8de02e54105ef8352adb1b693dff2e3a6310b716. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

