### PR TITLE
fix(devtools): CLAUDE.md.template makes reference to a venv that does not exist

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## KEY NOTES
 
-- If you run into any missing python dependency errors, try running your command with `source backend/.venv/bin/activate` \
+- If you run into any missing python dependency errors, try running your command with `source .venv/bin/activate` \
 to assume the python venv.
 - To make tests work, check the `.env` file at the root of the project to find an OpenAI key.
 - If using `playwright` to explore the frontend, you can usually log in with username `a@test.com` and password


### PR DESCRIPTION
## Description

Title.

## How Has This Been Tested?

Trust.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CLAUDE.md.template to use the correct venv activation command (`source .venv/bin/activate`) instead of `backend/.venv`. This prevents activation errors and fixes missing dependency issues when running local commands.

<sup>Written for commit 2a4a1096b3972e876c845b408d2ecf2c6cf76dd4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

