### PR TITLE
feat: enable skip clarification

### DIFF
--- a/backend/alembic/versions/18b5b2524446_add_is_clarification_to_chat_message.py
+++ b/backend/alembic/versions/18b5b2524446_add_is_clarification_to_chat_message.py
@@ -1,0 +1,29 @@
+"""add is_clarification to chat_message
+
+Revision ID: 18b5b2524446
+Revises: 87c52ec39f84
+Create Date: 2025-01-16
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "18b5b2524446"
+down_revision = "87c52ec39f84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_message",
+        sa.Column(
+            "is_clarification", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_message", "is_clarification")

--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -26,6 +26,8 @@ class ChatStateContainer:
         self.answer_tokens: str | None = None
         # Store citation mapping for building citation_docs_info during partial saves
         self.citation_to_doc: dict[int, SearchDoc] = {}
+        # True if this turn is a clarification question (deep research flow)
+        self.is_clarification: bool = False
 
     def add_tool_call(self, tool_call: ToolCallInfo) -> None:
         """Add a tool call to the accumulated state."""
@@ -42,6 +44,10 @@ class ChatStateContainer:
     def set_citation_mapping(self, citation_to_doc: dict[int, Any]) -> None:
         """Set the citation mapping from citation processor."""
         self.citation_to_doc = citation_to_doc
+
+    def set_is_clarification(self, is_clarification: bool) -> None:
+        """Set whether this turn is a clarification question."""
+        self.is_clarification = is_clarification
 
 
 def run_chat_llm_with_state_containers(

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -708,3 +708,21 @@ def get_custom_agent_prompt(persona: Persona, chat_session: ChatSession) -> str 
         return chat_session.project.instructions
     else:
         return None
+
+
+def is_last_assistant_message_clarification(chat_history: list[ChatMessage]) -> bool:
+    """Check if the last assistant message in chat history was a clarification question.
+
+    This is used in the deep research flow to determine whether to skip the
+    clarification step when the user has already responded to a clarification.
+
+    Args:
+        chat_history: List of ChatMessage objects in chronological order
+
+    Returns:
+        True if the last assistant message has is_clarification=True, False otherwise
+    """
+    for message in reversed(chat_history):
+        if message.message_type == MessageType.ASSISTANT:
+            return message.is_clarification
+    return False

--- a/backend/onyx/chat/save_chat.py
+++ b/backend/onyx/chat/save_chat.py
@@ -148,6 +148,7 @@ def save_chat_turn(
     citation_docs_info: list[CitationDocInfo],
     db_session: Session,
     assistant_message: ChatMessage,
+    is_clarification: bool = False,
 ) -> None:
     """
     Save a chat turn by populating the assistant_message and creating related entities.
@@ -175,10 +176,12 @@ def save_chat_turn(
         citation_docs_info: List of citation document information for building citations mapping
         db_session: Database session for persistence
         assistant_message: The ChatMessage object to populate (should already exist in DB)
+        is_clarification: Whether this assistant message is a clarification question (deep research flow)
     """
     # 1. Update ChatMessage with message content, reasoning tokens, and token count
     assistant_message.message = message_text
     assistant_message.reasoning_tokens = reasoning_tokens
+    assistant_message.is_clarification = is_clarification
 
     # Calculate token count using default tokenizer, when storing, this should not use the LLM
     # specific one so we use a system default tokenizer here.

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2141,6 +2141,8 @@ class ChatMessage(Base):
     time_sent: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+    # True if this assistant message is a clarification question (deep research flow)
+    is_clarification: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # Relationships
     chat_session: Mapped[ChatSession] = relationship("ChatSession")

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -101,6 +101,9 @@ def run_deep_research_llm_loop(
         llm_step_result = cast(LlmStepResult, llm_step_result)
 
         if not llm_step_result.tool_calls:
+            # Mark this turn as a clarification question
+            state_container.set_is_clarification(True)
+
             emitter.emit(
                 Packet(turn_index=current_tool_call_index, obj=OverallStop(type="stop"))
             )


### PR DESCRIPTION
## Description

If the last message from the agent is asking for a clarification, don't ask another set of questions.

## How Has This Been Tested?

Only validated the DR flow

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips redundant clarification in deep research: if the last assistant message was a clarification, we don’t ask again. Adds an is_clarification flag to ChatMessage and threads it through state and saving.

- **New Features**
  - Add ChatMessage.is_clarification and set it on clarification turns in DR.
  - Skip clarification by checking the last assistant message in chat history.
  - Propagate is_clarification via state_container and save_chat_turn.

- **Migration**
  - Run DB migrations to add chat_message.is_clarification (default false).

<sup>Written for commit 31e84e93069089358a6125570b0c6a2f2403916d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

