### PR TITLE
chore(tf): Update VPC calling

### DIFF
--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -56,11 +56,10 @@ module "postgres" {
 }
 
 module "s3" {
-  source      = "../s3"
-  bucket_name = local.bucket_name
-  region      = var.region
-  vpc_id      = local.vpc_id
-  tags        = local.merged_tags
+  source             = "../s3"
+  bucket_name        = local.bucket_name
+  tags               = local.merged_tags
+  s3_vpc_endpoint_id = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
 }
 
 module "eks" {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -40,6 +40,17 @@ variable "vpc_cidr_block" {
   default     = null
 }
 
+variable "s3_vpc_endpoint_id" {
+  type        = string
+  description = "ID of an existing S3 gateway VPC endpoint when reusing an existing VPC"
+  default     = null
+
+  validation {
+    condition     = var.create_vpc || var.s3_vpc_endpoint_id != null
+    error_message = "s3_vpc_endpoint_id must be provided when create_vpc is false."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   description = "Base tags applied to all AWS resources"

--- a/deployment/terraform/modules/aws/s3/main.tf
+++ b/deployment/terraform/modules/aws/s3/main.tf
@@ -3,21 +3,6 @@ resource "aws_s3_bucket" "bucket" {
   tags   = var.tags
 }
 
-data "aws_route_tables" "vpc" {
-  filter {
-    name   = "vpc-id"
-    values = [var.vpc_id]
-  }
-}
-
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${var.region}.s3"
-  vpc_endpoint_type = "Gateway"
-  route_table_ids   = data.aws_route_tables.vpc.ids
-  tags              = var.tags
-}
-
 resource "aws_s3_bucket_policy" "bucket_policy" {
   bucket = aws_s3_bucket.bucket.id
 
@@ -38,7 +23,7 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
         ],
         Condition = {
           StringEquals = {
-            "aws:SourceVpce" = aws_vpc_endpoint.s3.id
+            "aws:SourceVpce" = var.s3_vpc_endpoint_id
           }
         }
       }

--- a/deployment/terraform/modules/aws/s3/variables.tf
+++ b/deployment/terraform/modules/aws/s3/variables.tf
@@ -3,18 +3,13 @@ variable "bucket_name" {
   description = "Name of the S3 bucket"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS region"
-}
-
-variable "vpc_id" {
-  type        = string
-  description = "VPC ID where your EKS cluster runs"
-}
-
 variable "tags" {
   type        = map(string)
-  description = "Tags to apply to S3 resources and VPC endpoint"
+  description = "Tags to apply to S3 resources"
   default     = {}
+}
+
+variable "s3_vpc_endpoint_id" {
+  type        = string
+  description = "ID of the S3 gateway VPC endpoint allowed to access this bucket"
 }

--- a/deployment/terraform/modules/aws/vpc/outputs.tf
+++ b/deployment/terraform/modules/aws/vpc/outputs.tf
@@ -13,3 +13,8 @@ output "public_subnets" {
 output "vpc_cidr_block" {
   value = module.vpc.vpc_cidr_block
 }
+
+output "s3_vpc_endpoint_id" {
+  description = "ID of the S3 gateway VPC endpoint created for this VPC"
+  value       = aws_vpc_endpoint.s3.id
+}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Update the terraform code to pass in the VPC endpoint id instead of grabbing the VPC data 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Already using in our internal clusters

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Terraform AWS modules to use a provided S3 VPC endpoint ID. The VPC module now creates the S3 gateway endpoint and outputs its ID, and the S3 bucket policy restricts access to that endpoint.

- **Refactors**
  - VPC: creates the S3 gateway VPC endpoint and outputs s3_vpc_endpoint_id.
  - Onyx: passes s3_vpc_endpoint_id from VPC output or uses the user-provided value when reusing an existing VPC.
  - S3: removes VPC/region inputs and endpoint creation; bucket policy uses s3_vpc_endpoint_id.
  - README updated to document the new input and outputs.

- **Migration**
  - When create_vpc is false, provide s3_vpc_endpoint_id for the existing VPC endpoint (validated).
  - Update any usage of the S3 module to remove vpc_id/region and supply s3_vpc_endpoint_id.

<sup>Written for commit 72f745281ed342151d2877d549e234b300a8ebcd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

