### PR TITLE
feat: Deep Research first couple stages

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -1,3 +1,7 @@
+# TODO: Notes for potential extensions and future improvements:
+# 1. Allow tools that aren't search specific tools
+# 2. Use user provided custom prompts
+
 from collections.abc import Callable
 from typing import cast
 
@@ -15,16 +19,28 @@ from onyx.deep_research.dr_mock_tools import get_clarification_tool_definitions
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.utils import model_is_reasoning_model
 from onyx.prompts.deep_research.orchestration_layer import CLARIFICATION_PROMPT
+from onyx.prompts.deep_research.orchestration_layer import ORCHESTRATOR_PROMPT
+from onyx.prompts.deep_research.orchestration_layer import ORCHESTRATOR_PROMPT_REASONING
+from onyx.prompts.deep_research.orchestration_layer import RESEARCH_PLAN_PROMPT
 from onyx.prompts.prompt_utils import get_current_llm_day_time
+from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+from onyx.server.query_and_chat.streaming_models import AgentResponseStart
+from onyx.server.query_and_chat.streaming_models import DeepResearchPlanDelta
+from onyx.server.query_and_chat.streaming_models import DeepResearchPlanStart
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.tool import Tool
+from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+from onyx.tools.tool_implementations.search.search_tool import SearchTool
+from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-MAX_MESSAGES_FOR_CLARIFICATION = 5
+MAX_USER_MESSAGES_FOR_CONTEXT = 5
+MAX_ORCHESTRATOR_CYCLES = 8
 
 
 def run_deep_research_llm_loop(
@@ -42,6 +58,8 @@ def run_deep_research_llm_loop(
     # Here for lazy load LiteLLM
     from onyx.llm.litellm_singleton.config import initialize_litellm
 
+    # An approximate limit. In extreme cases it may still fail but this should allow deep research
+    # to work in most cases.
     if llm.config.max_input_tokens < 25000:
         raise RuntimeError(
             "Cannot run Deep Research with an LLM that has less than 25,000 max input tokens"
@@ -50,10 +68,16 @@ def run_deep_research_llm_loop(
     initialize_litellm()
 
     available_tokens = llm.config.max_input_tokens
-    current_tool_call_index = 0
 
     llm_step_result: LlmStepResult | None = None
 
+    # Filter tools to only allow web search, internal search, and open URL
+    allowed_tool_names = {SearchTool.NAME, WebSearchTool.NAME, OpenURLTool.NAME}
+    [tool for tool in tools if tool.name in allowed_tool_names]
+
+    #########################################################
+    # CLARIFICATION STEP (optional)
+    #########################################################
     if not skip_clarification:
         clarification_prompt = CLARIFICATION_PROMPT.format(
             current_datetime=get_current_llm_day_time()
@@ -71,7 +95,7 @@ def run_deep_research_llm_loop(
             reminder_message=None,
             project_files=None,
             available_tokens=available_tokens,
-            last_n_user_messages=MAX_MESSAGES_FOR_CLARIFICATION,
+            last_n_user_messages=MAX_USER_MESSAGES_FOR_CONTEXT,
         )
 
         step_generator = run_llm_step(
@@ -79,7 +103,7 @@ def run_deep_research_llm_loop(
             tool_definitions=get_clarification_tool_definitions(),
             tool_choice=ToolChoiceOptions.AUTO,
             llm=llm,
-            turn_index=current_tool_call_index,
+            turn_index=0,
             # No citations in this step, it should just pass through all
             # tokens directly so initialized as an empty citation processor
             citation_processor=DynamicCitationProcessor(),
@@ -94,7 +118,7 @@ def run_deep_research_llm_loop(
                 packet = next(step_generator)
                 emitter.emit(packet)
             except StopIteration as e:
-                llm_step_result, current_tool_call_index = e.value
+                llm_step_result, _ = e.value
                 break
 
         # Type narrowing: generator always returns a result, so this can't be None
@@ -104,9 +128,127 @@ def run_deep_research_llm_loop(
             # Mark this turn as a clarification question
             state_container.set_is_clarification(True)
 
-            emitter.emit(
-                Packet(turn_index=current_tool_call_index, obj=OverallStop(type="stop"))
-            )
+            emitter.emit(Packet(turn_index=0, obj=OverallStop(type="stop")))
 
             # If a clarification is asked, we need to end this turn and wait on user input
             return
+
+    #########################################################
+    # RESEARCH PLAN STEP
+    #########################################################
+    system_prompt = ChatMessageSimple(
+        message=RESEARCH_PLAN_PROMPT.format(
+            current_datetime=get_current_llm_day_time()
+        ),
+        token_count=300,
+        message_type=MessageType.SYSTEM,
+    )
+
+    truncated_message_history = construct_message_history(
+        system_prompt=system_prompt,
+        custom_agent_prompt=None,
+        simple_chat_history=simple_chat_history,
+        reminder_message=None,
+        project_files=None,
+        available_tokens=available_tokens,
+        last_n_user_messages=MAX_USER_MESSAGES_FOR_CONTEXT,
+    )
+
+    research_plan_generator = run_llm_step(
+        history=truncated_message_history,
+        tool_definitions=[],
+        tool_choice=ToolChoiceOptions.NONE,
+        llm=llm,
+        turn_index=0,
+        # No citations in this step, it should just pass through all
+        # tokens directly so initialized as an empty citation processor
+        citation_processor=DynamicCitationProcessor(),
+        state_container=state_container,
+        final_documents=None,
+        user_identity=user_identity,
+    )
+
+    while True:
+        try:
+            packet = next(research_plan_generator)
+            # Translate AgentResponseStart/Delta packets to DeepResearchPlanStart/Delta
+            if isinstance(packet.obj, AgentResponseStart):
+                emitter.emit(
+                    Packet(
+                        turn_index=packet.turn_index,
+                        obj=DeepResearchPlanStart(),
+                    )
+                )
+            elif isinstance(packet.obj, AgentResponseDelta):
+                emitter.emit(
+                    Packet(
+                        turn_index=packet.turn_index,
+                        obj=DeepResearchPlanDelta(content=packet.obj.content),
+                    )
+                )
+            else:
+                # Pass through other packet types (e.g., ReasoningStart, ReasoningDelta, etc.)
+                emitter.emit(packet)
+        except StopIteration as e:
+            llm_step_result, _ = e.value
+            break
+    llm_step_result = cast(LlmStepResult, llm_step_result)
+
+    research_plan = llm_step_result.answer
+
+    #########################################################
+    # RESEARCH EXECUTION STEP
+    #########################################################
+    is_reasoning_model = model_is_reasoning_model(
+        llm.config.model_name, llm.config.model_provider
+    )
+
+    orchestrator_prompt_template = (
+        ORCHESTRATOR_PROMPT if not is_reasoning_model else ORCHESTRATOR_PROMPT_REASONING
+    )
+
+    token_count_prompt = orchestrator_prompt_template.format(
+        current_datetime=get_current_llm_day_time(),
+        current_cycle_count=1,
+        max_cycles=MAX_ORCHESTRATOR_CYCLES,
+        research_plan=research_plan,
+    )
+    orchestration_tokens = token_counter(token_count_prompt)
+
+    for cycle in range(MAX_ORCHESTRATOR_CYCLES):
+        orchestrator_prompt = orchestrator_prompt_template.format(
+            current_datetime=get_current_llm_day_time(),
+            current_cycle_count=cycle,
+            max_cycles=MAX_ORCHESTRATOR_CYCLES,
+            research_plan=research_plan,
+        )
+
+        system_prompt = ChatMessageSimple(
+            message=orchestrator_prompt,
+            token_count=orchestration_tokens,
+            message_type=MessageType.SYSTEM,
+        )
+
+        truncated_message_history = construct_message_history(
+            system_prompt=system_prompt,
+            custom_agent_prompt=None,
+            simple_chat_history=simple_chat_history,
+            reminder_message=None,
+            project_files=None,
+            available_tokens=available_tokens,
+            last_n_user_messages=MAX_USER_MESSAGES_FOR_CONTEXT,
+        )
+
+        research_plan_generator = run_llm_step(
+            history=truncated_message_history,
+            tool_definitions=[],
+            tool_choice=ToolChoiceOptions.AUTO,
+            llm=llm,
+            turn_index=cycle,
+            # No citations in this step, it should just pass through all
+            # tokens directly so initialized as an empty citation processor
+            citation_processor=DynamicCitationProcessor(),
+            state_container=state_container,
+            final_documents=None,
+            user_identity=user_identity,
+        )

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -10,7 +10,7 @@ You are a clarification agent that runs prior to deep research. Assess whether y
 
 If the user query is already very detailed or lengthy (more than 3 sentences), do not ask for clarification and instead call the `{GENERATE_PLAN_TOOL_NAME}` tool.
 
-For context, the date is {{current_datetime}}.
+{{current_datetime}}.
 
 Be conversational and friendly, prefer saying "could you" rather than "I need" etc.
 
@@ -29,7 +29,7 @@ Stick closely to the user query and stay on topic but be curious and avoid dupli
 Be sure to take into account the time sensitive aspects of the research topic and make sure to emphasize up to date information where appropriate. \
 Focus on providing a thorough research of the user's query over being helpful.
 
-For context, the date is {current_datetime}.
+{current_datetime}.
 
 The research plan should be formatted as a numbered list of steps and have less than 7 individual steps.
 
@@ -43,7 +43,7 @@ ORCHESTRATOR_PROMPT = f"""
 You are an orchestrator agent for deep research. Your job is to conduct research by calling the {RESEARCH_AGENT_TOOL_NAME} tool with high level research tasks. \
 This delegates the lower level research work to the {RESEARCH_AGENT_TOOL_NAME} which will provide back the results of the research.
 
-For context, the date is {{current_datetime}}.
+{{current_datetime}}.
 
 Before calling {GENERATE_REPORT_TOOL_NAME}, reason to double check that all aspects of the user's query have been well researched and that all key topics around the plan have been researched. \
 There are cases where new discoveries from research may lead to a deviation from the original research plan.

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -34,6 +34,9 @@ class StreamingType(Enum):
     REASONING_DONE = "reasoning_done"
     CITATION_INFO = "citation_info"
 
+    DEEP_RESEARCH_PLAN_START = "deep_research_plan_start"
+    DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta"
+
 
 class BaseObj(BaseModel):
     type: str = ""
@@ -222,6 +225,20 @@ class CustomToolDelta(BaseObj):
     file_ids: list[str] | None = None
 
 
+class DeepResearchPlanStart(BaseObj):
+    type: Literal["deep_research_plan_start"] = (
+        StreamingType.DEEP_RESEARCH_PLAN_START.value
+    )
+
+
+class DeepResearchPlanDelta(BaseObj):
+    type: Literal["deep_research_plan_delta"] = (
+        StreamingType.DEEP_RESEARCH_PLAN_DELTA.value
+    )
+
+    content: str
+
+
 """Packet"""
 
 # Discriminated union of all possible packet object types
@@ -254,6 +271,9 @@ PacketObj = Union[
     ReasoningDone,
     # Citation Packets
     CitationInfo,
+    # Deep Research Packets
+    DeepResearchPlanStart,
+    DeepResearchPlanDelta,
 ]
 
 


### PR DESCRIPTION
## Description

Couple more Deep Research steps

## How Has This Been Tested?

N/A

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Deep Research with a plan generation step and iterative orchestration, and streams the plan to clients with new packet types. Also restricts tools to web/search and enforces a 25k input token minimum.

- **New Features**
  - Research plan step with streaming via DeepResearchPlanStart and DeepResearchPlanDelta.
  - Iterative orchestration cycles (up to 8), using reasoning prompts when supported.
  - Tool access restricted to Search, WebSearch, and OpenURL.

- **Migration**
  - Handle DeepResearchPlanStart and DeepResearchPlanDelta in the client.
  - Use an LLM with ≥25k max input tokens for Deep Research, or disable it.

<sup>Written for commit 95f4f11bb130d936d3f995cd77c0ebd5b6fd2a44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

