### PR TITLE
chore: some readme updates

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -80,7 +80,7 @@ def run_deep_research_llm_loop(
     #########################################################
     if not skip_clarification:
         clarification_prompt = CLARIFICATION_PROMPT.format(
-            current_datetime=get_current_llm_day_time()
+            current_datetime=get_current_llm_day_time(full_sentence=False)
         )
         system_prompt = ChatMessageSimple(
             message=clarification_prompt,
@@ -138,7 +138,7 @@ def run_deep_research_llm_loop(
     #########################################################
     system_prompt = ChatMessageSimple(
         message=RESEARCH_PLAN_PROMPT.format(
-            current_datetime=get_current_llm_day_time()
+            current_datetime=get_current_llm_day_time(full_sentence=False)
         ),
         token_count=300,
         message_type=MessageType.SYSTEM,
@@ -208,7 +208,7 @@ def run_deep_research_llm_loop(
     )
 
     token_count_prompt = orchestrator_prompt_template.format(
-        current_datetime=get_current_llm_day_time(),
+        current_datetime=get_current_llm_day_time(full_sentence=False),
         current_cycle_count=1,
         max_cycles=MAX_ORCHESTRATOR_CYCLES,
         research_plan=research_plan,
@@ -217,7 +217,7 @@ def run_deep_research_llm_loop(
 
     for cycle in range(MAX_ORCHESTRATOR_CYCLES):
         orchestrator_prompt = orchestrator_prompt_template.format(
-            current_datetime=get_current_llm_day_time(),
+            current_datetime=get_current_llm_day_time(full_sentence=False),
             current_cycle_count=cycle,
             max_cycles=MAX_ORCHESTRATOR_CYCLES,
             research_plan=research_plan,

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -10,7 +10,7 @@ You are a clarification agent that runs prior to deep research. Assess whether y
 
 If the user query is already very detailed or lengthy (more than 3 sentences), do not ask for clarification and instead call the `{GENERATE_PLAN_TOOL_NAME}` tool.
 
-{{current_datetime}}.
+For context, the date is {{current_datetime}}.
 
 Be conversational and friendly, prefer saying "could you" rather than "I need" etc.
 
@@ -29,7 +29,7 @@ Stick closely to the user query and stay on topic but be curious and avoid dupli
 Be sure to take into account the time sensitive aspects of the research topic and make sure to emphasize up to date information where appropriate. \
 Focus on providing a thorough research of the user's query over being helpful.
 
-{current_datetime}.
+For context, the date is {current_datetime}.
 
 The research plan should be formatted as a numbered list of steps and have less than 7 individual steps.
 
@@ -43,7 +43,7 @@ ORCHESTRATOR_PROMPT = f"""
 You are an orchestrator agent for deep research. Your job is to conduct research by calling the {RESEARCH_AGENT_TOOL_NAME} tool with high level research tasks. \
 This delegates the lower level research work to the {RESEARCH_AGENT_TOOL_NAME} which will provide back the results of the research.
 
-{{current_datetime}}.
+For context, the date is {{current_datetime}}.
 
 Before calling {GENERATE_REPORT_TOOL_NAME}, reason to double check that all aspects of the user's query have been well researched and that all key topics around the plan have been researched. \
 There are cases where new discoveries from research may lead to a deviation from the original research plan.


### PR DESCRIPTION
## Description

nothing big

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified deep research prompts by using shorter date context and switched to non-sentence datetime formatting. Cleaned up and reorganized the chat README for clearer guidance.

- **Refactors**
  - Use get_current_llm_day_time(full_sentence=False) in clarification, plan, and orchestrator prompts.
  - Change prompt templates to say "For context, the date is {{current_datetime}}." instead of inserting the raw value.

<sup>Written for commit c8df9a5117560582503926139677ec273880bb46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

