### PR TITLE
chore(fe): popover component uses z-index.css

### DIFF
--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -22,7 +22,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "bg-background-neutral-00 p-1 z-[30000] rounded-12 overflow-hidden border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "bg-background-neutral-00 p-1 z-popover rounded-12 overflow-hidden border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Effectively addresses https://github.com/onyx-dot-app/onyx/pull/6789#discussion_r2625102718. This is semantically consistent with the new z-index.css, so I think relatively safe and worth to start QA'ing against.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Popover component to use the z-popover token from z-index.css instead of a hardcoded z-[30000]. This standardizes layering and reduces overlay conflicts across the app.

<sup>Written for commit 2c93c61d21445ac5327223829041e5611bfa6339. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

