### PR TITLE
fix(style): "More Agents" page is responsive

### DIFF
--- a/web/src/refresh-components/layouts/PageLayout.tsx
+++ b/web/src/refresh-components/layouts/PageLayout.tsx
@@ -11,7 +11,7 @@ export default function PageWrapper(
       {/* WARNING: The id="page-wrapper-scroll-container" above is used by PageHeader.tsx
           to detect scroll position and show/hide the scroll shadow.
           DO NOT REMOVE this ID without updating PageHeader.tsx accordingly. */}
-      <div className="h-full w-[50rem]">
+      <div className="h-full w-[min(50rem,100%)]">
         <div {...props} />
       </div>
     </div>


### PR DESCRIPTION
## Description

**before**
<img width="1416" height="1820" alt="20251217_00h18m18s_grim" src="https://github.com/user-attachments/assets/b33ba6e1-48b4-4b24-b8c8-49fe3192435c" />

**after**
<img width="1416" height="1820" alt="20251217_00h18m25s_grim" src="https://github.com/user-attachments/assets/73947582-471e-4974-b8af-3b9c49a13925" />

## How Has This Been Tested?



## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the “More Agents” page responsive by letting the content container shrink on small screens while capping width at 50rem. This removes overflow and horizontal scrolling on narrow viewports.

- **Bug Fixes**
  - Updated PageLayout container from w-[50rem] to w-[min(50rem,100%)] to scale correctly on smaller viewports.

<sup>Written for commit f21beb4b70cdb84ee43ab7d89a3139af4b15aaa8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

