### PR TITLE
fix(style): standardize projects page layout

### DIFF
--- a/web/src/app/chat/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/chat/components/projects/ProjectContextPanel.tsx
@@ -136,7 +136,7 @@ export default function ProjectContextPanel({
           }}
         />
       </projectFilesModal.Provider>
-      <div className="flex flex-col gap-6 w-full max-w-[800px] mx-auto mt-10 mb-[1.5rem]">
+      <div className="flex flex-col gap-6 w-full max-w-[min(50rem,100%)] mx-auto p-4 pt-14 pb-6">
         <div className="flex flex-col gap-1 text-text-04">
           <SvgFolderOpen className="h-8 w-8 text-text-04" />
           <div className="group flex items-center gap-2">


### PR DESCRIPTION
## Description

Makes it more visually appealing on small screens and match layout with Agents & Assistants page.

## How Has This Been Tested?

**before**
<img width="1416" height="1820" alt="20251217_00h50m23s_grim" src="https://github.com/user-attachments/assets/107c1638-a979-41d9-a2dc-9364c79c1528" />

**after**
<img width="1416" height="1820" alt="20251217_00h50m54s_grim" src="https://github.com/user-attachments/assets/8328aa2e-51e0-4bf3-9531-ededc31f992e" />

(same margins as Agents and Assistants page)
<img width="1416" height="1820" alt="20251217_00h52m04s_grim" src="https://github.com/user-attachments/assets/bb519160-81d7-4423-b60d-c710b010886d" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the Projects page layout to match the Agents & Assistants page for consistent spacing and better readability on small screens. Replaced the fixed 800px width and margin-based spacing with a responsive max-width and consistent padding.

<sup>Written for commit 3aced0627f4f3f5f7e9d2cb80070f98b82491feb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

