### PR TITLE
chore(fe): followups to 7f79e34aa

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -673,7 +673,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
               {/* ChatInputBar container */}
               <div
                 ref={inputRef}
-                className="max-w-[50rem] w-full pointer-events-auto flex flex-col justify-center items-center"
+                className="max-w-[50rem] w-full pointer-events-auto flex flex-col px-4 justify-center items-center"
               >
                 {(showOnboarding ||
                   (user?.role !== UserRole.ADMIN &&

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         side={side}
         className={cn(
-          "z-[30001] rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-tooltip rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           width,
           className
         )}


### PR DESCRIPTION
## Description

Re: chat-input padding: judging by [this](https://github.com/onyx-dot-app/onyx/pull/6774) screenshot,
<img width="1644" height="936" alt="image" src="https://github.com/user-attachments/assets/5d3d4ce8-cd89-4637-9b81-933bd4556c77" />
I suspect this made sense, but after [fix(style): standardize projects page layout](https://github.com/onyx-dot-app/onyx/pull/6807) (or maybe another change), it seems no longer unnecessary?

<img width="2880" height="1920" alt="20251217_01h27m27s_grim" src="https://github.com/user-attachments/assets/83685f62-f78a-4d86-881d-a5d1a5ce09ad" />

Also, the tooltip z-index issue was resolved in [chore(fe): popover component uses z-index.css](https://github.com/onyx-dot-app/onyx/pull/6804).

## How Has This Been Tested?



## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored consistent chat input spacing and standardized tooltip z-index to match our layout and z-index tokens. This cleans up padding and ensures tooltips stack correctly.

- **Refactors**
  - Added px-4 to the ChatInputBar container for consistent horizontal spacing.
  - Replaced hard-coded z-index with z-tooltip in TooltipContent.

<sup>Written for commit 0eba19c38794c5899a79d240837d27f23f396da6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

