### PR TITLE
fix: don't leave redis ports exposed

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -298,8 +298,6 @@ services:
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -304,8 +304,6 @@ services:
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -334,8 +334,6 @@ services:
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 6379 port mapping from Redis in all production Docker Compose files to prevent external access and reduce the attack surface. Redis remains reachable by internal services via the Docker network.

<sup>Written for commit 7f47a03dea2e651103aecb87ba95dc5fea895d95. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

