### PR TITLE
fix: confluence params (#6773)

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -579,13 +579,18 @@ class OnyxConfluence:
         while url_suffix:
             logger.debug(f"Making confluence call to {url_suffix}")
             try:
+                # Only pass params if they're not already in the URL to avoid duplicate
+                # params accumulating. Confluence's _links.next already includes these.
+                params = {}
+                if "body-format=" not in url_suffix:
+                    params["body-format"] = "atlas_doc_format"
+                if "expand=" not in url_suffix:
+                    params["expand"] = "body.atlas_doc_format"
+
                 raw_response = self.get(
                     path=url_suffix,
                     advanced_mode=True,
-                    params={
-                        "body-format": "atlas_doc_format",
-                        "expand": "body.atlas_doc_format",
-                    },
+                    params=params,
                 )
             except Exception as e:
                 logger.exception(f"Error in confluence call to {url_suffix}")


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Confluence pagination by only passing body-format and expand when they’re not already in the _links.next URL. This prevents duplicate query params from accumulating across requests and avoids API errors.

<sup>Written for commit 5c8758e2ebf37ccf40ce8cf7937f7fd0f88d6cb3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

