### PR TITLE
chore(devtools): go onboarding docs + replace hatch-vcs w/ code script

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -63,6 +63,20 @@ uv add --dev onyx-devtools --upgrade-package onyx-devtools
 ## Building from source
 
 Generally, `go build .` or `go install .` are sufficient.
+`go build .` will output a `tools/ods/ods` binary which you can call normally,
+
+```shell
+./ods --version
+```
+
+while `go install .` will output to your [GOPATH](https://go.dev/wiki/SettingGOPATH) (defaults `~/go/bin/ods`),
+
+```shell
+~/go/bin/ods --version
+```
+
+_Typically, `GOPATH` is added to your shell's `PATH`, but this may be confused easily during development
+with the pip version of `ods` installed in the Onyx venv._
 
 To build the wheel,
 

--- a/tools/ods/internal/_version.py
+++ b/tools/ods/internal/_version.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import os
+import re
+
+_tag = os.environ.get("GITHUB_REF_NAME", "v0.0.0-dev").removeprefix("ods/")
+_match = re.search(r"v?(\d+\.\d+\.\d+)", _tag)
+__version__ = _match.group(1) if _match else "0.0.0"

--- a/tools/ods/pyproject.toml
+++ b/tools/ods/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "go-bin~=1.24.11", "manygo"]
+requires = ["hatchling", "go-bin~=1.24.11", "manygo"]
 build-backend = "hatchling.build"
 
 [project]
@@ -30,7 +30,8 @@ Repository = "https://github.com/onyx-dot-app/onyx"
 include = ["go.mod", "go.sum", "main.go", "**/*.go", "**/*.py"]
 
 [tool.hatch.version]
-source = "vcs"
+source = "code"
+path = "internal/_version.py"
 
 [tool.hatch.version.raw-options]
 root = "../.."


### PR DESCRIPTION
## Description

`hatch-vcs` is supposed to be work out of the box, but I think I missed a config when using a prefixed semver tag ( like `ods/v0.2.0`), so just use a simple python script.

Also add some golang-specific help to the docs to ease onboard. That being said, I think for most, the easiest workflow will be `uv pip install .` and then use the dev version from the python venv, but maybe worth explaining.

## How Has This Been Tested?

```
[0] ~/code/onyx/tools/ods [jamsion/ods-qol] 2025-12-17 13:20:04
$ GITHUB_REF_NAME=ods/v0.2.0 uv build --wheel
Building wheel...
Successfully built dist/onyx_devtools-0.2.0-py3-none-any.whl

[0] ~/code/onyx/tools/ods [jamsion/ods-qol] 2025-12-17 13:20:04
$ uv pip install .                           
Using Python 3.12.12 environment at: /home/jamison/code/onyx/.venv
Resolved 12 packages in 334ms
      Built onyx-devtools @ file:///home/jamison/code/onyx/tools/ods
Prepared 1 package in 358ms
Uninstalled 1 package in 0.93ms
Installed 1 package in 1ms
 ~ onyx-devtools==0.0.0 (from file:///home/jamison/code/onyx/tools/ods)

[0] ~/code/onyx/tools/ods [jamsion/ods-qol] 2025-12-17 13:20:11
$ source ../../.venv/bin/activate 

[0] ~/code/onyx/tools/ods [jamsion/ods-qol] 2025-12-17 13:20:19
$ ods --version
ods version dev
commit none
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hatch-vcs with a small Python version script to reliably handle prefixed tags (e.g., ods/v0.2.0). Added Go build/install guidance to the README to make onboarding easier and avoid PATH confusion.

- **Refactors**
  - Switched Hatch version source from VCS to code (internal/_version.py).
  - Version is parsed from GITHUB_REF_NAME, stripping "ods/" and extracting semver; falls back to 0.0.0.
  - Removed hatch-vcs from build requirements and updated pyproject accordingly.
  - Expanded README with Go build/install tips and notes on GOPATH vs venv binaries.

<sup>Written for commit cbeb2699cbf5c1ee52303013ea4d34d61f90b3d7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

