### PR TITLE
fix(web): Better Handling

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -585,7 +585,14 @@ class WebConnector(LoadConnector):
                 while scroll_attempts < WEB_CONNECTOR_MAX_SCROLL_ATTEMPTS:
                     page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
                     # wait for the content to load if we scrolled
-                    page.wait_for_load_state("networkidle", timeout=30000)
+                    try:
+                        page.wait_for_load_state("networkidle", timeout=30000)
+                    except Exception:
+                        # Some pages never reach networkidle due to continuous network activity
+                        # Continue scraping with the content that's already loaded
+                        logger.debug(
+                            f"{index}: Networkidle timeout on scroll attempt {scroll_attempts}, continuing"
+                        )
                     time.sleep(0.5)  # let javascript run
 
                     new_height = page.evaluate("document.body.scrollHeight")


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle networkidle timeouts during page scroll in the web connector to prevent the scraper from hanging on pages with continuous network activity. This keeps scraping going and improves reliability.

- **Bug Fixes**
  - Wrapped the networkidle wait in a try/except during scroll; on timeout, log a debug message and continue scraping instead of blocking.

<sup>Written for commit f49e32038756ef51b5bac713879d287690b7701f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

