### PR TITLE
feat: Deep Research orchestration start

### DIFF
--- a/backend/onyx/deep_research/dr_mock_tools.py
+++ b/backend/onyx/deep_research/dr_mock_tools.py
@@ -1,6 +1,13 @@
 GENERATE_PLAN_TOOL_NAME = "generate_plan"
 
+RESEARCH_AGENT_TOOL_NAME = "research_agent"
 
+GENERATE_REPORT_TOOL_NAME = "generate_report"
+
+THINK_TOOL_NAME = "think_tool"
+
+
+# ruff: noqa: E501, W605 start
 def get_clarification_tool_definitions() -> list[dict]:
     return [
         {
@@ -16,3 +23,61 @@ def get_clarification_tool_definitions() -> list[dict]:
             },
         }
     ]
+
+
+def get_orchestrator_tools(include_think_tool: bool) -> list[dict]:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": RESEARCH_AGENT_TOOL_NAME,
+                "description": "Conduct research on a specific topic.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "The research task to investigate, should be 1-2 descriptive sentences outlining the direction of investigation.",
+                        }
+                    },
+                    "required": ["task"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": GENERATE_REPORT_TOOL_NAME,
+                "description": "Generate the final research report from all of the findings. Should be called when all aspects of the user's query have been researched, or maximum cycles are reached.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        },
+    ]
+    if include_think_tool:
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": THINK_TOOL_NAME,
+                    "description": "Use this for reasoning between research_agent calls and before calling generate_report. Think deeply about key results, identify knowledge gaps, and plan next steps.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "reasoning": {
+                                "type": "string",
+                                "description": "Your chain of thought reasoning, use paragraph format, no lists.",
+                            }
+                        },
+                        "required": ["reasoning"],
+                    },
+                },
+            }
+        )
+    return tools
+
+
+# ruff: noqa: E501, W605 end

--- a/backend/onyx/deep_research/utils.py
+++ b/backend/onyx/deep_research/utils.py
@@ -1,0 +1,149 @@
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel
+
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_NAME
+from onyx.llm.model_response import ChatCompletionDeltaToolCall
+from onyx.llm.model_response import Delta
+from onyx.llm.model_response import FunctionCall
+
+
+# JSON prefixes to detect in think_tool arguments
+# The schema is: {"reasoning": "...content..."}
+JSON_PREFIX_WITH_SPACE = '{"reasoning": "'
+JSON_PREFIX_NO_SPACE = '{"reasoning":"'
+
+
+class ThinkToolProcessorState(BaseModel):
+    """State for tracking think tool processing across streaming deltas."""
+
+    think_tool_found: bool = False
+    think_tool_index: int | None = None
+    think_tool_id: str | None = None
+    full_arguments: str = ""  # Full accumulated arguments for final tool call
+    accumulated_args: str = ""  # Working buffer for JSON parsing
+    json_prefix_stripped: bool = False
+    # Buffer holds content that might be the JSON suffix "}
+    # We hold back 2 chars to avoid emitting the closing "}
+    buffer: str = ""
+
+
+def _extract_reasoning_chunk(state: ThinkToolProcessorState) -> str | None:
+    """
+    Extract reasoning content from accumulated arguments, stripping JSON wrapper.
+
+    Returns the next chunk of reasoning to emit, or None if nothing to emit yet.
+    """
+    # If we haven't found the JSON prefix yet, look for it
+    if not state.json_prefix_stripped:
+        # Try both prefix variants
+        for prefix in [JSON_PREFIX_WITH_SPACE, JSON_PREFIX_NO_SPACE]:
+            prefix_pos = state.accumulated_args.find(prefix)
+            if prefix_pos != -1:
+                # Found prefix - extract content after it
+                content_start = prefix_pos + len(prefix)
+                state.buffer = state.accumulated_args[content_start:]
+                state.accumulated_args = ""
+                state.json_prefix_stripped = True
+                break
+
+        if not state.json_prefix_stripped:
+            # Haven't seen full prefix yet, keep accumulating
+            return None
+    else:
+        # Already stripped prefix, add new content to buffer
+        state.buffer += state.accumulated_args
+        state.accumulated_args = ""
+
+    # Hold back last 2 chars in case they're the JSON suffix "}
+    if len(state.buffer) <= 2:
+        return None
+
+    # Emit everything except last 2 chars
+    to_emit = state.buffer[:-2]
+    state.buffer = state.buffer[-2:]
+
+    return to_emit if to_emit else None
+
+
+def create_think_tool_token_processor() -> (
+    Callable[[Delta | None, Any], tuple[Delta | None, Any]]
+):
+    """
+    Create a custom token processor that converts think_tool calls to reasoning content.
+
+    When the think_tool is detected:
+    - Tool call arguments are converted to reasoning_content (JSON wrapper stripped)
+    - All other deltas (content, other tool calls) are dropped
+
+    This allows non-reasoning models to emit chain-of-thought via the think_tool,
+    which gets displayed as reasoning tokens in the UI.
+
+    Returns:
+        A function compatible with run_llm_step's custom_token_processor parameter.
+        The function takes (Delta, state) and returns (modified Delta | None, new state).
+    """
+
+    def process_token(delta: Delta | None, state: Any) -> tuple[Delta | None, Any]:
+        if state is None:
+            state = ThinkToolProcessorState()
+
+        # Handle flush signal (delta=None) - emit the complete tool call
+        if delta is None:
+            if state.think_tool_found and state.think_tool_id:
+                # Return the complete think tool call
+                complete_tool_call = ChatCompletionDeltaToolCall(
+                    id=state.think_tool_id,
+                    index=state.think_tool_index or 0,
+                    type="function",
+                    function=FunctionCall(
+                        name=THINK_TOOL_NAME,
+                        arguments=state.full_arguments,
+                    ),
+                )
+                return Delta(tool_calls=[complete_tool_call]), state
+            return None, state
+
+        # Check for think tool in tool_calls
+        if delta.tool_calls:
+            for tool_call in delta.tool_calls:
+                # Detect think tool by name
+                if tool_call.function and tool_call.function.name == THINK_TOOL_NAME:
+                    state.think_tool_found = True
+                    state.think_tool_index = tool_call.index
+
+                # Capture tool call id when available
+                if (
+                    state.think_tool_found
+                    and tool_call.index == state.think_tool_index
+                    and tool_call.id
+                ):
+                    state.think_tool_id = tool_call.id
+
+                # Accumulate arguments for the think tool
+                if (
+                    state.think_tool_found
+                    and tool_call.index == state.think_tool_index
+                    and tool_call.function
+                    and tool_call.function.arguments
+                ):
+                    # Track full arguments for final tool call
+                    state.full_arguments += tool_call.function.arguments
+                    # Also accumulate for JSON parsing
+                    state.accumulated_args += tool_call.function.arguments
+
+                    # Try to extract reasoning content
+                    reasoning_chunk = _extract_reasoning_chunk(state)
+                    if reasoning_chunk:
+                        # Return delta with reasoning_content to trigger reasoning streaming
+                        return Delta(reasoning_content=reasoning_chunk), state
+
+        # If think tool found, drop all other content
+        if state.think_tool_found:
+            return None, state
+
+        # No think tool detected, pass through original delta
+        return delta, state
+
+    return process_token

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -6,7 +6,8 @@ from onyx.prompts.deep_research.dr_tool_prompts import THINK_TOOL_NAME
 
 # ruff: noqa: E501, W605 start
 CLARIFICATION_PROMPT = f"""
-You are a clarification agent that runs prior to deep research. Assess whether you need to ask clarifying questions, or if the user has already provided enough information for you to start research. Clarifications are generally helpful.
+You are a clarification agent that runs prior to deep research. Assess whether you need to ask clarifying questions, or if the user has already provided enough information for you to start research. \
+CRITICAL - Never directly answer the user's query, you must only ask clarifying questions or call the `{GENERATE_PLAN_TOOL_NAME}` tool.
 
 If the user query is already very detailed or lengthy (more than 3 sentences), do not ask for clarification and instead call the `{GENERATE_PLAN_TOOL_NAME}` tool.
 


### PR DESCRIPTION
## Description

Orchestration layer beginnings

## How Has This Been Tested?

N/A

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the Deep Research orchestration layer with initial agent tools and streaming reasoning support. Adds a custom token processor to llm_step and uses it to convert think_tool calls into reasoning for non‑reasoning models.

- **New Features**
  - Orchestrator loop: runs cycles, calls LLM with orchestrator tools, emits packets, validates tool calls on the first cycle, and stores answer tokens.
  - Think tool processor: streams reasoning_content from think_tool JSON args, accumulates full arguments, and flushes the final tool call.
  - llm_step: new custom_token_processor hook with flush support for per-token transformation and finalization.
  - Tools: adds research_agent, generate_report, and optional think_tool for non‑reasoning models.
  - Prompts: clarification prompt now explicitly forbids answering and requires either asking questions or calling generate_plan.

<sup>Written for commit 38e0d93de15add7008ba3f2ffc723a81e8e592f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

