### PR TITLE
feat: more orchestrator stuff

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -36,6 +36,8 @@ from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDone
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
+from onyx.tools.models import TOOL_CALL_MSG_ARGUMENTS
+from onyx.tools.models import TOOL_CALL_MSG_FUNC_NAME
 from onyx.tools.models import ToolCallKickoff
 from onyx.tracing.framework.create import generation_span
 from onyx.utils.b64 import get_image_type_from_bytes
@@ -43,10 +45,6 @@ from onyx.utils.logger import setup_logger
 
 
 logger = setup_logger()
-
-
-TOOL_CALL_MSG_FUNC_NAME = "function_name"
-TOOL_CALL_MSG_ARGUMENTS = "arguments"
 
 
 def _format_message_history_for_logging(

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -15,9 +15,13 @@ from onyx.chat.llm_step import run_llm_step
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import LlmStepResult
 from onyx.configs.constants import MessageType
+from onyx.deep_research.dr_mock_tools import GENERATE_REPORT_TOOL_NAME
 from onyx.deep_research.dr_mock_tools import get_clarification_tool_definitions
 from onyx.deep_research.dr_mock_tools import get_orchestrator_tools
+from onyx.deep_research.dr_mock_tools import RESEARCH_AGENT_TOOL_NAME
 from onyx.deep_research.dr_mock_tools import THINK_TOOL_NAME
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_MESSAGE
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_TOKEN_COUNT
 from onyx.deep_research.utils import create_think_tool_token_processor
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
@@ -34,6 +38,7 @@ from onyx.server.query_and_chat.streaming_models import DeepResearchPlanDelta
 from onyx.server.query_and_chat.streaming_models import DeepResearchPlanStart
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.models import ToolCallInfo
 from onyx.tools.tool import Tool
 from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
@@ -284,10 +289,97 @@ def run_deep_research_llm_loop(
 
         # TODO generate report if there are no tool calls and cycle is not 0
 
+        most_recent_reasoning: str | None = None
         if tool_calls:
-            for tool_call in tool_calls:
-                if tool_call.tool_name == THINK_TOOL_NAME:
-                    pass
+            # Check if there's a THINK_TOOL in the calls - if so, only process that one
+            think_tool_call = next(
+                (
+                    tool_call
+                    for tool_call in tool_calls
+                    if tool_call.tool_name == THINK_TOOL_NAME
+                ),
+                None,
+            )
+
+            generate_report_tool_call = next(
+                (
+                    tool_call
+                    for tool_call in tool_calls
+                    if tool_call.tool_name == GENERATE_REPORT_TOOL_NAME
+                ),
+                None,
+            )
+
+            if generate_report_tool_call:
+                logger.info("Generate report tool call found, not implemented yet.")
+            elif think_tool_call:
+                # Only process the THINK_TOOL and skip all other tool calls
+                # This will not actually get saved to the db as a tool call but we'll attach it to the tool(s) called after
+                # it as if it were just a reasoning model doing it. In the chat history, because it happens in 2 steps,
+                # we will show it as a separate message.
+                most_recent_reasoning = state_container.reasoning_tokens
+                tool_call_message = think_tool_call.to_msg_str()
+
+                think_tool_msg = ChatMessageSimple(
+                    message=tool_call_message,
+                    token_count=token_counter(tool_call_message),
+                    message_type=MessageType.TOOL_CALL,
+                    tool_call_id=think_tool_call.tool_call_id,
+                    image_files=None,
+                )
+                simple_chat_history.append(think_tool_msg)
+
+                think_tool_response_msg = ChatMessageSimple(
+                    message=THINK_TOOL_RESPONSE_MESSAGE,
+                    token_count=THINK_TOOL_RESPONSE_TOKEN_COUNT,
+                    message_type=MessageType.TOOL_CALL_RESPONSE,
+                    tool_call_id=think_tool_call.tool_call_id,
+                    image_files=None,
+                )
+                simple_chat_history.append(think_tool_response_msg)
+            else:
+                for tool_call in tool_calls:
+                    if tool_call.tool_name != RESEARCH_AGENT_TOOL_NAME:
+                        logger.warning(f"Unexpected tool call: {tool_call.tool_name}")
+                        continue
+
+                    tool_call_info = ToolCallInfo(
+                        parent_tool_call_id=None,
+                        turn_index=cycle + reasoning_cycles,
+                        tool_name=tool_call.tool_name,
+                        tool_call_id=tool_call.tool_call_id,
+                        tool_id=999,  # TODO
+                        reasoning_tokens=most_recent_reasoning,
+                        tool_call_arguments=tool_call.tool_args,
+                        tool_call_response="pending",  # TODO
+                        search_docs=None,  # TODO
+                        generated_images=None,  # TODO
+                    )
+                    state_container.add_tool_call(tool_call_info)
+
+                    tool_call_message = tool_call.to_msg_str()
+                    tool_call_token_count = token_counter(tool_call_message)
+
+                    tool_call_msg = ChatMessageSimple(
+                        message=tool_call_message,
+                        token_count=tool_call_token_count,
+                        message_type=MessageType.TOOL_CALL,
+                        tool_call_id=tool_call.tool_call_id,
+                        image_files=None,
+                    )
+                    simple_chat_history.append(tool_call_msg)
+
+                    tool_call_response_msg = ChatMessageSimple(
+                        message="pending",  # TODO
+                        token_count=0,  # TODO
+                        message_type=MessageType.TOOL_CALL_RESPONSE,
+                        tool_call_id=tool_call.tool_call_id,
+                        image_files=None,
+                    )
+                    simple_chat_history.append(tool_call_response_msg)
+
+            if not think_tool_call:
+                most_recent_reasoning = None
 
         if llm_step_result.answer:
             state_container.set_answer_tokens(llm_step_result.answer)

--- a/backend/onyx/deep_research/dr_mock_tools.py
+++ b/backend/onyx/deep_research/dr_mock_tools.py
@@ -80,4 +80,6 @@ def get_orchestrator_tools(include_think_tool: bool) -> list[dict]:
     return tools
 
 
+THINK_TOOL_RESPONSE_MESSAGE = "Acknowledged, please continue."
+THINK_TOOL_RESPONSE_TOKEN_COUNT = 10
 # ruff: noqa: E501, W605 end

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from typing import Literal
 from uuid import UUID
@@ -16,6 +17,10 @@ from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.server.query_and_chat.streaming_models import GeneratedImage
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
+
+
+TOOL_CALL_MSG_FUNC_NAME = "function_name"
+TOOL_CALL_MSG_ARGUMENTS = "arguments"
 
 
 class CustomToolUserFileSnapshot(BaseModel):
@@ -50,6 +55,14 @@ class ToolCallKickoff(BaseModel):
     tool_call_id: str
     tool_name: str
     tool_args: dict[str, Any]
+
+    def to_msg_str(self) -> str:
+        return json.dumps(
+            {
+                TOOL_CALL_MSG_FUNC_NAME: self.tool_name,
+                TOOL_CALL_MSG_ARGUMENTS: self.tool_args,
+            }
+        )
 
 
 class ToolRunnerResponse(BaseModel):


### PR DESCRIPTION
## Description


## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds orchestrator handling for THINK and Research Agent tool calls in Deep Research and centralizes tool-call message formatting. Improves traceability of reasoning and prepares for report generation.

- **New Features**
  - Handle THINK tool exclusively when present; append its call and a canned response to chat history and carry reasoning tokens forward.
  - Record RESEARCH_AGENT tool calls in state with ToolCallInfo and add “pending” responses to chat.
  - Stub generate report call path (logging only for now).

- **Refactors**
  - Moved TOOL_CALL_MSG_* constants to onyx.tools.models and added ToolCallKickoff.to_msg_str().
  - Updated llm_loop and llm_step to use centralized tool-call message builder; removed unused code.

<sup>Written for commit 471e5a67b3747b5541a79251b2f2d8804b7acdec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



