### PR TITLE
fix(fe): apply z-sticky to ChatInput

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -672,7 +672,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
               {/* ChatInputBar container */}
               <div
                 ref={inputRef}
-                className="max-w-[50rem] w-full pointer-events-auto flex flex-col px-4 justify-center items-center"
+                className="max-w-[50rem] w-full pointer-events-auto z-sticky flex flex-col px-4 justify-center items-center"
               >
                 {(showOnboarding ||
                   (user?.role !== UserRole.ADMIN &&


### PR DESCRIPTION
## Description

**before**
<img width="1410" height="158" alt="20251217_17h18m02s_grim" src="https://github.com/user-attachments/assets/1b0160fc-479f-4b27-98c3-359a67bacf53" />


**after**
<img width="1402" height="144" alt="20251217_17h18m15s_grim" src="https://github.com/user-attachments/assets/e9dcdff6-66bf-463b-80c1-9db3480c1ceb" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the ChatInput stays above other content and remains clickable. Adds the z-sticky class to the ChatInput container to fix z-index overlap during scroll.

<sup>Written for commit b14f0970e38eef5e54442ce56aef7b58e432c43d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

