### PR TITLE
fix(fe): avoid chat message shift on hover

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -239,7 +239,7 @@ export default function HumanMessage({
         )}
       >
         <FileDisplay alignBubble files={files || []} />
-        <div className="flex flex-wrap ml-auto justify-end break-words">
+        <div className="flex flex-wrap justify-end break-words">
           {isEditing ? (
             <MessageEditing
               content={content}


### PR DESCRIPTION
## Description

Motivation + design sign off for reference, https://onyx-company.slack.com/archives/C0832RVRVG8/p1765915523727209

Moves the Copy and Edit buttons below chat messages, next to the message pagination (when applicable). Where there is no pagination, there is a dummy div to provide additional vertical buffer as to avoid shifting on hover.

#### Shared chat

<img width="2880" height="1920" alt="20251217_22h33m25s_grim" src="https://github.com/user-attachments/assets/5a8ebf64-7854-4309-9ca8-f6542e313001" />

<img width="1116" height="1820" alt="20251217_22h41m19s_grim" src="https://github.com/user-attachments/assets/101af196-08a9-498d-9859-50f5692306f3" />

___

#### Desktop

Chat with text wrapping:
<img width="2880" height="1920" alt="20251217_22h35m19s_grim" src="https://github.com/user-attachments/assets/3b00663c-a319-4788-8424-64adec4e2df9" />

w/ hover:
<img width="2880" height="1920" alt="20251217_22h35m24s_grim" src="https://github.com/user-attachments/assets/2d98b69c-c96a-4847-8508-19bbf1c45179" />

Short message w/ pagination:
<img width="2880" height="1920" alt="20251217_22h35m37s_grim" src="https://github.com/user-attachments/assets/7d5188e5-5dec-48bc-8384-fc5b4dc531ef" />

___

#### Small viewport

w/o hover:
<img width="1116" height="1820" alt="20251217_22h39m49s_grim" src="https://github.com/user-attachments/assets/cf887b17-c18b-4f34-b8b3-0cfbb1c81117" />

w/ hover:
<img width="1116" height="1820" alt="20251217_22h39m54s_grim" src="https://github.com/user-attachments/assets/27d92d62-9b95-4265-869d-6e92483d36a8" />

w/ pagination:
<img width="1116" height="1820" alt="20251217_22h38m44s_grim" src="https://github.com/user-attachments/assets/44fc69a5-a988-45a7-b9b8-4cf52a1fe282" />

___

#### Before and after margins for reference:

<img width="1716" height="1032" alt="20251217_22h27m05s_grim" src="https://github.com/user-attachments/assets/5a08ceb7-96ab-4684-9491-6f30ae8fc129" />
<img width="1716" height="1032" alt="20251217_22h27m10s_grim" src="https://github.com/user-attachments/assets/477e2a31-1d09-465c-bce1-36b52bf8e165" />
<img width="1116" height="1820" alt="20251217_22h26m53s_grim" src="https://github.com/user-attachments/assets/016555df-0f91-4a00-82d1-762d35540c0a" />
<img width="1116" height="1820" alt="20251217_22h26m58s_grim" src="https://github.com/user-attachments/assets/9036de29-3445-4394-9110-138f15520e06" />


## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Copy and Edit buttons below chat messages (next to pagination) to prevent layout shift on hover. Adds spacer when pagination is absent and adjusts alignment for consistent behavior across screen sizes.

- **Bug Fixes**
  - Repositioned controls under the bubble; they appear on hover without moving content.
  - Added spacer to keep height stable when no pagination is shown; kept MessageSwitcher right-aligned.

<sup>Written for commit 12c08c34a5bbc18d77c14b3051f465e3b84bfeaf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





