### PR TITLE
fix(fe): center-align credential update icons

### DIFF
--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -114,7 +114,7 @@ function CredentialSelectionTable({
                   <td className="p-2">
                     {new Date(credential.time_updated).toLocaleString()}
                   </td>
-                  <td className="pt-3 flex gap-x-2 content-center mt-auto">
+                  <td className="p-2 flex gap-x-2 content-center mt-auto">
                     <IconButton
                       onClick={async () => {
                         onDeleteCredential(credential);


### PR DESCRIPTION
## Description

<img width="2880" height="1920" alt="20251218_00h43m14s_grim" src="https://github.com/user-attachments/assets/01d60be4-06fb-4b06-bb43-50f8a1138bfc" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centered the credential action icons in the credentials table by replacing uneven top padding with uniform p-2 on the actions cell. This fixes the visual misalignment with the row content.

<sup>Written for commit 9d8c5d4a072ab996774bd3c3197441ad5bcb33a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

