### PR TITLE
fix: TextView tooltip z-index

### DIFF
--- a/web/src/components/chat/TextView.tsx
+++ b/web/src/components/chat/TextView.tsx
@@ -153,8 +153,8 @@ export default function TextView({
     <Dialog open onOpenChange={onClose}>
       <DialogContent
         hideCloseIcon
-        overlayClassName="z-[3000]"
-        className="z-[3001] max-w-4xl w-[90vw] flex flex-col justify-between gap-y-0 h-[90vh] max-h-[90vh] p-0"
+        overlayClassName="z-modal-overlay"
+        className="z-modal max-w-4xl w-[90vw] flex flex-col justify-between gap-y-0 h-[90vh] max-h-[90vh] p-0"
       >
         <DialogHeader className="px-4 mb-0 pt-2 pb-3 flex flex-row items-center justify-between border-b">
           <DialogTitle className="text-lg font-medium truncate">

--- a/web/src/refresh-components/buttons/IconButton.tsx
+++ b/web/src/refresh-components/buttons/IconButton.tsx
@@ -304,7 +304,7 @@ export default function IconButton({
   const buttonElement = (
     <button
       className={cn(
-        "flex items-center justify-center h-fit w-fit group/IconButton",
+        "flex items-center justify-center h-fit w-fit group/IconButton z-tooltip",
         internal ? "p-1" : "p-2",
         disabled && "cursor-not-allowed",
         internal ? "rounded-08" : "rounded-12",


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed tooltip stacking in TextView by replacing hard-coded z-index values with shared classes (z-modal, z-modal-overlay) and adding z-tooltip to IconButton. Tooltips now render correctly above modal content without being hidden.

<sup>Written for commit eb14e8ab07f4f4d120674b44e1c5bb4181fc0af6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

