### PR TITLE
fix: text view auto focus on button

### DIFF
--- a/web/src/components/chat/TextView.tsx
+++ b/web/src/components/chat/TextView.tsx
@@ -152,6 +152,7 @@ export default function TextView({
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent
+        onOpenAutoFocus={(e) => e.preventDefault()}
         hideCloseIcon
         overlayClassName="z-modal-overlay"
         className="z-modal max-w-4xl w-[90vw] flex flex-col justify-between gap-y-0 h-[90vh] max-h-[90vh] p-0"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the TextView dialog from auto-focusing the first button on open to avoid unwanted focus and scroll jumps.
Added onOpenAutoFocus={(e) => e.preventDefault()} to DialogContent so the modal opens without stealing focus.

<sup>Written for commit ee01a242e31176beb19a49f8a490467a028d330e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

