### PR TITLE
chore(gha): run playwright and jest similar to other tests

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -4,7 +4,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
   push:
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: read

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -4,7 +4,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
   push:
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Runs playwright and jest on the same triggers as the other tests.

This doesn't completely stop them from running in forks -- they'll still run when folks open a PR in the fork -- but that's rare and that's configured at the fork-level anyways, so they can remove them if they'd like.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Playwright and Jest GitHub Actions with our other test workflows. They now run on merge_group, pull_request to main and release/**, and on tag pushes v*.*.*.

<sup>Written for commit 35a41e6fa6a53de6ea3dec035ef916178f46e2d9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

