### PR TITLE
fix(users): Clean up Invited Users who are Active

### DIFF
--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -249,6 +249,17 @@ def accept_user_invite(email: str, tenant_id: str) -> None:
             )
             raise
 
+    # Remove from invited users list since they've accepted
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+    try:
+        invited_users = get_invited_users()
+        if email in invited_users:
+            invited_users.remove(email)
+            write_invited_users(invited_users)
+            logger.info(f"Removed {email} from invited users list after acceptance")
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
 
 def deny_user_invite(email: str, tenant_id: str) -> None:
     """


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently someone who already is using Onyx can appear in the Invite list since we don't clean up the invite list. 

This PR focuses on cleaning up this logic

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally my own instance

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing already-active users in the Invited list and remove invites after acceptance to keep user management clean and accurate.

- **Bug Fixes**
  - Filter list_invited_users to exclude emails of active users.
  - Filter list_all_users to exclude invited emails that are already accepted or Slack users.
  - Remove a user’s email from invited users on accept_user_invite.

<sup>Written for commit 42a69b0822c37cd24391d2c73eb6fdfd88a9397d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

