### PR TITLE
fix: handle 401s in attachment fetching

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -526,7 +526,11 @@ class ConfluenceConnector(
             page_id = _get_page_id(page, allow_missing=True)
             page_title = page.get("title", "unknown")
             if e.response and e.response.status_code in [401, 403]:
-                failure_message_prefix = "Invalid credentials (401)" if e.response.status_code == 401 else "Permission denied (403)"
+                failure_message_prefix = (
+                    "Invalid credentials (401)"
+                    if e.response.status_code == 401
+                    else "Permission denied (403)"
+                )
                 failure_message = (
                     f"{failure_message_prefix} when fetching attachments for page '{page_title}' "
                     f"(ID: {page_id}). The user may not have permission to query attachments on this page. "


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle 401 errors when fetching Confluence attachments so syncs don’t fail. We now log a warning, skip attachments, and record a ConnectorFailure; 403 handling is unchanged but unified.

- **Bug Fixes**
  - Treat 401 and 403 as non-fatal: log clear messages, attach page link, and continue.
  - Add _get_page_id to safely normalize page IDs (string, or "unknown"); use it in queries and conversions to avoid KeyError.

<sup>Written for commit 1edab1ccb46bc85b8d28d5df8ff79064c37dfcdd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





