### PR TITLE
fix(slack): add batch processing and rate limit detection for thread context

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -583,6 +583,12 @@ LINEAR_CLIENT_SECRET = os.getenv("LINEAR_CLIENT_SECRET")
 SLACK_NUM_THREADS = int(os.getenv("SLACK_NUM_THREADS") or 8)
 MAX_SLACK_QUERY_EXPANSIONS = int(os.environ.get("MAX_SLACK_QUERY_EXPANSIONS", "5"))
 
+# Slack federated search thread context settings
+# Batch size for fetching thread context (controls concurrent API calls per batch)
+SLACK_THREAD_CONTEXT_BATCH_SIZE = int(
+    os.environ.get("SLACK_THREAD_CONTEXT_BATCH_SIZE", "5")
+)
+
 DASK_JOB_CLIENT_ENABLED = (
     os.environ.get("DASK_JOB_CLIENT_ENABLED", "").lower() == "true"
 )

--- a/backend/onyx/federated_connectors/slack/models.py
+++ b/backend/onyx/federated_connectors/slack/models.py
@@ -47,10 +47,10 @@ class SlackEntities(BaseModel):
 
     # Message count per slack request
     max_messages_per_query: int = Field(
-        default=25,
+        default=10,
         description=(
             "Maximum number of messages to retrieve per search query. "
-            "Higher values provide more context but may be slower."
+            "Higher values increase API calls and may trigger rate limits."
         ),
     )
 

--- a/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
+++ b/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
@@ -1,0 +1,240 @@
+"""Tests for Slack thread context fetching with rate limit handling."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from onyx.context.search.federated.models import SlackMessage
+from onyx.context.search.federated.slack_search import (
+    _get_thread_context_or_raise_on_rate_limit,
+)
+from onyx.context.search.federated.slack_search import (
+    fetch_thread_contexts_with_rate_limit_handling,
+)
+from onyx.context.search.federated.slack_search import SlackRateLimitError
+
+
+def _create_mock_message(
+    message_id: str = "1234567890.123456",
+    thread_id: str | None = "1234567890.000000",
+    text: str = "test message",
+    channel_id: str = "C123456",
+) -> SlackMessage:
+    """Create a mock SlackMessage for testing."""
+    return SlackMessage(
+        document_id=f"{channel_id}_{message_id}",
+        channel_id=channel_id,
+        message_id=message_id,
+        thread_id=thread_id,
+        link=f"https://slack.com/archives/{channel_id}/p{message_id.replace('.', '')}",
+        metadata={"channel": "test-channel"},
+        timestamp=datetime.now(),
+        recency_bias=1.0,
+        semantic_identifier="user in #test-channel: test message",
+        text=text,
+        highlighted_texts=set(),
+        slack_score=1000.0,
+    )
+
+
+class TestSlackRateLimitError:
+    """Test SlackRateLimitError exception."""
+
+    def test_exception_is_raised(self) -> None:
+        """Test that SlackRateLimitError can be raised and caught."""
+        with pytest.raises(SlackRateLimitError):
+            raise SlackRateLimitError("Rate limited")
+
+
+class TestGetThreadContextOrRaiseOnRateLimit:
+    """Test _get_thread_context_or_raise_on_rate_limit function."""
+
+    def test_non_thread_message_returns_original_text(self) -> None:
+        """Test that non-thread messages return their original text."""
+        message = _create_mock_message(thread_id=None, text="original text")
+
+        result = _get_thread_context_or_raise_on_rate_limit(
+            message, "xoxp-token", "T12345"
+        )
+
+        assert result == "original text"
+
+    @patch("onyx.context.search.federated.slack_search.WebClient")
+    def test_rate_limit_raises_exception(self, mock_webclient_class: MagicMock) -> None:
+        """Test that 429 rate limit raises SlackRateLimitError."""
+        message = _create_mock_message(text="original text")
+
+        # Create mock response with 429 status
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+
+        # Create mock client that raises rate limit error
+        mock_client = MagicMock()
+        mock_client.conversations_replies.side_effect = SlackApiError(
+            "ratelimited", mock_response
+        )
+        mock_webclient_class.return_value = mock_client
+
+        with pytest.raises(SlackRateLimitError):
+            _get_thread_context_or_raise_on_rate_limit(message, "xoxp-token", "T12345")
+
+    @patch("onyx.context.search.federated.slack_search.WebClient")
+    def test_other_api_error_returns_original_text(
+        self, mock_webclient_class: MagicMock
+    ) -> None:
+        """Test that non-rate-limit API errors return original text."""
+        message = _create_mock_message(text="original text")
+
+        # Create mock response with non-429 error
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        mock_client = MagicMock()
+        mock_client.conversations_replies.side_effect = SlackApiError(
+            "internal_error", mock_response
+        )
+        mock_webclient_class.return_value = mock_client
+
+        result = _get_thread_context_or_raise_on_rate_limit(
+            message, "xoxp-token", "T12345"
+        )
+
+        assert result == "original text"
+
+    @patch("onyx.context.search.federated.slack_search.batch_get_user_profiles")
+    @patch("onyx.context.search.federated.slack_search.WebClient")
+    def test_successful_thread_fetch_returns_context(
+        self, mock_webclient_class: MagicMock, mock_batch_profiles: MagicMock
+    ) -> None:
+        """Test that successful thread fetch returns thread context."""
+        message = _create_mock_message(
+            message_id="1234567890.123456",
+            thread_id="1234567890.000000",
+            text="original text",
+        )
+
+        # Mock user profile lookup
+        mock_batch_profiles.return_value = {
+            "U111": "User One",
+            "U222": "User Two",
+            "U333": "User Three",
+        }
+
+        # Create mock response with thread messages
+        mock_response = MagicMock()
+        mock_response.get.return_value = [
+            {
+                "text": "Thread starter message",
+                "user": "U111",
+                "ts": "1234567890.000000",
+            },
+            {"text": "Reply 1", "user": "U222", "ts": "1234567890.111111"},
+            {"text": "Reply 2 (matched)", "user": "U333", "ts": "1234567890.123456"},
+        ]
+        mock_response.validate.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.conversations_replies.return_value = mock_response
+        mock_webclient_class.return_value = mock_client
+
+        result = _get_thread_context_or_raise_on_rate_limit(
+            message, "xoxp-token", "T12345"
+        )
+
+        # Should contain thread starter and replies with resolved usernames
+        assert "Thread starter message" in result
+        assert "Reply" in result
+        assert "User One" in result
+
+
+class TestFetchThreadContextsWithRateLimitHandling:
+    """Test fetch_thread_contexts_with_rate_limit_handling function."""
+
+    def test_empty_message_list_returns_empty(self) -> None:
+        """Test that empty message list returns empty list."""
+        result = fetch_thread_contexts_with_rate_limit_handling(
+            slack_messages=[],
+            access_token="xoxp-token",
+            team_id="T12345",
+        )
+
+        assert result == []
+
+    @patch(
+        "onyx.context.search.federated.slack_search._get_thread_context_or_raise_on_rate_limit"
+    )
+    @patch(
+        "onyx.context.search.federated.slack_search.run_functions_tuples_in_parallel"
+    )
+    def test_batch_processing_respects_batch_size(
+        self,
+        mock_parallel: MagicMock,
+        mock_get_context: MagicMock,
+    ) -> None:
+        """Test that messages are processed in batches of specified size."""
+        messages = [
+            _create_mock_message(message_id=f"123456789{i}.000000") for i in range(7)
+        ]
+
+        # Mock parallel execution to return enriched text
+        mock_parallel.return_value = ["enriched"] * 3  # batch_size=3
+
+        fetch_thread_contexts_with_rate_limit_handling(
+            slack_messages=messages,
+            access_token="xoxp-token",
+            team_id="T12345",
+            batch_size=3,
+            max_messages=None,
+        )
+
+        # Should have called parallel execution 3 times (7 messages / 3 batch = 3 batches)
+        assert mock_parallel.call_count == 3
+
+    @patch(
+        "onyx.context.search.federated.slack_search._get_thread_context_or_raise_on_rate_limit"
+    )
+    @patch(
+        "onyx.context.search.federated.slack_search.run_functions_tuples_in_parallel"
+    )
+    def test_rate_limit_stops_further_batches(
+        self,
+        mock_parallel: MagicMock,
+        mock_get_context: MagicMock,
+    ) -> None:
+        """Test that rate limiting stops processing of subsequent batches."""
+        messages = [
+            _create_mock_message(message_id=f"123456789{i}.000000", text=f"msg{i}")
+            for i in range(6)
+        ]
+
+        # First batch succeeds, second batch hits rate limit
+        mock_parallel.side_effect = [
+            ["enriched1", "enriched2"],  # First batch succeeds
+            SlackRateLimitError("Rate limited"),  # Second batch fails
+        ]
+
+        result = fetch_thread_contexts_with_rate_limit_handling(
+            slack_messages=messages,
+            access_token="xoxp-token",
+            team_id="T12345",
+            batch_size=2,
+            max_messages=None,
+        )
+
+        # Should have 6 results total
+        assert len(result) == 6
+        # First 2 should be enriched
+        assert result[0] == "enriched1"
+        assert result[1] == "enriched2"
+        # Next 2 (rate limited batch) should be original text
+        assert result[2] == "msg2"
+        assert result[3] == "msg3"
+        # Last 2 (skipped due to rate limit) should be original text
+        assert result[4] == "msg4"
+        assert result[5] == "msg5"
+
+        # Should only call parallel twice (stopped after rate limit)
+        assert mock_parallel.call_count == 2


### PR DESCRIPTION
## Description

Fixes Slack federated search thread pool exhaustion when rate limited. When Slack API returns 429 rate limit errors, thread context fetches would hang and block the backend API server's thread pool, affecting all users.

**Changes:**
- Process thread context fetches in controlled batches (default 5 concurrent) instead of unbounded parallelism
- Stop fetching additional batches immediately when 429 rate limit is detected
- Reduce `max_messages_per_query` default from 25 to 10 (fewer messages means less API pressure)
- Add `SLACK_THREAD_CONTEXT_BATCH_SIZE` env var for runtime tuning
- Remove unused `get_contextualized_thread_text` function

## How Has This Been Tested?

- Unit tests added for rate limit detection and batch processing behavior
- Tests verify: rate limit raises exception, batches are processed correctly, rate limit stops further batches

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch processing and 429 rate-limit detection to Slack thread context fetches to prevent backend thread pool exhaustion and stabilize federated search.

- **Bug Fixes**
  - Stop fetching additional batches immediately when a 429 is detected.
  - Fetch thread context in controlled batches (default 5 concurrent) instead of unbounded parallelism.

- **New Features**
  - SLACK_THREAD_CONTEXT_BATCH_SIZE env var for runtime tuning.
  - Lower default max_messages_per_query from 25 to 10 to reduce API pressure.

<sup>Written for commit 7e7b83552484996482ee2722ca2994dd4ff0bea8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

