### PR TITLE
fix: small MCP UI changes

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1730,12 +1730,12 @@ def get_mcp_server_db_tools(
 
 
 @admin_router.post("/servers/create", response_model=MCPServerCreateResponse)
-def upsert_mcp_server_with_tools(
+def upsert_mcp_server(
     request: MCPToolCreateRequest,
     db_session: Session = Depends(get_session),
     user: User | None = Depends(current_curator_or_admin_user),
 ) -> MCPServerCreateResponse:
-    """Create or update an MCP server and associated tools"""
+    """Create or update an MCP server (no tools yet)"""
 
     # Validate auth_performer for non-none auth types
     if request.auth_type != MCPAuthenticationType.NONE and not request.auth_performer:
@@ -1851,14 +1851,8 @@ def create_mcp_server_simple(
 ) -> MCPServer:
     """Create MCP server with minimal information - auth to be configured later"""
 
-    if not user:
-        raise HTTPException(
-            status_code=401,
-            detail="Must be logged in as a curator or admin to create MCP server",
-        )
-
     mcp_server = create_mcp_server__no_commit(
-        owner_email=user.email,
+        owner_email=user.email if user else "",
         name=request.name,
         description=request.description,
         server_url=request.server_url,

--- a/web/src/refresh-components/SimpleTooltip.tsx
+++ b/web/src/refresh-components/SimpleTooltip.tsx
@@ -40,11 +40,7 @@ export default function SimpleTooltip({
   const isDomElement =
     React.isValidElement(children) && typeof children.type === "string";
 
-  const triggerChild = isDomElement ? (
-    children
-  ) : (
-    <span className="inline-flex">{children}</span>
-  );
+  const triggerChild = isDomElement ? children : <span>{children}</span>;
 
   return (
     <TooltipProvider>

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -59,8 +59,9 @@ export function PerUserAuthConfig({
     updateRequiredFields(headersObject);
   };
 
-  // Extract required fields from placeholders in header values
-  const updateRequiredFields = (headers: Record<string, string>) => {
+  const computeRequiredFieldsFromHeaders = (
+    headers: Record<string, string>
+  ): string[] => {
     const placeholderRegex = /\{([^}]+)\}/g;
     const requiredFields = new Set<string>();
 
@@ -76,8 +77,13 @@ export function PerUserAuthConfig({
         });
       }
     });
+    return Array.from(requiredFields);
+  };
 
-    setFieldValue("auth_template.required_fields", Array.from(requiredFields));
+  // Extract required fields from placeholders in header values
+  const updateRequiredFields = (headers: Record<string, string>) => {
+    const requiredFields = computeRequiredFieldsFromHeaders(headers);
+    setFieldValue("auth_template.required_fields", requiredFields);
   };
 
   // Update user credential value
@@ -89,7 +95,9 @@ export function PerUserAuthConfig({
     });
   };
 
-  const requiredFields: string[] = values.auth_template?.required_fields || [];
+  const requiredFields: string[] = values.auth_template?.required_fields?.length
+    ? values.auth_template.required_fields
+    : computeRequiredFieldsFromHeaders(values.auth_template?.headers || {});
   const userCredentials = values.user_credentials || {};
 
   return (
@@ -111,11 +119,11 @@ export function PerUserAuthConfig({
         <FormField.Description>
           Format headers for each user to fill in their individual credentials.
           Use placeholders like{" "}
-          <Text text03 secondaryMono className="inline">
+          <Text text03 secondaryMono className="inline" as="span">
             {"{api_key}"}
           </Text>{" "}
           or{" "}
-          <Text text03 secondaryMono className="inline">
+          <Text text03 secondaryMono className="inline" as="span">
             {"{user_email}"}
           </Text>
           . Users will be prompted to provide values for placeholders (except


### PR DESCRIPTION
## Description

Addressing the following small UI problems:
- in tool selection popover, mcp tool toggles were not left justified due to the containing span (part of SimpleTooltip) having inline-flex
- could not create MCP servers for local development (removed erroring on user is None, as that is the local dev auth=disabled case)
- when configuring a per-user API key, the admin-configured header values would only appear after editing some text when re-entering the modal

## How Has This Been Tested?

tested in UI. I really want to get some per user API key tests in, but that will have to wait

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes small MCP UI issues and unblocks creating servers in local dev. Improves tool selection layout and makes per-user API key config reflect required fields immediately.

- **Bug Fixes**
  - Tool selection popover: remove inline-flex wrapper in SimpleTooltip so MCP tool toggles are left-aligned.
  - Local dev: allow creating MCP servers when auth is disabled (user is None) by using an empty owner_email.
  - Per-user API key modal: compute required_fields from header placeholders on load and on change; keep placeholder examples inline.

<sup>Written for commit 4fdb6c449f274320f1b18e620afd8ab8a4ae1d18. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

