### PR TITLE
fix: reset actions popover to main menu on open

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -476,6 +476,14 @@ export default function ActionsPopover({
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen);
+    if (newOpen) {
+      setSecondaryView(null);
+      setSearchTerm("");
+    }
+  };
+
   const mcpFooter = showActiveReauthRow ? (
     <LineItem
       onClick={handleFooterReauthClick}
@@ -610,7 +618,7 @@ export default function ActionsPopover({
 
   return (
     <>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <div data-testid="action-management-toggle">
             <IconButton


### PR DESCRIPTION
## Description

Reset the actions popover to show the main menu each time it opens instead of retaining the last viewed state.

## How Has This Been Tested?

Manual testing

![2025-12-18 15 10 53](https://github.com/user-attachments/assets/ff2d9531-0d9c-4d43-9472-e8ee1026653f)


## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the Actions popover to show the main menu every time it opens. Clears the secondary view and search term on open to avoid stale state and prevent a flash during the close animation.

<sup>Written for commit 5626ee90458602477f3a9a4f61f19c4b29cd53ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



