### PR TITLE
fix: persist user-selected connector sources on follow-up messages

### DIFF
--- a/web/src/app/chat/hooks/useChatSessionController.ts
+++ b/web/src/app/chat/hooks/useChatSessionController.ts
@@ -113,24 +113,24 @@ export function useChatSessionController({
 
     textAreaRef.current?.focus();
 
-    // Only clear things if we're going from one chat session to another
-    const isChatSessionSwitch = existingChatSessionId !== priorChatSessionId;
-    if (isChatSessionSwitch) {
-      // De-select documents
-      // Reset all filters
+    const isCreatingNewSession =
+      priorChatSessionId === null && existingChatSessionId !== null;
+    const isSwitchingBetweenSessions =
+      priorChatSessionId !== null &&
+      existingChatSessionId !== priorChatSessionId;
+
+    // Clear uploaded files on any session change (they're already in context)
+    if (isCreatingNewSession || isSwitchingBetweenSessions) {
+      setCurrentMessageFiles([]);
+    }
+
+    // Only reset filters/selections when switching between existing sessions
+    if (isSwitchingBetweenSessions) {
+      setSelectedDocuments([]);
       filterManager.setSelectedDocumentSets([]);
       filterManager.setSelectedSources([]);
       filterManager.setSelectedTags([]);
       filterManager.setTimeRange(null);
-
-      // Remove uploaded files
-      setCurrentMessageFiles([]);
-
-      // If switching from one chat to another, then need to scroll again
-      // If we're creating a brand new chat, then don't need to scroll
-      if (priorChatSessionId !== null) {
-        setSelectedDocuments([]);
-      }
     }
 
     async function initialSessionFetch() {

--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -22,6 +22,7 @@ export interface ActionItemProps {
   hasNoConnectors?: boolean;
   toolAuthStatus?: ToolAuthStatus;
   onOAuthAuthenticate?: () => void;
+  onForceToggle?: (toolId: number, newState: ToolState) => void;
   onClose?: () => void;
 }
 
@@ -32,6 +33,7 @@ export default function ActionLineItem({
   hasNoConnectors = false,
   toolAuthStatus,
   onOAuthAuthenticate,
+  onForceToggle,
   onClose,
 }: ActionItemProps) {
   const { currentProjectId } = useProjectsContext();
@@ -61,6 +63,7 @@ export default function ActionLineItem({
   function handleToggle() {
     const target = isForced ? ToolState.Enabled : ToolState.Forced;
     setToolStatus(tool.id, target);
+    onForceToggle?.(tool.id, target);
   }
 
   function handleDisable() {


### PR DESCRIPTION
## Description

Persist user-selected connector sources for internal search across follow-up messages within the same conversation.

## How Has This Been Tested?

Manual testing -> sent a message with just slack enabled and it persisted

![2025-12-18 16 24 23](https://github.com/user-attachments/assets/14ad7d1b-c70c-4aea-92c8-0c086542048a)


## Additional Options

- [x] Override Linear Check

















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist user-selected connector sources and related filters across follow-up messages in the same chat. Filters now reset only when switching to another existing session, and internal search auto-pin respects explicit unpin.

- **Bug Fixes**
  - Preserve selected sources, document sets, tags, and time range when starting a new chat; always clear uploaded files on any session change.
  - Only reset filters, selected documents, and forced tool IDs when moving between existing sessions. Auto-force internal search when a source is enabled, and unforce it when the last source is disabled; remember explicit unpins and don’t auto-pin again until the user re-pins.
  - Auto-open the sources sub-menu when pinning internal search to make connector management easier.

<sup>Written for commit e3712a813d17482fa91917d6ba7dfd55da19b9d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















