### PR TITLE
feat(new vector db interface): Implement delete for Vespa

### DIFF
--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -181,7 +181,7 @@ class Deletable(abc.ABC):
     @abc.abstractmethod
     def delete(
         self,
-        # TODO: Fine for now but this can probably be a batch operation that
+        # TODO(andrei): Fine for now but this can probably be a batch operation that
         # takes in a list of IDs.
         document_id: str,
         chunk_count: int | None = None,

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -458,7 +458,7 @@ class VespaDocumentIndex(DocumentIndex):
                     new_chunk_count=doc_id_to_new_chunk_cnt[doc_id],
                 )
                 for doc_id in doc_id_to_chunk_cnt_diff.keys()
-                # TODO, WARNING: Don't we need to sanitize these doc IDs?
+                # TODO(andrei), WARNING: Don't we need to sanitize these doc IDs?
             ]
 
             for enriched_doc_info in enriched_doc_infos:


### PR DESCRIPTION
## Description
This PR implements VespaIndex's delete method to the new vector db interface we want to have, introduced in https://github.com/onyx-dot-app/onyx/pull/5700.

## How Has This Been Tested?
#6867 tests it.

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hard-delete support and bulk metadata updates for Vespa in the new vector DB interface. Also standardizes update/delete interfaces and cleans up docs.

- **New Features**
  - Implemented VespaDocumentIndex.delete(document_id, chunk_count=None) to hard-delete all document chunks.
  - Added VespaIndex.update(update_requests, tenant_id) to batch-update ACL, document sets, boost, and hidden.
  - Sanitizes document IDs before operations. delete() returns deleted chunk count; update_single() now returns updated chunk count and supports user projects and document_id updates (migration-only).

- **Refactors**
  - Updated Deletable.delete signature to (document_id: str, chunk_count: int | None = None).
  - Clarified interface docs and comments.

<sup>Written for commit a591212403ec81bc0197b6e445ec47ea325e27d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


