### PR TITLE
fix(tests): add research agent tool to tool seeding test

### DIFF
--- a/backend/tests/integration/tests/migrations/test_tool_seeding.py
+++ b/backend/tests/integration/tests/migrations/test_tool_seeding.py
@@ -44,10 +44,10 @@ def test_tool_seeding_migration() -> None:
         )
         tools = result.fetchall()
 
-        # Should have all 6 builtin tools
+        # Should have all 8 builtin tools
         assert (
-            len(tools) == 7
-        ), f"Should have created exactly 7 builtin tools, got {len(tools)}"
+            len(tools) == 8
+        ), f"Should have created exactly 8 builtin tools, got {len(tools)}"
 
         # Check SearchTool
         search_tool = next((t for t in tools if t[1] == "SearchTool"), None)
@@ -92,3 +92,13 @@ def test_tool_seeding_migration() -> None:
             python_tool[2] == "Code Interpreter"
         ), "PythonTool display name should be 'Code Interpreter'"
         assert python_tool[5] is None, "PythonTool should not have a user_id (builtin)"
+
+        # Check ResearchAgent (Deep Research as a tool)
+        research_agent = next((t for t in tools if t[1] == "ResearchAgent"), None)
+        assert research_agent is not None, "ResearchAgent should exist"
+        assert (
+            research_agent[2] == "Research Agent"
+        ), "ResearchAgent display name should be 'Research Agent'"
+        assert (
+            research_agent[5] is None
+        ), "ResearchAgent should not have a user_id (builtin)"


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the tool seeding migration test to include the ResearchAgent (Deep Research) builtin tool. The test now expects 8 builtin tools and verifies the ResearchAgent name and that it has no user_id.

- **Bug Fixes**
  - Add ResearchAgent assertions and bump expected builtin tool count from 7 to 8 in test_tool_seeding_migration.

<sup>Written for commit ccce1c7f14437a846f7989020aba7920c957e473. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

