### PR TITLE
fix(style): bottom message padding on small screen

### DIFF
--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -442,7 +442,7 @@ export default function AIMessage({
       <div
         // for e2e tests
         data-testid={displayComplete ? "onyx-ai-message" : undefined}
-        className="md:py-5 relative flex"
+        className="pb-5 md:pt-5 relative flex"
       >
         <div className="mx-auto w-[min(50rem,100%)] px-4 max-w-message-max">
           <div className="flex items-start">


### PR DESCRIPTION
## Description

I changed this in https://github.com/onyx-dot-app/onyx/pull/6881 because the padding between messages is now provided by the copy message icon being below the human message (https://github.com/onyx-dot-app/onyx/pull/6835), but this is still needed on the bottom, at least for the last element.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix bottom padding on small screens to keep the last message from touching the edge. Applies pb-5 on all screens and keeps md:pt-5 for medium and up.

<sup>Written for commit 8734ec3773f0c71839f4038d3a253a059004f0eb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

