### PR TITLE
fix(fe): chat attachment alignment regression

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -43,7 +43,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
           id="onyx-file"
           className={cn("mt-2 auto", alignBubble && "ml-auto")}
         >
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col items-end gap-2">
             {textFiles.map((file) => (
               <Attachment key={file.id} fileName={file.name || file.id} />
             ))}
@@ -56,7 +56,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
           id="onyx-image"
           className={cn("mt-2 auto", alignBubble && "ml-auto")}
         >
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col items-end gap-2">
             {imageFiles.map((file) => (
               <InMessageImage key={file.id} fileId={file.id} />
             ))}
@@ -66,7 +66,7 @@ function FileDisplay({ files, alignBubble }: FileDisplayProps) {
 
       {csvFiles.length > 0 && (
         <div className={cn("mt-2 auto", alignBubble && "ml-auto")}>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col items-end gap-2">
             {csvFiles.map((file) => {
               return (
                 <div key={file.id} className="w-fit">


### PR DESCRIPTION
## Description

This regressed in https://github.com/onyx-dot-app/onyx/pull/6835

**before**
<img width="1920" height="1080" alt="20251219_07h29m27s_grim" src="https://github.com/user-attachments/assets/29217b1e-36d6-4361-926e-bc25ca155c45" />

**after**
<img width="1920" height="1080" alt="20251219_07h29m14s_grim" src="https://github.com/user-attachments/assets/7c07dd43-9eaf-423b-9a35-5192312cac64" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that caused chat attachments in human messages to misalign when the bubble is right-aligned. Text, image, and CSV attachments now align to the bubble edge by applying items-end to their stacks.

<sup>Written for commit 93e73ccaaff8d2bc6dfcf96a719cd65e076107e4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

