### PR TITLE
fix icon button z-index

### DIFF
--- a/web/src/refresh-components/buttons/IconButton.tsx
+++ b/web/src/refresh-components/buttons/IconButton.tsx
@@ -304,7 +304,7 @@ export default function IconButton({
   const buttonElement = (
     <button
       className={cn(
-        "flex items-center justify-center h-fit w-fit group/IconButton z-tooltip",
+        "flex items-center justify-center h-fit w-fit group/IconButton",
         internal ? "p-1" : "p-2",
         disabled && "cursor-not-allowed",
         internal ? "rounded-08" : "rounded-12",


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed z-tooltip from IconButton to fix incorrect z-index stacking. This prevents the button from overlaying surrounding UI and lets tooltips/popovers render correctly.

<sup>Written for commit 1476d5626bfae90abc7f947bb8e9ce4cc134ca92. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

