### PR TITLE
feat: allow cmd+click on connector rows in admin panel

### DIFF
--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -34,7 +34,6 @@ import { PageSelector } from "@/components/PageSelector";
 import { ConnectorStaggeredSkeleton } from "./ConnectorRowSkeleton";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgSettings } from "@opal/icons";
-import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 // Helper to handle navigation with cmd/ctrl+click support
 // NOTE: using this rather than Next/Link (or similar) since shadcn
@@ -44,7 +43,7 @@ import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.share
 function navigateWithModifier(
   e: React.MouseEvent,
   url: string,
-  router: AppRouterInstance
+  router: ReturnType<typeof useRouter>
 ) {
   if (e.metaKey || e.ctrlKey) {
     window.open(url, "_blank");


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow cmd/ctrl-click on connector and federated connector rows (and their Settings button) in the Admin Indexing Status table to open details in a new tab. Standard clicks still navigate in the same tab for consistent, expected behavior.

<sup>Written for commit d9be669edd55a3d4f9ea30e7e3e74ce6a35e4845. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





