### PR TITLE
chore(pre-commit): run uv-sync in active venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: d30b4298e4fb63ce8609e29acdbcf4c9018a483c
     hooks:
       - id: uv-sync
-        args: ["--locked", "--all-extras"]
+        args: ["--active", "--locked", "--all-extras"]
       - id: uv-lock
         files: ^pyproject\.toml$
       - id: uv-export


### PR DESCRIPTION
## Description

Similar to https://github.com/onyx-dot-app/onyx/pull/6890

## How Has This Been Tested?

`prek run --hook-stage post-checkout`

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --active to uv-sync in pre-commit so dependency sync runs in the currently activated virtualenv. This avoids creating a new env and ensures locked deps and all extras apply to the active venv (e.g., on post-checkout).

<sup>Written for commit d2b04b11d2d1fa9b4fe5cbd32e4fafa6e6de7069. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

