### PR TITLE
fix(fe): Set up provider logos are equal size

### DIFF
--- a/web/src/app/admin/configuration/llm/ProviderIcon.tsx
+++ b/web/src/app/admin/configuration/llm/ProviderIcon.tsx
@@ -1,0 +1,17 @@
+import { defaultTailwindCSS, IconProps } from "@/components/icons/icons";
+import { getProviderIcon } from "@/app/admin/configuration/llm/utils";
+
+export interface ProviderIconProps extends IconProps {
+  provider: string;
+  modelName?: string;
+}
+
+export const ProviderIcon = ({
+  provider,
+  modelName,
+  size = 16,
+  className = defaultTailwindCSS,
+}: ProviderIconProps) => {
+  const Icon = getProviderIcon(provider, modelName);
+  return <Icon size={size} className={className} />;
+};

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -1,6 +1,5 @@
 import { JSX } from "react";
 import {
-  defaultTailwindCSS,
   AnthropicIcon,
   AmazonIcon,
   AzureIcon,
@@ -105,24 +104,6 @@ export const getProviderIcon = (
 
   // Fallback to CPU icon if no matches
   return CPUIcon;
-};
-
-// ============================================================================
-// LLM PROVIDER ICON COMPONENT
-// ============================================================================
-export interface ProviderIconProps extends IconProps {
-  provider: string;
-  modelName?: string;
-}
-
-export const ProviderIcon = ({
-  provider,
-  modelName,
-  size = 16,
-  className = defaultTailwindCSS,
-}: ProviderIconProps) => {
-  const Icon = getProviderIcon(provider, modelName);
-  return <Icon size={size} className={className} />;
 };
 
 export const isAnthropic = (provider: string, modelName: string) =>

--- a/web/src/refresh-components/onboarding/components/LLMProvider.tsx
+++ b/web/src/refresh-components/onboarding/components/LLMProvider.tsx
@@ -14,7 +14,7 @@ import {
   SvgServer,
   SvgSettings,
 } from "@opal/icons";
-import { ProviderIcon } from "@/app/admin/configuration/llm/utils";
+import { ProviderIcon } from "@/app/admin/configuration/llm/ProviderIcon";
 
 export interface LLMProviderProps {
   title: string;

--- a/web/src/refresh-components/onboarding/steps/LLMStep.tsx
+++ b/web/src/refresh-components/onboarding/steps/LLMStep.tsx
@@ -10,7 +10,7 @@ import LLMConnectionModal, {
 } from "@/refresh-components/onboarding/components/LLMConnectionModal";
 import { cn } from "@/lib/utils";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
-import { ProviderIcon } from "@/app/admin/configuration/llm/utils";
+import { ProviderIcon } from "@/app/admin/configuration/llm/ProviderIcon";
 import { SvgCheckCircle, SvgCpu, SvgExternalLink } from "@opal/icons";
 
 type LLMStepProps = {


### PR DESCRIPTION
## Description

The exported provider icons have their sizes pre-defined and I figured it made more sense to move the helper to icons.tsx rather than reconstruct the icon component to size it properly.

## How Has This Been Tested?

<img width="678" height="1030" alt="image" src="https://github.com/user-attachments/assets/1990da16-1295-4f17-a96f-1f82f7f02012" />

## Additional Options

- [x] Override Linear Check


































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized LLM provider logos to consistent sizes across onboarding and the connect modal. Icons are now resolved by provider name to show the correct vendor logo.

- **Bug Fixes**
  - Consistent icons: 24px in provider cards/modal, 16px in lists and stacked views.
  - Aggregator providers infer vendor logo from model name.
  - Fallback: server icon when no provider set; CPU icon for unknown providers.

- **Refactors**
  - Switched LLMProvider prop from icon to providerName and render via the new ProviderIcon component.

<sup>Written for commit 3ff1d5e566f728bb450cdbdb2fa4590d4c05ce15. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

































