### PR TITLE
revert: "chore: Update Packet structure to make the positioning info an object"

### DIFF
--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -9,7 +9,6 @@ from onyx.context.search.models import SearchDoc
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import PacketException
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import ToolCallInfo
 from onyx.utils.threadpool_concurrency import run_in_background
 from onyx.utils.threadpool_concurrency import wait_on_background
@@ -132,7 +131,7 @@ def run_chat_llm_with_state_containers(
             # If execution fails, emit an exception packet
             emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=0),
+                    turn_index=0,
                     obj=PacketException(type="error", exception=e),
                 )
             )

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -29,7 +29,6 @@ from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER
 from onyx.prompts.chat_prompts import OPEN_URL_REMINDER
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import ToolCallInfo
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool import Tool
@@ -626,7 +625,7 @@ def run_llm_loop(
 
         emitter.emit(
             Packet(
-                placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
+                turn_index=llm_cycle_count + reasoning_cycles,
                 obj=OverallStop(type="stop"),
             )
         )

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -38,7 +38,6 @@ from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
 from onyx.server.query_and_chat.streaming_models import AgentResponseStart
 from onyx.server.query_and_chat.streaming_models import CitationInfo
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDone
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
@@ -513,11 +512,11 @@ def run_llm_step_pkt_generator(
                 state_container.set_reasoning_tokens(accumulated_reasoning)
                 if not reasoning_start:
                     yield Packet(
-                        placement=Placement(turn_index=turn_index),
+                        turn_index=turn_index,
                         obj=ReasoningStart(),
                     )
                 yield Packet(
-                    placement=Placement(turn_index=turn_index),
+                    turn_index=turn_index,
                     obj=ReasoningDelta(reasoning=delta.reasoning_content),
                 )
                 reasoning_start = True
@@ -525,7 +524,7 @@ def run_llm_step_pkt_generator(
             if delta.content:
                 if reasoning_start:
                     yield Packet(
-                        placement=Placement(turn_index=turn_index),
+                        turn_index=turn_index,
                         obj=ReasoningDone(),
                     )
                     has_reasoned = 1
@@ -536,7 +535,7 @@ def run_llm_step_pkt_generator(
 
                 if not answer_start:
                     yield Packet(
-                        placement=Placement(turn_index=turn_index),
+                        turn_index=turn_index,
                         obj=AgentResponseStart(
                             final_documents=final_documents,
                         ),
@@ -550,12 +549,12 @@ def run_llm_step_pkt_generator(
                             # Save answer incrementally to state container
                             state_container.set_answer_tokens(accumulated_answer)
                             yield Packet(
-                                placement=Placement(turn_index=turn_index),
+                                turn_index=turn_index,
                                 obj=AgentResponseDelta(content=result),
                             )
                         elif isinstance(result, CitationInfo):
                             yield Packet(
-                                placement=Placement(turn_index=turn_index),
+                                turn_index=turn_index,
                                 obj=result,
                             )
                 else:
@@ -564,14 +563,14 @@ def run_llm_step_pkt_generator(
                     # Save answer incrementally to state container
                     state_container.set_answer_tokens(accumulated_answer)
                     yield Packet(
-                        placement=Placement(turn_index=turn_index),
+                        turn_index=turn_index,
                         obj=AgentResponseDelta(content=delta.content),
                     )
 
             if delta.tool_calls:
                 if reasoning_start:
                     yield Packet(
-                        placement=Placement(turn_index=turn_index),
+                        turn_index=turn_index,
                         obj=ReasoningDone(),
                     )
                     has_reasoned = 1
@@ -636,12 +635,12 @@ def run_llm_step_pkt_generator(
                 # Save answer incrementally to state container
                 state_container.set_answer_tokens(accumulated_answer)
                 yield Packet(
-                    placement=Placement(turn_index=turn_index),
+                    turn_index=turn_index,
                     obj=AgentResponseDelta(content=result),
                 )
             elif isinstance(result, CitationInfo):
                 yield Packet(
-                    placement=Placement(turn_index=turn_index),
+                    turn_index=turn_index,
                     obj=result,
                 )
 

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -44,7 +44,6 @@ from onyx.server.query_and_chat.streaming_models import DeepResearchPlanDelta
 from onyx.server.query_and_chat.streaming_models import DeepResearchPlanStart
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import SectionEnd
 from onyx.tools.fake_tools.research_agent import run_research_agent_calls
 from onyx.tools.models import ToolCallInfo
@@ -200,9 +199,7 @@ def run_deep_research_llm_loop(
             # Mark this turn as a clarification question
             state_container.set_is_clarification(True)
 
-            emitter.emit(
-                Packet(placement=Placement(turn_index=0), obj=OverallStop(type="stop"))
-            )
+            emitter.emit(Packet(turn_index=0, obj=OverallStop(type="stop")))
 
             # If a clarification is asked, we need to end this turn and wait on user input
             return
@@ -248,14 +245,14 @@ def run_deep_research_llm_loop(
             if isinstance(packet.obj, AgentResponseStart):
                 emitter.emit(
                     Packet(
-                        placement=Placement(turn_index=packet.placement.turn_index),
+                        turn_index=packet.turn_index,
                         obj=DeepResearchPlanStart(),
                     )
                 )
             elif isinstance(packet.obj, AgentResponseDelta):
                 emitter.emit(
                     Packet(
-                        placement=Placement(turn_index=packet.placement.turn_index),
+                        turn_index=packet.turn_index,
                         obj=DeepResearchPlanDelta(content=packet.obj.content),
                     )
                 )
@@ -269,7 +266,7 @@ def run_deep_research_llm_loop(
             emitter.emit(
                 Packet(
                     # Marks the last turn end which should be the plan generation
-                    placement=Placement(turn_index=orchestrator_start_turn_index - 1),
+                    turn_index=orchestrator_start_turn_index - 1,
                     obj=SectionEnd(),
                 )
             )

--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -24,7 +24,6 @@ from onyx.server.query_and_chat.streaming_models import OpenUrlStart
 from onyx.server.query_and_chat.streaming_models import OpenUrlUrls
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
@@ -60,7 +59,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=AgentResponseStart(
                 final_documents=final_search_docs,
             ),
@@ -69,7 +68,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=AgentResponseDelta(
                 content=message_text,
             ),
@@ -78,7 +77,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=SectionEnd(),
         )
     )
@@ -95,12 +94,12 @@ def create_citation_packets(
     for citation_info in citation_info_list:
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index),
+                turn_index=turn_index,
                 obj=citation_info,
             )
         )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -108,20 +107,18 @@ def create_citation_packets(
 def create_reasoning_packets(reasoning_text: str, turn_index: int) -> list[Packet]:
     packets: list[Packet] = []
 
-    packets.append(
-        Packet(placement=Placement(turn_index=turn_index), obj=ReasoningStart())
-    )
+    packets.append(Packet(turn_index=turn_index, obj=ReasoningStart()))
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=ReasoningDelta(
                 reasoning=reasoning_text,
             ),
         ),
     )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -133,24 +130,21 @@ def create_image_generation_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=ImageGenerationToolStart(),
         )
     )
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=ImageGenerationFinal(images=images),
         ),
     )
 
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
-            obj=SectionEnd(),
-        )
-    )
+    packets.append(Packet(turn_index=turn_index, tab_index=tab_index, obj=SectionEnd()))
 
     return packets
 
@@ -167,14 +161,16 @@ def create_custom_tool_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=CustomToolStart(tool_name=tool_name),
         )
     )
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=CustomToolDelta(
                 tool_name=tool_name,
                 response_type=response_type,
@@ -184,12 +180,7 @@ def create_custom_tool_packets(
         ),
     )
 
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
-            obj=SectionEnd(),
-        )
-    )
+    packets.append(Packet(turn_index=turn_index, tab_index=tab_index, obj=SectionEnd()))
 
     return packets
 
@@ -204,32 +195,30 @@ def create_fetch_packets(
     # Emit start packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=OpenUrlStart(),
         )
     )
     # Emit URLs packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=OpenUrlUrls(urls=urls),
         )
     )
     # Emit documents packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=OpenUrlDocuments(
                 documents=[SearchDoc(**doc.model_dump()) for doc in fetch_docs]
             ),
         )
     )
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
-            obj=SectionEnd(),
-        )
-    )
+    packets.append(Packet(turn_index=turn_index, tab_index=tab_index, obj=SectionEnd()))
     return packets
 
 
@@ -244,7 +233,8 @@ def create_search_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=SearchToolStart(
                 is_internet_search=is_internet_search,
             ),
@@ -255,7 +245,8 @@ def create_search_packets(
     if search_queries:
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolQueriesDelta(queries=search_queries),
             ),
         )
@@ -267,7 +258,8 @@ def create_search_packets(
         )
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolDocumentsDelta(
                     documents=[
                         SearchDoc(**doc.model_dump()) for doc in sorted_search_docs
@@ -276,12 +268,7 @@ def create_search_packets(
             ),
         )
 
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
-            obj=SectionEnd(),
-        )
-    )
+    packets.append(Packet(turn_index=turn_index, tab_index=tab_index, obj=SectionEnd()))
 
     return packets
 
@@ -450,8 +437,6 @@ def translate_assistant_message_to_packets(
             )
 
     # Add overall stop packet at the end
-    packet_list.append(
-        Packet(placement=Placement(turn_index=final_turn_index), obj=OverallStop())
-    )
+    packet_list.append(Packet(turn_index=final_turn_index, obj=OverallStop()))
 
     return packet_list

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -292,12 +292,16 @@ class Placement(BaseModel):
     # Which iterative block in the UI is this part of, these are ordered and smaller ones happened first
     turn_index: int
     # For parallel tool calls to preserve order of execution
-    tab_index: int = 0
+    tab_index: int
     # Used for tools/agents that call other tools, this currently doesn't support nested agents but can be added later
-    sub_turn_index: int | None = None
+    sub_turn_index: int
 
 
 class Packet(BaseModel):
-    placement: Placement
+    turn_index: int | None
+    # For parallel tool calls to preserve order of execution
+    tab_index: int = 0
+    # Used for tools/agents that call other tools, this currently doesn't support nested agents but can be added later
+    sub_turn_index: int | None = None
 
     obj: Annotated[PacketObj, Field(discriminator="type")]

--- a/backend/onyx/server/query_and_chat/streaming_utils.py
+++ b/backend/onyx/server/query_and_chat/streaming_utils.py
@@ -16,7 +16,6 @@ from onyx.server.query_and_chat.streaming_models import OpenUrlDocuments
 from onyx.server.query_and_chat.streaming_models import OpenUrlStart
 from onyx.server.query_and_chat.streaming_models import OpenUrlUrls
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
@@ -63,7 +62,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=AgentResponseStart(
                 final_documents=SearchDoc.from_saved_search_docs(final_documents or []),
             ),
@@ -84,7 +83,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=AgentResponseDelta(
                 content=adjusted_message_text,
             ),
@@ -93,7 +92,7 @@ def create_message_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=SectionEnd(),
         )
     )
@@ -110,12 +109,12 @@ def create_citation_packets(
     for citation_info in citation_info_list:
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index),
+                turn_index=turn_index,
                 obj=citation_info,
             )
         )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -123,20 +122,18 @@ def create_citation_packets(
 def create_reasoning_packets(reasoning_text: str, turn_index: int) -> list[Packet]:
     packets: list[Packet] = []
 
-    packets.append(
-        Packet(placement=Placement(turn_index=turn_index), obj=ReasoningStart())
-    )
+    packets.append(Packet(turn_index=turn_index, obj=ReasoningStart()))
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=ReasoningDelta(
                 reasoning=reasoning_text,
             ),
         ),
     )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -148,19 +145,19 @@ def create_image_generation_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=ImageGenerationToolStart(),
         )
     )
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=ImageGenerationFinal(images=images),
         ),
     )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -176,14 +173,14 @@ def create_custom_tool_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=CustomToolStart(tool_name=tool_name),
         )
     )
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=CustomToolDelta(
                 tool_name=tool_name,
                 response_type=response_type,
@@ -193,7 +190,7 @@ def create_custom_tool_packets(
         ),
     )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets
 
@@ -207,27 +204,27 @@ def create_fetch_packets(
     # Emit start packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=OpenUrlStart(),
         )
     )
     # Emit URLs packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=OpenUrlUrls(urls=urls),
         )
     )
     # Emit documents packet
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=OpenUrlDocuments(
                 documents=SearchDoc.from_saved_search_docs(fetch_docs)
             ),
         )
     )
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
     return packets
 
 
@@ -241,7 +238,7 @@ def create_search_packets(
 
     packets.append(
         Packet(
-            placement=Placement(turn_index=turn_index),
+            turn_index=turn_index,
             obj=SearchToolStart(
                 is_internet_search=is_internet_search,
             ),
@@ -252,7 +249,7 @@ def create_search_packets(
     if search_queries:
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index),
+                turn_index=turn_index,
                 obj=SearchToolQueriesDelta(queries=search_queries),
             ),
         )
@@ -261,13 +258,13 @@ def create_search_packets(
     if saved_search_docs:
         packets.append(
             Packet(
-                placement=Placement(turn_index=turn_index),
+                turn_index=turn_index,
                 obj=SearchToolDocumentsDelta(
                     documents=SearchDoc.from_saved_search_docs(saved_search_docs)
                 ),
             ),
         )
 
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
+    packets.append(Packet(turn_index=turn_index, obj=SectionEnd()))
 
     return packets

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -142,7 +142,8 @@ def run_research_agent_call(
 
     emitter.emit(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=ResearchAgentStart(research_task=research_topic),
         )
     )

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -17,7 +17,6 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import CHAT_SESSION_ID_PLACEHOLDER
 from onyx.tools.models import CustomToolCallSummary
 from onyx.tools.models import CustomToolUserFileSnapshot
@@ -137,7 +136,8 @@ class CustomTool(Tool[None]):
     def emit_start(self, turn_index: int, tab_index: int) -> None:
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=CustomToolStart(tool_name=self._name),
             )
         )
@@ -212,7 +212,8 @@ class CustomTool(Tool[None]):
         # Emit CustomToolDelta packet
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=CustomToolDelta(
                     tool_name=self._name,
                     response_type=response_type,

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -18,7 +18,6 @@ from onyx.server.query_and_chat.streaming_models import ImageGenerationFinal
 from onyx.server.query_and_chat.streaming_models import ImageGenerationToolHeartbeat
 from onyx.server.query_and_chat.streaming_models import ImageGenerationToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool import Tool
 from onyx.tools.tool_implementations.images.models import (
@@ -124,7 +123,8 @@ class ImageGenerationTool(Tool[None]):
     def emit_start(self, turn_index: int, tab_index: int) -> None:
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=ImageGenerationToolStart(),
             )
         )
@@ -259,7 +259,8 @@ class ImageGenerationTool(Tool[None]):
             # Emit a heartbeat packet to prevent timeout
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=ImageGenerationToolHeartbeat(),
                 )
             )
@@ -303,7 +304,8 @@ class ImageGenerationTool(Tool[None]):
         # Emit final packet with generated images
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=ImageGenerationFinal(images=generated_images_metadata),
             )
         )

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -9,7 +9,6 @@ from onyx.db.models import MCPServer
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import CustomToolCallSummary
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool import Tool
@@ -91,7 +90,8 @@ class MCPTool(Tool[None]):
     def emit_start(self, turn_index: int, tab_index: int) -> None:
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=CustomToolStart(tool_name=self._name),
             )
         )
@@ -146,7 +146,8 @@ class MCPTool(Tool[None]):
                 # Emit CustomToolDelta packet
                 self.emitter.emit(
                     Packet(
-                        placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                        turn_index=turn_index,
+                        tab_index=tab_index,
                         obj=CustomToolDelta(
                             tool_name=self._name,
                             response_type="json",
@@ -181,7 +182,8 @@ class MCPTool(Tool[None]):
             # Emit CustomToolDelta packet
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=CustomToolDelta(
                         tool_name=self._name,
                         response_type="json",
@@ -235,7 +237,8 @@ class MCPTool(Tool[None]):
             # Emit CustomToolDelta packet
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=CustomToolDelta(
                         tool_name=self._name,
                         response_type="json",

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -13,7 +13,6 @@ from onyx.server.query_and_chat.streaming_models import OpenUrlDocuments
 from onyx.server.query_and_chat.streaming_models import OpenUrlStart
 from onyx.server.query_and_chat.streaming_models import OpenUrlUrls
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.tools.models import OpenURLToolOverrideKwargs
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool import Tool
@@ -183,7 +182,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         """Emit start packet to signal tool has started."""
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=OpenUrlStart(),
             )
         )
@@ -211,7 +211,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
 
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=OpenUrlUrls(urls=urls),
             )
         )
@@ -247,7 +248,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         # Emit documents packet AFTER crawling completes
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=OpenUrlDocuments(documents=search_docs),
             )
         )

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -15,7 +15,6 @@ from onyx.configs.constants import FileOrigin
 from onyx.file_store.utils import build_full_frontend_file_url
 from onyx.file_store.utils import get_default_file_store
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import PythonToolDelta
 from onyx.server.query_and_chat.streaming_models import PythonToolStart
 from onyx.tools.models import LlmPythonExecutionResult
@@ -146,7 +145,8 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         # Emit start event with the code
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=PythonToolStart(code=code),
             )
         )
@@ -253,7 +253,8 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             # Emit delta with stdout/stderr and generated files
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=PythonToolDelta(
                         stdout=truncated_stdout,
                         stderr=truncated_stderr,
@@ -288,7 +289,8 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             # Emit error delta
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=PythonToolDelta(
                         stdout="",
                         stderr=error_msg,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -65,7 +65,6 @@ from onyx.secondary_llm_flows.document_filter import select_sections_for_expansi
 from onyx.secondary_llm_flows.query_expansion import keyword_query_expansion
 from onyx.secondary_llm_flows.query_expansion import semantic_query_rephrase
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolQueriesDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolStart
@@ -359,7 +358,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
     def emit_start(self, turn_index: int, tab_index: int) -> None:
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolStart(),
             )
         )
@@ -488,7 +488,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             # Emit the queries early so the UI can display them immediately
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=SearchToolQueriesDelta(
                         queries=all_queries,
                     ),
@@ -596,7 +597,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
 
             self.emitter.emit(
                 Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                    turn_index=turn_index,
+                    tab_index=tab_index,
                     obj=SearchToolDocumentsDelta(
                         documents=final_ui_docs,
                     ),

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -10,7 +10,6 @@ from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.web_search import fetch_active_web_search_provider
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolQueriesDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolStart
@@ -114,7 +113,8 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
     def emit_start(self, turn_index: int, tab_index: int) -> None:
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolStart(is_internet_search=True),
             )
         )
@@ -140,7 +140,8 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
         # Emit queries
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolQueriesDelta(queries=queries),
             )
         )
@@ -204,7 +205,8 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
         # Emit documents
         self.emitter.emit(
             Packet(
-                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                turn_index=turn_index,
+                tab_index=tab_index,
                 obj=SearchToolDocumentsDelta(documents=search_docs),
             )
         )

--- a/backend/onyx/tools/tool_runner.py
+++ b/backend/onyx/tools/tool_runner.py
@@ -8,7 +8,6 @@ from onyx.chat.models import ChatMessageSimple
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import Placement
 from onyx.server.query_and_chat.streaming_models import SectionEnd
 from onyx.tools.models import ChatMinimalTextMessage
 from onyx.tools.models import OpenURLToolOverrideKwargs
@@ -128,7 +127,8 @@ def _run_single_tool(
     # Emit SectionEnd after tool completes (success or failure)
     tool.emitter.emit(
         Packet(
-            placement=Placement(turn_index=turn_index, tab_index=tab_index),
+            turn_index=turn_index,
+            tab_index=tab_index,
             obj=SectionEnd(),
         )
     )

--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -349,10 +349,10 @@ export function useChatController({
         if (!hasStop) {
           const maxTurnIndex =
             packets.length > 0
-              ? Math.max(...packets.map((p) => p.placement.turn_index))
+              ? Math.max(...packets.map((p) => p.turn_index))
               : 0;
           const stopPacket: Packet = {
-            placement: { turn_index: maxTurnIndex + 1 },
+            turn_index: maxTurnIndex + 1,
             obj: { type: PacketType.STOP },
           } as Packet;
 

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -236,7 +236,8 @@ export default function AIMessage({
     const { turn_index, tab_index } = parseToolKey(groupKey);
 
     const syntheticPacket: Packet = {
-      placement: { turn_index, tab_index },
+      turn_index,
+      tab_index,
       obj: { type: PacketType.SECTION_END },
     };
 
@@ -253,8 +254,8 @@ export default function AIMessage({
       const packet = rawPackets[i];
       if (!packet) continue;
 
-      const currentTurnIndex = packet.placement.turn_index;
-      const currentTabIndex = packet.placement.tab_index ?? 0;
+      const currentTurnIndex = packet.turn_index;
+      const currentTabIndex = packet.tab_index ?? 0;
       const currentGroupKey = `${currentTurnIndex}-${currentTabIndex}`;
       // If we see a new turn_index (not just tab_index), inject SECTION_END for previous groups
       // We only inject SECTION_END when moving to a completely new turn, not for parallel tools

--- a/web/src/app/chat/message/messageComponents/MultiToolRenderer.test.tsx
+++ b/web/src/app/chat/message/messageComponents/MultiToolRenderer.test.tsx
@@ -455,21 +455,24 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: {
               type: "search_tool_start",
               is_internet_search: false,
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: {
               type: "search_tool_queries_delta",
               queries: ["test query"],
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: {
               type: "search_tool_documents_delta",
               documents: [
@@ -478,7 +481,8 @@ describe("MultiToolRenderer - Parallel Tools", () => {
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: {
               type: "section_end",
             },
@@ -490,21 +494,24 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: {
               type: "search_tool_start",
               is_internet_search: true,
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: {
               type: "search_tool_queries_delta",
               queries: ["web query"],
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: {
               type: "search_tool_documents_delta",
               documents: [
@@ -513,7 +520,8 @@ describe("MultiToolRenderer - Parallel Tools", () => {
             },
           },
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: {
               type: "section_end",
             },
@@ -544,13 +552,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_start", is_internet_search: false },
           },
-          {
-            placement: { turn_index: 0, tab_index: 0 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 0, obj: { type: "section_end" } },
         ],
       },
       {
@@ -558,13 +564,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: { type: "search_tool_start", is_internet_search: true },
           },
-          {
-            placement: { turn_index: 0, tab_index: 1 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 1, obj: { type: "section_end" } },
         ],
       },
     ];
@@ -593,13 +597,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_start", is_internet_search: false },
           },
-          {
-            placement: { turn_index: 0, tab_index: 0 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 0, obj: { type: "section_end" } },
         ],
       },
       {
@@ -607,13 +609,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: { type: "search_tool_start", is_internet_search: true },
           },
-          {
-            placement: { turn_index: 0, tab_index: 1 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 1, obj: { type: "section_end" } },
         ],
       },
     ];
@@ -645,17 +645,16 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_start", is_internet_search: false },
           },
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_queries_delta", queries: ["test"] },
           },
-          {
-            placement: { turn_index: 0, tab_index: 0 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 0, obj: { type: "section_end" } },
         ],
       },
       {
@@ -663,13 +662,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: { type: "search_tool_start", is_internet_search: true },
           },
-          {
-            placement: { turn_index: 0, tab_index: 1 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 1, obj: { type: "section_end" } },
         ],
       },
     ];
@@ -698,13 +695,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_start", is_internet_search: false },
           },
-          {
-            placement: { turn_index: 0, tab_index: 0 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 0, obj: { type: "section_end" } },
         ],
       },
       {
@@ -712,13 +707,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: { type: "search_tool_start", is_internet_search: true },
           },
-          {
-            placement: { turn_index: 0, tab_index: 1 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 1, obj: { type: "section_end" } },
         ],
       },
     ];
@@ -774,13 +767,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 0,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 0 },
+            turn_index: 0,
+            tab_index: 0,
             obj: { type: "search_tool_start", is_internet_search: false },
           },
-          {
-            placement: { turn_index: 0, tab_index: 0 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 0, obj: { type: "section_end" } },
         ],
       },
       {
@@ -788,13 +779,11 @@ describe("MultiToolRenderer - Parallel Tools", () => {
         tab_index: 1,
         packets: [
           {
-            placement: { turn_index: 0, tab_index: 1 },
+            turn_index: 0,
+            tab_index: 1,
             obj: { type: "search_tool_start", is_internet_search: true },
           },
-          {
-            placement: { turn_index: 0, tab_index: 1 },
-            obj: { type: "section_end" },
-          },
+          { turn_index: 0, tab_index: 1, obj: { type: "section_end" } },
         ],
       },
     ];

--- a/web/src/app/chat/services/packetUtils.ts
+++ b/web/src/app/chat/services/packetUtils.ts
@@ -76,7 +76,7 @@ export function isFinalAnswerComplete(packets: Packet[]) {
   return packets.some(
     (packet) =>
       packet.obj.type === PacketType.SECTION_END &&
-      packet.placement.turn_index === messageStartPacket.placement.turn_index
+      packet.turn_index === messageStartPacket.turn_index
   );
 }
 
@@ -97,8 +97,8 @@ export function groupPacketsByTurnIndex(
       >,
       packet
     ) => {
-      const turn_index = packet.placement.turn_index;
-      const tab_index = packet.placement.tab_index ?? 0;
+      const turn_index = packet.turn_index;
+      const tab_index = packet.tab_index ?? 0;
       const key = `${turn_index}-${tab_index}`;
       if (!acc.has(key)) {
         acc.set(key, { turn_index, tab_index, packets: [] });

--- a/web/src/app/chat/services/streamingModels.ts
+++ b/web/src/app/chat/services/streamingModels.ts
@@ -212,66 +212,70 @@ export type ObjTypes =
   | SectionEndObj
   | CitationObj;
 
-// Placement interface for packet positioning
-export interface Placement {
-  turn_index: number;
-  tab_index?: number; // For parallel tool calls - tools with same turn_index but different tab_index run in parallel
-  sub_turn_index?: number | null;
-}
-
 // Packet wrapper for streaming objects
 export interface Packet {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number; // For parallel tool calls - tools with same turn_index but different tab_index run in parallel
   obj: ObjTypes;
 }
 
 export interface ChatPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: ChatObj;
 }
 
 export interface StopPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: StopObj;
 }
 
 export interface CitationPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: CitationObj;
 }
 
 // New specific tool packet types
 export interface SearchToolPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: SearchToolObj;
 }
 
 export interface ImageGenerationToolPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: ImageGenerationToolObj;
 }
 
 export interface PythonToolPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: PythonToolObj;
 }
 
 export interface FetchToolPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: FetchToolObj;
 }
 
 export interface CustomToolPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: CustomToolObj;
 }
 
 export interface ReasoningPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: ReasoningObj;
 }
 
 export interface SectionEndPacket {
-  placement: Placement;
+  turn_index: number;
+  tab_index?: number;
   obj: SectionEndObj;
 }

--- a/web/tests/setup/multiToolTestHelpers.tsx
+++ b/web/tests/setup/multiToolTestHelpers.tsx
@@ -23,7 +23,8 @@ export const createToolPacket = (
   };
 
   return {
-    placement: { turn_index, tab_index },
+    turn_index,
+    tab_index,
     obj: {
       type: packetTypes[type],
       tool_name: `Tool ${turn_index + 1}`,
@@ -45,21 +46,24 @@ export const createInternalSearchToolGroup = (
 ): { turn_index: number; tab_index: number; packets: Packet[] } => {
   const packets: Packet[] = [
     {
-      placement: { turn_index, tab_index },
+      turn_index,
+      tab_index,
       obj: {
         type: PacketType.SEARCH_TOOL_START,
         is_internet_search: false,
       } as any,
     },
     {
-      placement: { turn_index, tab_index },
+      turn_index,
+      tab_index,
       obj: {
         type: PacketType.SEARCH_TOOL_QUERIES_DELTA,
         queries: ["example query"],
       } as any,
     },
     {
-      placement: { turn_index, tab_index },
+      turn_index,
+      tab_index,
       obj: {
         type: PacketType.SEARCH_TOOL_DOCUMENTS_DELTA,
         documents: [
@@ -71,7 +75,8 @@ export const createInternalSearchToolGroup = (
       } as any,
     },
     {
-      placement: { turn_index, tab_index },
+      turn_index,
+      tab_index,
       obj: {
         type: PacketType.SECTION_END,
       } as any,
@@ -108,21 +113,24 @@ export const createParallelToolGroups = (
         tab_index: i,
         packets: [
           {
-            placement: { turn_index, tab_index: i },
+            turn_index,
+            tab_index: i,
             obj: {
               type: PacketType.SEARCH_TOOL_START,
               is_internet_search: config.isInternet ?? false,
             } as any,
           },
           {
-            placement: { turn_index, tab_index: i },
+            turn_index,
+            tab_index: i,
             obj: {
               type: PacketType.SEARCH_TOOL_QUERIES_DELTA,
               queries: ["test query"],
             } as any,
           },
           {
-            placement: { turn_index, tab_index: i },
+            turn_index,
+            tab_index: i,
             obj: {
               type: PacketType.SEARCH_TOOL_DOCUMENTS_DELTA,
               documents: [
@@ -131,7 +139,8 @@ export const createParallelToolGroups = (
             } as any,
           },
           {
-            placement: { turn_index, tab_index: i },
+            turn_index,
+            tab_index: i,
             obj: {
               type: PacketType.SECTION_END,
             } as any,


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#6899

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Packet “Placement” change and restores flat Packet fields (turn_index, tab_index, sub_turn_index). Updates backend emitters and the web app to the previous schema to restore compatibility.

- **Refactors**
  - Removed Placement from Packet usage; emit and read turn_index/tab_index directly.
  - Updated streaming_models, session_loading, streaming_utils, LLM loops, deep research, and all tools to use flat fields.
  - Adjusted web Packet types, helpers, and components to use top-level fields; updated tests accordingly.

- **Migration**
  - If you consume the streaming API directly, expect turn_index/tab_index at the top level of Packet instead of packet.placement.*.

<sup>Written for commit 501e0fe8ea814050b76578b84c30d2a020f1d3d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

