### PR TITLE
feat: DR packets cont

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -444,7 +444,7 @@ def run_llm_loop(
                 tool_definitions=[tool.tool_definition() for tool in final_tools],
                 tool_choice=tool_choice,
                 llm=llm,
-                turn_index=llm_cycle_count + reasoning_cycles,
+                placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
                 citation_processor=citation_processor,
                 state_container=state_container,
                 # The rich docs representation is passed in so that when yielding the answer, it can also

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -93,7 +93,7 @@ def generate_intermediate_report(
         tool_definitions=[],
         tool_choice=ToolChoiceOptions.NONE,
         llm=llm,
-        turn_index=999,  # TODO
+        placement=Placement(turn_index=999),  # TODO
         citation_processor=DynamicCitationProcessor(),
         state_container=state_container,
         reasoning_effort=ReasoningEffort.LOW,
@@ -234,7 +234,7 @@ def run_research_agent_call(
             + research_agent_tools,
             tool_choice=ToolChoiceOptions.REQUIRED,
             llm=llm,
-            turn_index=llm_cycle_count + reasoning_cycles,
+            placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
             citation_processor=DynamicCitationProcessor(),
             state_container=state_container,
             reasoning_effort=ReasoningEffort.LOW,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch packet streaming to a Placement object for precise addressing across turns, tabs, and sub-turns. This makes Deep Research packets consistent and ready for multi-tab flows.

- **New Features**
  - Packets now carry tab_index and sub_turn_index via Placement, improving attribution of reasoning, answers, citations, and tool calls.

- **Refactors**
  - run_llm_step_pkt_generator and run_llm_step now take placement instead of turn_index and sub_turn_index; all emitted packets use placement.
  - Updated call sites in llm_loop, dr_loop, and fake_tools/research_agent to pass Placement and preserve placement when re-emitting plan packets.
  - Added a warning and final-report fallback when the orchestrator returns no tool calls.

<sup>Written for commit 43347b1b7840ebab4fea07772784fd4c8353801a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

