### PR TITLE
fix(chat): respect auto_scroll config

### DIFF
--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -178,11 +178,14 @@ const ChatUI = React.forwardRef(
       enableAutoScroll: user?.preferences.auto_scroll,
     });
 
+    // Scroll to bottom when messages change (e.g., loading a chat session)
+    // Note: useScrollonStream handles streaming scroll; this handles initial load
     useEffect(() => {
       if (!scrollContainerRef.current) return;
+      if (!user?.preferences.auto_scroll) return;
       scrollContainerRef.current.scrollTop =
         scrollContainerRef.current.scrollHeight;
-    }, [messages]);
+    }, [messages, user?.preferences.auto_scroll]);
 
     if (!liveAssistant) return <div className="flex-1" />;
 


### PR DESCRIPTION
## Description


## How Has This Been Tested?

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the user's auto_scroll preference in ChatUI so the view only auto-scrolls when enabled. Prevents unwanted jumps on load or message updates for users who disable auto-scroll.

<sup>Written for commit d8764c70f4501869dcaece4224cd31472681357f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

