### PR TITLE
feat: Deep Research packets 

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -444,6 +444,7 @@ def run_deep_research_llm_loop(
                 break
 
             research_results = run_research_agent_calls(
+                # The tool calls here contain the placement information
                 research_agent_calls=research_agent_calls,
                 tools=allowed_tools,
                 emitter=emitter,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add placement-aware packets to Deep Research so tool calls and reports render in the correct turn/tab/sub-turn. Also fix research cycle counting to only increment on search actions, preventing premature cycle caps.

- **New Features**
  - Propagate Placement(turn_index, tab_index, sub_turn_index) to all tool calls and report generation.
  - Replace hardcoded placement in intermediate/final reports; loop now forwards placement with calls.

- **Bug Fixes**
  - Increment research cycles only for SearchTool/WebSearchTool calls; reasoning steps no longer advance the cap.
  - Renamed and clarified cycle counter; last cycle now correctly disables further searches.

<sup>Written for commit b86bd086062034b742dc66cbadf5c48fc7895ccf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

