### PR TITLE
fix: reasoning width

### DIFF
--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -446,6 +446,7 @@ export default function AIMessage({
         <div className="mx-auto w-[min(50rem,100%)] px-4 max-w-message-max">
           <div className="flex items-start">
             <AgentAvatar agent={chatState.assistant} size={24} />
+            {/* w-full ensures the MultiToolRenderer non-expanded state takes up the full width */}
             <div className="max-w-message-max break-words pl-4 w-full">
               <div
                 ref={markdownRef}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the reasoning message container width so reasoning and tool content render at full width and don’t shrink in flex layouts.

- **Bug Fixes**
  - Added w-full to the AIMessage content wrapper to ensure full-width rendering.

<sup>Written for commit e386df6da9d3c4700c1b2ee36658c9b3d1a99006. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







