### PR TITLE
fix(docprocessing): Reusing Threads

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -89,6 +89,30 @@ _AUTH_ERROR_UNAUTHORIZED = "unauthorized"
 _AUTH_ERROR_INVALID_API_KEY = "invalid api key"
 _AUTH_ERROR_PERMISSION = "permission"
 
+# Thread-local storage for event loops
+# This prevents creating thousands of event loops during batch processing,
+# which was causing severe memory leaks with API-based embedding providers
+_thread_local = threading.local()
+
+
+def _get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Get or create a thread-local event loop for API embedding calls.
+
+    This prevents creating a new event loop for every batch during embedding,
+    which was causing memory leaks. Instead, each thread reuses the same loop.
+
+    Returns:
+        asyncio.AbstractEventLoop: The thread-local event loop
+    """
+    if (
+        not hasattr(_thread_local, "loop")
+        or _thread_local.loop is None
+        or _thread_local.loop.is_closed()
+    ):
+        _thread_local.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_thread_local.loop)
+    return _thread_local.loop
+
 
 WARM_UP_STRINGS = [
     "Onyx is amazing!",
@@ -776,16 +800,14 @@ class EmbeddingModel:
             # Route between direct API calls and model server calls
             if self.provider_type is not None:
                 # For API providers, make direct API call
-                loop = asyncio.new_event_loop()
-                try:
-                    asyncio.set_event_loop(loop)
-                    response = loop.run_until_complete(
-                        self._make_direct_api_call(
-                            embed_request, tenant_id=tenant_id, request_id=request_id
-                        )
+                # Use thread-local event loop to prevent memory leaks from creating
+                # thousands of event loops during batch processing
+                loop = _get_or_create_event_loop()
+                response = loop.run_until_complete(
+                    self._make_direct_api_call(
+                        embed_request, tenant_id=tenant_id, request_id=request_id
                     )
-                finally:
-                    loop.close()
+                )
             else:
                 # For local models, use model server
                 response = self._make_model_server_request(


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Before we were spawning a new thread for each docprocessing setup. This would just explode the docprocessing pod and cause it to OOM. 

This PR aims to reuse the event loop to prevent mem leaks

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse a thread-local asyncio event loop for API embedding calls in docprocessing, replacing per-batch loop creation. This prevents memory leaks and OOMs during large batch runs.

- **Bug Fixes**
  - Added thread-local storage and _get_or_create_event_loop to reuse a loop per thread.
  - Updated process_batch to use the shared loop for API providers; removed ad-hoc loop setup/teardown.

<sup>Written for commit 116d60605de48e9fb47eb3090790507b2a8ec7d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

