### PR TITLE
fix(fe): make "New Session" button a link

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -40,7 +40,6 @@ import MoveCustomAgentChatModal from "@/components/modals/MoveCustomAgentChatMod
 import { useProjectsContext } from "@/app/chat/projects/ProjectsContext";
 import { removeChatSessionFromProject } from "@/app/chat/projects/projectsService";
 import type { Project } from "@/app/chat/projects/projectsService";
-import { useAppRouter } from "@/hooks/appNavigation";
 import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -133,7 +132,6 @@ interface AppSidebarInnerProps {
 
 const MemoizedAppSidebarInner = memo(
   ({ folded, onFoldClick }: AppSidebarInnerProps) => {
-    const route = useAppRouter();
     const searchParams = useSearchParams();
     const combinedSettings = useSettingsContext();
     const { popup, setPopup } = usePopup();
@@ -358,32 +356,24 @@ const MemoizedAppSidebarInner = memo(
     const { isAdmin, isCurator } = useUser();
     const activeSidebarTab = useAppFocus();
     const createProjectModal = useCreateModal();
-    const newSessionButton = useMemo(
-      () => (
+    const newSessionButton = useMemo(() => {
+      const href =
+        combinedSettings?.settings?.disable_default_assistant && currentAgent
+          ? `/chat?assistantId=${currentAgent.id}`
+          : "/chat";
+      return (
         <div data-testid="AppSidebar/new-session">
           <SidebarTab
             leftIcon={SvgEditBig}
             folded={folded}
-            onClick={() => {
-              if (
-                combinedSettings?.settings?.disable_default_assistant &&
-                currentAgent
-              ) {
-                // Navigate to new chat with current assistant
-                route({ assistantId: currentAgent.id });
-              } else {
-                // Current behavior - go to default assistant
-                route({});
-              }
-            }}
+            href={href}
             active={activeSidebarTab.isNewSession()}
           >
             New Session
           </SidebarTab>
         </div>
-      ),
-      [folded, route, activeSidebarTab, combinedSettings, currentAgent]
-    );
+      );
+    }, [folded, activeSidebarTab, combinedSettings, currentAgent]);
     const moreAgentsButton = useMemo(
       () => (
         <div data-testid="AppSidebar/more-agents">


### PR DESCRIPTION
## Description

It was really bothering me this didn't have a right-click. I often open a new tab to start a new chat if I plan to continue my current chat.

<img width="638" height="1030" alt="20251220_04h21m42s_grim" src="https://github.com/user-attachments/assets/2377b092-2872-4eb2-9826-c8830b14cb9d" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned the “New Session” sidebar item into a link so you can right‑click and open in a new tab. Keeps routing behavior: when the default assistant is disabled and a current agent exists, it links to /chat?assistantId=currentAgent.id; otherwise it links to /chat.

<sup>Written for commit 5013071477b14440d181ad244c891846d3aae56b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

