### PR TITLE
fix(chat): only scroll to bottom on page load

### DIFF
--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -98,7 +98,7 @@ const ChatUI = React.forwardRef(
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const endDivRef = useRef<HTMLDivElement>(null);
     const scrollDist = useRef<number>(0);
-    const hasScrolledOnLoad = useRef(false);
+    const scrolledForSession = useRef<string | null>(null);
     const [aboveHorizon, setAboveHorizon] = useState(false);
     const debounceNumber = 100;
 
@@ -179,22 +179,17 @@ const ChatUI = React.forwardRef(
       enableAutoScroll: user?.preferences.auto_scroll,
     });
 
-    // Scroll to bottom only on initial chat load
+    // Scroll to bottom once per chat session when messages are loaded
     useEffect(() => {
       if (!scrollContainerRef.current) return;
-      if (hasScrolledOnLoad.current) return;
+      if (scrolledForSession.current === currentChatSessionId) return;
 
       if (messages.length > 0) {
         scrollContainerRef.current.scrollTop =
           scrollContainerRef.current.scrollHeight;
-        hasScrolledOnLoad.current = true;
+        scrolledForSession.current = currentChatSessionId;
       }
-    }, [messages]);
-
-    // Reset scroll flag when switching chat sessions
-    useEffect(() => {
-      hasScrolledOnLoad.current = false;
-    }, [currentChatSessionId]);
+    }, [messages, currentChatSessionId]);
 
     if (!liveAssistant) return <div className="flex-1" />;
 


### PR DESCRIPTION
## Description

Only automatically scrolls to the bottom on initial page load and otherwise defers scrolling to `useScrollonStream` which handles things like pause on user scroll + respects user configs.

## Additional Options

- [x] Override Linear Check

Fixes: https://linear.app/danswer/issue/DAN-3166/auto-scroll-when-streaming-output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-scroll to the bottom now happens only once per chat session when messages are first loaded. Subsequent scrolling is handled by useScrollonStream, respecting pause-on-user-scroll and user auto-scroll preferences.

<sup>Written for commit 3075f870f33a4cbd61cf7ef25e6355b562792e32. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

