### PR TITLE
fix(fe): make recent chat sidebar buttons links

### DIFF
--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -436,7 +436,7 @@ const ChatButton = memo(
       >
         <PopoverAnchor>
           <SidebarTab
-            onClick={() => route({ chatSessionId: chatSession.id })}
+            href={`/chat?chatId=${chatSession.id}`}
             active={active}
             rightChildren={rightMenu}
             focused={renaming}


### PR DESCRIPTION
## Description

These should be links so they support right-click open new + a11y

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made recent chat sidebar items real links, so users can right-click to open in a new tab and screen readers treat them as navigation. Replaced onClick routing with href to /chat?chatId={chatSessionId}.

<sup>Written for commit 999fcd35c2bb910ab37f93b2acb7323a33dd7330. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

