### PR TITLE
chore(fe): ensure chat padding on medium size viewport

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -672,7 +672,7 @@ export default function ChatPage({ firstMessage, headerData }: ChatPageProps) {
               {/* ChatInputBar container */}
               <div
                 ref={inputRef}
-                className="max-w-[50rem] w-full pointer-events-auto z-sticky flex flex-col px-4 md:px-0 justify-center items-center"
+                className="max-w-[50rem] w-full pointer-events-auto z-sticky flex flex-col px-4 lg:px-0 justify-center items-center"
               >
                 {(showOnboarding ||
                   (user?.role !== UserRole.ADMIN &&


### PR DESCRIPTION
## Description

**before**
<img width="948" height="1030" alt="20251220_06h37m04s_grim" src="https://github.com/user-attachments/assets/4d98b43a-c2f3-40f1-a6b2-c507c5bae76d" />

**after**
<img width="948" height="1030" alt="20251220_06h37m29s_grim" src="https://github.com/user-attachments/assets/c88359a5-973f-4d48-b7f4-79f6ad9d247d" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensured horizontal padding for the chat input bar on medium screens by changing the breakpoint from md:px-0 to lg:px-0. This prevents edge-to-edge content on tablets and improves readability.

<sup>Written for commit 652bf6825eb98630320c73b1c33469ec259a22d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

