### PR TITLE
fix(fe): ensure error messages have padding

### DIFF
--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -255,7 +255,7 @@ const ChatUI = React.forwardRef(
                 return (
                   <div
                     key={`error-${message.nodeId}`}
-                    className="max-w-message-max mx-auto"
+                    className="max-w-[min(50rem,100%)] mx-auto p-4"
                   >
                     <ErrorBanner
                       resubmit={handleResubmitLastMessage}
@@ -314,7 +314,7 @@ const ChatUI = React.forwardRef(
           {(((error !== null || loadError !== null) &&
             messages[messages.length - 1]?.type === "user") ||
             messages[messages.length - 1]?.type === "error") && (
-            <div className="max-w-message-max mx-auto">
+            <div className="max-w-[min(50rem,100%)] mx-auto p-4">
               <ErrorBanner
                 resubmit={handleResubmitLastMessage}
                 error={error || loadError || ""}


### PR DESCRIPTION
## Description

**before**
<img width="858" height="1030" alt="20251220_06h58m55s_grim" src="https://github.com/user-attachments/assets/edd5baf1-7846-445b-8014-1cddc7f8e611" />

**after**
<img width="858" height="1030" alt="20251220_06h58m24s_grim" src="https://github.com/user-attachments/assets/09611c1b-e7b7-44a4-803d-ca6f2ef0e08f" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add padding to error banners in ChatUI so errors don’t touch the edges and are easier to read. Also set a consistent max width (min(50rem, 100%)) for error containers to align with the message layout.

<sup>Written for commit 82af2149b920ea911272cdbf463dd7a03fd1c908. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

