### PR TITLE
fix(chat): attached images are flush right

### DIFF
--- a/web/src/app/chat/components/files/images/InMessageImage.tsx
+++ b/web/src/app/chat/components/files/images/InMessageImage.tsx
@@ -67,9 +67,7 @@ export function InMessageImage({
         onOpenChange={(open) => setFullImageShowing(open)}
       />
 
-      <div
-        className={cn("relative w-full h-full group", shapeContainerClasses)}
-      >
+      <div className={cn("relative group", shapeContainerClasses)}>
         {!imageLoaded && (
           <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />
         )}


### PR DESCRIPTION
## Description

This regressed in https://github.com/onyx-dot-app/onyx/pull/6835 or a similar change.

**before**
<img width="858" height="1030" alt="20251220_07h16m37s_grim" src="https://github.com/user-attachments/assets/e78be33b-a5ab-4986-ad69-ec31b95867c8" />

**after**
<img width="858" height="1030" alt="20251220_07h16m15s_grim" src="https://github.com/user-attachments/assets/afe15fcf-f3f5-458a-a884-2e988fef286c" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that made attached chat images align flush right and stretch to full size. Images now use their natural width and align correctly within the message.

- Removed w-full and h-full from the InMessageImage container to restore proper layout while keeping the loading skeleton overlay.

<sup>Written for commit 6b11caef50718d5e1852e03bc52652e5dd459de1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

