### PR TITLE
fix(desktop): Linux-specific fixes

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onyx-desktop",
-  "version": "0.1.0",
+  "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onyx-desktop",
-      "version": "0.1.0",
+      "version": "0.0.0-dev",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onyx-desktop",
-  "version": "0.1.0",
+  "version": "0.0.0-dev",
   "description": "Lightweight desktop app for Onyx Cloud",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Onyx",
-  "version": "0.1.0",
+  "version": "0.0.0-dev",
   "identifier": "app.onyx.desktop",
   "build": {
     "beforeBuildCommand": "",
@@ -23,6 +23,7 @@
         "fullscreen": false,
         "decorations": true,
         "transparent": true,
+        "backgroundColor": "#1a1a2e",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "acceptFirstMouse": true,
@@ -51,6 +52,7 @@
       "entitlements": null,
       "exceptionDomain": "cloud.onyx.app",
       "minimumSystemVersion": "10.15",
+      "signingIdentity": "-",
       "dmg": {
         "windowSize": {
           "width": 660,


### PR DESCRIPTION
## Description

Linux-specific (or non-macOS rather, but I didn't test Windows) fixes for the desktop app.

## How Has This Been Tested?

I believe these are from [this release](https://github.com/onyx-dot-app/onyx/releases/tag/untagged-4a936867dbf914fd0778) ([73ecf9c122dd0ae6e01c1090fe9124fa96bf68f2](https://github.com/onyx-dot-app/onyx/pull/6693/commits/73ecf9c122dd0ae6e01c1090fe9124fa96bf68f2))

<img width="1920" height="1080" alt="20251220_08h05m14s_grim" src="https://github.com/user-attachments/assets/47239edf-1786-4ce5-b475-e180faf5dd83" />



## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux window rendering by removing macOS-only titlebar/vibrancy and adding a solid background color. Also switches the desktop app to a dev version for ad hoc builds.

- **Bug Fixes**
  - Linux: set window background color (#1a1a2e) to avoid transparency issues.
  - Gate titlebar injection and vibrancy to macOS; no overlay/hidden title on Linux.
  - Page-load titlebar re-injection runs only on macOS.

- **Dependencies**
  - Bump version to 0.0.0-dev in package.json, lockfile, and tauri.conf.
  - Set macOS signingIdentity to "-" to bypass signing in CI.

<sup>Written for commit 2d05f450e58f93da411153e8698f8d4a9d345341. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

