### PR TITLE
Fix large brotli-compressed response with "urllib3==2.6.1"

### DIFF
--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -254,6 +254,11 @@ def bulk_fetch_issues(
     payload["fields"] = fields.split(",") if fields else ["*all"]
 
     try:
+        #ref issue: https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg2073419.html since "urllib3==2.6.1" JIRA pulls fails for some documents with :
+        # requests.exceptions.ContentDecodingError: ('Received response with content-encoding: br, but failed to decode it.', error("brotli: decoder process called with data when 'can_accept_more_data()' is False"))
+        jira_client._session.headers.update({
+            'Accept-Encoding': 'gzip, deflate'  # Exclude 'br' (brotli)
+        })
         response = jira_client._session.post(bulk_fetch_path, json=payload).json()
     except Exception as e:
         logger.error(f"Error fetching issues: {e}")


### PR DESCRIPTION
 #ref issue: https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg2073419.html since "urllib3==2.6.1" JIRA pulls fails for some documents with :
        # requests.exceptions.ContentDecodingError: ('Received response with content-encoding: br, but failed to decode it.', error("brotli: decoder process called with data when 'can_accept_more_data()' is False"))

## Description

Fix brotli decompression error when fetching Jira issues by disabling brotli compression support.

### Problem
The Jira connector was failing with a `ContentDecodingError` when fetching bulk issues:
```
brotli.error: brotli: decoder process called with data when 'can_accept_more_data()' is False
```

This is a known issue ([urllib3 #3734](https://github.com/urllib3/urllib3/issues/3734)) caused by an incompatibility between urllib3 versions < 2.6.2 and brotli >= 1.2.0 when handling chunked transfer-encoded responses.

### Solution
Disable brotli compression by updating the Jira session's `Accept-Encoding` header to only include `gzip` and `deflate`. This prevents the server from sending brotli-compressed responses while maintaining full data integrity.

### Impact
- ✅ Fixes the decompression error without data loss
- ✅ All Jira issue data is retrieved identically (compression format doesn't affect content)
- ⚠️ Slightly larger transfer sizes (~20-25% more bytes over the wire)
- ⚠️ Negligible performance impact for typical use cases

Alternative Solutions Considered

Upgrade urllib3 to >= 2.6.2 - Would be the ideal long-term fix but may require broader dependency updates

## How Has This Been Tested?

Validate test through actual JIRA sync connector and document indexing.

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable brotli for Jira bulk issue requests to fix ContentDecodingError with urllib3 2.6.1 on large responses. Restores successful syncs with a small increase in transfer size.

- **Bug Fixes**
  - Set the Jira session’s Accept-Encoding to "gzip, deflate" (exclude "br") to avoid the brotli decoder bug.
  - Prevents bulk fetch failures where the brotli decoder rejects additional data.

<sup>Written for commit e2eeffa8fb16e63558e6fea3494fcaf817a1546f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

