### PR TITLE
chore(deps): upgrade urllib3 2.6.1->2.6.2

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1141,7 +1141,7 @@ unstructured-client==0.25.4
     #   unstructured
 uritemplate==4.2.0
     # via google-api-python-client
-urllib3==2.6.1
+urllib3==2.6.2
     # via
     #   asana
     #   botocore

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -543,7 +543,7 @@ typing-inspection==0.4.2
     # via pydantic
 tzdata==2025.2
     # via faker
-urllib3==2.6.1
+urllib3==2.6.2
     # via
     #   botocore
     #   requests

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -337,7 +337,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-urllib3==2.6.1
+urllib3==2.6.2
     # via
     #   botocore
     #   requests

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -519,7 +519,7 @@ tzdata==2025.2
     # via
     #   kombu
     #   pandas
-urllib3==2.6.1
+urllib3==2.6.2
     # via
     #   botocore
     #   requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ backend = [
     "dropbox==12.0.2",
     "shapely==2.0.6",
     "stripe==10.12.0",
-    "urllib3==2.6.1",
+    "urllib3==2.6.2",
     "mistune==0.8.4",
     "sendgrid==6.12.5",
     "exa_py==1.15.4",

--- a/uv.lock
+++ b/uv.lock
@@ -3829,7 +3829,7 @@ requires-dist = [
     { name = "types-setuptools", marker = "extra == 'dev'", specifier = "==68.0.0.3" },
     { name = "unstructured", marker = "extra == 'backend'", specifier = "==0.15.1" },
     { name = "unstructured-client", marker = "extra == 'backend'", specifier = "==0.25.4" },
-    { name = "urllib3", marker = "extra == 'backend'", specifier = "==2.6.1" },
+    { name = "urllib3", marker = "extra == 'backend'", specifier = "==2.6.2" },
     { name = "uvicorn", specifier = "==0.35.0" },
     { name = "voyageai", specifier = "==0.2.3" },
     { name = "xmlsec", marker = "extra == 'backend'", specifier = "==1.3.14" },
@@ -6477,11 +6477,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/1d/0f3a93cca1ac5e8287842ed4eebbd0f7a991315089b1a0b01c7788aa7b63/urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f", size = 432678, upload-time = "2025-12-08T15:25:26.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/56/190ceb8cb10511b730b564fb1e0293fa468363dbad26145c34928a60cb0c/urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b", size = 131138, upload-time = "2025-12-08T15:25:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Closes https://github.com/onyx-dot-app/onyx/pull/6929

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade urllib3 to 2.6.2 across the backend to pick up the latest bug fixes and keep versions consistent. No application code changes.

- **Dependencies**
  - Bumped urllib3 from 2.6.1 to 2.6.2 in backend requirements (default, dev, ee, model_server).
  - Updated pyproject.toml and uv.lock to match.

<sup>Written for commit f5ed6cc8ce4c4acac7f81f9e55fbc9e724b4977e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

