### PR TITLE
Citation Processing

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -58,6 +58,8 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 MAX_USER_MESSAGES_FOR_CONTEXT = 5
+MAX_FINAL_REPORT_TOKENS = 10000
+
 # Might be something like:
 # 1. Research 1-2
 # 2. Think
@@ -117,6 +119,7 @@ def generate_final_report(
         reasoning_effort=ReasoningEffort.LOW,
         final_documents=None,
         user_identity=user_identity,
+        max_tokens=MAX_FINAL_REPORT_TOKENS,
     )
 
     final_report = llm_step_result.answer

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -503,7 +503,9 @@ def run_research_agent_calls(
         )
     ]
 
-    return run_functions_tuples_in_parallel(
+    research_agent_call_results = run_functions_tuples_in_parallel(
         functions_with_args,
         allow_failures=True,  # Continue even if some research agent calls fail
     )
+
+    return research_agent_call_results


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an option to preserve original citation text during streaming while still tracking seen citations, and exposes a getter for them. Also raises the deep research final report token cap to 10,000 to reduce truncation.

- **New Features**
  - DynamicCitationProcessor: process_token now accepts strip_citations (default True). When False, output keeps original [n]/[[n]]/【n】 text and emits no CitationInfo.
  - Tracks seen citations internally and exposes get_seen_citations(); works regardless of strip_citations.
  - Default behavior unchanged when not using the flag (citations stripped and CitationInfo emitted).
  - Deep research: sets MAX_FINAL_REPORT_TOKENS=10000 and passes max_tokens to final report generation.
  - Adds unit tests covering strip_citations behaviors and seen citation tracking.

<sup>Written for commit 171d24ae3af294e83f4fd5d517fc3d5388e22bea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

