### PR TITLE
fix: sanitize postgres to remove nul characters

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -778,8 +778,8 @@ def create_db_search_doc(
         hidden=server_search_doc.hidden,
         doc_metadata=server_search_doc.metadata,
         is_relevant=server_search_doc.is_relevant,
-        relevance_explanation=_sanitize_for_postgres(
-            server_search_doc.relevance_explanation
+        relevance_explanation=(
+            _sanitize_for_postgres(server_search_doc.relevance_explanation)
             if server_search_doc.relevance_explanation is not None
             else None
         ),


### PR DESCRIPTION
## Description

Sanitizes search doc before saving to db to remove nul characters

## How Has This Been Tested?

Locally

## Additional Options

- [x] [Optional] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes NUL (0x00) characters in search doc fields before saving to Postgres to prevent insert errors and ensure clean data.

- **Bug Fixes**
  - Added helpers to strip NULs from strings and lists.
  - Applied sanitization to document_id, semantic_identifier, link, blurb, relevance_explanation, match_highlights, primary_owners, and secondary_owners in create_db_search_doc, preserving None for optional fields.
  - Logs a warning if sanitization removes all characters from a string.

<sup>Written for commit 87940ef1bb93f3a0da30890a1883cb746e7943e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







