### PR TITLE
Log

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -54,6 +54,7 @@ from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.utils.logger import setup_logger
+from onyx.utils.timing import log_function_time
 
 logger = setup_logger()
 
@@ -133,6 +134,7 @@ def generate_final_report(
         raise ValueError("LLM failed to generate the final deep research report")
 
 
+@log_function_time(print_only=True)
 def run_deep_research_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added execution-time logging to run_deep_research_llm_loop using log_function_time (print_only) to surface duration of deep research runs without changing behavior.

<sup>Written for commit fd374fa15170454136827ffcbc821e511e476815. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

