### PR TITLE
fix(fe): chat content links use proper hrefs

### DIFF
--- a/web/src/app/chat/message/MemoizedTextComponents.tsx
+++ b/web/src/app/chat/message/MemoizedTextComponents.tsx
@@ -160,24 +160,23 @@ export const MemoizedLink = memo(
       );
     }
 
-    const handleMouseDown = () => {
-      let url = href || rest.children?.toString();
-
-      if (url && !url.includes("://")) {
-        // Only add https:// if the URL doesn't already have a protocol
-        const httpsUrl = `https://${url}`;
-        try {
-          new URL(httpsUrl);
-          url = httpsUrl;
-        } catch {
-          // If not a valid URL, don't modify original url
-        }
+    let url = href || rest.children?.toString();
+    if (url && !url.includes("://")) {
+      // Only add https:// if the URL doesn't already have a protocol
+      const httpsUrl = `https://${url}`;
+      try {
+        new URL(httpsUrl);
+        url = httpsUrl;
+      } catch {
+        // If not a valid URL, don't modify original url
       }
-      window.open(url, "_blank");
-    };
+    }
+
     return (
       <a
-        onMouseDown={handleMouseDown}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
         className="cursor-pointer text-link hover:text-link-hover"
       >
         {rest.children}


### PR DESCRIPTION
## Description

Ensures links in markdown have proper `href`s. This is more accessible, secure, and better UX.

**before**
<img width="758" height="1030" alt="20251221_11h51m35s_grim" src="https://github.com/user-attachments/assets/05821d5f-3597-4d31-af74-a437741efcb1" />

**after**
<img width="758" height="1030" alt="20251221_11h51m09s_grim" src="https://github.com/user-attachments/assets/2dbc2a2c-0f21-432b-a0be-670547fc55a8" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat markdown links use real anchor hrefs so they open reliably and are accessible. Removes the click handler and adds secure defaults.

- **Bug Fixes**
  - Build href from provided link or text; add https:// when missing and valid.
  - Replace onMouseDown with native anchor behavior, using target="_blank" and rel="noopener noreferrer".

<sup>Written for commit c3c07a64c279a5db96d85cc00a21fd478ff88781. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

