### PR TITLE
Fix misalignment in DR failed agents

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -514,6 +514,14 @@ def run_deep_research_llm_loop(
             citation_mapping = research_results.citation_mapping
 
             for tab_index, report in enumerate(research_results.intermediate_reports):
+                if report is None:
+                    # The LLM will not see that this research was even attempted, it may try
+                    # something similar again but this is not bad.
+                    logger.error(
+                        f"Research agent call at tab_index {tab_index} failed, skipping"
+                    )
+                    continue
+
                 current_tool_call = research_agent_calls[tab_index]
                 tool_call_info = ToolCallInfo(
                     parent_tool_call_id=None,

--- a/backend/onyx/deep_research/models.py
+++ b/backend/onyx/deep_research/models.py
@@ -15,5 +15,8 @@ class ResearchAgentCallResult(BaseModel):
 
 
 class CombinedResearchAgentCallResult(BaseModel):
-    intermediate_reports: list[str]
+    # The None is needed here to keep the mappings consistent
+    # we later skip the failed research results but we need to know
+    # which ones failed
+    intermediate_reports: list[str | None]
     citation_mapping: CitationMapping


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes misalignment when some Deep Research agent calls fail by preserving placeholders and skipping failed reports. This keeps tab indices and citation mapping consistent and avoids incorrect attributions.

- **Bug Fixes**
  - Return None on research agent failures and include it in results to preserve order.
  - Update CombinedResearchAgentCallResult.intermediate_reports to list[str | None].
  - Skip None reports in the DR loop and log the failure to keep tool-call/tab mapping correct.

- **Migration**
  - If you read intermediate_reports, handle None entries.

<sup>Written for commit 9d7ebe36ace92761a6fe1c0746dbcc8a07be8a1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

