### PR TITLE
perf(fe): Memoize useLlmManager Hook

### DIFF
--- a/plans/memoize_usellmmanager_hook_7788e497.plan.md
+++ b/plans/memoize_usellmmanager_hook_7788e497.plan.md
@@ -1,0 +1,79 @@
+---
+name: Memoize useLlmManager Hook
+overview: Memoize the `useLlmManager` hook's return value and callbacks to prevent unnecessary re-renders of components receiving `llmManager` as a prop.
+todos:
+  - id: memoize-callbacks
+    content: Wrap updateCurrentLlm, updateImageFilesPresent, and updateModelOverrideBasedOnChatSession with useCallback
+    status: completed
+  - id: memoize-return
+    content: Wrap the return object with useMemo and proper dependency array
+    status: completed
+---
+
+# Memoize useLlm
+
+Manager Hook
+
+## Problem
+
+The `useLlmManager` hook in [web/src/lib/hooks.ts](web/src/lib/hooks.ts) returns a new object literal on every render, causing all downstream components (including `LLMPopover`) to re-render unnecessarily.
+
+## Solution
+
+Memoize the hook's callbacks with `useCallback` and its return value with `useMemo`.
+
+## Changes to `web/src/lib/hooks.ts`
+
+### 1. Wrap callbacks with `useCallback`
+
+The following functions need to be memoized:
+
+- `updateCurrentLlm` (lines 685-688)
+
+- `updateImageFilesPresent` (lines 680-682)
+- `updateTemperature` (already exists but needs verification)
+- `updateModelOverrideBasedOnChatSession` (lines 695+)
+
+### 2. Wrap return object with `useMemo`
+
+Replace the plain object return (lines 774-789) with a `useMemo` that depends on the actual values:
+
+```typescript
+return useMemo(() => ({
+  updateModelOverrideBasedOnChatSession,
+  currentLlm,
+  updateCurrentLlm,
+  temperature,
+  updateTemperature,
+  imageFilesPresent,
+  updateImageFilesPresent,
+  liveAssistant: liveAssistant ?? null,
+  maxTemperature,
+  llmProviders,
+  isLoadingProviders,
+  hasAnyProvider,
+}), [
+  updateModelOverrideBasedOnChatSession,
+  currentLlm,
+  updateCurrentLlm,
+  temperature,
+  updateTemperature,
+  imageFilesPresent,
+  updateImageFilesPresent,
+  liveAssistant,
+  maxTemperature,
+  llmProviders,
+  isLoadingAllProviders,
+  isLoadingPersonaProviders,
+  personaId,
+  hasAnyProvider,
+]);
+```
+
+
+
+## Expected Impact
+
+- `llmManager` reference will only change when its underlying data actually changes
+
+- `LLMPopover` and other components receiving `llmManager` will stop re-rendering on every parent render


### PR DESCRIPTION
## Description



## How Has This Been Tested?

:grimacing: 

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized the useLlmManager hook to stabilize the llmManager reference and prevent unnecessary re-renders in LLMPopover and other consumers. This improves UI performance without changing behavior.

- **Refactors**
  - Wrapped updateImageFilesPresent, updateCurrentLlm, updateModelOverrideBasedOnChatSession, and updateTemperature with useCallback.
  - Memoized the returned llmManager object with useMemo.
  - Computed isLoadingProviders once and used it in dependencies.
  - Tuned dependency arrays to only change when relevant values update.

<sup>Written for commit 0214151e1d9e77721d3cdef8a86a253009c5753e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



