### PR TITLE
chore(fe): prevent header continuous render

### DIFF
--- a/web/src/layouts/ChatHeader.tsx
+++ b/web/src/layouts/ChatHeader.tsx
@@ -80,12 +80,12 @@ export default function ChatHeader({ settings, chatSession }: ChatHeaderProps) {
     );
   }, [availableProjects, searchTerm]);
 
-  const resetMoveState = () => {
+  const resetMoveState = useCallback(() => {
     setShowMoveOptions(false);
     setSearchTerm("");
     setPendingMoveProjectId(null);
     setShowMoveCustomAgentModal(false);
-  };
+  }, []);
 
   const performMove = useCallback(
     async (targetProjectId: number) => {
@@ -115,6 +115,7 @@ export default function ChatHeader({ settings, chatSession }: ChatHeaderProps) {
       fetchProjects,
       currentProjectId,
       setPopup,
+      resetMoveState,
     ]
   );
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/onyx-dot-app/onyx/pull/6952. Avoids the header from continuously render.

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops continuous re-renders in ChatHeader by stabilizing handler functions, reducing UI flicker during move and delete actions.

- **Bug Fixes**
  - Memoized resetMoveState, performMove, handleMoveClick, handleDeleteChat, and setDeleteConfirmationModalOpen with useCallback.
  - Popover/modal state updates are now predictable, avoiding repeated renders.

<sup>Written for commit 60d04f222d7b41206d8e742c932099cbe0f778d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



