### PR TITLE
chore(fe): conditionally render header on chatSession

### DIFF
--- a/web/src/layouts/ChatFooter.tsx
+++ b/web/src/layouts/ChatFooter.tsx
@@ -3,6 +3,8 @@
 import Text from "@/refresh-components/texts/Text";
 import { CombinedSettings } from "@/app/admin/settings/interfaces";
 import { ChatSession } from "@/app/chat/interfaces";
+import { useProjectsContext } from "@/app/chat/projects/ProjectsContext";
+import { usePathname } from "next/navigation";
 
 export interface ChatFooterProps {
   settings: CombinedSettings | null;
@@ -10,6 +12,8 @@ export interface ChatFooterProps {
 }
 
 export default function ChatFooter({ settings, chatSession }: ChatFooterProps) {
+  const { currentProjectId } = useProjectsContext();
+  const pathname = usePathname();
   const customFooterContent =
     settings?.enterpriseSettings?.custom_lower_disclaimer_content;
 
@@ -24,9 +28,11 @@ export default function ChatFooter({ settings, chatSession }: ChatFooterProps) {
     );
   }
 
-  // On the landing page (no chat session), render an empty spacer
+  // On the landing page (/chat with no chat session, no project), render an empty spacer
   // to balance the header and keep content centered
-  if (!chatSession) {
+  const isLandingPage =
+    pathname === "/chat" && !chatSession && !currentProjectId;
+  if (isLandingPage) {
     return <div className="h-16" />;
   }
 

--- a/web/src/layouts/ChatHeader.tsx
+++ b/web/src/layouts/ChatHeader.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/sections/sidebar/sidebarUtils";
 import { LOCAL_STORAGE_KEYS } from "@/sections/sidebar/constants";
 import { deleteChatSession } from "@/app/chat/services/lib";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import MoveCustomAgentChatModal from "@/components/modals/MoveCustomAgentChatModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { PopoverMenu } from "@/components/ui/popover";
@@ -63,9 +63,20 @@ export default function ChatHeader({ settings, chatSession }: ChatHeaderProps) {
   const { refreshChatSessions } = useChatSessions();
   const { popup, setPopup } = usePopup();
   const router = useRouter();
+  const pathname = usePathname();
 
   const customHeaderContent =
     settings?.enterpriseSettings?.custom_header_content;
+
+  // Determine if header should render:
+  // - Always show on landing page (/chat with no chatSession, no currentProjectId)
+  // - Always show on chat page (has chatSession)
+  // - Only show on project view / agents page if whitelabeling content exists
+  const isLandingPage =
+    pathname === "/chat" && !chatSession && !currentProjectId;
+  const isChatPage = !!chatSession;
+  const shouldRenderHeader =
+    isLandingPage || isChatPage || !!customHeaderContent;
 
   const availableProjects = useMemo(() => {
     if (!projects) return [];
@@ -204,6 +215,10 @@ export default function ChatHeader({ settings, chatSession }: ChatHeaderProps) {
     setDeleteConfirmationModalOpen,
     handleMoveClick,
   ]);
+
+  if (!shouldRenderHeader) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Description

The header is appearing more often than desired after https://github.com/onyx-dot-app/onyx/pull/6952.

## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally render ChatHeader so it shows only on the landing page (/chat with no session and no project), active chats, or when custom header content exists, and make ChatFooter add the spacer only on the landing page.

Replaced the actions visibility check from currentChatSessionId to chatSession and removed currentChatSessionId usage.

<sup>Written for commit a5f29eb00d72afd3c378a490da4c9b8e7ce3b2e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



