### PR TITLE
fix: test_multi_llm.py::test_multiple_tool_calls callsite fix

### DIFF
--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -246,6 +246,7 @@ def test_multiple_tool_calls(default_multi_llm: LitellmLLM) -> None:
             stream=False,
             temperature=0.0,  # Default value from GEN_AI_TEMPERATURE
             timeout=30,
+            max_tokens=None,
             parallel_tool_calls=True,
             mock_response=MOCK_LLM_RESPONSE,
         )
@@ -398,9 +399,10 @@ def test_multiple_tool_calls_streaming(default_multi_llm: LitellmLLM) -> None:
             stream=True,
             temperature=0.0,  # Default value from GEN_AI_TEMPERATURE
             timeout=30,
+            max_tokens=None,
+            stream_options={"include_usage": True},
             parallel_tool_calls=True,
             mock_response=MOCK_LLM_RESPONSE,
-            stream_options={"include_usage": True},
         )
 
 


### PR DESCRIPTION
## Description
https://github.com/onyx-dot-app/onyx/pull/6947 added `max_tokens=max_tokens,` to a `litellm.completion` callsite, the test should verify this new arg.

## How Has This Been Tested?
Ran the unit test locally.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added max_tokens=None to litellm.completion in test_multiple_tool_calls (streaming and non-streaming) to match the updated callsite and verify the argument is passed. Keeps tests in sync and prevents regressions around token limits.

<sup>Written for commit 72adfbf5134a3d38c9ab076cb48ebeb1617130e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
