### PR TITLE
fix: add Enterprise Grid support for Slack federated search

### DIFF
--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -119,11 +119,15 @@ def fetch_and_cache_channel_metadata(
             cursor = None
             channel_count = 0
             while True:
+                # Pass team_id for Enterprise Grid support
+                # Without team_id, conversations.list fails with "missing_argument: team_id"
+                # on Slack Enterprise Grid workspaces
                 response = slack_client.conversations_list(
                     types=channel_types,
                     exclude_archived=True,
                     limit=1000,
                     cursor=cursor,
+                    team_id=team_id,
                 )
                 response.validate()
 
@@ -434,6 +438,7 @@ def query_slack(
     entities: dict[str, Any] | None = None,
     available_channels: list[str] | None = None,
     channel_metadata_dict: dict[str, ChannelMetadata] | None = None,
+    team_id: str | None = None,
 ) -> SlackQueryResult:
 
     # Check if query has channel override (user specified channels in query)
@@ -470,6 +475,12 @@ def query_slack(
         if sort_by_time:
             search_params["sort"] = "timestamp"
             search_params["sort_dir"] = "desc"
+
+        # Pass team_id for Enterprise Grid support
+        # Without team_id, search.messages fails with "team_access_not_granted"
+        # on Enterprise Grid workspaces
+        if team_id:
+            search_params["team_id"] = team_id
 
         response = slack_client.search_messages(**search_params)
         response.validate()
@@ -1011,6 +1022,7 @@ def slack_retrieval(
                 entities,
                 available_channels,
                 channel_metadata_dict,
+                team_id,
             ),
         )
         for query_string in query_strings
@@ -1048,6 +1060,7 @@ def slack_retrieval(
                         dm_entities,
                         available_channels,
                         channel_metadata_dict,
+                        team_id,
                     ),
                 )
             )


### PR DESCRIPTION
## Problem
For Enterprise Grid org-level installs, the `auth.test` API returns the enterprise ID (starts with `E`) in the `team_id` field instead of an actual workspace ID (starts with `T`).
This causes:
     - `conversations.list` to fail with `missing_argument: team_id`
     - `search.messages` to fail with `team_access_not_granted`

 ## Root Cause
When a Slack app is installed at the Enterprise Grid organization level (not workspace level), `auth.test` returns:

     ```json
     {
       "team_id": "E01R*******",
       "enterprise_id": "E01R*******",
       "is_enterprise_install": true
     }```

   The Slack API expects a workspace ID (starting with T) for conversations.list and search.messages.

  ## Solution

   1. Detect org-level enterprise installs via is_enterprise_install flag
   2. When detected, use auth.teams.list to get actual workspace IDs
   3. Pass team_id to conversations.list and search.messages API calls

## Testing
Tested with Slack Enterprise Grid org-level OAuth tokens. Successfully searches messages across workspaces.

## Note
Currently uses the first available workspace returned by auth.teams.list. A future enhancement could allow users to select which workspace to search.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Enterprise Grid support to Slack federated search by resolving workspace IDs for org-level installs and passing team_id to Slack APIs. Prevents missing_argument and team_access_not_granted errors and enables searches across workspaces.

- **Bug Fixes**
  - Detect org-level installs via is_enterprise_install and resolve a workspace ID with auth.teams.list when team_id starts with E.
  - Validate the resolved team_id starts with T before using it; skip if invalid.
  - Pass team_id to conversations.list and search.messages.
  - Select the first available workspace if multiple are returned; log others for visibility.

<sup>Written for commit 3f5ae595bc8f05cf833d193ed662eee85ad7ff61. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



