### PR TITLE
feat(new vector db interface): Implement retrievals for Vespa

### DIFF
--- a/backend/onyx/context/search/retrieval/search_runner.py
+++ b/backend/onyx/context/search/retrieval/search_runner.py
@@ -513,6 +513,7 @@ def search_chunks(
     return top_chunks
 
 
+# TODO: This is unused code.
 def inference_sections_from_ids(
     doc_identifiers: list[tuple[str, int]],
     document_index: DocumentIndex,


### PR DESCRIPTION
## Description
This PR implements `VespaIndex`'s `random_retrieval` and `id_based_retrieval` methods to the new vector db interface we want to have, introduced in https://github.com/onyx-dot-app/onyx/pull/5700.

This PR concludes all the method implementations required for the new interface.

## How Has This Been Tested?
#6966 tests it.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ID-based and random retrieval in the new Vespa index, enabling ordered section fetches and seed-based random sampling. Updates interfaces to accept filters and optional batch retrieval, and adds a retrieval filters model for future ACL enforcement.

- **New Features**
  - Implemented id_based_retrieval in Vespa with ordered chunk/section fetch, filters, and batch or parallel modes.
  - Implemented random_retrieval in Vespa using Vespa’s random ranking with a seed; supports filters and limits.

- **Refactors**
  - Updated base interface signatures for id_based_retrieval (filters, batch) and random_retrieval (filters, limit).
  - Added IndexRetrievalFilters with a default public ACL (currently unused).

<sup>Written for commit 9db0c3307509654b2aa2dade5671135a61b7595f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
