### PR TITLE
feat(new vector db interface): Plug in retrievals for Vespa

### DIFF
--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -741,7 +741,6 @@ class VespaIndex(DocumentIndex):
             chunk_requests=generic_chunk_requests,
             filters=filters,
             batch_retrieval=batch_retrieval,
-            get_large_chunks=get_large_chunks,
         )
 
     @log_function_time(print_only=True, debug_only=True)


### PR DESCRIPTION
## Description
This PR plugs in `VespaDocumentIndex`'s `random_retrieval` and `id_based_retrieval` methods implemented in #6963 into the hotpath.

## How Has This Been Tested?
- On a local instance, created a file connector, waited for it to finish indexing.
- Found out what my document id was via `docker exec onyx_postgres psql -U postgres -c "SELECT id, semantic_id, chunk_count FROM document LIMIT 10;"`.
- Ran `curl -X GET "http://localhost:3000/api/document/document-size-info?document_id=FILE_CONNECTOR__68545734-af1c-48e2-aefc-d38b21bcdaf0" -v 2>&1 | head -50`, got back a number of chunks and tokens that makes sense. Also ran `curl -s "http://localhost:3000/api/document/chunk-info?document_id=FILE_CONNECTOR__68545734-af1c-48e2-aefc-d38b21bcdaf0&chunk_id=0" | jq '.'` and the chunk content makes sense. These test `id_based_retrieval`.
- Made a document set and an assistant, and ran `curl -X POST "http://localhost:3000/api/persona/assistant-prompt-refresh" -H "Content-Type: application/json" -d @/tmp/starter_msg_request.json 2>&1` with body 
    ```
    {
      "name": "War and Peace Assistant",
      "description": "Expert on Tolstoy's War and Peace",
      "instructions": "Help users understand and discuss War and Peace",
      "document_set_ids": [1],
      "generation_count": 2
    }
    ```
    This errored on some LLM call because I didn't have this configured but this passed the `random_retrieval` point in the code by then.

## Additional Options

- [x] [Optional] Override Linear Check
