### PR TITLE
revert: "fix(fe): make recent chat sidebar buttons links"

### DIFF
--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -436,7 +436,7 @@ const ChatButton = memo(
       >
         <PopoverAnchor>
           <SidebarTab
-            href={`/chat?chatId=${chatSession.id}`}
+            onClick={() => route({ chatSessionId: chatSession.id })}
             active={active}
             rightChildren={rightMenu}
             focused={renaming}


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#6924

Causing: https://onyx-company.slack.com/archives/C0832RVRVG8/p1766433472201599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that made Recent Chat sidebar buttons links. SidebarTab now routes on click (route({ chatSessionId })) to fix the navigation regression in the Recent Chats sidebar.

<sup>Written for commit 8c650fd6e948b768706b2d1516f8277828fbbe8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

