### PR TITLE
feat: add PacketException handling

### DIFF
--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -50,6 +50,7 @@ from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import PacketException
 from onyx.server.query_and_chat.streaming_models import ResearchAgentStart
 from onyx.server.query_and_chat.streaming_models import SectionEnd
+from onyx.server.query_and_chat.streaming_models import StreamingType
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolCallInfo
 from onyx.tools.models import ToolCallKickoff
@@ -507,7 +508,7 @@ def run_research_agent_call(
         emitter.emit(
             Packet(
                 placement=Placement(turn_index=turn_index, tab_index=tab_index),
-                obj=PacketException(type="error", exception=e),
+                obj=PacketException(type=StreamingType.ERROR.value, exception=e),
             )
         )
         return None

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -276,8 +276,11 @@ export default function AIMessage({
       // Track this group key
       seenGroupKeysRef.current.add(currentGroupKey);
 
-      // Track SECTION_END packets
-      if (packet.obj.type === PacketType.SECTION_END) {
+      // Track SECTION_END and ERROR packets (both indicate completion)
+      if (
+        packet.obj.type === PacketType.SECTION_END ||
+        packet.obj.type === PacketType.ERROR
+      ) {
         groupKeysWithSectionEndRef.current.add(currentGroupKey);
       }
 

--- a/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
+++ b/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
@@ -56,7 +56,8 @@ function isReasoningPacket(packet: Packet): packet is ReasoningPacket {
   return (
     packet.obj.type === PacketType.REASONING_START ||
     packet.obj.type === PacketType.REASONING_DELTA ||
-    packet.obj.type === PacketType.SECTION_END
+    packet.obj.type === PacketType.SECTION_END ||
+    packet.obj.type === PacketType.ERROR
   );
 }
 

--- a/web/src/app/chat/message/messageComponents/renderers/CustomToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/CustomToolRenderer.tsx
@@ -17,8 +17,10 @@ function constructCustomToolState(packets: CustomToolPacket[]) {
   const toolDeltas = packets
     .filter((p) => p.obj.type === PacketType.CUSTOM_TOOL_DELTA)
     .map((p) => p.obj as CustomToolDelta);
-  const toolEnd = packets.find((p) => p.obj.type === PacketType.SECTION_END)
-    ?.obj as SectionEnd | null;
+  const toolEnd = packets.find(
+    (p) =>
+      p.obj.type === PacketType.SECTION_END || p.obj.type === PacketType.ERROR
+  )?.obj as SectionEnd | null;
 
   const toolName = toolStart?.tool_name || toolDeltas[0]?.tool_name || "Tool";
   const latestDelta = toolDeltas[toolDeltas.length - 1] || null;

--- a/web/src/app/chat/message/messageComponents/renderers/FetchToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/FetchToolRenderer.tsx
@@ -40,7 +40,9 @@ const constructCurrentFetchState = (
     (packet) => packet.obj.type === PacketType.FETCH_TOOL_DOCUMENTS
   )?.obj as FetchToolDocuments | undefined;
   const sectionEnd = packets.find(
-    (packet) => packet.obj.type === PacketType.SECTION_END
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR
   );
 
   const urls = urlsPacket?.urls || [];

--- a/web/src/app/chat/message/messageComponents/renderers/ImageToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/ImageToolRenderer.tsx
@@ -22,7 +22,9 @@ function constructCurrentImageState(packets: ImageGenerationToolPacket[]) {
     )
     .map((packet) => packet.obj as ImageGenerationToolDelta);
   const imageEnd = packets.find(
-    (packet) => packet.obj.type === PacketType.SECTION_END
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR
   )?.obj as SectionEnd | null;
 
   const prompt = ""; // Image generation tools don't have a main description

--- a/web/src/app/chat/message/messageComponents/renderers/PythonToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/PythonToolRenderer.tsx
@@ -45,7 +45,9 @@ function constructCurrentPythonState(packets: PythonToolPacket[]) {
     .filter((packet) => packet.obj.type === PacketType.PYTHON_TOOL_DELTA)
     .map((packet) => packet.obj as PythonToolDelta);
   const pythonEnd = packets.find(
-    (packet) => packet.obj.type === PacketType.SECTION_END
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR
   )?.obj as SectionEnd | null;
 
   const code = pythonStart?.code || "";

--- a/web/src/app/chat/message/messageComponents/renderers/ReasoningRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/ReasoningRenderer.tsx
@@ -19,6 +19,7 @@ function constructCurrentReasoningState(packets: ReasoningPacket[]) {
   const hasEnd = packets.some(
     (p) =>
       p.obj.type === PacketType.SECTION_END ||
+      p.obj.type === PacketType.ERROR ||
       // Support reasoning_done from backend
       (p.obj as any).type === PacketType.REASONING_DONE
   );

--- a/web/src/app/chat/message/messageComponents/renderers/SearchToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/SearchToolRenderer.tsx
@@ -57,7 +57,9 @@ const constructCurrentSearchState = (
     .map((packet) => packet.obj as SearchToolDocumentsDelta);
 
   const searchEnd = packets.find(
-    (packet) => packet.obj.type === PacketType.SECTION_END
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR
   )?.obj as SectionEnd | null;
 
   // Extract queries from query delta packets

--- a/web/src/app/chat/message/messageComponents/renderers/SearchToolRendererV2.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/SearchToolRendererV2.tsx
@@ -58,7 +58,9 @@ export const constructCurrentSearchState = (
     .map((packet) => packet.obj as SearchToolDocumentsDelta);
 
   const searchEnd = packets.find(
-    (packet) => packet.obj.type === PacketType.SECTION_END
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR
   )?.obj as SectionEnd | null;
 
   // Extract queries from query delta packets

--- a/web/src/app/chat/message/messageComponents/toolDisplayHelpers.tsx
+++ b/web/src/app/chat/message/messageComponents/toolDisplayHelpers.tsx
@@ -7,6 +7,7 @@ import {
   FiLink,
   FiSearch,
   FiTool,
+  FiXCircle,
 } from "react-icons/fi";
 
 import {
@@ -15,6 +16,20 @@ import {
   SearchToolPacket,
 } from "@/app/chat/services/streamingModels";
 import { constructCurrentSearchState } from "./renderers/SearchToolRendererV2";
+
+/**
+ * Check if a packet group contains an ERROR packet (tool failed)
+ */
+export function hasToolError(packets: Packet[]): boolean {
+  return packets.some((p) => p.obj.type === PacketType.ERROR);
+}
+
+/**
+ * Get an error icon for failed tools
+ */
+export function getToolErrorIcon(): JSX.Element {
+  return <FiXCircle className="w-3.5 h-3.5 text-error" />;
+}
 
 export function getToolKey(turn_index: number, tab_index: number): string {
   return `${turn_index}-${tab_index}`;

--- a/web/src/app/chat/services/packetUtils.ts
+++ b/web/src/app/chat/services/packetUtils.ts
@@ -26,6 +26,7 @@ export function isToolPacket(
   ];
   if (includeSectionEnd) {
     toolPacketTypes.push(PacketType.SECTION_END);
+    toolPacketTypes.push(PacketType.ERROR);
   }
   return toolPacketTypes.includes(packet.obj.type as PacketType);
 }
@@ -72,10 +73,11 @@ export function isFinalAnswerComplete(packets: Packet[]) {
     return false;
   }
 
-  // Check if there's a corresponding SECTION_END with the same turn_index
+  // Check if there's a corresponding SECTION_END or ERROR with the same turn_index
   return packets.some(
     (packet) =>
-      packet.obj.type === PacketType.SECTION_END &&
+      (packet.obj.type === PacketType.SECTION_END ||
+        packet.obj.type === PacketType.ERROR) &&
       packet.placement.turn_index === messageStartPacket.placement.turn_index
   );
 }

--- a/web/src/app/chat/services/streamingModels.ts
+++ b/web/src/app/chat/services/streamingModels.ts
@@ -12,6 +12,7 @@ export enum PacketType {
 
   STOP = "stop",
   SECTION_END = "section_end",
+  ERROR = "error",
 
   // Specific tool packets
   SEARCH_TOOL_START = "search_tool_start",
@@ -66,6 +67,11 @@ export interface Stop extends BaseObj {
 
 export interface SectionEnd extends BaseObj {
   type: "section_end";
+}
+
+export interface PacketError extends BaseObj {
+  type: "error";
+  message?: string;
 }
 
 // Specific tool packets
@@ -175,23 +181,36 @@ export type StopObj = Stop;
 
 export type SectionEndObj = SectionEnd;
 
+export type PacketErrorObj = PacketError;
+
 // Specific tool objects
 export type SearchToolObj =
   | SearchToolStart
   | SearchToolQueriesDelta
   | SearchToolDocumentsDelta
-  | SectionEnd;
+  | SectionEnd
+  | PacketError;
 export type ImageGenerationToolObj =
   | ImageGenerationToolStart
   | ImageGenerationToolDelta
-  | SectionEnd;
-export type PythonToolObj = PythonToolStart | PythonToolDelta | SectionEnd;
+  | SectionEnd
+  | PacketError;
+export type PythonToolObj =
+  | PythonToolStart
+  | PythonToolDelta
+  | SectionEnd
+  | PacketError;
 export type FetchToolObj =
   | FetchToolStart
   | FetchToolUrls
   | FetchToolDocuments
-  | SectionEnd;
-export type CustomToolObj = CustomToolStart | CustomToolDelta | SectionEnd;
+  | SectionEnd
+  | PacketError;
+export type CustomToolObj =
+  | CustomToolStart
+  | CustomToolDelta
+  | SectionEnd
+  | PacketError;
 export type NewToolObj =
   | SearchToolObj
   | ImageGenerationToolObj
@@ -199,9 +218,17 @@ export type NewToolObj =
   | FetchToolObj
   | CustomToolObj;
 
-export type ReasoningObj = ReasoningStart | ReasoningDelta | SectionEnd;
+export type ReasoningObj =
+  | ReasoningStart
+  | ReasoningDelta
+  | SectionEnd
+  | PacketError;
 
-export type CitationObj = CitationStart | CitationInfo | SectionEnd;
+export type CitationObj =
+  | CitationStart
+  | CitationInfo
+  | SectionEnd
+  | PacketError;
 
 // Union type for all possible streaming objects
 export type ObjTypes =
@@ -210,6 +237,7 @@ export type ObjTypes =
   | ReasoningObj
   | StopObj
   | SectionEndObj
+  | PacketErrorObj
   | CitationObj;
 
 // Placement interface for packet positioning


### PR DESCRIPTION
## Description

add handling for new PacketException on the FE. this should function as a section_end style packet signifying completion but for handling failure cases

## How Has This Been Tested?

Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added ERROR packet handling across the streaming pipeline so tool failures count as completion and are shown in the UI with clear error indicators.

- **New Features**
  - Backend: emit PacketException with StreamingType.ERROR in research_agent on failures.
  - Protocol: added PacketType.ERROR and PacketError; included in tool, reasoning, and citation unions.
  - UI: treat ERROR like SECTION_END across AIMessage, MultiToolRenderer, and tool renderers; show a red X and “Completed with errors” when a tool fails.
  - Utilities: updated isToolPacket and isFinalAnswerComplete to consider ERROR; added hasToolError helper.

<sup>Written for commit cfdb81972656dd7b37b66ff405287a01332866df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

