### PR TITLE
fix(docprocessing): Limiting worker count

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -836,7 +836,7 @@ class EmbeddingModel:
         if num_threads >= 1 and self.provider_type and len(text_batches) > 1:
             # Limit max workers to prevent overwhelming the API with too many concurrent requests
             # This helps prevent retry storms by reducing connection pressure
-            max_workers = min(
+            max_workers: int = min(
                 num_threads, len(text_batches), 4
             )  # Cap at 4 concurrent threads
             if len(text_batches) > 20:


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We currently don't do a great job of spawning workers. This PR aims to control this a bit for some workflows that cause an explosion in mem usage. 

```
Celery Worker (6 threads) 
  └─> process_batch()
       └─> EmbeddingModel.encode()  [SYNC]
            └─> _batch_encode_texts()  [SYNC]
                 └─> ThreadPoolExecutor(8 workers)  [🔥 48 concurrent ops!]
                      └─> process_batch()  [SYNC]
                           └─> _make_direct_api_call()  [SYNC wrapper]
                                └─> loop.run_until_complete()  [Event loop bridge]
                                     └─> CloudEmbedding.embed()  [ASYNC]
                                          └─> _embed_vertex()  [ASYNC]
                                               └─> client.aio.embed_content()  [ASYNC - Google SDK]
```

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tried to index some workflows like Google Drive that were constantly killing us.

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit worker concurrency for API-based embedding in document processing to reduce retry storms: max 4 threads, lowered to 2 when batch count >20. This reduces API pressure and improves stability without changing results.

<sup>Written for commit 20befc630f5651796939c3f74c0538f075c96f90. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



