### PR TITLE
fix(docprocessing): Cleaning up Event Pools

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -131,12 +131,14 @@ def _get_or_create_event_loop() -> asyncio.AbstractEventLoop:
         # Also recreate periodically based on usage count to prevent gradual accumulation
         if not hasattr(_thread_local, "loop_task_count"):
             _thread_local.loop_task_count = 0
-        _thread_local.loop_task_count += 1
 
         # Recreate every 100 operations to prevent gradual accumulation
-        if _thread_local.loop_task_count > 100:
+        if _thread_local.loop_task_count >= 100:
             logger.debug("Recreating event loop after 100 operations")
             should_recreate = True
+
+        if not should_recreate:
+            _thread_local.loop_task_count += 1
 
     # Recreate or create new loop
     if (


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved event loop management in document processing to stop gradual memory leaks from accumulated asyncio tasks. Threads reuse a single loop, which is safely recreated when task buildup or usage thresholds are hit.

- **Bug Fixes**
  - Recreate the loop if >5 pending tasks are detected.
  - Recreate every 100 operations to avoid gradual accumulation.
  - Cancel pending tasks before closing the old loop.
  - Reset per-thread loop task count and set the fresh loop.

<sup>Written for commit 054f636a37038c6eac7b928cf69dc6d14c1db0c7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



