### PR TITLE
fix: test_connector_pause_while_indexing keeps timing out, lower the number of docs to wait for to 4 from 16

### DIFF
--- a/backend/tests/integration/tests/connector/test_connector_creation.py
+++ b/backend/tests/integration/tests/connector/test_connector_creation.py
@@ -118,10 +118,11 @@ def test_connector_pause_while_indexing(reset: None) -> None:
         input_type=InputType.POLL,
     )
 
-    # A bit flaky in our CI due to varying indexing times
-    # 120s timeout is relatively arbitrary, but hopefully enough to catch the flakiness
+    # NOTE: A bit flaky in our CI due to varying indexing times. Empirically
+    # 120s was not always enough to index 16 docs from Confluence so trying to
+    # bump down the indexing progress to wait for to 4 docs from 16.
     CCPairManager.wait_for_indexing_in_progress(
-        cc_pair_1, timeout=120, num_docs=16, user_performing_action=admin_user
+        cc_pair_1, timeout=120, num_docs=4, user_performing_action=admin_user
     )
 
     CCPairManager.pause_cc_pair(cc_pair_1, user_performing_action=admin_user)


### PR DESCRIPTION
## Description
This test keeps on timing out, it seems 120s is not always enough to index 16 docs from Confluence. Bumping that doc number count to 4. Longer term question is why do we call out to a specific 3rd party connector for a test which tests generic connector logic, a file connector could prob be fine for this.

## How Has This Been Tested?
I'm relying on ci for this one.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the indexed-docs threshold from 16 to 4 in test_connector_pause_while_indexing to prevent CI timeouts. This stabilizes the test under variable Confluence indexing speeds.

<sup>Written for commit a2527922f3ab4d620605adcae25a8c60162b284d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

