### PR TITLE
feat: add optional image parsing for docx

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -29,10 +29,10 @@ from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
-from onyx.file_processing.extract_file_text import docx_to_text_and_images
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.extract_file_text import pptx_to_text
+from onyx.file_processing.extract_file_text import read_docx_file
 from onyx.file_processing.extract_file_text import read_pdf_file
 from onyx.file_processing.extract_file_text import xlsx_to_text
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -214,7 +214,7 @@ def _download_and_extract_sections_basic(
         mime_type
         == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     ):
-        text, _ = docx_to_text_and_images(io.BytesIO(response_call()))
+        text, _ = read_docx_file(io.BytesIO(response_call()))
         return [TextSection(link=link, text=text)]
 
     elif (


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make DOCX image extraction optional. Text extraction now defaults to no images, which speeds up common paths and reduces processing.

- **New Features**
  - Added read_docx_file(..., extract_images=False) to control image extraction and optionally stream via image_callback.
  - Updated DOCX callers to use read_docx_file: text-only paths use the default; image-aware path passes extract_images=True.

<sup>Written for commit 0429d95bc9df89913a268ce3bd4af47fe5d8b59e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

