### PR TITLE
fix(vertex-ai): Bump Default Batch Size

### DIFF
--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -86,7 +86,7 @@ API_BASED_EMBEDDING_TIMEOUT = int(os.environ.get("API_BASED_EMBEDDING_TIMEOUT", 
 # Local batch size for VertexAI embedding models currently calibrated for item size of 512 tokens
 # NOTE: increasing this value may lead to API errors due to token limit exhaustion per call.
 VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE = int(
-    os.environ.get("VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE", "25")
+    os.environ.get("VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE", "50")
 )
 
 # Only used for OpenAI


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
As part of the followup to this PR: https://github.com/onyx-dot-app/onyx/pull/6980 we are bumping the default

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default VertexAI embedding local batch size from 25 to 50 to speed up embedding throughput. The value remains configurable via the VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE env var; monitor for token-limit errors on larger items.

<sup>Written for commit 7bc5ab87662b0b64ed4245fc5d08e3ed227191b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

