### PR TITLE
feat: DR Tab for intermediate reports and Index increment for final report section end

### DIFF
--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -118,6 +118,7 @@ def generate_intermediate_report(
         final_documents=None,
         user_identity=user_identity,
         max_tokens=MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS,
+        use_existing_tab_index=True,
     )
 
     while True:


### PR DESCRIPTION
The intermediate report did not specify the tab which would lead to confusion for which tab the answer should stream from.

The final report section end was off by 1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the tab for intermediate reports so answers stream in the correct tab, and fix the off-by-one error when ending the final report section. This makes report placement consistent and prevents confusion in the UI.

- **Bug Fixes**
  - Intermediate reports now use the current tab index (use_existing_tab_index=True).
  - Final report turn index is corrected: generate_final_report reports if reasoning occurred, we increment reasoning_cycles accordingly, and compute placement/OverallStop as orchestrator_start_turn_index + cycle + reasoning_cycles.

<sup>Written for commit cb7849af4ab05631b8311b1113813351fde11c9c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

