### PR TITLE
Small Tuning

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1,3 +1,4 @@
+import os
 import re
 import traceback
 from collections.abc import Callable
@@ -544,7 +545,10 @@ def stream_chat_message_objects(
         # for stop signals. run_llm_loop itself doesn't know about stopping.
         # Note: DB session is not thread safe but nothing else uses it and the
         # reference is passed directly so it's ok.
-        if new_msg_req.deep_research:
+        if (
+            new_msg_req.deep_research
+            or os.environ.get("FORCE_DEEP_RESEARCH_LOOP", "false").lower() == "true"
+        ):
             if chat_session.project_id:
                 raise RuntimeError("Deep research is not supported for projects")
 

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -156,7 +156,7 @@ def build_system_prompt(
             system_prompt += company_context
         if memories:
             system_prompt += "\n".join(
-                memory.strip() for memory in memories if memory.strip()
+                "- " + memory.strip() for memory in memories if memory.strip()
             )
 
     # Append citation guidance after company context if placeholder was not present

--- a/backend/onyx/tools/tool_implementations/web_search/utils.py
+++ b/backend/onyx/tools/tool_implementations/web_search/utils.py
@@ -6,7 +6,7 @@ from onyx.tools.tool_implementations.web_search.models import WEB_SEARCH_PREFIX
 from onyx.tools.tool_implementations.web_search.models import WebSearchResult
 
 
-def truncate_search_result_content(content: str, max_chars: int = 20000) -> str:
+def truncate_search_result_content(content: str, max_chars: int = 15000) -> str:
     """Truncate search result content to a maximum number of characters"""
     if len(content) <= max_chars:
         return content


### PR DESCRIPTION
## Description

Very small tuning things in prompt and hyperparameters

## How Has This Been Tested?

Def works

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an env flag to force the deep research loop, improve memory formatting in the system prompt, and reduce web search content size to save tokens. This tightens behavior and lowers token usage.

- **New Features**
  - Added FORCE_DEEP_RESEARCH_LOOP env var to run deep research even when the request doesn’t set deep_research; still blocked for project chats.
  - Tuning: memories are now rendered as bullet points in the system prompt; web search content is truncated to 15,000 chars to reduce token load.

<sup>Written for commit 4fba8586ed5a14f58f81a74b21b5f272b59dc4a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

