### PR TITLE
chore(desktop): deployment automation for the desktop app

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -183,7 +183,7 @@ jobs:
           package-manager-cache: false
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b # ratchet:dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b # zizmor: ignore[impostor-commit]
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}


### PR DESCRIPTION
## Description



## How Has This Been Tested?

Example run: https://github.com/onyx-dot-app/onyx/actions/runs/20467099998
Example release: https://github.com/onyx-dot-app/onyx/releases/tag/untagged-ce9050788fc3f527bac3

## Additional Options

- [x] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates desktop app builds in CI with Tauri, producing macOS (universal), Windows, and Linux packages and drafting GitHub releases with correct versions. Tightens workflow permissions and adds desktop status to Slack failure alerts.

- **New Features**
  - Added build-desktop job gated by determine-builds.
  - Cross-platform packages: macOS universal, Windows, Linux deb/rpm (amd64, arm).
  - Version injection from tag or short SHA; dev builds use 0.0.0-dev+sha (Windows uses numeric-only).
  - Draft releases via tauri-apps/tauri-action with versioned tag and name.

- **Refactors**
  - Set default workflow permissions to {}.
  - Added short-sha and build-desktop outputs; included desktop in failure notifications.
  - Updated action pins (setup-uv v7.1.5, docker/metadata-action v5).

<sup>Written for commit 92584ec78f835e94eadcb8e52adf55902f9c11c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







