### PR TITLE
fix: thinking blocks newline rendering

### DIFF
--- a/backend/onyx/deep_research/utils.py
+++ b/backend/onyx/deep_research/utils.py
@@ -53,6 +53,7 @@ def _unescape_json_string(s: str) -> str:
     result = result.replace("\\r", "\r")
     result = result.replace("\\t", "\t")
     result = result.replace('\\"', '"')
+    result = result.replace('\\/', '/')
 
     # Finally, restore escaped backslashes as single backslashes
     result = result.replace(placeholder, "\\")


### PR DESCRIPTION
## Description

Fixes an issue where thinking blocks did not render newlines correctly. The problem stemmed from JSON escape sequences (e.g., `\n`) not being unescaped when extracting reasoning content from `think_tool` arguments.

A new utility function, `_unescape_json_string()`, has been added to properly decode these JSON escape sequences, ensuring newlines and other special characters are rendered as intended.

## How Has This Been Tested?

- Ran existing unit and e2e tests (`npm test`, `npm run test-e2e`, `npm run test-unit`). All tests passed.
- Manually verified that thinking blocks now correctly display newlines in the UI.

## Additional Options

- [x] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C0832RVRVG8/p1766287341243269?thread_ts=1766287341.243269&cid=C0832RVRVG8)

<a href="https://cursor.com/background-agent?bcId=bc-5e46bb1a-fd31-478d-9bcc-e38051c92d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e46bb1a-fd31-478d-9bcc-e38051c92d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect newline rendering in thinking blocks by decoding JSON escape sequences from think_tool arguments. Newlines and other special characters now display correctly in the UI.

- **Bug Fixes**
  - Added _unescape_json_string to decode \n, \t, \r, \", and \/ while preserving escaped backslashes.
  - Applied unescaping in _extract_reasoning_chunk so reasoning text renders as intended.

<sup>Written for commit a1af7623ccbfbb8d41c0703acb18418b8c64812f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



