### PR TITLE
chore(desktop): fix windows version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -202,7 +202,7 @@ jobs:
           if [ "${EVENT_NAME}" == "workflow_dispatch" ]; then
             VERSION="0.0.0-dev+${SHORT_SHA}"
           else
-            VERSION="${GITHUB_REF_NAME#v}+${SHORT_SHA}"
+            VERSION="${GITHUB_REF_NAME#v}"
           fi
           echo "Injecting version: $VERSION"
 
@@ -229,7 +229,8 @@ jobs:
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $VERSION = "0.0.0"
           } else {
-            $VERSION = "$env:GITHUB_REF_NAME" -replace '^v', ''
+            # Strip 'v' prefix and any pre-release suffix (e.g., -beta.13) for MSI compatibility
+            $VERSION = "$env:GITHUB_REF_NAME" -replace '^v', '' -replace '-.*$', ''
           }
           Write-Host "Injecting version: $VERSION"
 


### PR DESCRIPTION
## Description

Fixes https://github.com/onyx-dot-app/onyx/actions/runs/20472011456/job/58829251112#step:9:600

Also drops the commit suffix on macOS/Linux prod versions -- this was only intended to distinguish dev builds.

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows MSI build failures by generating an MSI-safe version. Also removes the commit hash from macOS/Linux production versions.

- **Bug Fixes**
  - Windows: strip the "v" prefix and any pre-release suffix for MSI compatibility.
  - macOS/Linux: strip the "v" prefix; prod uses the plain tag version; dev stays 0.0.0-dev+<short_sha>.

<sup>Written for commit 0d182ae6358b7f06162f34c24581a6c93e05a54f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





