### PR TITLE
chore: Tuning Deep Research

### DIFF
--- a/backend/onyx/prompts/deep_research/dr_tool_prompts.py
+++ b/backend/onyx/prompts/deep_research/dr_tool_prompts.py
@@ -17,7 +17,7 @@ THINK_TOOL_NAME = "think_tool"
 WEB_SEARCH_TOOL_DESCRIPTION = """
 
 ## web_search
-Use the web_search tool to get search results from the web. You should use this tool to get context for your research. These should be optimized for search engines like Google. \
+Use the `web_search` tool to get search results from the web. You should use this tool to get context for your research. These should be optimized for search engines like Google. \
 Use concise and specific queries and avoid merging multiple queries into one. You can call web_search with multiple queries at once (3 max) but generally only do this when there is a clear opportunity for parallel searching. \
 If you use multiple queries, ensure that the queries are related in topic but not similar such that the results would be redundant.
 """

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -53,6 +53,8 @@ In these cases, ensure that the new directions are thoroughly investigated prior
 NEVER output normal response tokens, you must only call tools.
 
 # Tools
+You have currently used {{current_cycle_count}} of {{max_cycles}} max research cycles. You do not need to use all cycles.
+
 ## {RESEARCH_AGENT_TOOL_NAME}
 The research task provided to the {RESEARCH_AGENT_TOOL_NAME} should be reasonably high level rather with a clear direction for investigation. \
 It should not be a single short query, rather it should be 1 or 2 descriptive sentences that outline the direction of the investigation.
@@ -62,11 +64,10 @@ You absolutely must provide all of the context needed to complete the task in th
 
 You should call the {RESEARCH_AGENT_TOOL_NAME} MANY times before completing with the {GENERATE_REPORT_TOOL_NAME} tool.
 
-You are encouraged to call the {RESEARCH_AGENT_TOOL_NAME} in parallel if the tasks are independent and do not build on each other, which is often the case. NEVER call more than 3 {RESEARCH_AGENT_TOOL_NAME} calls in parallel.
+You are encouraged to call the {RESEARCH_AGENT_TOOL_NAME} in parallel if the research tasks are not dependent on each other, which is typically the case. NEVER call more than 3 {RESEARCH_AGENT_TOOL_NAME} calls in parallel.
 
 ## {GENERATE_REPORT_TOOL_NAME}
 You should call the {GENERATE_REPORT_TOOL_NAME} tool if any of the following conditions are met:
-- You are close to or at the maximum number of cycles. You have currently used {{current_cycle_count}} of {{max_cycles}} cycles.
 - You have researched all of the relevant topics of the research plan.
 - You have shifted away from the original research plan and believe that you are done.
 - You have all of the information needed to thoroughly answer all aspects of the user's query.
@@ -134,6 +135,8 @@ Between calls, think deeply on what to do next. Be curious, identify knowledge g
 NEVER output normal response tokens, you must only call tools.
 
 # Tools
+You have currently used {{current_cycle_count}} of {{max_cycles}} max research cycles. You do not need to use all cycles.
+
 ## {RESEARCH_AGENT_TOOL_NAME}
 The research task provided to the {RESEARCH_AGENT_TOOL_NAME} should be reasonably high level rather with a clear direction for investigation. \
 It should not be a single short query, rather it should be 1 or 2 descriptive sentences that outline the direction of the investigation.
@@ -143,12 +146,10 @@ You absolutely must provide all of the context needed to complete the task in th
 
 You should call the {RESEARCH_AGENT_TOOL_NAME} MANY times before completing with the {GENERATE_REPORT_TOOL_NAME} tool.
 
-You are encouraged to call the {RESEARCH_AGENT_TOOL_NAME} in parallel if the tasks are independent and do not build on each other, which is often the case.
-NEVER call more than 3 {RESEARCH_AGENT_TOOL_NAME} calls in parallel.
+You are encouraged to call the {RESEARCH_AGENT_TOOL_NAME} in parallel if the research tasks are not dependent on each other, which is typically the case. NEVER call more than 3 {RESEARCH_AGENT_TOOL_NAME} calls in parallel.
 
 ## {GENERATE_REPORT_TOOL_NAME}
 You should call the {GENERATE_REPORT_TOOL_NAME} tool if any of the following conditions are met:
-- You are close to or at the maximum number of cycles. You have currently used {{current_cycle_count}} of {{max_cycles}} cycles.
 - You have researched all of the relevant topics of the research plan.
 - You have shifted away from the original research plan and believe that you are done.
 - You have all of the information needed to thoroughly answer all aspects of the user's query.
@@ -160,7 +161,8 @@ You should call the {GENERATE_REPORT_TOOL_NAME} tool if any of the following con
 
 
 USER_ORCHESTRATOR_PROMPT_REASONING = """
-Remember to refer to the system prompt and follow how to use the tools. Never run more than 3 research_agent calls in parallel.
+Remember to refer to the system prompt and follow how to use the tools. \
+You are encouraged to call the {RESEARCH_AGENT_TOOL_NAME} in parallel when the research tasks are not dependent on each other, but never call more than 3 {RESEARCH_AGENT_TOOL_NAME} calls in parallel.
 
 Don't mention this reminder or underlying details about the system.
 """.strip()

--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -30,7 +30,7 @@ After a set of searches + reads, use the {THINK_TOOL_NAME} to analyze the result
 or why there is enough information to answer the research task comprehensively.
 
 ## {GENERATE_REPORT_TOOL_NAME}
-Once you have completed your research, call the {GENERATE_REPORT_TOOL_NAME} tool. \
+Once you have completed your research, call the `{GENERATE_REPORT_TOOL_NAME}` tool. \
 You should only call this tool after you have fully researched the topic. \
 Consider other potential areas of research and weigh that against the materials already gathered before calling this tool.
 """.strip()
@@ -73,7 +73,7 @@ You are a highly capable, thoughtful, and precise research agent that conducts r
 You iteratively call the tools available to you including {{available_tools}} until you have completed your research at which point you call the {GENERATE_REPORT_TOOL_NAME} tool. Between calls, think about the results of the previous tool call and plan the next steps. \
 Reason thoroughly about what could be missing, identify knowledge gaps, and what queries might address them. Or consider why there is enough information to answer the research task comprehensively.
 
-Once you have completed your research, call the {GENERATE_REPORT_TOOL_NAME} tool.
+Once you have completed your research, call the `{GENERATE_REPORT_TOOL_NAME}` tool.
 
 NEVER output normal response tokens, you must only call tools.
 
@@ -85,7 +85,7 @@ You have a limited number of cycles of searches to complete your research but yo
 {{optional_web_search_tool_description}}\
 {{optional_open_url_tool_description}}
 ## {GENERATE_REPORT_TOOL_NAME}
-Once you have completed your research, call the {GENERATE_REPORT_TOOL_NAME} tool. You should only call this tool after you have fully researched the topic.
+Once you have completed your research, call the `{GENERATE_REPORT_TOOL_NAME}` tool. You should only call this tool after you have fully researched the topic.
 """.strip()
 
 


### PR DESCRIPTION
## Description

A couple parameter and prompt changes + 1 case of handling a LLM outputting bad value for a tool call

## How Has This Been Tested?

works locally, logs in braintrust

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened tool argument parsing to handle JSON-in-string outputs from the LLM and tuned Deep Research prompts for clearer cycle usage and parallelization guidance. This reduces tool call failures and improves orchestration behavior.

- **Bug Fixes**
  - Parse JSON-looking string values inside tool args (e.g., queries: '["q1","q2"]') to prevent malformed calls.
  - Expanded _parse_tool_args_to_dict to defensively handle dicts and nested stringified JSON.

- **New Features**
  - Added cycle usage notice in orchestrator prompts; clarified you don’t need to use all cycles.
  - Clarified guidance to parallelize independent research_agent tasks; capped at 3 calls.
  - Standardized tool name formatting with backticks and tightened wording for web_search and generate_report.

<sup>Written for commit c1ec6e876bc89349b4c57d340999058103cb1573. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

