### PR TITLE
chore: bolding enhancement

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -134,7 +134,6 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1975,7 +1974,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1991,7 +1989,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -2007,7 +2004,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -2021,7 +2017,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2032,7 +2027,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -2048,7 +2042,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2472,7 +2465,6 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2709,7 +2701,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2721,7 +2712,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2729,7 +2719,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3210,7 +3199,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3219,7 +3207,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.56.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.56.1"
@@ -5950,6 +5938,54 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "dev": true,
@@ -6024,6 +6060,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6132,7 +6174,6 @@
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -6141,7 +6182,6 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -6254,7 +6294,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -6322,7 +6361,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6332,7 +6370,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7026,7 +7064,6 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
@@ -7035,22 +7072,18 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
@@ -7060,12 +7093,10 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7076,7 +7107,6 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -7084,7 +7114,6 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -7092,12 +7121,10 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7112,7 +7139,6 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7124,7 +7150,6 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7135,7 +7160,6 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7148,7 +7172,6 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -7157,12 +7180,10 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/abab": {
@@ -7198,7 +7219,6 @@
     },
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -7238,7 +7258,6 @@
     },
     "node_modules/ajv": {
       "version": "8.17.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -7253,7 +7272,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -7269,7 +7287,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -7316,7 +7333,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7335,7 +7351,6 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -7361,7 +7376,6 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -7737,7 +7751,7 @@
     },
     "node_modules/babel-plugin-react-compiler": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -7953,7 +7967,6 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -8027,7 +8040,6 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8210,7 +8222,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -8573,7 +8584,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -8933,7 +8943,6 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
@@ -8946,7 +8955,6 @@
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -9092,7 +9100,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -9112,7 +9119,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -9125,7 +9131,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -9265,7 +9270,6 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -9834,7 +9838,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -9845,7 +9848,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9877,7 +9879,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -9933,7 +9934,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -9945,7 +9945,6 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9960,7 +9959,6 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9981,7 +9979,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9996,7 +9993,6 @@
     },
     "node_modules/fastq": {
       "version": "1.19.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -10115,7 +10111,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -10130,7 +10125,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -10475,7 +10469,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -10486,7 +10479,6 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -10547,7 +10539,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -10593,7 +10584,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11407,7 +11397,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11760,7 +11749,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -12417,7 +12405,6 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -12518,7 +12505,6 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -12637,7 +12623,6 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -12652,7 +12637,6 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -12757,6 +12741,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -13105,12 +13098,10 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -13642,7 +13633,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -13654,7 +13644,6 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13665,7 +13654,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13673,7 +13661,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -13734,7 +13721,6 @@
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -13779,7 +13765,6 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/next": {
@@ -16845,7 +16830,6 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -17055,7 +17039,6 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/param-case": {
@@ -17237,7 +17220,6 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17245,7 +17227,6 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -17312,7 +17293,7 @@
     },
     "node_modules/playwright": {
       "version": "1.56.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.56.1"
@@ -17329,7 +17310,7 @@
     },
     "node_modules/playwright-core": {
       "version": "1.56.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -17385,7 +17366,6 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -17401,7 +17381,6 @@
     },
     "node_modules/postcss-import/node_modules/resolve": {
       "version": "1.22.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -17420,7 +17399,6 @@
     },
     "node_modules/postcss-js": {
       "version": "4.1.0",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17444,7 +17422,6 @@
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17564,7 +17541,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17588,7 +17564,6 @@
     },
     "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -17814,7 +17789,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17833,7 +17807,6 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -18104,7 +18077,6 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -18384,7 +18356,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18484,7 +18455,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -18543,7 +18513,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18583,7 +18552,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18658,7 +18626,6 @@
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -18686,7 +18653,6 @@
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -18888,7 +18854,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19022,7 +18987,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -19036,7 +19000,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -19049,12 +19012,10 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -19172,7 +19133,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -19184,7 +19144,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -19354,7 +19313,6 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -19375,7 +19333,6 @@
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -19383,7 +19340,6 @@
     },
     "node_modules/sucrase/node_modules/glob": {
       "version": "10.4.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -19402,7 +19358,6 @@
     },
     "node_modules/sucrase/node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -19416,7 +19371,6 @@
     },
     "node_modules/sucrase/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -19424,7 +19378,6 @@
     },
     "node_modules/sucrase/node_modules/glob/node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -19481,7 +19434,6 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -19524,7 +19476,6 @@
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -19536,7 +19487,6 @@
     },
     "node_modules/tailwindcss/node_modules/resolve": {
       "version": "1.22.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -19555,7 +19505,6 @@
     },
     "node_modules/tapable": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19567,7 +19516,6 @@
     },
     "node_modules/terser": {
       "version": "5.44.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -19584,7 +19532,6 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.14",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -19617,7 +19564,6 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
       "version": "27.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -19630,7 +19576,6 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -19644,12 +19589,10 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -19690,7 +19633,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -19698,7 +19640,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -19819,7 +19760,6 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
@@ -20373,7 +20313,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {
@@ -20493,7 +20432,6 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -20525,7 +20463,6 @@
     },
     "node_modules/webpack": {
       "version": "5.102.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -20621,7 +20558,6 @@
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -20633,7 +20569,6 @@
     },
     "node_modules/webpack/node_modules/eslint-scope/node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -20801,7 +20736,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -20817,7 +20751,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20914,7 +20847,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Description

Increased the `font-weight` of `strong` (bold) elements in markdown content from `600` (semibold) to `700` (bold). This makes bold text slightly more prominent.

## How Has This Been Tested?
CI

## Additional Options

-   [x] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C09BHKH5PML/p1766530440499969?thread_ts=1766530440.499969&cid=C09BHKH5PML)

<a href="https://cursor.com/background-agent?bcId=bc-81814703-dc91-4bdd-9213-645c4450bc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81814703-dc91-4bdd-9213-645c4450bc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set bold weight for .font-main-content-body strong to 700 in globals.css so bold text is clearer and easier to scan.

<sup>Written for commit 0825e86baf5f992f3ed27f2ebc8a26ff37df1b11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







