### PR TITLE
fix: masking

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -165,7 +165,7 @@ class LitellmLLM(LLM):
 
     def _safe_model_config(self) -> dict:
         dump = self.config.model_dump()
-        dump["api_key"] = mask_string(dump.get("api_key", ""))
+        dump["api_key"] = mask_string(dump.get("api_key") or "")
         credentials_file = dump.get("credentials_file")
         if isinstance(credentials_file, str) and credentials_file:
             dump["credentials_file"] = mask_string(credentials_file)


### PR DESCRIPTION
## Description

Ran into:

```
   for packet in llm.stream(
  File "/Users/chrisweaver/projects/onyx/backend/onyx/llm/multi_llm.py", line 436, in stream
    self._completion(
  File "/Users/chrisweaver/projects/onyx/backend/onyx/llm/multi_llm.py", line 242, in _completion
    self._record_call(prompt)
  File "/Users/chrisweaver/projects/onyx/backend/onyx/llm/multi_llm.py", line 183, in _record_call
    "model": cast(JSON_ro, self._safe_model_config()),
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/backend/onyx/llm/multi_llm.py", line 168, in _safe_model_config
    dump["api_key"] = mask_string(dump.get("api_key", ""))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/backend/onyx/server/utils.py", line 46, in mask_string
    return "****...**" + sensitive_str[-4:]
                         ~~~~~~~~~~~~~^^^^^
TypeError: 'NoneType' object is not subscriptable
```

caused by `api_key` being `None`.

## How Has This Been Tested?

Ran with the same model (`us.writer.palmyra-x5-v1:0` on bedrock) and got the expected error

## Additional Options

- [x] [Optional] Override Linear Check
