### PR TITLE
chore(devtools): `ods openapi all` outputs to generated/

### DIFF
--- a/tools/ods/cmd/openapi.go
+++ b/tools/ods/cmd/openapi.go
@@ -10,7 +10,7 @@ import (
 // Default paths relative to git root
 const (
 	DefaultSchemaPath = "backend/generated/openapi.json"
-	DefaultClientDir  = "backend/generated/onyx_openapi_client"
+	DefaultClientDir  = "backend/generated/"
 )
 
 // OpenAPIOptions holds options for the openapi command.
@@ -200,4 +200,3 @@ func runOpenAPIAll(opts *OpenAPIOptions) {
 
 	log.Info("Generation completed successfully")
 }
-


### PR DESCRIPTION
## Description

This is currently output to `backend/generated/onyx_openapi_client/onyx_openapi_client/` when it should be `backend/generated/onyx_openapi_client/`.

This is currently causing this to import as Any which is being exposed here, https://github.com/onyx-dot-app/onyx/actions/runs/20472280039/job/58830068588?pr=6995#step:8:37

## How Has This Been Tested?

```
git clean -fdx backend/generated/
cd tools/ods/
go install .
cd -
~/.go/bin/ods openapi all
mypy .
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `ods openapi all` to output the OpenAPI client to `backend/generated/`, fixing the package layout. This prevents `Any` imports and resolves mypy errors in CI.

<sup>Written for commit ee562a66bcce623d23ae018e4a418b9ef39d33a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

