### PR TITLE
fix: improve scrollbar for code blocks

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -105,7 +105,7 @@
         "@types/react-dom": "^19.2.2",
         "@types/stats.js": "^0.17.4",
         "@types/uuid": "^9.0.8",
-        "@typescript/native-preview": "^7.0.0-dev.20251222.1",
+        "@typescript/native-preview": "7.0.0-dev.20251222.1",
         "babel-plugin-react-compiler": "^1.0.0",
         "chromatic": "^11.25.2",
         "eslint": "^9.39.1",

--- a/web/src/app/chat/message/custom-code-styles.css
+++ b/web/src/app/chat/message/custom-code-styles.css
@@ -166,16 +166,50 @@ pre[class*="language-"] {
     height: 8px; /* Horizontal scrollbar height */
   }
 
+  /* Light mode scrollbar */
+  ::-webkit-scrollbar-track {
+    background: #e5e7eb; /* Light track background color */
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #c9cdd1; /* Light handle color - subtle */
+    border-radius: 10px;
+    transition: background 0.2s ease;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #6b7280; /* Light handle color on hover */
+  }
+
+  scrollbar-width: thin;
+  scrollbar-color: #c9cdd1 #e5e7eb; /* thumb and track colors for light mode */
+}
+
+/* Light mode - highlight scrollbar when hovering code block */
+.prose
+  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
+  ::-webkit-scrollbar-thumb {
+    background: #9ca3af; /* More visible on code block hover */
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #6b7280;
+  }
+
+  scrollbar-color: #9ca3af #e5e7eb;
+}
+
+/* Dark mode scrollbar for code blocks */
+.dark
+  .prose
+  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   ::-webkit-scrollbar-track {
     background: #1f2937; /* Dark track background color */
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #4b5563; /* Dark handle color */
-    border-radius: 10px;
-    transition:
-      background 0.3s ease,
-      box-shadow 0.3s ease; /* Smooth transition for hover effect */
+    background: #374151; /* Dark handle color - subtle */
+    transition: background 0.2s ease;
   }
 
   ::-webkit-scrollbar-thumb:hover {
@@ -183,6 +217,21 @@ pre[class*="language-"] {
     box-shadow: 0 0 10px #6b7280; /* Light up effect on hover */
   }
 
-  scrollbar-width: thin;
-  scrollbar-color: #4b5563 #1f2937; /* thumb and track colors */
+  scrollbar-color: #374151 #1f2937; /* thumb and track colors for dark mode */
+}
+
+/* Dark mode - highlight scrollbar when hovering code block */
+.dark
+  .prose
+  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
+  ::-webkit-scrollbar-thumb {
+    background: #4b5563; /* More visible on code block hover */
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #6b7280;
+    box-shadow: 0 0 10px #6b7280;
+  }
+
+  scrollbar-color: #4b5563 #1f2937;
 }


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/6c7b8d6a-2157-42a4-b40b-e42ff27bb371

Previously was dark in light mode + there was no hover state.

## How Has This Been Tested?

Local

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved code block scrollbars in chat for both light and dark mode to make them easier to see and use. Also pinned @typescript/native-preview to a fixed dev version to prevent accidental updates.

- **Bug Fixes**
  - Light mode: updated track/thumb colors, hover highlight, and thin scrollbar; added scrollbar-color for Firefox.
  - Dark mode: consistent track/thumb colors with hover glow; scoped styles to prose code blocks only.

- **Dependencies**
  - Pinned @typescript/native-preview to 7.0.0-dev.20251222.1.

<sup>Written for commit 377013b42057c8bca5a47ccbd3e2fff145d4652c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

