### PR TITLE
chore(fe): "Copy code"->"Copy"

### DIFF
--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -49,7 +49,7 @@ export const CodeBlock = memo(function CodeBlock({
       ) : (
         <div className="flex items-center space-x-2">
           <SvgCopy height={14} width={14} stroke="currentColor" />
-          <Text secondaryMono>Copy code</Text>
+          <Text secondaryMono>Copy</Text>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Maybe we make it lowercase to match the language text on the other side (and to be hip).

**before**
<img width="820" height="240" alt="20251224_00h15m30s_grim" src="https://github.com/user-attachments/assets/99d33348-f530-49ec-8fa5-7d3452d200c0" />

**after**
<img width="828" height="236" alt="20251224_00h15m51s_grim" src="https://github.com/user-attachments/assets/6f1c71cb-531a-4f07-ba32-bd6f2d5a58e3" />

<img width="1244" height="842" alt="image" src="https://github.com/user-attachments/assets/e3034db5-c6f4-4796-9fd3-608c409bfe54" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened the copy button label in chat code blocks from "Copy code" to "Copy" for a cleaner UI and consistency with the icon.

<sup>Written for commit 8de4dda5f19a29f5e3b602288947ef05b9fccc7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

