### PR TITLE
chore(docs): update docker compose command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ You will need Docker installed to run these containers.
 First navigate to `onyx/deployment/docker_compose`, then start up Postgres/Vespa/Redis/MinIO with:
 
 ```bash
-docker compose up -d index relational_db cache minio
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d index relational_db cache minio
 ```
 
 (index refers to Vespa, relational_db refers to Postgres, and cache refers to Redis)


### PR DESCRIPTION
## Description

I was trying to setup a local dev environment based on the contribution guidelines, but it seems like the base docker-compose.yaml doesn't define port forwarding configurations. So someone who is following the instruction might get confused as to why the app is not starting up. The updated command starts up the app with merged base and dev configurations which would work out of the box.

Sorry if this seems like too trivial of a change to raise a PR for 😅 

## How Has This Been Tested?

I ran the command and the app is starting up properly :D 

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Docker Compose command in CONTRIBUTING.md to merge base and dev configs (-f docker-compose.yml -f docker-compose.dev.yml) when starting index, relational_db, cache, and minio. This applies dev port mappings so the app starts and is accessible locally.

<sup>Written for commit ca935794a6e073280b08bda05a17287498158cf0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

