### PR TITLE
fix: multiple tool calls unit test

### DIFF
--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -249,6 +249,7 @@ def test_multiple_tool_calls(default_multi_llm: LitellmLLM) -> None:
             max_tokens=None,
             parallel_tool_calls=True,
             mock_response=MOCK_LLM_RESPONSE,
+            allowed_openai_params=["tool_choice"],
         )
 
 
@@ -403,6 +404,7 @@ def test_multiple_tool_calls_streaming(default_multi_llm: LitellmLLM) -> None:
             stream_options={"include_usage": True},
             parallel_tool_calls=True,
             mock_response=MOCK_LLM_RESPONSE,
+            allowed_openai_params=["tool_choice"],
         )
 
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed multiple tool calls unit tests by allowing the OpenAI “tool_choice” param to pass through. This prevents param filtering from breaking parallel tool call behavior in both non-streaming and streaming tests.

- **Bug Fixes**
  - Added allowed_openai_params=["tool_choice"] in both tests.
  - Ensures mock responses and parallel tool calls behave as expected.

<sup>Written for commit c520d6e5d26e777f7ed832bb4513611f34ffa0f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

