### PR TITLE
fix(docprocessing): Set Worker Max Tasks per Child

### DIFF
--- a/backend/onyx/background/celery/configs/docprocessing.py
+++ b/backend/onyx/background/celery/configs/docprocessing.py
@@ -25,7 +25,7 @@ task_acks_late = shared_config.task_acks_late
 # task_track_started = True
 
 worker_concurrency = CELERY_WORKER_DOCPROCESSING_CONCURRENCY
-worker_pool = "threads"
+worker_pool = "prefork"
 worker_prefetch_multiplier = 1
 
 # Restart worker threads after N tasks to prevent Python memory fragmentation


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch docprocessing Celery workers to the prefork pool and set worker_max_tasks_per_child=50 to mitigate Python memory fragmentation. This restarts worker processes after 50 tasks to prevent gradual memory growth and improve stability.

<sup>Written for commit b8cc9be5fe5ba757213dc3ed79a20915073d1a9c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



