### PR TITLE
chore(fe): remove reliance on data-testid prop

### DIFF
--- a/web/src/components/FormErrorHelpers.tsx
+++ b/web/src/components/FormErrorHelpers.tsx
@@ -19,13 +19,8 @@ export function FormErrorFocus() {
       try {
         let target: HTMLElement | null = null;
 
-        // 1) Try by id, then data-testid
         for (const key of keys) {
-          target =
-            (document.getElementById(key) as HTMLElement | null) ||
-            (document.querySelector(
-              `[data-testid="${key}"]`
-            ) as HTMLElement | null);
+          target = document.getElementById(key) as HTMLElement | null;
           if (target) break;
         }
 


### PR DESCRIPTION
## Description

This is from https://github.com/onyx-dot-app/onyx/pull/7030#discussion_r2646514968

## How Has This Been Tested?

:shrug: 

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove reliance on data-testid in FormErrorFocus by targeting fields by id only. This simplifies the focus logic and avoids coupling to test-only attributes.

<sup>Written for commit 2e9811308731d692a50e194770b2da8c2e4271ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

