### PR TITLE
perf(fe): avoid needless renders on new message

### DIFF
--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -712,7 +712,88 @@ const ChatInputBar = React.memo(
         </>
       );
     }
-  )
+  ),
+  (prevProps, nextProps) => {
+    // Compare primitive props
+    if (
+      prevProps.retrievalEnabled !== nextProps.retrievalEnabled ||
+      prevProps.deepResearchEnabled !== nextProps.deepResearchEnabled ||
+      prevProps.disabled !== nextProps.disabled ||
+      prevProps.chatState !== nextProps.chatState ||
+      prevProps.currentSessionFileTokenCount !==
+        nextProps.currentSessionFileTokenCount ||
+      prevProps.availableContextTokens !== nextProps.availableContextTokens ||
+      prevProps.initialMessage !== nextProps.initialMessage
+    ) {
+      return false;
+    }
+
+    // Compare selectedDocuments array
+    if (
+      prevProps.selectedDocuments.length !== nextProps.selectedDocuments.length
+    ) {
+      return false;
+    }
+    for (let i = 0; i < prevProps.selectedDocuments.length; i++) {
+      if (
+        prevProps.selectedDocuments[i]?.document_id !==
+        nextProps.selectedDocuments[i]?.document_id
+      ) {
+        return false;
+      }
+    }
+
+    // Compare selectedAssistant
+    if (prevProps.selectedAssistant?.id !== nextProps.selectedAssistant?.id) {
+      return false;
+    }
+
+    // Compare filterManager - check key properties
+    const prevFilter = prevProps.filterManager;
+    const nextFilter = nextProps.filterManager;
+    if (
+      prevFilter.timeRange?.from !== nextFilter.timeRange?.from ||
+      prevFilter.timeRange?.to !== nextFilter.timeRange?.to ||
+      prevFilter.selectedDocumentSets.length !==
+        nextFilter.selectedDocumentSets.length
+    ) {
+      return false;
+    }
+    for (let i = 0; i < prevFilter.selectedDocumentSets.length; i++) {
+      if (
+        prevFilter.selectedDocumentSets[i] !==
+        nextFilter.selectedDocumentSets[i]
+      ) {
+        return false;
+      }
+    }
+
+    // Compare llmManager - check current model
+    if (
+      prevProps.llmManager.currentLlm?.modelName !==
+        nextProps.llmManager.currentLlm?.modelName ||
+      prevProps.llmManager.isLoadingProviders !==
+        nextProps.llmManager.isLoadingProviders
+    ) {
+      return false;
+    }
+
+    // Compare function props by reference (they should be stable via useCallback)
+    if (
+      prevProps.removeDocs !== nextProps.removeDocs ||
+      prevProps.toggleDocumentSidebar !== nextProps.toggleDocumentSidebar ||
+      prevProps.stopGenerating !== nextProps.stopGenerating ||
+      prevProps.onSubmit !== nextProps.onSubmit ||
+      prevProps.onHeightChange !== nextProps.onHeightChange ||
+      prevProps.handleFileUpload !== nextProps.handleFileUpload ||
+      prevProps.toggleDeepResearch !== nextProps.toggleDeepResearch ||
+      prevProps.setPresentingDocument !== nextProps.setPresentingDocument
+    ) {
+      return false;
+    }
+
+    return true;
+  }
 );
 ChatInputBar.displayName = "ChatInputBar";
 

--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { FileDescriptor } from "@/app/chat/interfaces";
 import "katex/dist/katex.min.css";
 import MessageSwitcher from "@/app/chat/message/MessageSwitcher";
@@ -102,7 +102,7 @@ interface HumanMessageProps {
   disableSwitchingForStreaming?: boolean;
 }
 
-export default function HumanMessage({
+function HumanMessage({
   content: initialContent,
   files,
   messageId,
@@ -257,3 +257,56 @@ export default function HumanMessage({
     </div>
   );
 }
+
+// Comparison function for React.memo
+function areHumanMessagePropsEqual(
+  prevProps: HumanMessageProps,
+  nextProps: HumanMessageProps
+): boolean {
+  // Compare primitive props
+  if (
+    prevProps.content !== nextProps.content ||
+    prevProps.messageId !== nextProps.messageId ||
+    prevProps.disableSwitchingForStreaming !==
+      nextProps.disableSwitchingForStreaming
+  ) {
+    return false;
+  }
+
+  // Compare files array
+  const prevFiles = prevProps.files || [];
+  const nextFiles = nextProps.files || [];
+  if (prevFiles.length !== nextFiles.length) {
+    return false;
+  }
+  for (let i = 0; i < prevFiles.length; i++) {
+    if (prevFiles[i]?.id !== nextFiles[i]?.id) {
+      return false;
+    }
+  }
+
+  // Compare otherMessagesCanSwitchTo array
+  const prevOther = prevProps.otherMessagesCanSwitchTo || [];
+  const nextOther = nextProps.otherMessagesCanSwitchTo || [];
+  if (prevOther.length !== nextOther.length) {
+    return false;
+  }
+  for (let i = 0; i < prevOther.length; i++) {
+    if (prevOther[i] !== nextOther[i]) {
+      return false;
+    }
+  }
+
+  // Compare function props by reference (they should be stable via useCallback)
+  if (
+    prevProps.onEdit !== nextProps.onEdit ||
+    prevProps.onMessageSelection !== nextProps.onMessageSelection ||
+    prevProps.stopGenerating !== nextProps.stopGenerating
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export default React.memo(HumanMessage, areHumanMessagePropsEqual);

--- a/web/src/app/chat/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/chat/message/messageComponents/markdownUtils.tsx
@@ -48,6 +48,30 @@ export const useMarkdownComponents = (
   processedContent: string,
   className?: string
 ) => {
+  // Memoize state values to prevent unnecessary callback recreation
+  // when state object reference changes but values remain the same
+  // Use content-based keys to detect actual changes
+  const docsKey = useMemo(
+    () => (state?.docs ? state.docs.map((d) => d.document_id).join(",") : ""),
+    [state?.docs]
+  );
+  const userFilesKey = useMemo(
+    () =>
+      state?.userFiles
+        ? state.userFiles.map((f) => f.id || f.file_id).join(",")
+        : "",
+    [state?.userFiles]
+  );
+  const citationsKey = useMemo(
+    () =>
+      state?.citations
+        ? Object.keys(state.citations)
+            .map((k) => `${k}:${state.citations?.[Number(k)]}`)
+            .join(",")
+        : "",
+    [state?.citations]
+  );
+
   const paragraphCallback = useCallback(
     (props: any) => (
       <MemoizedParagraph className={className}>
@@ -69,12 +93,7 @@ export const useMarkdownComponents = (
         {props.children}
       </MemoizedAnchor>
     ),
-    [
-      state?.docs,
-      state?.userFiles,
-      state?.citations,
-      state?.setPresentingDocument,
-    ]
+    [state?.setPresentingDocument, docsKey, userFilesKey, citationsKey]
   );
 
   const markdownComponents = useMemo(


### PR DESCRIPTION
## Description

TBD

## How Has This Been Tested?

Hmmm

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts unnecessary re-renders in ChatUI when new messages arrive or stream, improving scroll smoothness and reducing CPU use.

- **Performance**
  - Memoized AIMessage and HumanMessage with React.memo and custom prop comparators.
  - Added AIMessageWrapper to stabilize chatState and regenerate via useMemo.
  - Memoized ChatInputBar with a prop comparator to avoid re-renders during typing.
  - Stabilized markdown callbacks using memoized keys for docs, files, and citations; cleaned parent/previous message lookup to keep props stable.

<sup>Written for commit c52ea86e078dd92b295194e952fd2d56e7419c02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



