### PR TITLE
feat: `InputDatePicker` fixes

### DIFF
--- a/web/src/refresh-components/inputs/InputDatePicker.tsx
+++ b/web/src/refresh-components/inputs/InputDatePicker.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Button from "@/refresh-components/buttons/Button";
 import Calendar from "@/refresh-components/Calendar";
 import {
@@ -6,7 +8,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { SvgCalendar } from "@opal/icons";
 
 export interface InputDatePickerProps {
@@ -28,9 +30,13 @@ export default function InputDatePicker({
 }: InputDatePickerProps) {
   const validStartYear = Math.max(startYear, 1970);
   const currYear = extractYear(new Date());
-  const years = Array(currYear - validStartYear + 1)
-    .fill(currYear)
-    .map((currYear, index) => currYear - index);
+  const years = useMemo(
+    () =>
+      Array(currYear - validStartYear + 1)
+        .fill(currYear)
+        .map((currYear, index) => currYear - index),
+    [currYear, validStartYear]
+  );
   const [open, setOpen] = useState(false);
   const [internalDate, setInternalDate] = useState<Date | null>(
     selectedDateProp ?? null


### PR DESCRIPTION
## Description

- Makes `setSelectedDate` prop optional in InputDatePicker component.

## Notes

No UI changes; screenshots not required.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make selectedDate and setSelectedDate optional in InputDatePicker. Adds internal state for uncontrolled mode, fixes controlled detection, and memoizes the years list; date changes use a safe handler so Today click won’t throw.

<sup>Written for commit 7ec8f0c766f7489bad0ff89b167b54bdea8f7661. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







