### PR TITLE
feat: Add useOnChangeValue hook and update form components

### DIFF
--- a/web/src/hooks/formHooks.ts
+++ b/web/src/hooks/formHooks.ts
@@ -37,7 +37,7 @@ import { useField } from "formik";
  * }
  * ```
  */
-export function useFormInputCallback<T = any>(
+export function useOnChangeEvent<T = any>(
   name: string,
   f?: (event: T) => void
 ) {
@@ -46,5 +46,48 @@ export function useFormInputCallback<T = any>(
     helpers.setTouched(true);
     f?.(event);
     field.onChange(event);
+  };
+}
+
+/**
+ * Custom hook for handling form value changes in Formik forms.
+ *
+ * This hook automatically sets the field as "touched" when its value changes,
+ * enabling immediate validation feedback after the first user interaction.
+ * Use this for components that pass values directly (not events).
+ *
+ * @example
+ * ```tsx
+ * function MySelect({ name, onValueChange }: Props) {
+ *   const [field] = useField(name);
+ *   const onChange = useOnChangeValue(name, onValueChange);
+ *
+ *   return (
+ *     <Select value={field.value} onValueChange={onChange} />
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * function MyDatePicker({ name }: Props) {
+ *   const [field] = useField(name);
+ *   const onChange = useOnChangeValue(name);
+ *
+ *   return (
+ *     <DatePicker selectedDate={field.value} setSelectedDate={onChange} />
+ *   );
+ * }
+ * ```
+ */
+export function useOnChangeValue<T = any>(
+  name: string,
+  f?: (value: T) => void
+) {
+  const [, , helpers] = useField<T>(name);
+  return (value: T) => {
+    helpers.setTouched(true);
+    f?.(value);
+    helpers.setValue(value);
   };
 }

--- a/web/src/refresh-components/form/CheckboxField.tsx
+++ b/web/src/refresh-components/form/CheckboxField.tsx
@@ -2,7 +2,7 @@
 
 import { useField } from "formik";
 import Checkbox, { CheckboxProps } from "@/refresh-components/inputs/Checkbox";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeValue } from "@/hooks/formHooks";
 
 interface CheckboxFieldProps extends Omit<CheckboxProps, "checked"> {
   name: string;
@@ -14,13 +14,9 @@ export default function UnlabeledCheckboxField({
   ...props
 }: CheckboxFieldProps) {
   const [field] = useField<boolean>({ name, type: "checkbox" });
-  const onChange = useFormInputCallback<boolean>(name, onCheckedChange);
+  const onChange = useOnChangeValue(name, onCheckedChange);
 
   return (
-    <Checkbox
-      checked={field.value}
-      onCheckedChange={(checked) => onChange(Boolean(checked))}
-      {...props}
-    />
+    <Checkbox checked={field.value} onCheckedChange={onChange} {...props} />
   );
 }

--- a/web/src/refresh-components/form/InputDatePickerField.tsx
+++ b/web/src/refresh-components/form/InputDatePickerField.tsx
@@ -4,7 +4,7 @@ import { useField } from "formik";
 import InputDatePicker, {
   InputDatePickerProps,
 } from "@/refresh-components/inputs/InputDatePicker";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeValue } from "@/hooks/formHooks";
 
 interface InputDatePickerFieldProps
   extends Omit<InputDatePickerProps, "selectedDate" | "setSelectedDate"> {
@@ -18,7 +18,7 @@ export default function InputDatePickerField({
   ...props
 }: InputDatePickerFieldProps) {
   const [field] = useField<Date | null>(name);
-  const onChange = useFormInputCallback(name, setSelectedDate);
+  const onChange = useOnChangeValue(name, setSelectedDate);
 
   return (
     <InputDatePicker

--- a/web/src/refresh-components/form/InputSelectField.tsx
+++ b/web/src/refresh-components/form/InputSelectField.tsx
@@ -4,7 +4,7 @@ import { useField } from "formik";
 import InputSelect, {
   InputSelectRootProps,
 } from "@/refresh-components/inputs/InputSelect";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeValue } from "@/hooks/formHooks";
 
 export interface InputSelectFieldProps
   extends Omit<InputSelectRootProps, "value"> {
@@ -18,7 +18,7 @@ export default function InputSelectField({
   ...selectProps
 }: InputSelectFieldProps) {
   const [field, meta] = useField(name);
-  const onChange = useFormInputCallback(name, onValueChange);
+  const onChange = useOnChangeValue(name, onValueChange);
   const hasError = meta.touched && meta.error;
 
   return (

--- a/web/src/refresh-components/form/InputTextAreaField.tsx
+++ b/web/src/refresh-components/form/InputTextAreaField.tsx
@@ -4,7 +4,7 @@ import { useField } from "formik";
 import InputTextArea, {
   InputTextAreaProps,
 } from "@/refresh-components/inputs/InputTextArea";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeEvent } from "@/hooks/formHooks";
 
 export interface InputTextAreaFieldProps
   extends Omit<InputTextAreaProps, "value"> {
@@ -17,7 +17,7 @@ export default function InputTextAreaField({
   ...textareaProps
 }: InputTextAreaFieldProps) {
   const [field, meta] = useField(name);
-  const onChange = useFormInputCallback(name, onChangeProp);
+  const onChange = useOnChangeEvent(name, onChangeProp);
   const hasError = meta.touched && meta.error;
 
   return (

--- a/web/src/refresh-components/form/InputTypeInElementField.tsx
+++ b/web/src/refresh-components/form/InputTypeInElementField.tsx
@@ -6,7 +6,7 @@ import InputTypeIn, {
 } from "@/refresh-components/inputs/InputTypeIn";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgMinusCircle } from "@opal/icons";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeEvent } from "@/hooks/formHooks";
 
 export interface InputTypeInElementFieldProps
   extends Omit<InputTypeInProps, "value" | "onClear"> {
@@ -22,7 +22,7 @@ export default function InputTypeInElementField({
   ...inputProps
 }: InputTypeInElementFieldProps) {
   const [field, meta] = useField(name);
-  const onChange = useFormInputCallback(name, onChangeProp);
+  const onChange = useOnChangeEvent(name, onChangeProp);
   const hasError = meta.touched && meta.error;
   const isEmpty = !field.value || field.value.trim() === "";
 

--- a/web/src/refresh-components/form/InputTypeInField.tsx
+++ b/web/src/refresh-components/form/InputTypeInField.tsx
@@ -4,7 +4,7 @@ import { useField } from "formik";
 import InputTypeIn, {
   InputTypeInProps,
 } from "@/refresh-components/inputs/InputTypeIn";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeEvent } from "@/hooks/formHooks";
 
 export interface InputTypeInFieldProps
   extends Omit<InputTypeInProps, "value" | "onClear"> {
@@ -17,7 +17,7 @@ export default function InputTypeInField({
   ...inputProps
 }: InputTypeInFieldProps) {
   const [field, meta, helpers] = useField(name);
-  const onChange = useFormInputCallback(name, onChangeProp);
+  const onChange = useOnChangeEvent(name, onChangeProp);
   const hasError = meta.touched && meta.error;
 
   return (

--- a/web/src/refresh-components/form/SwitchField.tsx
+++ b/web/src/refresh-components/form/SwitchField.tsx
@@ -2,7 +2,7 @@
 
 import { useField } from "formik";
 import Switch, { SwitchProps } from "@/refresh-components/inputs/Switch";
-import { useFormInputCallback } from "@/hooks/formHooks";
+import { useOnChangeValue } from "@/hooks/formHooks";
 
 interface SwitchFieldProps extends Omit<SwitchProps, "checked"> {
   name: string;
@@ -14,13 +14,13 @@ export default function SwitchField({
   ...props
 }: SwitchFieldProps) {
   const [field] = useField<boolean>({ name, type: "checkbox" });
-  const onChange = useFormInputCallback<boolean>(name, onCheckedChange);
+  const onChange = useOnChangeValue(name, onCheckedChange);
 
   return (
     <Switch
       id={name}
       checked={field.value}
-      onCheckedChange={(checked) => onChange(Boolean(checked))}
+      onCheckedChange={onChange}
       {...props}
     />
   );


### PR DESCRIPTION
## Description

- Add new useOnChangeValue hook for handlers that expect values (not events)
- Update InputSelectField to use useOnChangeValue
- Update InputDatePickerField to use useOnChangeValue
- Update SwitchField to use useOnChangeValue (remove unnecessary Boolean wrapper)
- Update CheckboxField to use useOnChangeValue (remove unnecessary Boolean wrapper)
- Keep useOnChangeEvent for text input components that receive DOM events

## Notes

No UI changes; screenshots not required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds useOnChangeValue for value-based form inputs and updates form fields for consistent Formik behavior and immediate validation. Text inputs keep an event-based hook.

- **Refactors**
  - Added useOnChangeValue (sets touched and value) and switched InputSelectField, InputDatePickerField, SwitchField, and CheckboxField to use it; removed Boolean wrappers.
  - Renamed useFormInputCallback to useOnChangeEvent and applied it to InputTextAreaField, InputTypeInField, and InputTypeInElementField.

- **Migration**
  - If you import useFormInputCallback, rename it to useOnChangeEvent; use useOnChangeValue for value-only handlers.

<sup>Written for commit 8c8fe9890ff988c1710c2add45e221cf7d13d795. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

