### PR TITLE
fix: google index names

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -64,12 +64,12 @@ _BASE_EMBEDDING_MODELS = [
     _BaseEmbeddingModel(
         name="google/gemini-embedding-001",
         dim=3072,
-        index_name="danswer_chunk_google_gemini_embedding_001",
+        index_name="danswer_chunk_gemini_embedding_001",
     ),
     _BaseEmbeddingModel(
         name="google/text-embedding-005",
         dim=768,
-        index_name="danswer_chunk_google_text_embedding_005",
+        index_name="danswer_chunk_text_embedding_005",
     ),
     _BaseEmbeddingModel(
         name="voyage/voyage-large-2-instruct",


### PR DESCRIPTION
## Description

Index names for cloud are wrong.

## How Has This Been Tested?

Checked `index_name` in `search_settings` table for cloud, and it matches the new name.

## Additional Options

- [x] [Optional] Override Linear Check
