### PR TITLE
chore(desktop): skip desktop on beta tags

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -51,20 +51,23 @@ jobs:
           IS_STABLE_STANDALONE=false
           IS_BETA_STANDALONE=false
 
-          if [[ "$TAG" == *cloud* ]]; then
-            IS_CLOUD=true
-            BUILD_WEB_CLOUD=true
-          else
-            BUILD_WEB=true
-            BUILD_DESKTOP=true
-          fi
-
           # Version checks (for web - any stable version)
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             IS_STABLE=true
           fi
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
             IS_BETA=true
+          fi
+
+          if [[ "$TAG" == *cloud* ]]; then
+            IS_CLOUD=true
+            BUILD_WEB_CLOUD=true
+          else
+            BUILD_WEB=true
+            # Skip desktop builds on beta tags
+            if [[ "$IS_BETA" != "true" ]]; then
+              BUILD_DESKTOP=true
+            fi
           fi
 
           # Version checks (for backend/model-server - stable version excluding cloud tags)


### PR DESCRIPTION
## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip desktop builds on beta tags in the deployment workflow. Beta releases now build web only (or web-cloud for cloud tags), reducing CI time and preventing unnecessary desktop artifacts.

<sup>Written for commit 68f97222c9b78330805d4963407a648fb574dff4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

