### PR TITLE
fix: Fix overlay bug in which overlay would cover the main modal content

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -125,7 +125,6 @@ interface ModalContentProps
   tall?: boolean;
   mini?: boolean;
   preventAccidentalClose?: boolean;
-  skipOverlay?: boolean;
 }
 const ModalContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
@@ -141,7 +140,6 @@ const ModalContent = React.forwardRef<
       tall,
       mini,
       preventAccidentalClose = true,
-      skipOverlay = false,
       ...props
     },
     ref
@@ -271,7 +269,7 @@ const ModalContent = React.forwardRef<
         value={{ closeButtonRef, hasAttemptedClose, setHasAttemptedClose }}
       >
         <DialogPrimitive.Portal>
-          {!skipOverlay && <ModalOverlay />}
+          <ModalOverlay />
           <DialogPrimitive.Content
             ref={(node) => {
               // Handle forwarded ref

--- a/web/src/sections/actions/MCPPageContent.tsx
+++ b/web/src/sections/actions/MCPPageContent.tsx
@@ -28,7 +28,6 @@ import {
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 import useMcpServers from "@/hooks/useMcpServers";
-import Modal from "@/refresh-components/Modal";
 
 export default function MCPPageContent() {
   // Data fetching
@@ -537,15 +536,6 @@ export default function MCPPageContent() {
     <div className="flex flex-col h-full overflow-hidden">
       {popup}
 
-      {/* Shared overlay that persists across modal transitions */}
-      {showSharedOverlay && (
-        <div
-          className="fixed inset-0 z-modal-overlay bg-mask-03 backdrop-blur-03 pointer-events-none data-[state=open]:animate-in data-[state=open]:fade-in-0"
-          data-state="open"
-          aria-hidden="true"
-        />
-      )}
-
       <div className="flex-shrink-0 mb-4">
         <Actionbar
           hasActions={isLoading || mcpServers.length > 0}
@@ -598,7 +588,6 @@ export default function MCPPageContent() {
       <authModal.Provider>
         <MCPAuthenticationModal
           mcpServer={activeServer}
-          skipOverlay
           setPopup={setPopup}
           onTriggerFetchTools={triggerFetchToolsInPlace}
           mutateMcpServers={mutateMcpServers}
@@ -607,7 +596,6 @@ export default function MCPPageContent() {
 
       <manageServerModal.Provider>
         <AddMCPServerModal
-          skipOverlay
           activeServer={activeServer}
           setActiveServer={setActiveServer}
           disconnectModal={disconnectModal}
@@ -631,7 +619,6 @@ export default function MCPPageContent() {
         onConfirmDisconnect={handleConfirmDisconnect}
         onConfirmDisconnectAndDelete={handleConfirmDisconnectAndDelete}
         isDisconnecting={isDisconnecting}
-        skipOverlay
       />
     </div>
   );

--- a/web/src/sections/actions/OpenApiPageContent.tsx
+++ b/web/src/sections/actions/OpenApiPageContent.tsx
@@ -410,7 +410,6 @@ export default function OpenApiPageContent() {
 
       <addOpenAPIActionModal.Provider>
         <AddOpenAPIActionModal
-          skipOverlay
           setPopup={setPopup}
           existingTool={toolBeingEdited}
           onEditAuthentication={handleEditAuthenticationFromModal}
@@ -432,7 +431,6 @@ export default function OpenApiPageContent() {
       <openAPIAuthModal.Provider>
         <OpenAPIAuthenticationModal
           isOpen={openAPIAuthModal.isOpen}
-          skipOverlay
           onClose={resetAuthModal}
           title={authenticationModalTitle}
           entityName={selectedTool?.name ?? null}
@@ -455,7 +453,6 @@ export default function OpenApiPageContent() {
         onConfirmDisconnect={handleConfirmDisconnectFromModal}
         onConfirmDisconnectAndDelete={handleDeleteToolFromModal}
         isDisconnecting={isDisconnecting || isDeleting}
-        skipOverlay
       />
     </div>
   );

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -22,7 +22,6 @@ import { ModalCreationInterface } from "@/refresh-components/contexts/ModalConte
 import { SvgCheckCircle, SvgServer, SvgUnplug } from "@opal/icons";
 
 interface AddMCPServerModalProps {
-  skipOverlay?: boolean;
   activeServer: MCPServer | null;
   setActiveServer: (server: MCPServer | null) => void;
   disconnectModal: ModalCreationInterface;
@@ -42,7 +41,6 @@ const validationSchema = Yup.object().shape({
 });
 
 export default function AddMCPServerModal({
-  skipOverlay = false,
   activeServer,
   setActiveServer,
   disconnectModal,
@@ -131,11 +129,7 @@ export default function AddMCPServerModal({
 
   return (
     <Modal open={isOpen} onOpenChange={handleModalClose}>
-      <Modal.Content
-        tall
-        preventAccidentalClose={false}
-        skipOverlay={skipOverlay}
-      >
+      <Modal.Content tall preventAccidentalClose={false}>
         <Formik
           initialValues={initialValues}
           validationSchema={validationSchema}

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -35,7 +35,6 @@ import InfoBlock from "@/refresh-components/messages/InfoBlock";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 
 interface AddOpenAPIActionModalProps {
-  skipOverlay?: boolean;
   onSuccess?: (tool: ToolSnapshot) => void;
   onUpdate?: (tool: ToolSnapshot) => void;
   setPopup: (popup: PopupSpec) => void;
@@ -92,7 +91,6 @@ function SchemaActions({ definition, onFormat }: SchemaActionsProps) {
   );
 }
 export default function AddOpenAPIActionModal({
-  skipOverlay = false,
   onSuccess,
   onUpdate,
   setPopup,
@@ -327,7 +325,7 @@ export default function AddOpenAPIActionModal({
   return (
     <>
       <Modal open={isOpen} onOpenChange={handleModalClose}>
-        <Modal.Content tall skipOverlay={skipOverlay}>
+        <Modal.Content tall>
           <Formik
             initialValues={initialValues}
             validationSchema={validationSchema}

--- a/web/src/sections/actions/modals/DisconnectEntityModal.tsx
+++ b/web/src/sections/actions/modals/DisconnectEntityModal.tsx
@@ -13,7 +13,6 @@ interface DisconnectEntityModalProps {
   onConfirmDisconnect: () => void;
   onConfirmDisconnectAndDelete?: () => void;
   isDisconnecting?: boolean;
-  skipOverlay?: boolean;
 }
 
 export default function DisconnectEntityModal({
@@ -23,7 +22,6 @@ export default function DisconnectEntityModal({
   onConfirmDisconnect,
   onConfirmDisconnectAndDelete,
   isDisconnecting = false,
-  skipOverlay = false,
 }: DisconnectEntityModalProps) {
   const disconnectButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -41,7 +39,6 @@ export default function DisconnectEntityModal({
       <Modal.Content
         mini
         preventAccidentalClose={false}
-        skipOverlay={skipOverlay}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           disconnectButtonRef.current?.focus();
@@ -52,7 +49,6 @@ export default function DisconnectEntityModal({
             <SvgUnplug className={cn(className, "stroke-action-danger-05")} />
           )}
           title={`Disconnect ${name}`}
-          className="p-4"
           onClose={onClose}
         />
 

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -39,7 +39,6 @@ import { AuthType } from "@/lib/constants";
 
 interface MCPAuthenticationModalProps {
   mcpServer: MCPServer | null;
-  skipOverlay?: boolean;
   setPopup?: (spec: PopupSpec) => void;
   onTriggerFetchTools?: (serverId: number) => Promise<void> | void;
   mutateMcpServers: KeyedMutator<MCPServersResponse>;
@@ -105,7 +104,6 @@ const validationSchema = Yup.object().shape({
 
 export default function MCPAuthenticationModal({
   mcpServer,
-  skipOverlay = false,
   setPopup,
   onTriggerFetchTools,
   mutateMcpServers,
@@ -322,7 +320,7 @@ export default function MCPAuthenticationModal({
 
   return (
     <Modal open={isOpen} onOpenChange={toggle}>
-      <Modal.Content tall skipOverlay={skipOverlay}>
+      <Modal.Content tall>
         <Modal.Header
           icon={SvgArrowExchange}
           title={`Authenticate ${mcpServer?.name || "MCP Server"}`}

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -39,7 +39,6 @@ interface OpenAPIAuthenticationModalProps {
   onClose: () => void;
   title: string;
   description?: string;
-  skipOverlay?: boolean;
   defaultMethod?: AuthMethod;
   oauthConfigId?: number | null;
   initialHeaders?: KeyValue[] | null;
@@ -71,7 +70,6 @@ export default function OpenAPIAuthenticationModal({
   onClose,
   title,
   description = "Authenticate your connection to start using the OpenAPI actions.",
-  skipOverlay = false,
   defaultMethod = "oauth",
   oauthConfigId = null,
   initialHeaders = null,
@@ -314,7 +312,7 @@ export default function OpenAPIAuthenticationModal({
         }
       }}
     >
-      <Modal.Content tall skipOverlay={skipOverlay}>
+      <Modal.Content tall>
         <Modal.Header
           icon={SvgArrowExchange}
           title={title}


### PR DESCRIPTION
## Description

Fixes bug with overlay overlapping the main modal content. This also removes the `skipOverlay` flag, which was deemed to be unnecessary.

## Screenshots

### Before

<img width="1512" height="1069" alt="image" src="https://github.com/user-attachments/assets/ae3b2d7c-d87d-4172-b7e9-4a78d15e8208" />

### After

<img width="1514" height="1067" alt="image" src="https://github.com/user-attachments/assets/de7029aa-7d5d-45a5-b75c-b5f82996136e" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a modal overlay layering bug that caused the overlay to cover modal content. Simplifies modal usage by removing the skipOverlay prop and consolidating overlay rendering.

- **Bug Fixes**
  - Overlay is now rendered once by Modal.Content and positioned behind modal content.
  - Removed shared page-level overlays (MCP/OpenAPI) to prevent double overlays.
  - Standardized overlay stacking with z-modal-overlay to avoid conflicts.

- **Refactors**
  - Removed skipOverlay from Modal.Content and all modals.
  - Cleaned up Modal.Header classes to reduce stacking issues.

<sup>Written for commit bcc59a476b10589c3df6a108cf06d006c3e99603. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

