### PR TITLE
fix: Overlay ordering bug

### DIFF
--- a/web/src/sections/actions/MCPPageContent.tsx
+++ b/web/src/sections/actions/MCPPageContent.tsx
@@ -539,7 +539,7 @@ export default function MCPPageContent() {
       {/* Shared overlay that persists across modal transitions */}
       {showSharedOverlay && (
         <div
-          className="fixed inset-0 z-[2000] bg-mask-03 backdrop-blur-03 pointer-events-none data-[state=open]:animate-in data-[state=open]:fade-in-0"
+          className="fixed inset-0 z-modal-overlay bg-mask-03 backdrop-blur-03 pointer-events-none data-[state=open]:animate-in data-[state=open]:fade-in-0"
           data-state="open"
           aria-hidden="true"
         />

--- a/web/src/sections/actions/OpenApiPageContent.tsx
+++ b/web/src/sections/actions/OpenApiPageContent.tsx
@@ -367,7 +367,7 @@ export default function OpenApiPageContent() {
       {popup}
       {showSharedOverlay && (
         <div
-          className="fixed inset-0 z-[2000] bg-mask-03 backdrop-blur-03 pointer-events-none data-[state=open]:animate-in data-[state=open]:fade-in-0"
+          className="fixed inset-0 z-modal-overlay bg-mask-03 backdrop-blur-03 pointer-events-none data-[state=open]:animate-in data-[state=open]:fade-in-0"
           data-state="open"
           aria-hidden="true"
         />


### PR DESCRIPTION
## Description

Fixes bug with overlay overlapping the main modal content.

## Screenshots

### Before

<img width="1512" height="1069" alt="image" src="https://github.com/user-attachments/assets/ae3b2d7c-d87d-4172-b7e9-4a78d15e8208" />

### After

<img width="1512" height="1065" alt="image" src="https://github.com/user-attachments/assets/97a819b9-c7e3-4f4a-86ca-31451dff3323" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed overlay stacking so modal content renders above the shared overlay and no longer appears dimmed.

- **Bug Fixes**
  - Replaced hard-coded z-[2000] with z-modal-overlay for the shared overlay.
  - Applied to MCPPageContent and OpenApiPageContent.
  - Prevents the overlay from visually overlapping modal content.

<sup>Written for commit e0467bbf093c9a1fea8df60a1ed3cf79486eeb37. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->