### PR TITLE
fix(ui): Copy Traceback button

### DIFF
--- a/web/src/components/modals/ExceptionTraceModal.tsx
+++ b/web/src/components/modals/ExceptionTraceModal.tsx
@@ -1,13 +1,17 @@
 import { useState } from "react";
 import Modal from "@/refresh-components/Modal";
+import Text from "@/refresh-components/texts/Text";
 import { SvgAlertTriangle, SvgCheck, SvgCopy } from "@opal/icons";
+
+interface ExceptionTraceModalProps {
+  onOutsideClick: () => void;
+  exceptionTrace: string;
+}
+
 export default function ExceptionTraceModal({
   onOutsideClick,
   exceptionTrace,
-}: {
-  onOutsideClick: () => void;
-  exceptionTrace: string;
-}) {
+}: ExceptionTraceModalProps) {
   const [copyClicked, setCopyClicked] = useState(false);
 
   return (
@@ -21,24 +25,22 @@ export default function ExceptionTraceModal({
         <Modal.Body className="overflow-y-auto overflow-x-hidden pr-3 max-h-[70vh]">
           <div className="mb-6">
             {!copyClicked ? (
-              <div
+              <button
+                type="button"
                 onClick={() => {
                   navigator.clipboard.writeText(exceptionTrace!);
                   setCopyClicked(true);
                   setTimeout(() => setCopyClicked(false), 2000);
                 }}
-                className="flex w-fit cursor-pointer hover:bg-accent-background p-2 border-border border rounded"
+                className="flex w-fit items-center hover:bg-accent-background p-2 border-border border rounded"
               >
-                Copy full trace
-                <SvgCopy className="stroke-text-04 ml-2 my-auto" />
-              </div>
+                <Text as="span">Copy full trace</Text>
+                <SvgCopy className="stroke-text-04 ml-2 h-4 w-4 flex flex-shrink-0" />
+              </button>
             ) : (
-              <div className="flex w-fit hover:bg-accent-background p-2 border-border border rounded cursor-default">
-                Copied to clipboard
-                <SvgCheck
-                  className="my-auto ml-2 flex flex-shrink-0"
-                  size={16}
-                />
+              <div className="flex w-fit items-center hover:bg-accent-background p-2 border-border border rounded cursor-default">
+                <Text as="span">Copied to clipboard</Text>
+                <SvgCheck className="stroke-text-04 my-auto ml-2 h-4 w-4 flex flex-shrink-0" />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The copy icon in the traceback modal was not sized correctly. Fixing this.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Before: 
<img width="1235" height="587" alt="Screenshot 2025-12-26 at 11 09 04 AM" src="https://github.com/user-attachments/assets/ca987e09-1ff2-4a18-8bf1-68f3104aa234" />

After:
<img width="1206" height="527" alt="Screenshot 2025-12-26 at 11 08 43 AM" src="https://github.com/user-attachments/assets/8b1f3dd5-3ca3-459a-b7f8-96089ef113c9" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Copy Traceback control in the Exception Trace modal by correcting icon sizing and aligning the label with the icon. Replaces the clickable div with a proper button and standardizes text/icon styling to improve accessibility and readability.

<sup>Written for commit 6972bf5e25aa50e6a1f2d315dc5d8ec5a4928a11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

