### PR TITLE
fix(chat): Custom Agent Chat Rename

### DIFF
--- a/web/src/app/chat/hooks/useChatSessionController.ts
+++ b/web/src/app/chat/hooks/useChatSessionController.ts
@@ -272,7 +272,7 @@ export function useChatSessionController({
           await nameChatSession(existingChatSessionId);
           refreshChatSessions();
         }
-      } else if (newMessageHistory.length === 2 && !chatSession.description) {
+      } else if (newMessageHistory.length >= 2 && !chatSession.description) {
         await nameChatSession(existingChatSessionId);
         refreshChatSessions();
       }


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently when you try and chat with a custom agent, it never renames the chat. This is to fix this workflow 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally with multiple different agents including the default one and custom ones.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat auto-naming for custom agents. New chats are named once after the first assistant reply when no explicit title is provided, preventing unnamed sessions.

- **Bug Fixes**
  - Auto-name only when there’s no ?title, no prior user messages, and the session has no description.
  - Rename trigger now runs when history has 2+ messages (was exactly 2), covering custom agent flows.

<sup>Written for commit e6b0c3defedae014e4e8b60b10ee20a9497a1702. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

