### PR TITLE
chore(gha): automatically merge in latest in CI

### DIFF
--- a/.github/actions/sync-with-head/action.yml
+++ b/.github/actions/sync-with-head/action.yml
@@ -1,0 +1,44 @@
+name: "Merge on Main or Release"
+description: "Merges in the specific release branch if targeted, otherwise defaults to merging in main."
+inputs:
+  base_ref:
+    description: "The branch the PR is targeting"
+    required: true
+  remote_name:
+    description: "The remote name"
+    required: false
+    default: "origin"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Merge Upstream Target
+      shell: bash
+      env:
+        INPUT_TARGET: ${{ inputs.base_ref }}
+        REMOTE: ${{ inputs.remote_name }}
+      run: |
+
+        if [[ "$INPUT_TARGET" =~ ^release/ ]]; then
+          UPSTREAM_TARGET="$INPUT_TARGET"
+          echo "PR targets a release branch. Using: $UPSTREAM_TARGET"
+        else
+          UPSTREAM_TARGET="main"
+          # Stacked PRs default to `main` upstream. This avoids needing to re-run the tests
+          # against HEAD when the base branch is changed.
+          echo "PR targets '$INPUT_TARGET'. Defaulting merge to: $UPSTREAM_TARGET"
+        fi
+
+        # Configure Identity
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Fetch and Merge
+        echo "Fetching latest changes from $REMOTE/$UPSTREAM_TARGET..."
+        git fetch "$REMOTE" "$UPSTREAM_TARGET"
+
+        echo "Merging in $REMOTE/$UPSTREAM_TARGET..."
+        if ! git merge "$REMOTE/$UPSTREAM_TARGET" --no-edit; then
+          echo "::error::Merge failed. Pull latest changes from $UPSTREAM_TARGET into your branch to resolve conflicts locally."
+          exit 1
+        fi

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -55,6 +55,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Discover test directories
         id: set-matrix
@@ -89,6 +96,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Setup Python and Install Dependencies
         uses: ./.github/actions/setup-python-and-install-dependencies

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -26,8 +26,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
       with:
-        fetch-depth: 0
         persist-credentials: false
+        fetch-depth: 0
+
+    - name: Sync with HEAD
+      if: github.event_name == 'pull_request'
+      uses: ./.github/actions/sync-with-head
+      with:
+        base_ref: ${{ github.base_ref }}
 
     - name: Set up Helm
       uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # ratchet:azure/setup-helm@v4.3.1

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -51,6 +51,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Discover test directories
         id: set-matrix
@@ -82,6 +89,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Format branch name for cache
         id: format-branch
@@ -137,6 +151,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Format branch name for cache
         id: format-branch

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -26,6 +26,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Setup node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # ratchet:actions/setup-node@v4

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -18,6 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
+
       - name: Check PR title for Conventional Commits
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-linear-check.yml
+++ b/.github/workflows/pr-linear-check.yml
@@ -15,6 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
+
       - name: Check PR body for Linear link or override
         env:
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -63,6 +63,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Format branch name for cache
         id: format-branch
@@ -118,6 +125,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Format branch name for cache
         id: format-branch
@@ -173,6 +187,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Format branch name for cache
         id: format-branch
@@ -238,8 +259,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Setup node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # ratchet:actions/setup-node@v4

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -30,6 +30,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Setup Python and Install Dependencies
         uses: ./.github/actions/setup-python-and-install-dependencies

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -142,6 +142,13 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
 
       - name: Setup Python and Install Dependencies
         uses: ./.github/actions/setup-python-and-install-dependencies

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -35,6 +35,13 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
       with:
         persist-credentials: false
+        fetch-depth: 0
+
+    - name: Sync with HEAD
+      if: github.event_name == 'pull_request'
+      uses: ./.github/actions/sync-with-head
+      with:
+        base_ref: ${{ github.base_ref }}
 
     - name: Setup Python and Install Dependencies
       uses: ./.github/actions/setup-python-and-install-dependencies

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -20,10 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Sync with HEAD
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/sync-with-head
+        with:
+          base_ref: ${{ github.base_ref }}
+
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # ratchet:actions/setup-python@v6
         with:
           python-version: "3.11"


### PR DESCRIPTION
## Description

This ensures that presubmits, pre-merge queue jobs, run on the latest version of main/HEAD. This reduces the necessity for merge queue jobs as we have more confidence in presubmit by running the tests near HEAD regardless of how fresh the dev branch is kept. This should also reduce merge queue churn by failing in presubmit for integration issues rather than later.

The biggest drawback is this may cause unexpected failures in CI which require pulling in HEAD to reproduce locally. Devs may see failures in CI because their local branch is missing the commits from HEAD we now pull in in CI which expose the integration issues.

Note, we only merge in `main` and `release` branches. There is a world where we always merge in the `base_ref`, but I think there are pitfalls w.r.t. stacked PRs if we did this, i.e. tests wouldn't re-run after the base branch changes, so this is effectively a safer approach and if we have issues with Stacked PRs, we can re-evaluate as needed.

## How Has This Been Tested?

Captured by existing.

## Additional Options

- [x] Override Linear Check




















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite GitHub Action that merges the latest from main (or the targeted release/* branch) into PR branches during CI. Runs after checkout across all PR workflows to keep branches current and avoid re-running tests when the base changes.

<sup>Written for commit 5605a6f41422229bc0dfc082844bfa23f59da2a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



















