### PR TITLE
fix: disable responses api/reasoning param for gpt chat models

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -248,10 +248,14 @@ class LitellmLLM(LLM):
         )
 
         # Needed to get reasoning tokens from the model
+        # TODO: GPT 5 chat models are listed as reasoning models in the model_cost_map
+        # However, OpenAI's responses API does not accept reasoning.effort
+        # as a parameter for chat models, despite what is documented.
+        # If/when this is fixed, we can use the responses api with chat models.
         use_responses_api = (
             is_true_openai_model(self.config.model_provider, self.config.model_name)
             or self.config.model_provider == AZURE_PROVIDER_NAME
-        )
+        ) and "-chat" not in self.config.model_name
         if use_responses_api:
             model_provider = f"{self.config.model_provider}/responses"
         else:


### PR DESCRIPTION
## Description

- OpenAI API does not accept reasoning.effort for gpt chat models like gpt-5-chat-latest
- Litellm has these chat models listed as reasoning models
- OpenAI documentation implies they are reasoning models

Additionally
- We cannot designate them as non-reasoning models in Onyx because 1) our code passes self.temperature for non-reasoning models 2) these chat models will only accept temperature 1

## How Has This Been Tested?

Tested gpt-5, 5.1, and 5.2 chat models locally

## Additional Options
Fixes https://linear.app/danswer/issue/DAN-3245/gpt-5-chat-latest
- [ ] [Optional] Override Linear Check
