### PR TITLE
fix(ui): Align Tools Pages

### DIFF
--- a/web/src/app/admin/actions/mcp/page.tsx
+++ b/web/src/app/admin/actions/mcp/page.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { SvgMcp } from "@opal/icons";
 import MCPPageContent from "@/sections/actions/MCPPageContent";
-import * as SettingsLayouts from "@/layouts/settings-layouts";
+import { AdminPageTitle } from "@/components/admin/Title";
+import Text from "@/refresh-components/texts/Text";
+import { SvgMcp } from "@opal/icons";
 
 export default function Main() {
   return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header
-        icon={SvgMcp}
-        title="MCP Actions"
-        description="Connect MCP (Model Context Protocol) servers to add custom actions and tools for your assistants."
-        separator
-      />
-      <SettingsLayouts.Body>
-        <MCPPageContent />
-      </SettingsLayouts.Body>
-    </SettingsLayouts.Root>
+    <div className="container">
+      <AdminPageTitle icon={SvgMcp} title="MCP Actions" />
+      <Text secondaryBody text03 className="pt-4 pb-6">
+        Connect MCP (Model Context Protocol) servers to add custom actions and
+        tools for your assistants.
+      </Text>
+      <MCPPageContent />
+    </div>
   );
 }

--- a/web/src/app/admin/actions/open-api/page.tsx
+++ b/web/src/app/admin/actions/open-api/page.tsx
@@ -1,21 +1,19 @@
 "use client";
 
 import { SvgActions } from "@opal/icons";
-import * as SettingsLayouts from "@/layouts/settings-layouts";
+import { AdminPageTitle } from "@/components/admin/Title";
 import OpenApiPageContent from "@/sections/actions/OpenApiPageContent";
+import Text from "@/refresh-components/texts/Text";
 
 export default function Main() {
   return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header
-        icon={SvgActions}
-        title="OpenAPI Actions"
-        description="Connect OpenAPI servers to add custom actions and tools for your assistants."
-        separator
-      />
-      <SettingsLayouts.Body>
-        <OpenApiPageContent />
-      </SettingsLayouts.Body>
-    </SettingsLayouts.Root>
+    <div className="container">
+      <AdminPageTitle icon={SvgActions} title="OpenAPI Actions" />
+      <Text secondaryBody text03 className="pt-4 pb-6">
+        Connect OpenAPI servers to add custom actions and tools for your
+        assistants.
+      </Text>
+      <OpenApiPageContent />
+    </div>
   );
 }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently we don't align the Tools pages that were refactored. This just aligns the admin pages

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally.

Before:
<img width="1725" height="658" alt="Screenshot 2025-12-26 at 2 23 10 PM" src="https://github.com/user-attachments/assets/5677dafc-18d5-4897-a911-bb98e318a64b" />
<img width="1728" height="727" alt="Screenshot 2025-12-26 at 2 23 48 PM" src="https://github.com/user-attachments/assets/9d5c479a-dde3-4ac8-8437-ee41fe457f64" />


After:
<img width="1728" height="759" alt="Screenshot 2025-12-26 at 2 22 48 PM" src="https://github.com/user-attachments/assets/b950fd44-809a-48e9-b783-e2ff2ae9b354" />
<img width="1721" height="605" alt="Screenshot 2025-12-26 at 2 23 02 PM" src="https://github.com/user-attachments/assets/32c685ba-fec4-42a8-91ee-06f36e23feee" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the MCP Actions and OpenAPI Actions admin pages with the new admin layout for consistent headers and spacing. Replaced SettingsLayouts with AdminPageTitle and Text inside a container; page content stays the same.

<sup>Written for commit d646dbfe3ae01ca5897c0aff125ae1e5b744e5e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

