### PR TITLE
fix(ui): Align Performance Pages

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -7,32 +7,29 @@ import {
   TableCell,
   TableHeader,
 } from "@/components/ui/table";
-import Text from "@/components/ui/text";
-
-import { FiDownload } from "react-icons/fi";
+import Text from "@/refresh-components/texts/Text";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { ThreeDotsLoader } from "@/components/Loading";
-import { ChatSessionMinimal } from "../usage/types";
+import { ChatSessionMinimal } from "@/app/ee/admin/performance/usage/types";
 import { timestampToReadableDate } from "@/lib/dateUtils";
-import { FiFrown, FiMinus, FiSmile, FiMeh } from "react-icons/fi";
 import { Dispatch, SetStateAction, useCallback, useState } from "react";
 import { Feedback, TaskStatus } from "@/lib/types";
 import {
   DateRange,
   AdminDateRangeSelector,
-} from "../../../../../components/dateRangeSelectors/AdminDateRangeSelector";
+} from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { PageSelector } from "@/components/PageSelector";
 import Link from "next/link";
 import type { Route } from "next";
-import { FeedbackBadge } from "./FeedbackBadge";
-import KickoffCSVExport from "./KickoffCSVExport";
+import { FeedbackBadge } from "@/app/ee/admin/performance/query-history/FeedbackBadge";
+import KickoffCSVExport from "@/app/ee/admin/performance/query-history/KickoffCSVExport";
 import CardSection from "@/components/admin/CardSection";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR from "swr";
-import { TaskQueueState } from "./types";
-import { withRequestId } from "./utils";
+import { TaskQueueState } from "@/app/ee/admin/performance/query-history/types";
+import { withRequestId } from "@/app/ee/admin/performance/query-history/utils";
 import {
   DOWNLOAD_QUERY_HISTORY_URL,
   LIST_QUERY_HISTORY_URL,
@@ -40,13 +37,15 @@ import {
   ITEMS_PER_PAGE,
   PAGES_PER_BATCH,
   PREVIOUS_CSV_TASK_BUTTON_NAME,
-} from "./constants";
+} from "@/app/ee/admin/performance/query-history/constants";
 import { humanReadableFormatWithTime } from "@/lib/time";
 import Modal from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import { Badge } from "@/components/ui/badge";
 import {
+  SvgDownloadCloud,
   SvgFileText,
+  SvgMinus,
   SvgMinusCircle,
   SvgThumbsDown,
   SvgThumbsUp,
@@ -121,7 +120,7 @@ function SelectFeedbackType({
             <InputSelect.Item value="dislike" icon={SvgThumbsDown}>
               Dislike
             </InputSelect.Item>
-            <InputSelect.Item value="mixed" icon={FiMeh}>
+            <InputSelect.Item value="mixed" icon={SvgMinus}>
               Mixed
             </InputSelect.Item>
           </InputSelect.Content>
@@ -216,10 +215,10 @@ function PreviousQueryHistoryExportsModal({
                               task.taskId
                             )}
                           >
-                            <FiDownload color="primary" />
+                            <SvgDownloadCloud className="h-4 w-4 text-action-link-05" />
                           </a>
                         ) : (
-                          <FiDownload color="primary" className="opacity-20" />
+                          <SvgDownloadCloud className="h-4 w-4 text-action-link-05 opacity-20" />
                         )}
                       </TableCell>
                     </TableRow>

--- a/web/src/app/ee/admin/performance/query-history/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { AdminPageTitle } from "@/components/admin/Title";
-import { QueryHistoryTable } from "./QueryHistoryTable";
+import { QueryHistoryTable } from "@/app/ee/admin/performance/query-history/QueryHistoryTable";
 import { SvgServer } from "@opal/icons";
 export default function QueryHistoryPage() {
   return (
-    <main className="pt-4 mx-auto container">
+    <div className="container">
       <AdminPageTitle title="Query History" icon={SvgServer} />
 
       <QueryHistoryTable />
-    </main>
+    </div>
   );
 }

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -1,27 +1,24 @@
 "use client";
 
-import { AdminDateRangeSelector } from "../../../../../components/dateRangeSelectors/AdminDateRangeSelector";
-import { OnyxBotChart } from "./OnyxBotChart";
-import { FeedbackChart } from "./FeedbackChart";
-import { QueryPerformanceChart } from "./QueryPerformanceChart";
-import { PersonaMessagesChart } from "./PersonaMessagesChart";
-import { useTimeRange } from "../lib";
+import { AdminDateRangeSelector } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
+import { OnyxBotChart } from "@/app/ee/admin/performance/usage/OnyxBotChart";
+import { FeedbackChart } from "@/app/ee/admin/performance/usage/FeedbackChart";
+import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPerformanceChart";
+import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
+import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import { AdminPageTitle } from "@/components/admin/Title";
-import { FiActivity } from "react-icons/fi";
-import UsageReports from "./UsageReports";
+import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
 import Separator from "@/refresh-components/Separator";
 import { useAdminPersonas } from "@/hooks/useAdminPersonas";
+import { SvgActivity } from "@opal/icons";
 
 export default function AnalyticsPage() {
   const [timeRange, setTimeRange] = useTimeRange();
   const { personas } = useAdminPersonas();
 
   return (
-    <main className="pt-4 mx-auto container">
-      <AdminPageTitle
-        title="Usage Statistics"
-        icon={<FiActivity size={32} />}
-      />
+    <div className="container">
+      <AdminPageTitle title="Usage Statistics" icon={SvgActivity} />
       <AdminDateRangeSelector
         value={timeRange}
         onValueChange={(value) => setTimeRange(value as any)}
@@ -35,6 +32,6 @@ export default function AnalyticsPage() {
       />
       <Separator />
       <UsageReports />
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fix the alignment of the Performance pages

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned layouts on Performance > Usage and Query History pages by using the shared container and updating icons/components for consistent spacing and visuals.

- **Bug Fixes**
  - Standardized page wrappers to use div.container on both pages.
  - Replaced react-icons with @opal/icons (e.g., SvgActivity, SvgDownloadCloud, SvgMinus).
  - Switched to refreshed components and absolute imports (Text, AdminDateRangeSelector, FeedbackBadge, KickoffCSVExport).
  - Minor visual tweaks to icon sizing and styles; no logic or API changes.

<sup>Written for commit 56f7abf6f045e244fdf99c62e072800da036aa81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

