### PR TITLE
chore(alembic): fix new_chat_history downgrade

### DIFF
--- a/backend/alembic/versions/a852cbe15577_new_chat_history.py
+++ b/backend/alembic/versions/a852cbe15577_new_chat_history.py
@@ -280,6 +280,14 @@ def downgrade() -> None:
     op.add_column(
         "chat_message", sa.Column("alternate_assistant_id", sa.Integer(), nullable=True)
     )
+    # Recreate the FK constraint that was implicitly dropped when the column was dropped
+    op.create_foreign_key(
+        "fk_chat_message_persona",
+        "chat_message",
+        "persona",
+        ["alternate_assistant_id"],
+        ["id"],
+    )
     op.add_column(
         "chat_message", sa.Column("rephrased_query", sa.Text(), nullable=True)
     )


### PR DESCRIPTION
## Description

Fixes an inconsistent downgrade exposed by https://github.com/onyx-dot-app/onyx/pull/7069, https://github.com/onyx-dot-app/onyx/actions/runs/20534088069/job/58989930092?pr=7069#step:9:2027

```
FAILED tests/integration/tests/migrations/test_alembic_main.py::test_up_down_consistency - pytest_alembic.plugin.error.AlembicTestFailure: Failed to downgrade through each revision individually.

Failing Revision:
    23957775e5f5

Alembic Error:
    (psycopg2.errors.UndefinedObject) constraint "fk_chat_message_persona" of relation "chat_message" does not exist

    [SQL: ALTER TABLE chat_message DROP CONSTRAINT fk_chat_message_persona]
    (Background on this error at: https://sqlalche.me/e/20/f405)

```

## How Has This Been Tested?

Tests included in https://github.com/onyx-dot-app/onyx/pull/7069

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the new_chat_history Alembic downgrade by recreating the fk_chat_message_persona foreign key (chat_message.alternate_assistant_id -> persona.id). This ensures downgrades restore the schema correctly instead of leaving the column without its constraint.

<sup>Written for commit 426d6342b9c5e518013ab6bee17622c065e2b46a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

