### PR TITLE
refactor: layouts reorganization

### DIFF
--- a/web/src/layouts/actions-layouts.tsx
+++ b/web/src/layouts/actions-layouts.tsx
@@ -85,6 +85,11 @@ const ActionsLayoutContext = createContext<
   ActionsLayoutContextValue | undefined
 >(undefined);
 
+interface ActionsLayoutProviderProps {
+  children: React.ReactNode;
+  value: ActionsLayoutContextValue;
+}
+
 /**
  * ActionsLayout Provider Component
  *
@@ -94,10 +99,7 @@ const ActionsLayoutContext = createContext<
 function ActionsLayoutProvider({
   children,
   value,
-}: {
-  children: React.ReactNode;
-  value: ActionsLayoutContextValue;
-}) {
+}: ActionsLayoutProviderProps) {
   return (
     <ActionsLayoutContext.Provider value={value}>
       {children}


### PR DESCRIPTION
## Description

- The context value only updates when `isFolded` changes.
- The Provider component reference stays stable unless the context value changes.
- Children won't remount unnecessarily, preserving their state.

## Notes

No UI changes; screenshots not required.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defined a stable ActionsLayout Provider at module level and memoized the context value to prevent children from remounting when isFolded changes. Callers now pass contextValue to Provider via value, preserving child state and reducing unnecessary renders with no UI changes.

<sup>Written for commit d4b458f37509d9898aaaaf7623454018f1080c9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





