### PR TITLE
fix: rendering parallel research agents cleanly

### DIFF
--- a/web/src/app/chat/message/messageComponents/renderers/ResearchAgentRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/ResearchAgentRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useRef } from "react";
 import { FiUsers, FiCircle, FiTarget } from "react-icons/fi";
 import { SvgChevronDown } from "@opal/icons";
 import { cn } from "@/lib/utils";
@@ -164,6 +164,15 @@ export const ResearchAgentRenderer: MessageRenderer<
     (p) => p.obj.type === PacketType.SECTION_END
   );
   const [isExpanded, toggleExpanded] = useState(true);
+  const hasCalledCompleteRef = useRef(false);
+
+  // Call onComplete when research agent is complete
+  useEffect(() => {
+    if (isComplete && !hasCalledCompleteRef.current) {
+      hasCalledCompleteRef.current = true;
+      onComplete();
+    }
+  }, [isComplete, onComplete]);
 
   // Get the full report content from parent packets only
   const fullReportContent = parentPackets


### PR DESCRIPTION
## Description
The bug: 

https://github.com/user-attachments/assets/6ef287b9-6051-4e81-a741-3bf13a20aae5

Fix the renderering of parallel research agents to make it cleaner

## How Has This Been Tested?

https://github.com/user-attachments/assets/9d1e541d-5f16-4812-ae28-bab9bc3fb2f6

## Additional Options

- [x] [Optional] Override Linear Check
