### PR TITLE
chore(gha): playwright and integration are optional on merge_group

### DIFF
--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -1,4 +1,4 @@
-name: Merge Group Specific
+name: Merge Group-Specific
 
 on:
   merge_group:
@@ -7,17 +7,25 @@ permissions:
   contents: read
 
 jobs:
-  # This is required on presubmit and optional on merge_group, so we no-op succeed for the latter.
+  # This job immediately succeeds to satisfy branch protection rules on merge_group events.
+  # There is a similarly named "required" job in pr-integration-tests.yml which runs the actual
+  # integration tests. That job runs on both pull_request and merge_group events, and this job
+  # exists solely to provide a fast-passing check with the same name for branch protection.
+  # The actual tests remain enforced on presubmit (pull_request events).
   required:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Success
-        run: true
-  # This is required on presubmit and optional on merge_group, so we no-op succeed for the latter.
+        run: echo "Success"
+  # This job immediately succeeds to satisfy branch protection rules on merge_group events.
+  # There is a similarly named "playwright-required" job in pr-playwright-tests.yml which runs
+  # the actual playwright tests. That job runs on both pull_request and merge_group events, and
+  # this job exists solely to provide a fast-passing check with the same name for branch protection.
+  # The actual tests remain enforced on presubmit (pull_request events).
   playwright-required:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Success
-        run: true
+        run: echo "Success"


### PR DESCRIPTION
## Description



## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Playwright and integration tests non-blocking for merge_group to speed up the merge queue. Add a merge_group workflow with no-op "required" and "playwright-required" jobs while full checks still gate outside merge_group.

<sup>Written for commit 7c47460b2f21646bb582fc23132187405cd434cd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







