### PR TITLE
chore(pre-commit): rm check-yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,12 +75,6 @@ repos:
       #   pass_filenames: true
       #   files: ^backend/.*\.py$
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
-    hooks:
-      - id: check-yaml
-        files: ^.github/
-
   - repo: https://github.com/rhysd/actionlint
     rev: a443f344ff32813837fa49f7aa6cbc478d770e62 # frozen: v1.7.9
     hooks:


### PR DESCRIPTION
## Description

I think this is sufficiently covered by the `actionlint` hook, so we can remove to improve initialization time and reduce noise.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the check-yaml pre-commit hook for GitHub workflow YAMLs since actionlint already validates them. This speeds up pre-commit initialization and reduces duplicate lint noise.

<sup>Written for commit 297066087c2c2e75580be5529ac705dbbc70063c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

