### PR TITLE
fix: parallel tool tab hover

### DIFF
--- a/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
@@ -336,7 +336,10 @@ function ParallelToolTabs({
           </SimpleTooltip>
 
           {/* Collapse/expand button */}
-          <SimpleTooltip tooltip={isExpanded ? "Collapse" : "Expand"} side="top">
+          <SimpleTooltip
+            tooltip={isExpanded ? "Collapse" : "Expand"}
+            side="top"
+          >
             <button
               onClick={() => setIsExpanded(!isExpanded)}
               className="flex-shrink-0 p-1 rounded hover:bg-background-tint-02 active:bg-background-tint-00 transition-colors ml-0.5"


### PR DESCRIPTION
## Description

Adds hover effects and tooltips to the navigation (previous/next) and collapse/expand buttons within the parallel tool tabs.

## How Has This Been Tested?


https://github.com/user-attachments/assets/41e81fc6-501d-44ee-9ab0-536ee8a5097b

- Verified changes visually.
- Ran `npm run lint` (no new errors).
- Ran component tests for `MultiToolRenderer.tsx` (`npm test web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx`), all 33 tests passed.
- Ran `npm run typecheck` (pre-existing type errors unrelated to these changes).

## Additional Options

- [x] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C0832RVRVG8/p1766936299937519?thread_ts=1766936299.937519&cid=C0832RVRVG8)

<a href="https://cursor.com/background-agent?bcId=bc-38511b8d-da8c-4366-a90e-e2abf79ff0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38511b8d-da8c-4366-a90e-e2abf79ff0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tooltips and improved hover/active states to the Parallel Tool Tabs controls. Makes Previous/Next and Collapse/Expand clearer and easier to use.

- New Features
  - Tooltips for Previous, Next, and Collapse/Expand using SimpleTooltip.
  - Updated hover/active styles; disabled buttons keep muted/blocked state.
  - Tooltips are suppressed when actions are disabled; no behavior changes to navigation.

<sup>Written for commit 16d862163c1c2a34bec391631c60a36ef3ab48fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



