### PR TITLE
fix: think tool newline unescaping

### DIFF
--- a/backend/onyx/deep_research/utils.py
+++ b/backend/onyx/deep_research/utils.py
@@ -103,7 +103,9 @@ def _extract_reasoning_chunk(state: ThinkToolProcessorState) -> str | None:
 
     # If to_emit ends with a backslash, it might be the start of an escape sequence
     # Move it to the remaining buffer to process with the next chunk
-    while to_emit and to_emit[-1] == "\\":
+    # If to_emit ends with a backslash, it might be the start of an escape sequence
+    # Move it to the remaining buffer to process with the next chunk
+    if to_emit and to_emit[-1] == "\\":
         remaining = to_emit[-1] + remaining
         to_emit = to_emit[:-1]
 


### PR DESCRIPTION
## Description
The bug:
<img width="685" height="395" alt="Screenshot 2025-12-29 at 10 55 42" src="https://github.com/user-attachments/assets/4ada5d15-45ed-4e91-ba62-393198b8f3a9" />

Fix newline rendering in think\_tool reasoning content

When streaming think\_tool arguments character-by-character, escape sequences
like \n could be split across chunks. The holdback buffer logic would then
concatenate them without unescaping, causing literal \n text to appear in
the UI instead of actual newlines.

Changes:
- Increase holdback buffer from 2 to 3 characters to better handle escape sequences
- Detect trailing backslashes and move them to the buffer to prevent splitting
  escape sequences across chunks

This ensures all JSON escape sequences are properly unescaped before being
emitted as reasoning content.

## How Has This Been Tested?

Locally
<img width="635" height="377" alt="Screenshot 2025-12-29 at 10 54 17" src="https://github.com/user-attachments/assets/0624aa5f-2130-47a9-bc34-5f04e8782af3" />


## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix newline rendering in think_tool reasoning so JSON escapes like \n render as actual newlines instead of literal text. Increases the holdback buffer to 3 and moves trailing backslashes into the buffer to avoid splitting escape sequences across chunks.

<sup>Written for commit e60532e33c036316fd417fa3c688f36e67516a65. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



