### PR TITLE
feat: Add warnings support to `Formik` input layouts

### DIFF
--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -202,7 +202,7 @@ function ErrorLayout({ name }: FieldErrorLayoutProps) {
   const { status } = useFormikContext();
   const warning = status?.warnings?.[name];
   if (warning && typeof warning !== "string")
-    throw "The warning that is set must ALWAYS be a string";
+    throw new Error("The warning that is set must ALWAYS be a string");
 
   const hasError = meta.touched && meta.error;
   const hasWarning = warning; // Don't require touched for warnings


### PR DESCRIPTION
## Description

This adds the ability to display non-blocking warning messages in Formik forms through the status object. Warnings are displayed alongside validation errors but styled differently (yellow/warning color instead of red/error).

Key changes:
- ErrorLayout now checks for warnings in Formik's status.warnings object
- Warnings don't require the field to be touched (always visible when set)
- Warnings are displayed with warning-colored icon and text
- Both errors and warnings can be shown simultaneously

Usage:
1. Initialize Formik with initialStatus={{ warnings: {} }}
2. Use setStatus({ warnings: { fieldName: 'warning message' } })
3. Warnings will automatically appear under the field

## Screenshots

<img width="790" height="185" alt="image" src="https://github.com/user-attachments/assets/c9e45e88-5ae7-4681-8c96-0ca85078e7a3" />

<img width="792" height="189" alt="image" src="https://github.com/user-attachments/assets/ee959d50-cfa1-4bc3-a954-a874049ebd4e" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for non-blocking Formik warnings in input layouts. Warnings render alongside errors with yellow styling and don’t require the field to be touched.

- **New Features**
  - ErrorLayout reads status.warnings[name] via useFormikContext.
  - Shows errors and warnings together when both exist.
  - Throws if a warning is not a string.

- **Migration**
  - Initialize Formik with initialStatus: { warnings: {} }.
  - Set warnings with setStatus({ warnings: { fieldName: "message" } }).
  - Warnings appear under the field automatically.

<sup>Written for commit 2b0c5b3b921bfafdbe3393a754e68348b1c50d65. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





