### PR TITLE
chore(docker): add healthchecks

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -303,7 +303,7 @@ services:
     # ports:
     #   - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Description

Small QOL for debugging

## How Has This Been Tested?

```
$ docker ps
ef6e351a5e1b   onyxdotapp/onyx-backend:latest                   "/bin/sh -c 'alembic…"     54 minutes ago   Up 49 minutes (healthy)      0.0.0.0:8080->8080/tcp, [::]:8080 ->8080/tcp                                                    onyx-api_server-1
3fb85b8c2af0   postgres:15.2-alpine                             "docker-entrypoint.s…"     2 hours ago      Up About an hour (healthy)   0.0.0.0:5432->5432/tcp, [::]:5432 ->5432/tcp                         
...
```

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Docker healthchecks for the API server and Postgres to make container status clear and improve debugging.

- **New Features**
  - API server: HTTP check to http://localhost:8080/health via python (interval 30s, timeout 20s, retries 3, start_period 25s).
  - Postgres: pg_isready -U ${POSTGRES_USER:-postgres} (interval 10s, timeout 5s, retries 5).

<sup>Written for commit ed04fd1ea541687ccdcc0821d33cf6db9df40fb9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



