### PR TITLE
feat(ux): include a copy button for chat stack traces

### DIFF
--- a/web/src/app/chat/message/Resubmit.tsx
+++ b/web/src/app/chat/message/Resubmit.tsx
@@ -60,7 +60,7 @@ export const ErrorBanner = ({
               <div className="flex flex-1 justify-between">
                 <button
                   onClick={() => setIsStackTraceExpanded(!isStackTraceExpanded)}
-                  className="flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200"
+                  className="flex items-center gap-1.5 text-xs text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 cursor-pointer"
                 >
                   {isStackTraceExpanded ? (
                     <ChevronDown className="h-3 w-3" />


### PR DESCRIPTION
## Description

Almost every time I see a stack trace, I will want to copy it. I find selecting text to be a bit cumbersome. I believe this matches parities error modals anyways.

## How Has This Been Tested?

<img width="1587" height="2085" alt="20251229_11h36m45s_grim" src="https://github.com/user-attachments/assets/22287161-cfba-44d4-938a-ca90a55c3b81" />

## Additional Options

- [x] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a copy button to chat stack traces for one-click copying. Keeps the expand/collapse toggle and aligns with the error modal UX.

<sup>Written for commit 66ad0479fb783510ad7991f70ed4d6cb5c28abdb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





