### PR TITLE
chore(fe): refresh chat Stack Trace button

### DIFF
--- a/web/src/app/chat/message/Resubmit.tsx
+++ b/web/src/app/chat/message/Resubmit.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { SvgChevronDown, SvgChevronUp } from "@opal/icons";
+import { SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import Button from "@/refresh-components/buttons/Button";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { getErrorIcon, getErrorTitle } from "./errorHelpers";
@@ -61,11 +61,11 @@ export const ErrorBanner = ({
                 <Button
                   tertiary
                   leftIcon={
-                    isStackTraceExpanded ? SvgChevronDown : SvgChevronUp
+                    isStackTraceExpanded ? SvgChevronDown : SvgChevronRight
                   }
                   onClick={() => setIsStackTraceExpanded(!isStackTraceExpanded)}
                 >
-                  Stack Trace
+                  Stack trace
                 </Button>
                 <CopyIconButton tertiary getCopyText={() => stackTrace} />
               </div>


### PR DESCRIPTION
## Description

Replaces the vanilla `button` with a refresh as requested, https://github.com/onyx-dot-app/onyx/pull/7091#discussion_r2651650073

## How Has This Been Tested?

<img width="1587" height="2085" alt="20251229_12h21m35s_grim" src="https://github.com/user-attachments/assets/08cc7bad-6bc8-44c4-943b-b2dbea838a92" />

## Additional Options

- [x] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the chat error "Stack Trace" toggle to use the shared Button component and Opal icons for a more consistent UI.

- **Refactors**
  - Replaced native button with refresh Button.
  - Swapped lucide chevrons for @opal/icons SvgChevronUp/Down.
  - Center aligned content, title-cased label to "Stack Trace", and set CopyIconButton to tertiary.

<sup>Written for commit 84be15637a8c7ae7c1b965cf0c6b17641bd19ea3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



