### PR TITLE
fix: get_tenant_users script invalid sql stmt

### DIFF
--- a/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_users.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_users.py
@@ -36,7 +36,8 @@ def get_tenant_users(tenant_id: str) -> dict:
         with get_session_with_tenant(tenant_id=tenant_id) as db_session:
             # Query users from the tenant schema
             # Select only the email column
-            stmt = select(User.email).order_by(User.email)
+            user_email_column = User.__table__.c.email
+            stmt = select(user_email_column).order_by(user_email_column)
             result = db_session.execute(stmt)
             users = [row[0] for row in result]
 


### PR DESCRIPTION
## Description

Script was attempting to select columns that don't exist.

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

Deleted some tenants using the new version of script

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes get_tenant_users by selecting only the email column via ORM. This prevents “column does not exist” errors on tenants with older migrations and stabilizes cleanup scripts.

- **Bug Fixes**
  - Replaced select(User) with select(User.email) ordered by email.
  - Updated result handling to read rows directly (row[0]) instead of .scalars().

<sup>Written for commit b4d811efaf091984ecb867c8f201ab1f281ca0d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





