### PR TITLE
chore: docker compose no MCP server

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -13,9 +13,10 @@ services:
     ports:
       - "8080:8080"
 
-  mcp_server:
-    ports:
-      - "8090:8090"
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   ports:
+  #     - "8090:8090"
 
   relational_db:
     ports:

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -294,46 +294,47 @@ services:
       - ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=${ENABLE_PAID_ENTERPRISE_EDITION_FEATURES:-false}
       - NEXT_PUBLIC_CUSTOM_REFRESH_URL=${NEXT_PUBLIC_CUSTOM_REFRESH_URL:-}
 
-  mcp_server:
-    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-        echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-        exit 0;
-      else
-        exec python -m onyx.mcp_server_main;
-      fi"
-    ports:
-      - "8090:8090"
-    env_file:
-      - path: .env
-        required: false
-    depends_on:
-      - relational_db
-      - cache
-    restart: "no"
-    environment:
-      - POSTGRES_HOST=relational_db
-      - REDIS_HOST=cache
-      # MCP Server Configuration
-      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=api_server
-      - API_SERVER_PORT=8080
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    volumes:
-      - mcp_server_logs:/var/log/onyx
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
+  #   build:
+  #     context: ../../backend
+  #     dockerfile: Dockerfile
+  #   command: >
+  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
+  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
+  #       exit 0;
+  #     else
+  #       exec python -m onyx.mcp_server_main;
+  #     fi"
+  #   ports:
+  #     - "8090:8090"
+  #   env_file:
+  #     - path: .env
+  #       required: false
+  #   depends_on:
+  #     - relational_db
+  #     - cache
+  #   restart: "no"
+  #   environment:
+  #     - POSTGRES_HOST=relational_db
+  #     - REDIS_HOST=cache
+  #     # MCP Server Configuration
+  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
+  #     - API_SERVER_HOST=api_server
+  #     - API_SERVER_PORT=8080
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   volumes:
+  #     - mcp_server_logs:/var/log/onyx
 
   inference_model_server:
     image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
@@ -520,4 +521,4 @@ volumes:
 
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  mcp_server_logs:
+  # mcp_server_logs:

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -99,44 +99,45 @@ services:
         max-size: "50m"
         max-file: "6"
 
-  mcp_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-        echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-        exit 0;
-      else
-        exec python -m onyx.mcp_server_main;
-      fi"
-    env_file:
-      - path: .env
-        required: false
-    depends_on:
-      - relational_db
-      - cache
-    restart: "no"
-    environment:
-      - POSTGRES_HOST=relational_db
-      - REDIS_HOST=cache
-      # MCP Server Configuration
-      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      - API_SERVER_PORT=${API_SERVER_PORT:-8080}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    volumes:
-      - mcp_server_logs:/var/log/onyx
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+  #   build:
+  #     context: ../../backend
+  #     dockerfile: Dockerfile
+  #   command: >
+  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
+  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
+  #       exit 0;
+  #     else
+  #       exec python -m onyx.mcp_server_main;
+  #     fi"
+  #   env_file:
+  #     - path: .env
+  #       required: false
+  #   depends_on:
+  #     - relational_db
+  #     - cache
+  #   restart: "no"
+  #   environment:
+  #     - POSTGRES_HOST=relational_db
+  #     - REDIS_HOST=cache
+  #     # MCP Server Configuration
+  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
+  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
+  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   volumes:
+  #     - mcp_server_logs:/var/log/onyx
 
   relational_db:
     image: postgres:15.2-alpine
@@ -312,4 +313,4 @@ volumes:
   # Created by the container itself
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  mcp_server_logs:
+  # mcp_server_logs:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -119,44 +119,45 @@ services:
         max-size: "50m"
         max-file: "6"
 
-  mcp_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-        echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-        exit 0;
-      else
-        exec python -m onyx.mcp_server_main;
-      fi"
-    env_file:
-      - path: .env
-        required: false
-    depends_on:
-      - relational_db
-      - cache
-    restart: "no"
-    environment:
-      - POSTGRES_HOST=relational_db
-      - REDIS_HOST=cache
-      # MCP Server Configuration
-      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      - API_SERVER_PORT=${API_SERVER_PORT:-8080}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    volumes:
-      - mcp_server_logs:/var/log/onyx
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+  #   build:
+  #     context: ../../backend
+  #     dockerfile: Dockerfile
+  #   command: >
+  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
+  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
+  #       exit 0;
+  #     else
+  #       exec python -m onyx.mcp_server_main;
+  #     fi"
+  #   env_file:
+  #     - path: .env
+  #       required: false
+  #   depends_on:
+  #     - relational_db
+  #     - cache
+  #   restart: "no"
+  #   environment:
+  #     - POSTGRES_HOST=relational_db
+  #     - REDIS_HOST=cache
+  #     # MCP Server Configuration
+  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
+  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
+  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   volumes:
+  #     - mcp_server_logs:/var/log/onyx
 
   inference_model_server:
     image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
@@ -348,4 +349,4 @@ volumes:
   background_logs:
   inference_model_server_logs:
   indexing_model_server_logs:
-  mcp_server_logs:
+  # mcp_server_logs:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -131,44 +131,45 @@ services:
         max-size: "50m"
         max-file: "6"
 
-  mcp_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-        echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-        exit 0;
-      else
-        exec python -m onyx.mcp_server_main;
-      fi"
-    env_file:
-      - path: .env
-        required: false
-    depends_on:
-      - relational_db
-      - cache
-    restart: "no"
-    environment:
-      - POSTGRES_HOST=relational_db
-      - REDIS_HOST=cache
-      # MCP Server Configuration
-      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      - API_SERVER_PORT=${API_SERVER_PORT:-8080}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    volumes:
-      - mcp_server_logs:/var/log/onyx
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+  #   build:
+  #     context: ../../backend
+  #     dockerfile: Dockerfile
+  #   command: >
+  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
+  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
+  #       exit 0;
+  #     else
+  #       exec python -m onyx.mcp_server_main;
+  #     fi"
+  #   env_file:
+  #     - path: .env
+  #       required: false
+  #   depends_on:
+  #     - relational_db
+  #     - cache
+  #   restart: "no"
+  #   environment:
+  #     - POSTGRES_HOST=relational_db
+  #     - REDIS_HOST=cache
+  #     # MCP Server Configuration
+  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
+  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
+  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   volumes:
+  #     - mcp_server_logs:/var/log/onyx
 
   relational_db:
     image: postgres:15.2-alpine
@@ -378,4 +379,4 @@ volumes:
   background_logs:
   inference_model_server_logs:
   indexing_model_server_logs:
-  mcp_server_logs:
+  # mcp_server_logs:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -165,45 +165,46 @@ services:
     environment:
       - INTERNAL_URL=${INTERNAL_URL:-http://api_server:8080}
 
-  mcp_server:
-    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-        echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-        exit 0;
-      else
-        exec python -m onyx.mcp_server_main;
-      fi"
-    env_file:
-      - path: .env
-        required: false
-    depends_on:
-      - relational_db
-      - cache
-    restart: "no"
-    environment:
-      - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
-      - REDIS_HOST=${REDIS_HOST:-cache}
-      # MCP Server Configuration
-      - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-      - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      - API_SERVER_PORT=${API_SERVER_PORT:-8080}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-    # Optional, only for debugging purposes
-    volumes:
-      - mcp_server_logs:/var/log/onyx
+  # Uncomment the block below to enable the MCP server for Onyx.
+  # mcp_server:
+  #   image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
+  #   build:
+  #     context: ../../backend
+  #     dockerfile: Dockerfile
+  #   command: >
+  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
+  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
+  #       exit 0;
+  #     else
+  #       exec python -m onyx.mcp_server_main;
+  #     fi"
+  #   env_file:
+  #     - path: .env
+  #       required: false
+  #   depends_on:
+  #     - relational_db
+  #     - cache
+  #   restart: "no"
+  #   environment:
+  #     - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
+  #     - REDIS_HOST=${REDIS_HOST:-cache}
+  #     # MCP Server Configuration
+  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
+  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
+  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
+  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
+  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
+  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway"
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "6"
+  #   # Optional, only for debugging purposes
+  #   volumes:
+  #     - mcp_server_logs:/var/log/onyx
 
   inference_model_server:
     image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
@@ -456,6 +457,6 @@ volumes:
   # Logs preserved across container restarts
   api_server_logs:
   background_logs:
-  mcp_server_logs:
+  # mcp_server_logs:
   inference_model_server_logs:
   indexing_model_server_logs:


### PR DESCRIPTION
## Description

No longer starting a dead MCP server with the docker compose deployments

## How Has This Been Tested?

Works

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the MCP server across all Docker Compose configs by commenting out the service and its logs volume. This prevents a dead container from starting and makes MCP opt-in.

- **Migration**
  - To enable MCP: uncomment the mcp_server service block and the mcp_server_logs volume in your compose file.
  - Set MCP_SERVER_ENABLED=true and configure MCP_SERVER_PORT/CORS env vars as needed.

<sup>Written for commit 9a6a078c614dbb3ebd132ad5077c063f3620f867. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

