### PR TITLE
chore(fe): `Text` default span follow up

### DIFF
--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -78,7 +78,7 @@ export default function OnyxApiKeyForm({
           >
             {({ isSubmitting }) => (
               <Form className="w-full overflow-visible">
-                <Text>
+                <Text as="p">
                   Choose a memorable name for your API key. This is optional and
                   can be added or changed later!
                 </Text>

--- a/web/src/app/admin/api-key/page.tsx
+++ b/web/src/app/admin/api-key/page.tsx
@@ -63,7 +63,7 @@ function Main() {
 
   const introSection = (
     <div className="flex flex-col items-start gap-4">
-      <Text>
+      <Text as="p">
         API Keys allow you to access Onyx APIs programmatically. Click the
         button below to generate a new API Key.
       </Text>

--- a/web/src/app/admin/assistants/PersonaTable.tsx
+++ b/web/src/app/admin/assistants/PersonaTable.tsx
@@ -23,22 +23,24 @@ import { SvgAlertCircle, SvgTrash } from "@opal/icons";
 
 function PersonaTypeDisplay({ persona }: { persona: Persona }) {
   if (persona.builtin_persona) {
-    return <Text>Built-In</Text>;
+    return <Text as="p">Built-In</Text>;
   }
 
   if (persona.is_default_persona) {
-    return <Text>Default</Text>;
+    return <Text as="p">Default</Text>;
   }
 
   if (persona.is_public) {
-    return <Text>Public</Text>;
+    return <Text as="p">Public</Text>;
   }
 
   if (persona.groups.length > 0 || persona.users.length > 0) {
-    return <Text>Shared</Text>;
+    return <Text as="p">Shared</Text>;
   }
 
-  return <Text>Personal {persona.owner && <>({persona.owner.email})</>}</Text>;
+  return (
+    <Text as="p">Personal {persona.owner && <>({persona.owner.email})</>}</Text>
+  );
 }
 
 export function PersonasTable({
@@ -211,7 +213,7 @@ export function PersonasTable({
               }
             >
               <div className="flex flex-col gap-2">
-                <Text>{text}</Text>
+                <Text as="p">{text}</Text>
                 <Text as="p" text03>
                   {additionalText}
                 </Text>
@@ -315,7 +317,7 @@ export function PersonasTable({
                       onClick={() => openDeleteModal(persona)}
                     />
                   ) : (
-                    <Text>-</Text>
+                    <Text as="p">-</Text>
                   )}
                 </div>
               </div>,

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -139,11 +139,11 @@ export default function IndexAttemptErrorsModal({
         <Modal.Body className="flex flex-col gap-4 min-h-0">
           {!isResolvingErrors && (
             <div className="flex flex-col gap-2 flex-shrink-0">
-              <Text>
+              <Text as="p">
                 Below are the errors encountered during indexing. Each row
                 represents a failed document or entity.
               </Text>
-              <Text>
+              <Text as="p">
                 Click the button below to kick off a full re-index to try and
                 resolve these errors. This full re-index may take much longer
                 than a normal update.

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
@@ -131,7 +131,7 @@ export default function ReIndexModal({
       <Modal.Content small>
         <Modal.Header icon={SvgRefreshCw} title="Run Indexing" onClose={hide} />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             This will pull in and index all documents that have changed and/or
             have been added since the last successful indexing run.
           </Text>
@@ -141,11 +141,11 @@ export default function ReIndexModal({
 
           <Separator />
 
-          <Text>
+          <Text as="p">
             This will cause a complete re-indexing of all documents from the
             source.
           </Text>
-          <Text>
+          <Text as="p">
             <strong>NOTE:</strong> depending on the number of documents stored
             in the source, this may take a long time.
           </Text>

--- a/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
@@ -182,7 +182,7 @@ export default function ChangeCredentialsModal({
         <Modal.Body>
           {!isAzure && (
             <>
-              <Text>
+              <Text as="p">
                 You can modify your configuration by providing a new API key
                 {isProxy ? " or API URL." : "."}
               </Text>
@@ -239,7 +239,7 @@ export default function ChangeCredentialsModal({
 
                     <div>
                       <Label className="mt-2">Test Model</Label>
-                      <Text>
+                      <Text as="p">
                         Since you are using a liteLLM proxy, we&apos;ll need a
                         model name to test the connection with.
                       </Text>
@@ -283,7 +283,7 @@ export default function ChangeCredentialsModal({
           <Text as="p" className="mt-4 font-bold">
             You can delete your configuration.
           </Text>
-          <Text>
+          <Text as="p">
             This is only possible if you have already switched to a different
             embedding type!
           </Text>

--- a/web/src/app/admin/embeddings/modals/DeleteCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/DeleteCredentialsModal.tsx
@@ -30,7 +30,7 @@ export default function DeleteCredentialsModal({
           onClose={onCancel}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             You&apos;re about to delete your{" "}
             {getFormattedProviderName(modelProvider.provider_type)} credentials.
             Are you sure?

--- a/web/src/app/admin/embeddings/modals/InstantSwitchConfirmModal.tsx
+++ b/web/src/app/admin/embeddings/modals/InstantSwitchConfirmModal.tsx
@@ -20,12 +20,12 @@ export default function InstantSwitchConfirmModal({
           onClose={onClose}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             Instant switching will immediately change the embedding model
             without re-indexing. Searches will be over a partial set of
             documents (starting with 0 documents) until re-indexing is complete.
           </Text>
-          <Text>
+          <Text as="p">
             <strong>This is not reversible.</strong>
           </Text>
         </Modal.Body>

--- a/web/src/app/admin/embeddings/modals/ModelSelectionModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ModelSelectionModal.tsx
@@ -27,17 +27,17 @@ export default function ModelSelectionConfirmationModal({
           onClose={onCancel}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             You have selected: <strong>{selectedModel.model_name}</strong>. Are
             you sure you want to update to this new embedding model?
           </Text>
-          <Text>
+          <Text as="p">
             We will re-index all your documents in the background so you will be
             able to continue to use Onyx as normal with the old model in the
             meantime. Depending on how many documents you have indexed, this may
             take a while.
           </Text>
-          <Text>
+          <Text as="p">
             <i>NOTE:</i> this re-indexing process will consume more resources
             than normal. If you are self-hosting, we recommend that you allocate
             at least 16GB of RAM to Onyx during this process.

--- a/web/src/app/admin/embeddings/modals/ProviderCreationModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ProviderCreationModal.tsx
@@ -202,7 +202,7 @@ export default function ProviderCreationModal({
           >
             {({ isSubmitting, handleSubmit, setFieldValue }) => (
               <Form onSubmit={handleSubmit} className="space-y-4">
-                <Text>
+                <Text as="p">
                   You are setting the credentials for this provider. To access
                   this information, follow the instructions{" "}
                   <a

--- a/web/src/app/admin/embeddings/modals/SelectModelModal.tsx
+++ b/web/src/app/admin/embeddings/modals/SelectModelModal.tsx
@@ -24,7 +24,7 @@ export default function SelectModelModal({
           onClose={onCancel}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             You&apos;re selecting a new embedding model,{" "}
             <strong>{model.model_name}</strong>. If you update to this model,
             you will need to undergo a complete re-indexing. Are you sure?

--- a/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
@@ -547,15 +547,19 @@ export default function EmbeddingForm() {
               />
               <Modal.Body>
                 <div className="text-lg">
-                  <Text>
+                  <Text as="p">
                     {`${selectedProvider.model_name} is a lower accuracy model. We recommend the following alternatives:`}
                   </Text>
                   <ul className="list-disc list-inside mt-2 ml-4">
                     <li>
-                      <Text>Cohere embed-english-v3.0 for cloud-based</Text>
+                      <Text as="p">
+                        Cohere embed-english-v3.0 for cloud-based
+                      </Text>
                     </li>
                     <li>
-                      <Text>Nomic nomic-embed-text-v1 for self-hosted</Text>
+                      <Text as="p">
+                        Nomic nomic-embed-text-v1 for self-hosted
+                      </Text>
                     </li>
                   </ul>
                 </div>

--- a/web/src/app/admin/kg/KGEntityTypes.tsx
+++ b/web/src/app/admin/kg/KGEntityTypes.tsx
@@ -33,13 +33,13 @@ function TableHeader() {
   return (
     <div className="grid grid-cols-12 gap-y-4 px-8 p-4 border-b bg-background-tint-00">
       <div className="col-span-1">
-        <Text>Entity Name</Text>
+        <Text as="p">Entity Name</Text>
       </div>
       <div className="col-span-10">
-        <Text>Description</Text>
+        <Text as="p">Description</Text>
       </div>
       <div className="col-span-1 flex flex-1 justify-center">
-        <Text>Active</Text>
+        <Text as="p">Active</Text>
       </div>
     </div>
   );
@@ -122,7 +122,7 @@ function TableRow({ entityType }: { entityType: EntityType }) {
           )}
         >
           <div className="col-span-1 flex items-center">
-            <Text>{snakeToHumanReadable(entityType.name)}</Text>
+            <Text as="p">{snakeToHumanReadable(entityType.name)}</Text>
           </div>
           <div className="col-span-10 relative">
             <InputTypeIn
@@ -296,13 +296,13 @@ export default function KGEntityTypes({
                             <Text as="p" secondaryBody text02>
                               Entities Count
                             </Text>
-                            <Text>{stats.entities_count}</Text>
+                            <Text as="p">{stats.entities_count}</Text>
                           </span>
                           <span className="flex flex-col items-start">
                             <Text as="p" secondaryBody text02>
                               Last Updated
                             </Text>
-                            <Text>
+                            <Text as="p">
                               {stats.last_updated
                                 ? new Date(stats.last_updated).toLocaleString()
                                 : "N/A"}

--- a/web/src/app/admin/oauth-configs/OAuthConfigForm.tsx
+++ b/web/src/app/admin/oauth-configs/OAuthConfigForm.tsx
@@ -149,7 +149,7 @@ export const OAuthConfigForm = ({
         >
           {({ isSubmitting }) => (
             <Form className="w-full overflow-visible">
-              <Text>
+              <Text as="p">
                 Configure an OAuth provider that can be shared across multiple
                 custom tools. Users will authenticate with this provider when
                 using tools that require it.

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -358,7 +358,7 @@ const AddUserButton = ({
             />
             <Modal.Body>
               <div className="flex flex-col gap-2">
-                <Text>
+                <Text as="p">
                   Add the email addresses to import, separated by whitespaces.
                   Invited users will be able to login to this domain with their
                   email address.

--- a/web/src/components/admin/users/ResetPasswordModal.tsx
+++ b/web/src/components/admin/users/ResetPasswordModal.tsx
@@ -70,7 +70,7 @@ export default function ResetPasswordModal({
         <Modal.Body>
           {newPassword ? (
             <div>
-              <Text>New Password:</Text>
+              <Text as="p">New Password:</Text>
               <div className="flex items-center bg-background-tint-03 p-2 rounded gap-2">
                 <Text as="p" data-testid="new-password" className="flex-grow">
                   {newPassword}
@@ -88,7 +88,7 @@ export default function ResetPasswordModal({
               leftIcon={SvgRefreshCw}
             >
               {isLoading ? (
-                <Text>
+                <Text as="p">
                   <LoadingAnimation text="Resetting" />
                 </Text>
               ) : (

--- a/web/src/components/chat/FederatedOAuthModal.tsx
+++ b/web/src/components/chat/FederatedOAuthModal.tsx
@@ -153,7 +153,7 @@ export default function FederatedOAuthModal() {
         <Modal.Content small>
           <Modal.Header icon={SvgLink} title="Heads Up!" />
           <Modal.Body>
-            <Text>
+            <Text as="p">
               You can always connect your apps later by going to the{" "}
               <strong>User Settings</strong> menu (click your profile icon) and
               selecting <strong>Connectors</strong>.

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -160,7 +160,7 @@ export default function MCPApiKeyModal({
           onClose={handleClose}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             {isAuthenticated
               ? `Update your ${credsType} for ${serverName}.`
               : `Enter your ${credsType} for ${serverName} to enable authentication.`}

--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -197,7 +197,7 @@ export default function ModifyCredential({
               onClose={() => setConfirmDeletionCredential(null)}
             />
             <Modal.Body>
-              <Text>
+              <Text as="p">
                 Are you sure you want to delete this credential? You cannot
                 delete credentials that are linked to live connectors.
               </Text>

--- a/web/src/components/extension/Shortcuts.tsx
+++ b/web/src/components/extension/Shortcuts.tsx
@@ -249,7 +249,7 @@ export const MaxShortcutsReachedModal = ({
           onClose={onClose}
         />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             You&apos;ve reached the maximum limit of 8 shortcuts. To add a new
             shortcut, please remove an existing one.
           </Text>

--- a/web/src/components/modals/ConfirmEntityModal.tsx
+++ b/web/src/components/modals/ConfirmEntityModal.tsx
@@ -61,7 +61,7 @@ export function ConfirmEntityModal({
     >
       <div className="flex flex-col gap-4">
         {!removeConfirmationText && (
-          <Text>
+          <Text as="p">
             Are you sure you want to {actionText} <b>{entityName}</b>?
           </Text>
         )}

--- a/web/src/components/modals/GenericConfirmModal.tsx
+++ b/web/src/components/modals/GenericConfirmModal.tsx
@@ -22,7 +22,7 @@ export default function GenericConfirmModal({
       <Modal.Content small>
         <Modal.Header icon={SvgCheck} title={title} onClose={onClose} />
         <Modal.Body>
-          <Text>{message}</Text>
+          <Text as="p">{message}</Text>
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={onConfirm}>{confirmText}</Button>

--- a/web/src/components/modals/NoAssistantModal.tsx
+++ b/web/src/components/modals/NoAssistantModal.tsx
@@ -14,13 +14,13 @@ export default function NoAssistantModal() {
       <Modal.Content small>
         <Modal.Header icon={SvgUser} title="No Assistant Available" />
         <Modal.Body>
-          <Text>
+          <Text as="p">
             You currently have no assistant configured. To use this feature, you
             need to take action.
           </Text>
           {isAdmin ? (
             <>
-              <Text>
+              <Text as="p">
                 As an administrator, you can create a new assistant by visiting
                 the admin panel.
               </Text>
@@ -29,7 +29,7 @@ export default function NoAssistantModal() {
               </Button>
             </>
           ) : (
-            <Text>
+            <Text as="p">
               Please contact your administrator to configure an assistant for
               you.
             </Text>

--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -451,7 +451,7 @@ ModalBody.displayName = "ModalBody";
  *
  * // Space-between layout
  * <Modal.Footer className="flex justify-between p-4">
- *   <Text>3 files selected</Text>
+ *   <Text as="p">3 files selected</Text>
  *   <Button>Done</Button>
  * </Modal.Footer>
  * ```

--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -63,10 +63,10 @@ export default function Tag({
           active ? "max-w-[10rem] opacity-100" : "max-w-0 opacity-0"
         )}
       >
-        <Text>{children.length}</Text>
+        <Text as="p">{children.length}</Text>
       </div>
 
-      <Text>{label}</Text>
+      <Text as="p">{label}</Text>
     </button>
   );
 }

--- a/web/src/sections/sidebar/Settings/Settings.tsx
+++ b/web/src/sections/sidebar/Settings/Settings.tsx
@@ -146,7 +146,7 @@ function NotificationsPopover({ onClose }: NotificationsPopoverProps) {
       <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 flex flex-col gap-2 items-center">
         {!notifications || notifications.length === 0 ? (
           <div className="w-full h-full flex flex-col justify-center items-center">
-            <Text>No notifications</Text>
+            <Text as="p">No notifications</Text>
           </div>
         ) : (
           <div className="w-full flex flex-col gap-2">


### PR DESCRIPTION
## Description

I missed a class instances in https://github.com/onyx-dot-app/onyx/pull/7096 namely of the form `<Text>`.

## How Has This Been Tested?

Type-checking, some manual QA

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly render Text as paragraphs in block contexts to restore proper semantics after Text defaulted to span. Improves layout spacing and accessibility across modals, forms, tables, and settings with no functional changes.

- **Refactors**
  - Replaced <Text> with <Text as="p"> in modal bodies, admin forms/pages, tables (Personas, KG entity types), notifications, and various prompts.
  - Updated Tag and Modal examples to use paragraph semantics for consistent rendering.

<sup>Written for commit 9b9d60f7af6e44a435c1ae411862823c4b6534e7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

