### PR TITLE
chore(desktop): remove duplicate startup log, onyx-desktop

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -14,12 +14,12 @@ use tauri::menu::{
     CheckMenuItem, Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder, HELP_SUBMENU_ID,
 };
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+#[cfg(target_os = "macos")]
+use tauri::WebviewWindow;
 use tauri::Wry;
 use tauri::{
     webview::PageLoadPayload, AppHandle, Manager, Webview, WebviewUrl, WebviewWindowBuilder,
 };
-#[cfg(target_os = "macos")]
-use tauri::WebviewWindow;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 #[cfg(target_os = "macos")]
 use tokio::time::sleep;
@@ -67,7 +67,7 @@ impl Default for AppConfig {
 
 /// Get the config directory path
 fn get_config_dir() -> Option<PathBuf> {
-    ProjectDirs::from("app", "onyx", "desktop").map(|dirs| dirs.config_dir().to_path_buf())
+    ProjectDirs::from("app", "onyx", "onyx-desktop").map(|dirs| dirs.config_dir().to_path_buf())
 }
 
 /// Get the full config file path
@@ -89,7 +89,6 @@ fn load_config() -> AppConfig {
         match fs::read_to_string(&config_path) {
             Ok(contents) => match serde_json::from_str(&contents) {
                 Ok(config) => {
-                    println!("Loaded config from {:?}", config_path);
                     return config;
                 }
                 Err(e) => {


### PR DESCRIPTION
## Description

We print twice we loaded the config,

<img width="1416" height="902" alt="20251229_19h49m13s_grim" src="https://github.com/user-attachments/assets/c9d9e714-0d54-408f-b24c-d5be731cb90d" />

and properly namespace the config from `~/.config/desktop` to `~/.config/onyx-desktop`

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate “Loaded config” startup log and renamed the config directory to ~/.config/onyx-desktop for proper namespacing. This cleans up logs and aligns the desktop app’s config with its name.

- **Migration**
  - If you have ~/.config/desktop, move its config files to ~/.config/onyx-desktop.

<sup>Written for commit a60bdac875a83e91b570940b6307b7429cff1a06. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

