### PR TITLE
chore(desktop): disable nightly builds

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -64,8 +64,8 @@ jobs:
             BUILD_WEB_CLOUD=true
           else
             BUILD_WEB=true
-            # Skip desktop builds on beta tags
-            if [[ "$IS_BETA" != "true" ]]; then
+            # Skip desktop builds on beta tags and nightly runs
+            if [[ "$IS_BETA" != "true" ]] && [[ "$TAG" != nightly* ]]; then
               BUILD_DESKTOP=true
             fi
           fi


### PR DESCRIPTION
## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable desktop builds for nightly runs in the deployment workflow. Desktop builds now only run on non-beta, non-nightly tags, reducing CI time and avoiding unwanted nightly desktop artifacts.

<sup>Written for commit 0bcfb5b9a54ea68d121a3bf67d5d5470f86f0399. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

