### PR TITLE
refactor(ux): Share Chat modal uses CopyIconButton

### DIFF
--- a/web/src/app/chat/components/modal/ShareChatSessionModal.tsx
+++ b/web/src/app/chat/components/modal/ShareChatSessionModal.tsx
@@ -16,7 +16,7 @@ import { useCurrentAgent } from "@/hooks/useAgents";
 import { useSearchParams } from "next/navigation";
 import { useChatSessionStore } from "@/app/chat/stores/useChatSessionStore";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
-import IconButton from "@/refresh-components/buttons/IconButton";
+import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { copyAll } from "@/app/chat/message/copyingUtils";
 import { SvgCopy, SvgShare } from "@opal/icons";
 
@@ -123,13 +123,9 @@ export default function ShareChatSessionModal({
               view the message history using the following link:
             </Text>
 
-            <div className={cn("flex mt-2")}>
+            <div className="flex items-center mt-2">
               {/* <CopyButton content={shareLink} /> */}
-              <IconButton
-                icon={SvgCopy}
-                onClick={() => copyAll(shareLink)}
-                secondary
-              />
+              <CopyIconButton getCopyText={() => shareLink} secondary />
               <a
                 href={shareLink}
                 target="_blank"


### PR DESCRIPTION
## Description

It was bothering me this didn't give visual feedback and was not center-aligned with the adjacent text

<img width="808" height="1030" alt="20251229_23h08m39s_grim" src="https://github.com/user-attachments/assets/13dd3f96-378b-41ec-be21-447e84668aaa" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Share Chat modal’s generic copy button with CopyIconButton to show copy feedback and improve consistency. Also vertically aligned the button with the link for better layout.

<sup>Written for commit 2542a53b53e44413e82b04db40b1ad66239da7b8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

