### PR TITLE
chore(gha): ensure uv cache is pruned before upload

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -22,7 +22,7 @@ runs:
         done <<< "$REQUIREMENTS"
         echo "hash=$(echo "$hash" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-    # NOTE: This comes before Setup uv since their cleanups ran in reverse chronological order
+    # NOTE: This comes before Setup uv since clean-ups run in reverse chronological order
     # such that Setup uv's prune-cache is able to prune the cache before we upload.
     - name: Cache uv cache directory
       uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # ratchet:runs-on/cache@v4


### PR DESCRIPTION
## Description

Currently an order of operations issue where we upload the uv cache before the `Setup uv` clean up runs which prunes it. As a result, the cache is needlessly `~3186 MB` when I think it should be closer to `~400 MB`, https://github.com/onyx-dot-app/onyx/actions/runs/20602929211/job/59172401978#step:5:209

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the uv cache is pruned before upload by moving the cache step ahead of Setup uv in the composite action. This cuts the uploaded cache from ~3.1 GB to ~400 MB and speeds CI runs.

<sup>Written for commit 33fe80acf486329aeada05ddab4bbaa985fa6eff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

