### PR TITLE
fix: gemini default location global

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/VertexAIForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/VertexAIForm.tsx
@@ -22,7 +22,7 @@ import Separator from "@/refresh-components/Separator";
 export const VERTEXAI_PROVIDER_NAME = "vertex_ai";
 const VERTEXAI_DISPLAY_NAME = "Google Cloud Vertex AI";
 const VERTEXAI_DEFAULT_MODEL = "gemini-2.5-pro";
-const VERTEXAI_DEFAULT_LOCATION = "us-east1";
+const VERTEXAI_DEFAULT_LOCATION = "global";
 
 interface VertexAIFormValues extends BaseLLMFormValues {
   custom_config: {
@@ -132,7 +132,7 @@ export function VertexAIForm({
                       name="custom_config.vertex_location"
                       label="Location"
                       placeholder={VERTEXAI_DEFAULT_LOCATION}
-                      subtext="The Google Cloud region for your Vertex AI models (e.g., us-east1, us-central1, europe-west1)."
+                      subtext="The Google Cloud region for your Vertex AI models (e.g., global, us-east1, us-central1, europe-west1). See [Google's documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#google_model_endpoint_locations) to find the appropriate region for your model."
                       optional
                     />
 


### PR DESCRIPTION
## Description

- Gemini's newest models are only available via global region
- Anthropic models are also available in global
- Open weight models are not available in global
- Added gemini docs reference link for regions

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

- locally

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Vertex AI default location to "global" so Gemini 2.5 Pro and newer Gemini models work out of the box. Updated the Location field help text to include "global" and a link to Google docs; notes that Anthropic models are available in global, while open‑weight models are not.

<sup>Written for commit 0dcaf765f71ec3c921008cc77cbc2e9e33bf5577. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

