### PR TITLE
fix: suppress Jest act() warning spam in test output

### DIFF
--- a/web/src/app/chat/message/messageComponents/MultiToolRenderer.test.tsx
+++ b/web/src/app/chat/message/messageComponents/MultiToolRenderer.test.tsx
@@ -4,7 +4,13 @@
  */
 
 import React from "react";
-import { render, screen, waitFor, setupUser } from "@tests/setup/test-utils";
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  setupUser,
+} from "@tests/setup/test-utils";
 import MultiToolRenderer from "./MultiToolRenderer";
 import {
   createToolGroups,
@@ -198,8 +204,11 @@ describe("MultiToolRenderer - Streaming Mode", () => {
     jest.useFakeTimers();
   });
 
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
+  afterEach(async () => {
+    // Wrap timer execution in act() since it triggers React state updates
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 

--- a/web/tests/setup/jest.setup.ts
+++ b/web/tests/setup/jest.setup.ts
@@ -61,22 +61,26 @@ if (typeof window !== "undefined") {
   global.scrollTo = jest.fn();
 }
 
-// Suppress console errors in tests (optional - comment out if you want to see them)
-// const originalError = console.error;
-// beforeAll(() => {
-//   console.error = (...args: any[]) => {
-//     // Filter out known React warnings that are not actionable in tests
-//     if (
-//       typeof args[0] === "string" &&
-//       (args[0].includes("Warning: ReactDOM.render") ||
-//         args[0].includes("Not implemented: HTMLFormElement.prototype.submit"))
-//     ) {
-//       return;
-//     }
-//     originalError.call(console, ...args);
-//   };
-// });
+// Suppress specific known console errors that are not actionable in tests.
+// This pattern is recommended for handling third-party library warnings:
+// https://github.com/testing-library/user-event/issues/1114#issuecomment-1876164351
+//
+// Radix UI's compose-refs package triggers state updates during component unmount
+// which causes React to emit "not configured to support act" warnings. This happens
+// because the updates occur in React's commit phase, outside of any act() boundary.
+// The IS_REACT_ACT_ENVIRONMENT flag doesn't help because jsdom's globalThis is set
+// up before our setup file runs.
+const SUPPRESSED_ERRORS = [
+  "The current testing environment is not configured to support act",
+] as const;
 
-// afterAll(() => {
-//   console.error = originalError;
-// });
+const originalError = console.error;
+console.error = (...args: any[]) => {
+  if (
+    typeof args[0] === "string" &&
+    SUPPRESSED_ERRORS.some((error) => args[0].includes(error))
+  ) {
+    return;
+  }
+  originalError.call(console, ...args);
+};


### PR DESCRIPTION
## Description

Fixes the massive console.error spam from Jest tests that was making it hard to identify actual test failures. The spam looked like:

```
console.error
  The current testing environment is not configured to support act(...)
  ...
  at setRef (node_modules/@radix-ui/react-compose-refs/dist/index.js:42:12)
  ... (hundreds of lines)
```

This is a known issue with Radix UI + React + Jest. Radix UI's `compose-refs` package triggers state updates during component unmount, which happens in React's commit phase outside of any `act()` boundary.

Changes:
- Added a `SUPPRESSED_ERRORS` array pattern (following [testing-library/user-event#1114](https://github.com/testing-library/user-event/issues/1114#issuecomment-1876164351)) to filter the specific non-actionable warning
- Added `act` import to MultiToolRenderer tests and wrapped timer execution in `act()` to properly handle timer-triggered state updates

The actionable warning "An update to X inside a test was not wrapped in act" is NOT suppressed - only the configuration warning that we can't fix due to Radix UI internals.

## How Has This Been Tested?

- Ran `npm test` - all 121 tests pass
- Verified the act() warning spam is gone from test output
- Legitimate warnings (HTML nesting, input values, accessibility) are still shown

## Additional Options

- [x] Override Linear Check