### PR TITLE
chore(fe): baseline align inline code spans

### DIFF
--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -67,7 +67,6 @@ export const CodeBlock = memo(function CodeBlock({
           "text-text-05",
           "bg-background-tint-00",
           "rounded",
-          "align-bottom",
           "text-xs",
           "inline-block",
           "whitespace-pre-wrap",


### PR DESCRIPTION
## Description

Better vertically align code-snippets.

**before**
<img width="1387" height="858" alt="20251230_13h56m54s_grim" src="https://github.com/user-attachments/assets/b4fd69b1-d7bd-4da0-9b75-6cba1b103b05" />

**after**
<img width="1398" height="852" alt="20251230_13h56m39s_grim" src="https://github.com/user-attachments/assets/cad356b0-c2a3-4fc7-ba33-4c5e8b017742" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns code snippets with the text baseline in chat messages by removing the align-bottom class in CodeBlock. This fixes the lowered appearance of inline code and improves visual consistency.

<sup>Written for commit 09943fee4247eaec0328ec05d1074f31a83880b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

