### PR TITLE
perf(chat): consildate chat UI layout style

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -671,7 +671,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
               )}
 
               {/* ChatInputBar container */}
-              <div className="max-w-[50rem] w-full pointer-events-auto z-sticky flex flex-col px-4 lg:px-0 justify-center items-center">
+              <div className="w-[min(50rem,100%)] pointer-events-auto z-sticky flex flex-col px-4 justify-center items-center">
                 {(showOnboarding ||
                   (user?.role !== UserRole.ADMIN &&
                     !user?.personalization?.name)) &&

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -462,7 +462,7 @@ const ChatInputBar = React.memo(
             ref={containerRef}
             id="onyx-chat-input"
             className={cn(
-              "max-w-full w-[min(50rem,100%)] flex flex-col shadow-01 bg-background-neutral-00 rounded-16",
+              "w-full flex flex-col shadow-01 bg-background-neutral-00 rounded-16",
               disabled && "opacity-50 cursor-not-allowed pointer-events-none"
             )}
             aria-disabled={disabled}

--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -5,7 +5,6 @@ import { FileDescriptor } from "@/app/chat/interfaces";
 import "katex/dist/katex.min.css";
 import MessageSwitcher from "@/app/chat/message/MessageSwitcher";
 import Text from "@/refresh-components/texts/Text";
-import { cn } from "@/lib/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import Button from "@/refresh-components/buttons/Button";
@@ -46,15 +45,15 @@ function MessageEditing({
   return (
     <div className="w-full">
       <div
-        className={cn(
+        className={
           "w-full h-full border rounded-16 overflow-hidden p-3 flex flex-col gap-2"
-        )}
+        }
       >
         <textarea
           ref={textareaRef}
-          className={cn(
+          className={
             "w-full h-full resize-none outline-none bg-transparent overflow-y-scroll whitespace-normal break-word"
-          )}
+          }
           aria-multiline
           role="textarea"
           value={editedContent}
@@ -154,7 +153,7 @@ export default function HumanMessage({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className={cn("text-user-text max-w-[790px] px-4 w-full")}>
+      <div className={"text-user-text max-w-[790px] w-full"}>
         <FileDisplay alignBubble files={files || []} />
         <div className="flex flex-wrap justify-end break-words">
           {isEditing ? (

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -477,10 +477,13 @@ export default function AIMessage({
       <div
         // for e2e tests
         data-testid={displayComplete ? "onyx-ai-message" : undefined}
-        className="pb-5 md:pt-5 relative flex"
+        className="flex items-start px-4 pb-5 md:pt-5"
       >
-        <div className="mx-auto w-[min(50rem,100%)] px-4 max-w-message-max">
-          <div className="flex items-start">
+        {/** TODO(jamison): These fragments were kept to preserve whitespace and
+          improve the diff while removing elements. Remove them separately so
+          we can ignore the revision and preserve the git blame. **/}
+        <>
+          <>
             <AgentAvatar agent={chatState.assistant} size={24} />
             {/* w-full ensures the MultiToolRenderer non-expanded state takes up the full width */}
             <div className="max-w-message-max break-words pl-4 w-full">
@@ -683,8 +686,8 @@ export default function AIMessage({
                 </div>
               )}
             </div>
-          </div>
-        </div>
+          </>
+        </>
       </div>
     </>
   );

--- a/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
@@ -69,7 +69,7 @@ export default function SharedChatDisplay({
         />
       )}
 
-      <div className="flex flex-col h-full w-full overflow-hidden overflow-y-scroll">
+      <div className="flex flex-col items-center h-full w-full overflow-hidden overflow-y-scroll">
         <div className="sticky top-0 z-10 flex flex-col w-full bg-background-tint-01 px-8 py-4">
           <Text as="p" headingH2>
             {chatSession.description || UNNAMED_CHAT}
@@ -80,7 +80,7 @@ export default function SharedChatDisplay({
         </div>
 
         {isMounted ? (
-          <div className="w-full px-8">
+          <div className="w-[min(50rem,100%)]">
             {messages.map((message, i) => {
               if (message.type === "user") {
                 return (

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -240,135 +240,134 @@ const ChatUI = React.memo(
           <div
             key={currentChatSessionId}
             ref={scrollContainerRef}
-            className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
+            className="flex flex-1 justify-center min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
             onScroll={handleScroll}
           >
-            {messages.map((message, i) => {
-              const messageReactComponentKey = `message-${message.nodeId}`;
-              const parentMessage = message.parentNodeId
-                ? messageTree?.get(message.parentNodeId)
-                : null;
+            <div className="w-[min(50rem,100%)]">
+              {messages.map((message, i) => {
+                const messageReactComponentKey = `message-${message.nodeId}`;
+                const parentMessage = message.parentNodeId
+                  ? messageTree?.get(message.parentNodeId)
+                  : null;
 
-              if (message.type === "user") {
-                const nextMessage =
-                  messages.length > i + 1 ? messages[i + 1] : null;
+                if (message.type === "user") {
+                  const nextMessage =
+                    messages.length > i + 1 ? messages[i + 1] : null;
 
-                return (
-                  <div
-                    id={messageReactComponentKey}
-                    key={messageReactComponentKey}
-                  >
-                    <HumanMessage
-                      disableSwitchingForStreaming={
-                        (nextMessage && nextMessage.is_generating) || false
-                      }
-                      stopGenerating={stopGenerating}
-                      content={message.message}
-                      files={message.files}
-                      messageId={message.messageId}
-                      onEdit={(editedContent) => {
-                        if (
-                          message.messageId !== undefined &&
-                          message.messageId !== null
-                        ) {
-                          handleEditWithMessageId(
-                            editedContent,
-                            message.messageId
-                          );
-                        }
-                      }}
-                      otherMessagesCanSwitchTo={
-                        parentMessage?.childrenNodeIds ?? emptyChildrenIds
-                      }
-                      onMessageSelection={onMessageSelection}
-                    />
-                  </div>
-                );
-              } else if (message.type === "assistant") {
-                if ((error || loadError) && i === messages.length - 1) {
                   return (
                     <div
-                      key={`error-${message.nodeId}`}
-                      className="max-w-[min(50rem,100%)] mx-auto p-4"
+                      id={messageReactComponentKey}
+                      key={messageReactComponentKey}
                     >
-                      <ErrorBanner
-                        resubmit={handleResubmitLastMessage}
-                        error={error || loadError || ""}
-                        errorCode={message.errorCode || undefined}
-                        isRetryable={message.isRetryable ?? true}
-                        details={message.errorDetails || undefined}
-                        stackTrace={message.stackTrace || undefined}
+                      <HumanMessage
+                        disableSwitchingForStreaming={
+                          (nextMessage && nextMessage.is_generating) || false
+                        }
+                        stopGenerating={stopGenerating}
+                        content={message.message}
+                        files={message.files}
+                        messageId={message.messageId}
+                        onEdit={(editedContent) => {
+                          if (
+                            message.messageId !== undefined &&
+                            message.messageId !== null
+                          ) {
+                            handleEditWithMessageId(
+                              editedContent,
+                              message.messageId
+                            );
+                          }
+                        }}
+                        otherMessagesCanSwitchTo={
+                          parentMessage?.childrenNodeIds ?? emptyChildrenIds
+                        }
+                        onMessageSelection={onMessageSelection}
+                      />
+                    </div>
+                  );
+                } else if (message.type === "assistant") {
+                  if ((error || loadError) && i === messages.length - 1) {
+                    return (
+                      <div key={`error-${message.nodeId}`} className="p-4">
+                        <ErrorBanner
+                          resubmit={handleResubmitLastMessage}
+                          error={error || loadError || ""}
+                          errorCode={message.errorCode || undefined}
+                          isRetryable={message.isRetryable ?? true}
+                          details={message.errorDetails || undefined}
+                          stackTrace={message.stackTrace || undefined}
+                        />
+                      </div>
+                    );
+                  }
+
+                  // NOTE: it's fine to use the previous entry in messageHistory
+                  // since this is a "parsed" version of the message tree
+                  // so the previous message is guaranteed to be the parent of the current message
+                  const previousMessage = i !== 0 ? messages[i - 1] : null;
+                  const regenerate =
+                    message.messageId !== undefined && previousMessage
+                      ? createRegenerator({
+                          messageId: message.messageId,
+                          parentMessage: previousMessage,
+                        })
+                      : undefined;
+                  const chatStateData = {
+                    assistant: liveAssistant,
+                    docs: message.documents ?? emptyDocs,
+                    citations: message.citations,
+                    setPresentingDocument,
+                    regenerate,
+                    overriddenModel: llmManager.currentLlm?.modelName,
+                    researchType: message.researchType,
+                  };
+                  return (
+                    <div
+                      id={`message-${message.nodeId}`}
+                      key={messageReactComponentKey}
+                    >
+                      <AIMessage
+                        rawPackets={message.packets}
+                        chatState={chatStateData}
+                        nodeId={message.nodeId}
+                        messageId={message.messageId}
+                        currentFeedback={message.currentFeedback}
+                        llmManager={llmManager}
+                        otherMessagesCanSwitchTo={
+                          parentMessage?.childrenNodeIds ?? emptyChildrenIds
+                        }
+                        onMessageSelection={onMessageSelection}
                       />
                     </div>
                   );
                 }
+              })}
 
-                // NOTE: it's fine to use the previous entry in messageHistory
-                // since this is a "parsed" version of the message tree
-                // so the previous message is guaranteed to be the parent of the current message
-                const previousMessage = i !== 0 ? messages[i - 1] : null;
-                const regenerate =
-                  message.messageId !== undefined && previousMessage
-                    ? createRegenerator({
-                        messageId: message.messageId,
-                        parentMessage: previousMessage,
-                      })
-                    : undefined;
-                const chatStateData = {
-                  assistant: liveAssistant,
-                  docs: message.documents ?? emptyDocs,
-                  citations: message.citations,
-                  setPresentingDocument,
-                  regenerate,
-                  overriddenModel: llmManager.currentLlm?.modelName,
-                  researchType: message.researchType,
-                };
-                return (
-                  <div
-                    id={`message-${message.nodeId}`}
-                    key={messageReactComponentKey}
-                  >
-                    <AIMessage
-                      rawPackets={message.packets}
-                      chatState={chatStateData}
-                      nodeId={message.nodeId}
-                      messageId={message.messageId}
-                      currentFeedback={message.currentFeedback}
-                      llmManager={llmManager}
-                      otherMessagesCanSwitchTo={
-                        parentMessage?.childrenNodeIds ?? emptyChildrenIds
-                      }
-                      onMessageSelection={onMessageSelection}
-                    />
-                  </div>
-                );
-              }
-            })}
+              {(((error !== null || loadError !== null) &&
+                messages[messages.length - 1]?.type === "user") ||
+                messages[messages.length - 1]?.type === "error") && (
+                <div className="p-4">
+                  <ErrorBanner
+                    resubmit={handleResubmitLastMessage}
+                    error={error || loadError || ""}
+                    errorCode={
+                      messages[messages.length - 1]?.errorCode || undefined
+                    }
+                    isRetryable={
+                      messages[messages.length - 1]?.isRetryable ?? true
+                    }
+                    details={
+                      messages[messages.length - 1]?.errorDetails || undefined
+                    }
+                    stackTrace={
+                      messages[messages.length - 1]?.stackTrace || undefined
+                    }
+                  />
+                </div>
+              )}
 
-            {(((error !== null || loadError !== null) &&
-              messages[messages.length - 1]?.type === "user") ||
-              messages[messages.length - 1]?.type === "error") && (
-              <div className="max-w-[min(50rem,100%)] mx-auto p-4">
-                <ErrorBanner
-                  resubmit={handleResubmitLastMessage}
-                  error={error || loadError || ""}
-                  errorCode={
-                    messages[messages.length - 1]?.errorCode || undefined
-                  }
-                  isRetryable={
-                    messages[messages.length - 1]?.isRetryable ?? true
-                  }
-                  details={
-                    messages[messages.length - 1]?.errorDetails || undefined
-                  }
-                  stackTrace={
-                    messages[messages.length - 1]?.stackTrace || undefined
-                  }
-                />
-              </div>
-            )}
-
-            <div ref={endDivRef} />
+              <div ref={endDivRef} />
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
## Description

The theory is that a non-zero amount of computation on the Chat UI is solely consumed by each message being responsible for positioning itself (for example, see `w-[min(50rem,100%)]` in `AIMessage.tsx`). My guess is this is most notable during streaming given the messages are re-rendered many times.

In some very unscientific profiling, this might reduce overall layout overhead by ~10% or 2% of overall styling overhead during "intense" scrolling,
<img width="1584" height="2107" alt="20251230_15h42m47s_grim" src="https://github.com/user-attachments/assets/b0146edd-27ee-4eac-bd06-07b7fbc6348b" />

It would be really nice to refactor this and have semantically significant components in charge of these things (a `ChatUIContainer`, etc.) + de-duplicating the styling between the shared chat and default chat UI, but I think they're fine for later and this change will make those easier in the future.

Also fix two minor styling issues namely:
1. The chat bar extending beyond the projects container,
<img width="1560" height="1036" alt="20251230_15h11m37s_grim" src="https://github.com/user-attachments/assets/b485db5e-d75f-43a0-b16f-075220e76a5f" />

2. A small hack which caused the chat bar to have no padding on the transition between medium and large viewports,
<img width="1560" height="1036" alt="20251230_15h11m01s_grim" src="https://github.com/user-attachments/assets/ab0b7da4-007c-40ea-99d3-03cee3c3f390" />

## How Has This Been Tested?

**landing page**

<img width="3840" height="2160" alt="20251230_15h05m56s_grim" src="https://github.com/user-attachments/assets/f974153b-7fb8-4f24-bd23-45098c9b2b8d" />

**chat ui**
<img width="3840" height="2160" alt="20251230_15h06m47s_grim" src="https://github.com/user-attachments/assets/609e9b07-efaa-481e-a73b-f8d8d530c684" />

**shared chat**
<img width="3840" height="2160" alt="20251230_15h07m27s_grim" src="https://github.com/user-attachments/assets/92869f30-b34d-4e2d-a87f-03dd87438c44" />

**projects**
<img width="3840" height="2160" alt="20251230_15h05m35s_grim" src="https://github.com/user-attachments/assets/00e23cec-eb4f-4582-b575-026acd9ac21a" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated chat UI width and positioning into container components to reduce per-message layout work. This improves streaming and scroll performance, with an estimated ~10% layout overhead reduction in heavy use.

- **Refactors**
  - Centralized w[min(50rem,100%)] and max-width constraints in ChatUI and SharedChat; messages render full width inside the container.
  - Simplified AIMessage, HumanMessage, and ChatInputBar styles; removed redundant max-w/padding and centered content via the scroll container.
  - Standardized layout across default and shared chat for consistent width and alignment.

- **Bug Fixes**
  - Chat bar no longer extends beyond the projects container.
  - Restored padding at the medium-to-large viewport transition.

<sup>Written for commit 3968a323e8f0e736ddf95848f06e19c2765c6c08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



