### PR TITLE
fix: reenable force search parameter

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -31,6 +31,7 @@ from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import MilestoneRecordType
+from onyx.context.search.enums import OptionalSearchSetting
 from onyx.context.search.models import CitationDocInfo
 from onyx.context.search.models import SearchDoc
 from onyx.db.chat import create_new_chat_message
@@ -464,6 +465,18 @@ def stream_chat_message_objects(
             forced_tool_ids=new_msg_req.forced_tool_ids,
             search_tool_id=search_tool_id,
         )
+
+        # TODO: Remove this with the rework of the API - this forces search tool
+        # when retrieval_options.run_search is set to ALWAYS
+        if (
+            retrieval_options
+            and retrieval_options.run_search == OptionalSearchSetting.ALWAYS
+            and search_tool_id is not None
+        ):
+            if new_msg_req.forced_tool_ids is None:
+                new_msg_req.forced_tool_ids = [search_tool_id]
+            elif search_tool_id not in new_msg_req.forced_tool_ids:
+                new_msg_req.forced_tool_ids.insert(0, search_tool_id)
 
         emitter = get_default_emitter()
 

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -253,7 +253,7 @@ class RetrievalDetails(ChunkContext):
     # Use LLM to determine whether to do a retrieval or only rely on existing history
     # If the Persona is configured to not run search (0 chunks), this is bypassed
     # If no Prompt is configured, the only search results are shown, this is bypassed
-    run_search: OptionalSearchSetting = OptionalSearchSetting.ALWAYS
+    run_search: OptionalSearchSetting = OptionalSearchSetting.AUTO
     # Is this a real-time/streaming call or a question where Onyx can take more time?
     # Used to determine reranking flow
     real_time: bool = True


### PR DESCRIPTION
## Description

Make the force search parameter respected again.

## How Has This Been Tested?

Works via direct API calls to the backend

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the forced search behavior so setting run_search=ALWAYS actually runs the search tool, and adjusts the default to AUTO to avoid unwanted searches.

- **Bug Fixes**
  - When retrieval_options.run_search is ALWAYS and a search tool is available, insert its ID into forced_tool_ids so search runs.
  - Change RetrievalDetails.run_search default from ALWAYS to AUTO.

<sup>Written for commit c5211ac1b8e23f4895be882346c77c5d67d575d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

