### PR TITLE
fix: downgrade

### DIFF
--- a/backend/alembic/versions/9b66d3156fc6_user_file_schema_additions.py
+++ b/backend/alembic/versions/9b66d3156fc6_user_file_schema_additions.py
@@ -234,6 +234,8 @@ def downgrade() -> None:
         if "instructions" in columns:
             op.drop_column("user_project", "instructions")
         op.execute("ALTER TABLE user_project RENAME TO user_folder")
+        # Update NULL descriptions to empty string before setting NOT NULL constraint
+        op.execute("UPDATE user_folder SET description = '' WHERE description IS NULL")
         op.alter_column("user_folder", "description", nullable=False)
         logger.info("Renamed user_project back to user_folder")
 


### PR DESCRIPTION
## Description

Previously ran into 

```
  File "/Users/chrisweaver/projects/onyx/backend/alembic/versions/9b66d3156fc6_user_file_schema_additions.py", line 237, in downgrade
    op.alter_column("user_folder", "description", nullable=False)
  File "<string>", line 8, in alter_column
  File "<string>", line 3, in alter_column
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/operations/ops.py", line 1879, in alter_column
    return operations.invoke(alt)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/operations/base.py", line 401, in invoke
    return fn(self, operation)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/operations/toimpl.py", line 50, in alter_column
    operations.impl.alter_column(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/ddl/postgresql.py", line 181, in alter_column
    super().alter_column(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/ddl/impl.py", line 229, in alter_column
    self._exec(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/alembic/ddl/impl.py", line 193, in _exec
    return conn.execute(  # type: ignore[call-overload]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1413, in execute
    return meth(
           ^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/sql/ddl.py", line 181, in _execute_on_connection
    return connection._execute_ddl(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1525, in _execute_ddl
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
    return self._exec_single_context(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1987, in _exec_single_context
    self._handle_dbapi_exception(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 2344, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1968, in _exec_single_context
    self.dialect.do_execute(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 920, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 563, in execute
    self._adapt_connection.await_(
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 126, in await_only
    return current.driver.switch(awaitable)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 187, in greenlet_spawn
    value = await result
            ^^^^^^^^^^^^
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 542, in _prepare_and_execute
    self._handle_exception(error)
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 492, in _handle_exception
    self._adapt_connection._handle_exception(error)
  File "/Users/chrisweaver/projects/onyx/.venv/lib/python3.11/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 781, in _handle_exception
    raise translated_error from error
sqlalchemy.exc.IntegrityError: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.NotNullViolationError'>: column "description" of relation "user_folder" contains null values
[SQL: ALTER TABLE user_folder ALTER COLUMN description SET NOT NULL]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```

when downgrading. Now do I do not.

## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Alembic downgrade by updating NULL user_folder.description values to empty strings before reapplying the NOT NULL constraint. Prevents the asyncpg NotNullViolation/IntegrityError and lets the migration downgrade cleanly.

<sup>Written for commit f135d2b5a40ad027e5c2e34e730b427711f62de7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

