### PR TITLE
fix: lazy load tracing providers to avoid spamming logs when not configured

### DIFF
--- a/backend/onyx/tracing/braintrust_tracing.py
+++ b/backend/onyx/tracing/braintrust_tracing.py
@@ -2,12 +2,8 @@ import os
 import re
 from typing import Any
 
-import braintrust
-
 from onyx.configs.app_configs import BRAINTRUST_API_KEY
 from onyx.configs.app_configs import BRAINTRUST_PROJECT
-from onyx.tracing.braintrust_tracing_processor import BraintrustTracingProcessor
-from onyx.tracing.framework import set_trace_processors
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -74,6 +70,12 @@ def setup_braintrust_if_creds_available() -> None:
     if not BRAINTRUST_API_KEY:
         logger.info("Braintrust API key not provided, skipping Braintrust setup")
         return
+
+    # Lazy imports to avoid loading braintrust when not needed
+    import braintrust
+
+    from onyx.tracing.braintrust_tracing_processor import BraintrustTracingProcessor
+    from onyx.tracing.framework import set_trace_processors
 
     braintrust_logger = braintrust.init_logger(
         project=BRAINTRUST_PROJECT,

--- a/backend/onyx/tracing/langfuse_tracing.py
+++ b/backend/onyx/tracing/langfuse_tracing.py
@@ -1,13 +1,5 @@
-from typing import cast
-
-from openinference.instrumentation import OITracer
-from openinference.instrumentation import TraceConfig
-from opentelemetry import trace as trace_api
-
 from onyx.configs.app_configs import LANGFUSE_PUBLIC_KEY
 from onyx.configs.app_configs import LANGFUSE_SECRET_KEY
-from onyx.tracing.framework import set_trace_processors
-from onyx.tracing.openinference_tracing_processor import OpenInferenceTracingProcessor
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -19,8 +11,19 @@ def setup_langfuse_if_creds_available() -> None:
         logger.info("Langfuse credentials not provided, skipping Langfuse setup")
         return
 
+    # Lazy imports to avoid loading OpenTelemetry/OpenInference when not needed
+    from typing import cast
+
     import nest_asyncio  # type: ignore
     from langfuse import get_client
+    from openinference.instrumentation import OITracer
+    from openinference.instrumentation import TraceConfig
+    from opentelemetry import trace as trace_api
+
+    from onyx.tracing.framework import set_trace_processors
+    from onyx.tracing.openinference_tracing_processor import (
+        OpenInferenceTracingProcessor,
+    )
 
     nest_asyncio.apply()
     config = TraceConfig()


### PR DESCRIPTION
## Description

- when no tracing providers are configured, we still import all of the braintrust and langfuse provider code + modules they import
- kept getting log spam
```
DEBUG:    12/30/2025 05:24:58 PM                    provider.py  304: [API:BFMoEc4K] Creating span <onyx.tracing.framework.span_data.FunctionSpanData object at 0x15574e4b0> with id None
DEBUG:    12/30/2025 05:26:18 PM                    provider.py  304: [API:BFMoEc4K] Creating span <onyx.tracing.framework.span_data.FunctionSpanData object at 0x15572d190> with id None
```

## How Has This Been Tested?

- lazy loading the provider's imports fixes this

## Additional Options

- [x] [Optional] Override Linear Check
