### PR TITLE
fix: openai provider identification on the admin panel

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/getForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/getForm.tsx
@@ -13,7 +13,7 @@ export function detectIfRealOpenAIProvider(provider: LLMProviderView) {
     provider.provider === LLMProviderName.OPENAI &&
     provider.api_key &&
     !provider.api_base &&
-    !provider.custom_config
+    Object.keys(provider.custom_config || {}).length === 0
   );
 }
 


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpenAI provider detection in the admin panel by treating empty custom_config objects as empty. detectIfRealOpenAIProvider now checks Object.keys(provider.custom_config || {}).length === 0, so providers with only an API key and no api_base/custom config are correctly identified.

<sup>Written for commit 5ba87c290b8a8d7d0af67f735e40fa34e3ab0ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

