### PR TITLE
fix(desktop): Disable reload on Mac

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -427,16 +427,30 @@ fn setup_shortcuts(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 
     let app_handle = app.clone();
 
+    // Avoid hijacking the system-wide Cmd+R on macOS.
+    #[cfg(target_os = "macos")]
+    let shortcuts = [
+        new_chat,
+        back,
+        forward,
+        new_window_shortcut,
+        show_app,
+        open_settings,
+    ];
+
+    #[cfg(not(target_os = "macos"))]
+    let shortcuts = [
+        new_chat,
+        reload,
+        back,
+        forward,
+        new_window_shortcut,
+        show_app,
+        open_settings,
+    ];
+
     app.global_shortcut().on_shortcuts(
-        [
-            new_chat,
-            reload,
-            back,
-            forward,
-            new_window_shortcut,
-            show_app,
-            open_settings,
-        ],
+        shortcuts,
         move |_app, shortcut, _event| {
             if shortcut == &new_chat {
                 trigger_new_chat(&app_handle);


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Turning off reload on mac for now

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Just removal for mac

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the reload keyboard shortcut on macOS to avoid hijacking the system-wide Cmd+R. Other shortcuts remain unchanged.

- **Bug Fixes**
  - Skip registering the reload shortcut on macOS via conditional compilation; behavior on Windows/Linux is unchanged.

<sup>Written for commit e23d186ff1f0c9496beccf62a848f2c9cb3fe394. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

