### PR TITLE
fix: onboarding display

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -32,6 +32,17 @@ class LlmProviderNames(str, Enum):
         return self.value
 
 
+WELL_KNOWN_PROVIDER_NAMES = [
+    LlmProviderNames.OPENAI,
+    LlmProviderNames.ANTHROPIC,
+    LlmProviderNames.VERTEX_AI,
+    LlmProviderNames.BEDROCK,
+    LlmProviderNames.OPENROUTER,
+    LlmProviderNames.AZURE,
+    LlmProviderNames.OLLAMA_CHAT,
+]
+
+
 # Proper capitalization for known providers and vendors
 PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.OPENAI: "OpenAI",

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -3,6 +3,7 @@ import pathlib
 
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.constants import PROVIDER_DISPLAY_NAMES
+from onyx.llm.constants import WELL_KNOWN_PROVIDER_NAMES
 from onyx.llm.utils import get_max_input_tokens
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
@@ -211,7 +212,7 @@ def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
     llm_recommendations = _get_reccomendations()
 
     well_known_llms = []
-    for provider_name in LlmProviderNames:
+    for provider_name in WELL_KNOWN_PROVIDER_NAMES:
         known_model_names = fetch_models_for_provider(provider_name)
         recommended_visible_models = llm_recommendations.get_visible_models(
             provider_name


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding LLM provider picker to only show supported providers and hide internal/unsupported entries.

- **Bug Fixes**
  - Added WELL_KNOWN_PROVIDER_NAMES and used it to build the provider list in fetch_available_well_known_llms.
  - Stopped iterating over the full LlmProviderNames enum to prevent invalid items appearing during onboarding.

<sup>Written for commit b0d3881e1bedebd55c6ab5bb4a85cb3255dfedb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

