### PR TITLE
fix: when onboarding flow shows up

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -101,6 +101,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
     refreshChatSessions,
     currentChatSession,
     currentChatSessionId,
+    isLoading: isLoadingChatSessions,
   } = useChatSessions();
   const { ccPairs } = useCCPairs();
   const { tags } = useTags();
@@ -201,6 +202,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
     liveAssistant,
     isLoadingProviders: llmManager.isLoadingProviders,
     hasAnyProvider: llmManager.hasAnyProvider,
+    isLoadingChatSessions,
     chatSessionsCount: chatSessions.length,
   });
 

--- a/web/src/hooks/useShowOnboarding.ts
+++ b/web/src/hooks/useShowOnboarding.ts
@@ -9,6 +9,7 @@ interface UseShowOnboardingParams {
   liveAssistant: MinimalPersonaSnapshot | undefined;
   isLoadingProviders: boolean;
   hasAnyProvider: boolean | undefined;
+  isLoadingChatSessions: boolean;
   chatSessionsCount: number;
 }
 
@@ -16,6 +17,7 @@ export function useShowOnboarding({
   liveAssistant,
   isLoadingProviders,
   hasAnyProvider,
+  isLoadingChatSessions,
   chatSessionsCount,
 }: UseShowOnboardingParams) {
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -30,12 +32,16 @@ export function useShowOnboarding({
 
   // On first render, open onboarding if there are no configured LLM providers
   // OR if the user hasn't explicitly finished onboarding yet.
-  // Wait until providers have loaded before making this decision.
+  // Wait until both providers AND chat sessions have loaded before making this decision.
   // Skip onboarding entirely if the user has any existing chat sessions.
   const hasCheckedOnboarding = useRef(false);
   useEffect(() => {
-    // Only check once, and only after data has loaded
-    if (hasCheckedOnboarding.current || isLoadingProviders) {
+    // Only check once, and only after both providers and chat sessions have loaded
+    if (
+      hasCheckedOnboarding.current ||
+      isLoadingProviders ||
+      isLoadingChatSessions
+    ) {
       return;
     }
     hasCheckedOnboarding.current = true;
@@ -54,7 +60,12 @@ export function useShowOnboarding({
     // 1. No LLM providers configured, OR
     // 2. User hasn't explicitly finished onboarding (they navigated away before clicking "Finish Setup")
     setShowOnboarding(hasAnyProvider === false || !hasFinishedOnboarding);
-  }, [isLoadingProviders, hasAnyProvider, chatSessionsCount]);
+  }, [
+    isLoadingProviders,
+    isLoadingChatSessions,
+    hasAnyProvider,
+    chatSessionsCount,
+  ]);
 
   const hideOnboarding = () => {
     setShowOnboarding(false);


### PR DESCRIPTION
## Description

Was showing up for existing users.

## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the onboarding flow to returning users. Skips onboarding if the user has any chat sessions; onboarding logic is now handled by a new useShowOnboarding hook.

- **Refactors**
  - Added useShowOnboarding to manage onboarding state, provider checks, loading checks, and finish/hide actions.
  - ChatPage now uses the hook and passes chatSessions.length; moved localStorage and effect logic into the hook.

<sup>Written for commit 99a5c55ec9e44d6a7847ebd198c379145546970b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

