### PR TITLE
fix(ollama): rm unsupported `tool_choice` option

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -334,6 +334,7 @@ class LitellmLLM(LLM):
                 custom_llm_provider=self._custom_llm_provider or None,
                 messages=_prompt_to_dicts(prompt),
                 tools=tools,
+                tool_choice=tool_choice,
                 stream=stream,
                 temperature=temperature,
                 timeout=timeout_override or self._timeout,


### PR DESCRIPTION
## Description

Fixes a warning from the Ollama backend,

```
time=2026-01-01T21:59:09.461Z level=WARN source=types.go:801 msg="invalid option provided" option=tool_choice
```

## How Has This Been Tested?

Tested locally and confirmed no warning

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported tool_choice option from Ollama request options to prevent backend warnings and avoid sending invalid parameters. This silences the “invalid option provided: tool_choice” warning and keeps logs clean.

<sup>Written for commit eaee2f76d68dd7549e021c1f795e0e0b60a1c3e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

