### PR TITLE
chore(fe): follow up fixes to #7129

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -168,7 +168,7 @@ const HumanMessage = React.memo(function HumanMessage({
   return (
     <div
       id="onyx-human-message"
-      className="pt-5 pb-1 w-full lg:px-5 flex justify-center -mr-6 relative"
+      className="pt-5 pb-1 w-full flex justify-center -mr-6 relative"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -527,7 +527,7 @@ const AIMessage = React.memo(function AIMessage({
       <div
         // for e2e tests
         data-testid={displayComplete ? "onyx-ai-message" : undefined}
-        className="flex items-start px-4 pb-5 md:pt-5"
+        className="flex items-start pb-5 md:pt-5"
       >
         {/** TODO(jamison): These fragments were kept to preserve whitespace and
           improve the diff while removing elements. Remove them separately so

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -251,7 +251,7 @@ const ChatUI = React.memo(
             className="flex flex-1 justify-center min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
             onScroll={handleScroll}
           >
-            <div className="w-[min(50rem,100%)]">
+            <div className="w-[min(50rem,100%)] px-4">
               {messages.map((message, i) => {
                 const messageReactComponentKey = `message-${message.nodeId}`;
                 const parentMessage = message.parentNodeId


### PR DESCRIPTION
## Description

Fixes some responsive padding hacks I meant to include in #7129. In short, the chat container is solely responsible for horizontal padding now.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chat container solely handle horizontal padding for consistent spacing across breakpoints. Removes per-message padding and adds uniform padding on the message list wrapper.

- **Bug Fixes**
  - ChatUI: add px-4 to the message list wrapper.
  - HumanMessage: remove lg:px-5.
  - AIMessage: remove px-4.
  - Result: consistent alignment and reduced layout shift on small screens.

<sup>Written for commit c11ea9f382daa765d4c5d26382e0b91d4236f52f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

