### PR TITLE
chore(blame): introduce `.git-blame-ignore-revs` to ignore refactors

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Exclude these commits from git blame (e.g. mass reformatting).
+# These are ignored by GitHub automatically.
+# To enable this locally, run:
+#
+#    git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+3134e5f840c12c8f32613ce520101a047c89dcc2  # refactor(whitespace): rm temporary react fragments (#7161)


### PR DESCRIPTION
## Description

As promised in https://github.com/onyx-dot-app/onyx/pull/7161, ignore that ref from the git blame.

## How Has This Been Tested?

**before**
<img width="1920" height="1080" alt="20260101_22h22m11s_grim" src="https://github.com/user-attachments/assets/d983b5a1-df25-4e5e-a9d3-f5dec6b518cf" />

**after**
<img width="1920" height="1080" alt="20260101_22h18m04s_grim" src="https://github.com/user-attachments/assets/6ad76e18-934c-44a4-93ce-9e9b71e6a167" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a .git-blame-ignore-revs file to hide refactor-only commits from blame, keeping authorship history clear.

- **Migration**
  - Enable locally: git config blame.ignoreRevsFile .git-blame-ignore-revs (GitHub honors this file automatically).

<sup>Written for commit 7aa7d922f3f9c8dc6a058958f9f576a7ea0d9d79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

