### PR TITLE
chore(docker): publish inference_model_server port 9000 in dev

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -27,6 +27,10 @@ services:
       - "19071:19071"
       - "8081:8081"
 
+  inference_model_server:
+    ports:
+      - "9000:9000"
+
   cache:
     ports:
       - "6379:6379"


### PR DESCRIPTION
## Description

Otherwise,

```
ERROR:    01/02/2026 10:04:03 AM                   gpu_utils.py   34: Error: Unable to fetch GPU status. Error: HTTPConnectionPool(host='localhost', port=9000): Max retries exceeded with url: /api/gpu-status (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9000): Failed to establish a new connection: [Errno 111] Connection refused"))
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose inference_model_server port 9000 in dev docker-compose so the GPU status endpoint is reachable. Fixes local connection errors to localhost:9000 during development.

<sup>Written for commit d5f5cc63b7a8096bfb8bd275fe2369f48d7cf610. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

