### PR TITLE
New send message api

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/chat_backend.py
@@ -106,7 +106,6 @@ def handle_simplified_chat_message(
         new_msg_req=full_chat_msg_info,
         user=user,
         db_session=db_session,
-        enforce_chat_session_id_for_search_docs=False,
     )
 
     return gather_stream(packets)
@@ -210,7 +209,6 @@ def handle_send_message_simple_with_history(
         new_msg_req=full_chat_msg_info,
         user=user,
         db_session=db_session,
-        enforce_chat_session_id_for_search_docs=False,
     )
 
     return gather_stream(packets)

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -11,9 +11,6 @@ NUM_POSTPROCESSED_RESULTS = 20
 
 # May be less depending on model
 MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
-# For Chat, need to keep enough space for history and other prompt pieces
-# ~3k input, half for docs, half for chat history + prompts
-CHAT_TARGET_CHUNK_PERCENTAGE = 512 * 3 / 3072
 
 # Maximum percentage of the context window to fill with selected sections
 SELECTED_SECTIONS_MAX_WINDOW_PERCENTAGE = 0.8

--- a/backend/onyx/server/utils.py
+++ b/backend/onyx/server/utils.py
@@ -3,6 +3,7 @@ import json
 import os
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from fastapi import HTTPException
 from fastapi import status
@@ -17,24 +18,26 @@ class BasicAuthenticationError(HTTPException):
         super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
 
-class DateTimeEncoder(json.JSONEncoder):
-    """Custom JSON encoder that converts datetime objects to ISO format strings."""
+class OnyxJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder that converts datetime and UUID objects to strings."""
 
     def default(self, obj: Any) -> Any:
         if isinstance(obj, datetime):
             return obj.isoformat()
+        if isinstance(obj, UUID):
+            return str(obj)
         return super().default(obj)
 
 
 def get_json_line(
-    json_dict: dict[str, Any], encoder: type[json.JSONEncoder] = DateTimeEncoder
+    json_dict: dict[str, Any], encoder: type[json.JSONEncoder] = OnyxJSONEncoder
 ) -> str:
     """
-    Convert a dictionary to a JSON string with datetime handling, and add a newline.
+    Convert a dictionary to a JSON string with custom type handling, and add a newline.
 
     Args:
         json_dict: The dictionary to be converted to JSON.
-        encoder: JSON encoder class to use, defaults to DateTimeEncoder.
+        encoder: JSON encoder class to use, defaults to OnyxJSONEncoder.
 
     Returns:
         A JSON string representation of the input dictionary with a newline character.

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from enum import Enum
 from typing import Any
 from typing import Literal
 from uuid import UUID
@@ -22,6 +23,12 @@ from onyx.tools.tool_implementations.images.models import FinalImageGenerationRe
 
 TOOL_CALL_MSG_FUNC_NAME = "function_name"
 TOOL_CALL_MSG_ARGUMENTS = "arguments"
+
+
+class SearchToolUsage(str, Enum):
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    AUTO = "auto"
 
 
 class CustomToolUserFileSnapshot(BaseModel):

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import cast
 from uuid import UUID
 
@@ -27,6 +26,7 @@ from onyx.onyxbot.slack.models import SlackContext
 from onyx.tools.built_in_tools import get_built_in_tool_by_id
 from onyx.tools.interface import Tool
 from onyx.tools.models import DynamicSchemaInfo
+from onyx.tools.models import SearchToolUsage
 from onyx.tools.tool_implementations.custom.custom_tool import (
     build_custom_tools_from_openapi_schema_and_headers,
 )
@@ -60,12 +60,6 @@ class CustomToolConfig(BaseModel):
     chat_session_id: UUID | None = None
     message_id: int | None = None
     additional_headers: dict[str, str] | None = None
-
-
-class SearchToolUsage(str, Enum):
-    DISABLED = "disabled"
-    ENABLED = "enabled"
-    AUTO = "auto"
 
 
 def _get_image_generation_config(llm: LLM, db_session: Session) -> LLMConfig:

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -55,6 +55,7 @@ def create_project_files(
         project_as_filter=False,
         total_token_count=num_files * tokens_per_file,
         project_file_metadata=project_file_metadata,
+        project_uncapped_token_count=num_files * tokens_per_file,
     )
 
 

--- a/web/src/app/chat/message/messageComponents/hooks/useMessageSwitching.ts
+++ b/web/src/app/chat/message/messageComponents/hooks/useMessageSwitching.ts
@@ -17,9 +17,14 @@ export function useMessageSwitching({
   onMessageSelection,
 }: UseMessageSwitchingProps): UseMessageSwitchingReturn {
   // Calculate message switching state
-  const currentMessageInd = nodeId
+  const indexInSiblings = nodeId
     ? otherMessagesCanSwitchTo?.indexOf(nodeId)
     : undefined;
+  // indexOf returns -1 if not found, treat that as undefined
+  const currentMessageInd =
+    indexInSiblings !== undefined && indexInSiblings !== -1
+      ? indexInSiblings
+      : undefined;
 
   const includeMessageSwitcher =
     currentMessageInd !== undefined &&

--- a/web/src/app/chat/services/lib.tsx
+++ b/web/src/app/chat/services/lib.tsx
@@ -102,78 +102,46 @@ export type PacketType =
   | Packet;
 
 export interface SendMessageParams {
-  regenerate: boolean;
   message: string;
   fileDescriptors?: FileDescriptor[];
   parentMessageId: number | null;
   chatSessionId: string;
   filters: Filters | null;
-  selectedDocumentIds: number[] | null;
-  queryOverride?: string;
-  forceSearch?: boolean;
+  signal?: AbortSignal;
+  deepResearch?: boolean;
+  enabledToolIds?: number[];
+  // Single forced tool ID (new API uses singular, not array)
+  forcedToolId?: number | null;
+  // LLM override parameters
   modelProvider?: string;
   modelVersion?: string;
   temperature?: number;
-  systemPromptOverride?: string;
-  useExistingUserMessage?: boolean;
-  alternateAssistantId?: number;
-  signal?: AbortSignal;
-  currentMessageFiles?: FileDescriptor[];
-  deepResearch?: boolean;
-  enabledToolIds?: number[];
-  forcedToolIds?: number[];
 }
 
 export async function* sendMessage({
-  regenerate,
   message,
   fileDescriptors,
-  currentMessageFiles,
   parentMessageId,
   chatSessionId,
   filters,
-  selectedDocumentIds,
-  queryOverride,
-  forceSearch,
-  modelProvider,
-  modelVersion,
-  temperature,
-  systemPromptOverride,
-  useExistingUserMessage,
-  alternateAssistantId,
   signal,
   deepResearch,
   enabledToolIds,
-  forcedToolIds,
+  forcedToolId,
+  modelProvider,
+  modelVersion,
+  temperature,
 }: SendMessageParams): AsyncGenerator<PacketType, void, unknown> {
-  const documentsAreSelected =
-    selectedDocumentIds && selectedDocumentIds.length > 0;
+  // Build payload for new send-chat-message API
   const payload = {
-    alternate_assistant_id: alternateAssistantId,
+    message: message,
     chat_session_id: chatSessionId,
     parent_message_id: parentMessageId,
-    message: message,
-    // just use the default prompt for the assistant.
-    // should remove this in the future, as we don't support multiple prompts for a
-    // single assistant anyways
-    prompt_id: null,
-    search_doc_ids: documentsAreSelected ? selectedDocumentIds : null,
     file_descriptors: fileDescriptors,
-    current_message_files: currentMessageFiles,
-    regenerate,
-    retrieval_options: !documentsAreSelected
-      ? {
-          run_search: queryOverride || forceSearch ? "always" : "auto",
-          real_time: true,
-          filters: filters,
-        }
-      : null,
-    query_override: queryOverride,
-    prompt_override: systemPromptOverride
-      ? {
-          system_prompt: systemPromptOverride,
-        }
-      : null,
+    internal_search_filters: filters,
+    deep_research: deepResearch ?? false,
+    allowed_tool_ids: enabledToolIds,
+    forced_tool_id: forcedToolId ?? null,
     llm_override:
       temperature || modelVersion
         ? {
@@ -182,15 +150,11 @@ export async function* sendMessage({
             model_version: modelVersion,
           }
         : null,
-    use_existing_user_message: useExistingUserMessage,
-    deep_research: deepResearch ?? false,
-    allowed_tool_ids: enabledToolIds,
-    forced_tool_ids: forcedToolIds,
   };
 
   const body = JSON.stringify(payload);
 
-  const response = await fetch(`/api/chat/send-message`, {
+  const response = await fetch(`/api/chat/send-chat-message`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/web/src/app/chat/services/messageTree.ts
+++ b/web/src/app/chat/services/messageTree.ts
@@ -439,23 +439,22 @@ export const buildImmediateMessages = (
   initialUserNode: Message;
   initialAssistantNode: Message;
 } => {
-  const initialUserNode = messageToResend
-    ? { ...messageToResend } // clone the message to avoid mutating the original
-    : buildEmptyMessage({
-        messageType: "user",
-        parentNodeId,
-        message: userInput,
-        files,
-      });
+  // Always create a NEW message with a new nodeId for proper branching.
+  // When editing (messageToResend exists), this creates a sibling to the original
+  // message since they share the same parentNodeId.
+  const initialUserNode = buildEmptyMessage({
+    messageType: "user",
+    parentNodeId,
+    message: userInput,
+    files,
+  });
   const initialAssistantNode = buildEmptyMessage({
     messageType: "assistant",
     parentNodeId: initialUserNode.nodeId,
     nodeIdOffset: 1,
   });
 
-  initialUserNode.childrenNodeIds = initialUserNode.childrenNodeIds
-    ? [...initialUserNode.childrenNodeIds, initialAssistantNode.nodeId]
-    : [initialAssistantNode.nodeId];
+  initialUserNode.childrenNodeIds = [initialAssistantNode.nodeId];
   initialUserNode.latestChildNodeId = initialAssistantNode.nodeId;
 
   return {

--- a/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/chat/shared/[chatId]/SharedChatDisplay.tsx
@@ -88,6 +88,7 @@ export default function SharedChatDisplay({
                     key={message.messageId}
                     content={message.message}
                     files={message.files}
+                    nodeId={message.nodeId}
                   />
                 );
               } else if (message.type === "assistant") {

--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -229,9 +229,15 @@ export default function LLMPopover({
     });
   }, [filteredOptions]);
 
-  // Get display name for the currently selected model
+  // Get display name for the model to show in the button
+  // Use currentModelName prop if provided (e.g., for regenerate showing the model used),
+  // otherwise fall back to the globally selected model
   const currentLlmDisplayName = useMemo(() => {
-    const currentModel = llmManager.currentLlm.modelName;
+    // Only use currentModelName if it's a non-empty string
+    const currentModel =
+      currentModelName && currentModelName.trim()
+        ? currentModelName
+        : llmManager.currentLlm.modelName;
     if (!llmProviders) return currentModel;
 
     for (const provider of llmProviders) {
@@ -243,7 +249,7 @@ export default function LLMPopover({
       }
     }
     return currentModel;
-  }, [llmProviders, llmManager.currentLlm.modelName]);
+  }, [llmProviders, currentModelName, llmManager.currentLlm.modelName]);
 
   // Determine which group the current model belongs to (for auto-expand)
   const currentGroupKey = useMemo(() => {

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -275,6 +275,7 @@ const ChatUI = React.memo(
                         content={message.message}
                         files={message.files}
                         messageId={message.messageId}
+                        nodeId={message.nodeId}
                         onEdit={handleEditWithMessageId}
                         otherMessagesCanSwitchTo={
                           parentMessage?.childrenNodeIds ?? emptyChildrenIds


### PR DESCRIPTION
## Description

A cleaner send message backend API. Also fixes a bug with the message editing not showing arrows on the user message.

## How Has This Been Tested?
- Sending a message
- Regenerate a root message
- Regenerating a message further in the history
- Editing root message
- Editing message further in history
- Forcing tools
- Running queries w search filters
- Replaying sessions
- The new API directly via requests

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduced a new send-chat-message API with a simpler request model and automatic chat session creation, and fixed message switching arrows when editing user messages. Deprecated the old /send-message endpoint and improved chat history handling and project-aware tool selection.

- **New Features**
  - Added POST /send-chat-message to stream responses as JSON lines over text/event-stream; streams chat_session_id when a session is auto-created.
  - New SendMessageRequest with:
    - message, llm_override, allowed_tool_ids, forced_tool_id
    - file_descriptors, internal_search_filters, deep_research
    - parent_message_id placement: -1 (latest), null (root), or specific id
    - chat_session_id or chat_session_info (auto-creates session)
  - Centralized session creation via create_chat_session_from_request with project access validation.
  - Auto-creates a root message when missing.
  - Project search behavior: with the default persona in projects, disables search (and any forced search tool) when project files are already loaded or when the project has no files; otherwise enables it.

- **Migration**
  - Use /send-chat-message and SendMessageRequest instead of /send-message.
  - Replace forced_tool_ids with a single forced_tool_id; validated against available tools.
  - Parent placement logic changed; pass parent_message_id per the new semantics.
  - Removed CHAT_TARGET_CHUNK_PERCENTAGE; chunk percentage logic is no longer used.

<sup>Written for commit 292fb9b7f78b5155a19a2de7e3744a059cbb6f1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



