### PR TITLE
fix(braintrust): Updating naming for metric

### DIFF
--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -118,10 +118,10 @@ class BraintrustTracingProcessor(TracingProcessor):
 
     def _generation_log_data(self, span: Span[GenerationSpanData]) -> Dict[str, Any]:
         metrics = {}
-        ttft = _maybe_timestamp_elapsed(span.ended_at, span.started_at)
+        total_latency = _maybe_timestamp_elapsed(span.ended_at, span.started_at)
 
-        if ttft is not None:
-            metrics["time_to_first_token"] = ttft
+        if total_latency is not None:
+            metrics["total_latency_seconds"] = total_latency
 
         usage = span.span_data.usage or {}
         if "prompt_tokens" in usage:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing the naming for a metric given it is not the actual ttft in this situation.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Just a renaming of metric

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the generation metric to "total_latency_seconds" to reflect full span duration, not time-to-first-token. This clarifies metric semantics and prevents misleading data in Braintrust logs.

<sup>Written for commit 855fbb2cc6823298b6b7e55bbb7ed4f9a732c3cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

