### PR TITLE
fix(braintrust): Implement actual TTFA Metric

### DIFF
--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -130,9 +130,9 @@ class BraintrustTracingProcessor(TracingProcessor):
         if total_latency is not None:
             metrics["total_latency_seconds"] = total_latency
 
-        if span.span_data.time_to_first_token_seconds is not None:
-            metrics["time_to_first_token_seconds"] = (
-                span.span_data.time_to_first_token_seconds
+        if span.span_data.time_to_first_action_seconds is not None:
+            metrics["time_to_first_action_seconds"] = (
+                span.span_data.time_to_first_action_seconds
             )
 
         usage = span.span_data.usage or {}

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -150,7 +150,7 @@ def generation_span(
     model: str | None = None,
     model_config: Mapping[str, Any] | None = None,
     usage: dict[str, Any] | None = None,
-    time_to_first_token_seconds: float | None = None,
+    time_to_first_action_seconds: float | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
     disabled: bool = False,
@@ -169,6 +169,7 @@ def generation_span(
         model: The model identifier used for the generation.
         model_config: The model configuration (hyperparameters) used.
         usage: A dictionary of usage information (input tokens, output tokens, etc.).
+        time_to_first_action_seconds: Time elapsed before the first model action is observed.
         span_id: The ID of the span. Optional. If not provided, we will generate an ID. We
             recommend using `util.gen_span_id()` to generate a span ID, to guarantee that IDs are
             correctly formatted.
@@ -186,7 +187,7 @@ def generation_span(
             model=model,
             model_config=model_config,
             usage=usage,
-            time_to_first_token_seconds=time_to_first_token_seconds,
+            time_to_first_action_seconds=time_to_first_action_seconds,
         ),
         span_id=span_id,
         parent=parent,

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -99,7 +99,7 @@ class GenerationSpanData(SpanData):
         "model",
         "model_config",
         "usage",
-        "time_to_first_token_seconds",
+        "time_to_first_action_seconds",
     )
 
     def __init__(
@@ -109,14 +109,14 @@ class GenerationSpanData(SpanData):
         model: str | None = None,
         model_config: Mapping[str, Any] | None = None,
         usage: dict[str, Any] | None = None,
-        time_to_first_token_seconds: float | None = None,
+        time_to_first_action_seconds: float | None = None,
     ):
         self.input = input
         self.output = output
         self.model = model
         self.model_config = model_config
         self.usage = usage
-        self.time_to_first_token_seconds = time_to_first_token_seconds
+        self.time_to_first_action_seconds = time_to_first_action_seconds
 
     @property
     def type(self) -> str:
@@ -130,5 +130,5 @@ class GenerationSpanData(SpanData):
             "model": self.model,
             "model_config": self.model_config,
             "usage": self.usage,
-            "time_to_first_token_seconds": self.time_to_first_token_seconds,
+            "time_to_first_action_seconds": self.time_to_first_action_seconds,
         }

--- a/backend/onyx/tracing/openinference_tracing_processor.py
+++ b/backend/onyx/tracing/openinference_tracing_processor.py
@@ -233,8 +233,8 @@ def _get_attributes_from_generation_span_data(
         if base_url := param.get("base_url"):
             if "api.openai.com" in base_url:
                 yield LLM_PROVIDER, OpenInferenceLLMProviderValues.OPENAI.value
-    if obj.time_to_first_token_seconds is not None:
-        yield LLM_TIME_TO_FIRST_TOKEN_SECONDS, obj.time_to_first_token_seconds
+    if obj.time_to_first_action_seconds is not None:
+        yield LLM_TIME_TO_FIRST_ACTION_SECONDS, obj.time_to_first_action_seconds
     yield from _get_attributes_from_chat_completions_input(obj.input)
     yield from _get_attributes_from_chat_completions_output(obj.output)
     yield from _get_attributes_from_chat_completions_usage(obj.usage)
@@ -429,7 +429,7 @@ TOOL_NAME = SpanAttributes.TOOL_NAME
 TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS
 GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
 GRAPH_NODE_PARENT_ID = SpanAttributes.GRAPH_NODE_PARENT_ID
-LLM_TIME_TO_FIRST_TOKEN_SECONDS = "llm.time_to_first_token_seconds"
+LLM_TIME_TO_FIRST_ACTION_SECONDS = "llm.time_to_first_action_seconds"
 
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
In this PR: https://github.com/onyx-dot-app/onyx/pull/7168 the metric was incorrectly named so actually introducing the correct metric

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Setup braintrust locally to validate the metric was correct.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implement the correct Time To First Action for LLM streams. We now measure from stream start to the first content/tool action and log it as time_to_first_action_seconds; total end-to-end time is logged as total_latency_seconds.

- **Bug Fixes**
  - Compute time to first action when the first content/reasoning delta or tool call arrives.
  - Add time_to_first_action_seconds to GenerationSpanData and export to Braintrust/OpenInference.
  - Replace previous TTFT (span duration) with total_latency_seconds.

- **Migration**
  - Update dashboards/queries to use time_to_first_action_seconds.
  - Use total_latency_seconds for full request duration.

<sup>Written for commit 6879a253a520cea36a46a1c082a05c11c8fa6ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

