### PR TITLE
chore(docker): .dockerignore /tests/

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+/tests/


### PR DESCRIPTION
## Description

We rebuild the web image any time this `web/tests/` directory changes, but this image does not depend on any tests, so ignore/

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore web/tests/ in web/.dockerignore to prevent Docker rebuilds when only tests change. This reduces build time and avoids unnecessary cache invalidation since tests aren’t needed in the web image.

<sup>Written for commit 577e6a85b1c7394d47fc9ec78cd1f2b5ce79c1fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

