### PR TITLE
fix(braintrust): Fix Tenant ID to Token Association

### DIFF
--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -177,7 +177,7 @@ class BraintrustTracingProcessor(TracingProcessor):
             else self._spans[span.trace_id]
         )
         trace_metadata = self._trace_metadata.get(span.trace_id)
-        span_kwargs = dict(
+        span_kwargs: Dict[str, Any] = dict(
             id=span.span_id,
             name=_span_name(span),
             type=_span_type(span),


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently when we try to associate the tenant_id to the token usage, since they are not on the same span, we cannot create any charts with the current setup.

This fixes this issue by passing through the metadata to the levels that need the information

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested it locally. Attached screenshot

<img width="2413" height="1253" alt="Screenshot 2026-01-02 at 12 23 32 PM" src="https://github.com/user-attachments/assets/c694dfd5-4e9c-4d20-86d5-3ef6205bf136" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates trace metadata (e.g., tenant_id) to all spans so token usage spans carry tenant_id, fixing charting and attribution in Braintrust.

- **Bug Fixes**
  - Store trace-level metadata on trace start.
  - Pass metadata into span creation so child spans inherit tenant_id.
  - Cleanup metadata on trace end.

<sup>Written for commit f7f63bf3bade47da999c6156c12938f79a8a99f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

