### PR TITLE
chore(playwright): fix Exa configure tests

### DIFF
--- a/web/src/app/admin/configuration/web-search/WebProviderModalReducer.ts
+++ b/web/src/app/admin/configuration/web-search/WebProviderModalReducer.ts
@@ -2,6 +2,9 @@ export type WebProviderModalState = {
   /** Provider type currently being configured in the modal (null when closed). */
   providerType: string | null;
 
+  /** Existing provider ID when editing (null for new providers). */
+  existingProviderId: number | null;
+
   /** Raw API key input value (may be the masked placeholder). */
   apiKeyValue: string;
   /** Single provider-specific config field value (e.g. cx / base URL). */
@@ -22,6 +25,7 @@ export type WebProviderModalAction =
   | {
       type: "OPEN";
       providerType: string;
+      existingProviderId: number | null;
       initialApiKeyValue: string;
       initialConfigValue: string;
     }
@@ -35,6 +39,7 @@ export type WebProviderModalAction =
 
 export const initialWebProviderModalState: WebProviderModalState = {
   providerType: null,
+  existingProviderId: null,
   apiKeyValue: "",
   configValue: "",
   phase: "idle",
@@ -52,6 +57,7 @@ export function WebProviderModalReducer(
       return {
         ...state,
         providerType: action.providerType,
+        existingProviderId: action.existingProviderId,
         apiKeyValue: action.initialApiKeyValue,
         configValue: action.initialConfigValue,
         phase: "idle",
@@ -61,6 +67,7 @@ export function WebProviderModalReducer(
       return {
         ...state,
         providerType: null,
+        existingProviderId: null,
         apiKeyValue: "",
         configValue: "",
         phase: "idle",

--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -148,6 +148,7 @@ export default function Page() {
     dispatchSearchModal({
       type: "OPEN",
       providerType,
+      existingProviderId: provider?.id ?? null,
       initialApiKeyValue:
         requiresApiKey && hasStoredKey ? MASKED_API_KEY_PLACEHOLDER : "",
       initialConfigValue: getSingleConfigFieldValueForForm(
@@ -167,6 +168,7 @@ export default function Page() {
     dispatchContentModal({
       type: "OPEN",
       providerType,
+      existingProviderId: provider?.id ?? null,
       initialApiKeyValue: hasStoredKey ? MASKED_API_KEY_PLACEHOLDER : "",
       initialConfigValue:
         providerType === "firecrawl"
@@ -410,9 +412,12 @@ export default function Page() {
       searchProviderValues.config
     );
 
-    const existingProvider = searchProviders.find(
-      (provider) => provider.provider_type === selectedProviderType
-    );
+    // Use the stored provider ID from the modal state instead of looking it up again.
+    // This ensures we update the correct provider even if the data has changed.
+    const existingProviderId = searchModal.existingProviderId;
+    const existingProvider = existingProviderId
+      ? searchProviders.find((p) => p.id === existingProviderId)
+      : null;
 
     const providerRequiresApiKey =
       searchProviderRequiresApiKey(selectedProviderType);
@@ -703,9 +708,12 @@ export default function Page() {
       contentProviderValues.config
     );
 
-    const existingProvider = contentProviders.find(
-      (provider) => provider.provider_type === selectedContentProviderType
-    );
+    // Use the stored provider ID from the modal state instead of looking it up again.
+    // This ensures we update the correct provider even if the data has changed.
+    const existingProviderId = contentModal.existingProviderId;
+    const existingProvider = existingProviderId
+      ? contentProviders.find((p) => p.id === existingProviderId)
+      : null;
 
     // Check if config changed from stored values
     const storedBaseUrl = getSingleContentConfigFieldValueForForm(


### PR DESCRIPTION
## Description

I asked Claude to fix https://github.com/onyx-dot-app/onyx/actions/runs/20663951366/job/59332303803#step:16:1126 and this is what he came up with.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store the provider ID in the search and content configuration modals and use it on save to update the correct provider. This fixes the flaky Playwright “Exa configure” tests.

- **Bug Fixes**
  - Added existingProviderId to modal state and OPEN action.
  - Pass provider?.id when opening search/content modals.
  - Use existingProviderId to find the provider on save instead of provider_type.
  - Prevents updating the wrong provider when data changes, stabilizing the configure flow tests.

<sup>Written for commit aa55f87d2f94984389c34915795490db4ac6cf1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

