### PR TITLE
fix(tests): Integration Test Fix

### DIFF
--- a/backend/tests/integration/tests/connector/test_connector_creation.py
+++ b/backend/tests/integration/tests/connector/test_connector_creation.py
@@ -121,8 +121,10 @@ def test_connector_pause_while_indexing(reset: None) -> None:
     # NOTE: A bit flaky in our CI due to varying indexing times. Empirically
     # 120s was not always enough to index 16 docs from Confluence so trying to
     # bump down the indexing progress to wait for to 4 docs from 16.
+    # Also increasing timeout to 180s and reducing to 1 doc to give more time
+    # for indexing to start in slower CI environments and to catch it earlier
     CCPairManager.wait_for_indexing_in_progress(
-        cc_pair_1, timeout=120, num_docs=4, user_performing_action=admin_user
+        cc_pair_1, timeout=180, num_docs=1, user_performing_action=admin_user
     )
 
     CCPairManager.pause_cc_pair(cc_pair_1, user_performing_action=admin_user)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce CI flakiness in the connector pause test by making the indexing wait logic more robust and increasing the timeout. Adds clearer logging and error details when indexing hasn’t started or the cc_pair isn’t found.

- **Bug Fixes**
  - Increased timeout to 180s and lowered threshold to 1 doc before pausing.
  - Improved wait loop: handle “not in progress” and “cc_pair not found” states.
  - Added detailed logs and final status in timeout errors for easier debugging.

<sup>Written for commit 7c37b2eed7d679e030923a1e87b06173554d1808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

