### PR TITLE
revert: "chore(pre-commit): run uv-sync in active venv"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: d30b4298e4fb63ce8609e29acdbcf4c9018a483c
     hooks:
       - id: uv-sync
-        args: ["--active", "--locked", "--all-extras"]
+        args: ["--locked", "--all-extras"]
       - id: uv-lock
         files: ^pyproject\.toml$
       - id: uv-export


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#6898

pre-commit runs the hooks from a virtual environment which because the active venv when `uv sync` runs causing this to not actually sync the projects venv.

- [x] Override Linear Check