### PR TITLE
chore: Plugin issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,11 @@ model_server = [
 [tool.uv.workspace]
 members = ["backend", "tools/ods"]
 
+[tool.basedpyright]
+include = ["backend"]
+exclude = ["backend/generated"]
+typeCheckingMode = "off"
+
 [tool.setuptools.packages.find]
 where = ["backend"]
 include = ["onyx*", "tests*"]


### PR DESCRIPTION
## Description

Fix BasedPyright issues with the venv

## How Has This Been Tested?

N/A

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured BasedPyright in pyproject to analyze only the backend and skip generated code, fixing venv-related issues. Disabled type checking to avoid false positives from the venv.

- **Bug Fixes**
  - Added [tool.basedpyright] config: include backend, exclude backend/generated.
  - Set typeCheckingMode to off to prevent venv import resolution errors.

<sup>Written for commit f1a385af48ff47a17420460a966b1330d56ef53b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

