### PR TITLE
chore(vscode): recommend astral-sh.ty

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "astral-sh.ty"
+    ]
+}


### PR DESCRIPTION
## Description

The mypy extension takes a really long time and we plan on migrating to `ty` soon enough, so let's start by recommending the vscode extension. That way, we get fast IDE type-checking + a jump start on fixing issues.

I'm not sure how close `ty` is to stable, but they're at least out of alpha and there are only ~100 errors when checking the backend (and about 150 warnings) which may all be valid and just currently ignored because our mypy config isn't too strict.

## How Has This Been Tested?

<img width="1902" height="2085" alt="20260102_17h10m03s_grim" src="https://github.com/user-attachments/assets/36387a7c-7b08-420b-8eea-1b511b553924" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recommend the astral-sh.ty VSCode extension by adding .vscode/extensions.json. This speeds IDE type checking and supports our migration from mypy to ty.

<sup>Written for commit 6c045a9496416ad663ad9390f0ba8f90ff63b591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

