### PR TITLE
fix: regenerate models stuck in perma loading state

### DIFF
--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -67,8 +67,6 @@ export default function LLMPopover({
 }: LLMPopoverProps) {
   const llmProviders = llmManager.llmProviders;
   const isLoadingProviders = llmManager.isLoadingProviders;
-  console.log("llmManager", llmManager);
-  console.log("isLoadingProviders", isLoadingProviders);
 
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");


### PR DESCRIPTION
## Description

<img width="489" height="344" alt="Screenshot 2026-01-02 at 5 46 56 PM" src="https://github.com/user-attachments/assets/771cb001-e1f9-4db5-8be6-6ebfc777fb10" />

^ would just say `Loading Models` forever.


## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the regenerate flow where the model list stayed stuck on “Loading Models”. AIMessage now compares llmManager.isLoadingProviders, so the UI re-renders when providers finish loading.

<sup>Written for commit 1c4f8f0f27efc9e4e8bd9b7465c735857e6d9bee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

