### PR TITLE
feat: improve display for models that are no longer present

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -552,6 +552,16 @@ function getDefaultLlmDescriptor(
       modelName: defaultProvider.default_model_name,
     };
   }
+  const firstLlmProvider = llmProviders.find(
+    (provider) => provider.model_configurations.length > 0
+  );
+  if (firstLlmProvider) {
+    return {
+      name: firstLlmProvider.name,
+      provider: firstLlmProvider.provider,
+      modelName: firstLlmProvider.default_model_name,
+    };
+  }
   return null;
 }
 


### PR DESCRIPTION
## Description

Rather than just showing the CPU icon, just show the default model

## How Has This Been Tested?

local

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When a previously selected model is no longer available, the UI now falls back to the default provider/model instead of showing the CPU icon. This keeps the model display consistent and clear.

<sup>Written for commit db7c7d151506d50220e59482aed43dd316288cc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

