### PR TITLE
feat: Easy send message nonstreaming

### DIFF
--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -238,19 +238,17 @@ class ChatFullResponse(BaseModel):
     # Core response fields
     answer: str
     answer_citationless: str
-    message_id: int
-    chat_session_id: UUID | None = None
-    error_msg: str | None = None
+    pre_answer_reasoning: str | None = None
+    tool_calls: list[ToolCallResponse] = []
 
     # Documents & citations
     top_documents: list[SearchDoc]
     citation_info: list[CitationInfo]
 
-    # Reasoning before the final answer
-    pre_answer_reasoning: str | None = None
-
-    # Tool calls with full details
-    tool_calls: list[ToolCallResponse] = []
+    # Metadata
+    message_id: int
+    chat_session_id: UUID | None = None
+    error_msg: str | None = None
 
 
 class ChatLoadedFile(InMemoryChatFile):

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -867,11 +867,11 @@ def gather_stream_full(
     return ChatFullResponse(
         answer=final_answer,
         answer_citationless=remove_answer_citations(final_answer),
+        pre_answer_reasoning=reasoning,
+        tool_calls=tool_call_responses,
+        top_documents=top_documents,
         citation_info=citations,
         message_id=message_id,
         chat_session_id=chat_session_id,
         error_msg=error_msg,
-        top_documents=top_documents,
-        pre_answer_reasoning=reasoning,
-        tool_calls=tool_call_responses,
     )


### PR DESCRIPTION
## Description

Let the user not specify anything about the chat session at all

## How Has This Been Tested?

N/A

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow sending a message without specifying a chat session; if none is provided, the server now auto-creates one with default settings. Also tidied up ChatFullResponse field ordering with no behavior changes.

- **New Features**
  - Auto-create a chat session when both chat_session_id and chat_session_info are omitted.

- **Refactors**
  - Grouped ChatFullResponse metadata fields and aligned constructor args; no API or response changes.

<sup>Written for commit 19c09a1263882114d61101b05d27e215ec69f70a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

