### PR TITLE
chore(fe): rm unnecessary spacer from chat ui

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -209,29 +209,27 @@ const HumanMessage = React.memo(function HumanMessage({
                 </div>
               </div>
               {onEdit &&
-              isHovered &&
-              !isEditing &&
-              (!files || files.length === 0) ? (
-                <div className="flex flex-row gap-1 p-1">
-                  <CopyIconButton
-                    getCopyText={() => content}
-                    tertiary
-                    data-testid="HumanMessage/copy-button"
-                  />
-                  <IconButton
-                    icon={SvgEdit}
-                    tertiary
-                    tooltip="Edit"
-                    onClick={() => {
-                      setIsEditing(true);
-                      setIsHovered(false);
-                    }}
-                    data-testid="HumanMessage/edit-button"
-                  />
-                </div>
-              ) : (
-                <div className="w-7 h-10" />
-              )}
+                isHovered &&
+                !isEditing &&
+                (!files || files.length === 0) && (
+                  <div className="flex flex-row gap-1 p-1">
+                    <CopyIconButton
+                      getCopyText={() => content}
+                      tertiary
+                      data-testid="HumanMessage/copy-button"
+                    />
+                    <IconButton
+                      icon={SvgEdit}
+                      tertiary
+                      tooltip="Edit"
+                      onClick={() => {
+                        setIsEditing(true);
+                        setIsHovered(false);
+                      }}
+                      data-testid="HumanMessage/edit-button"
+                    />
+                  </div>
+                )}
             </>
           ) : (
             <>


### PR DESCRIPTION
## Description

:taco: 

## How Has This Been Tested?

:t-rex: 

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unnecessary spacer in HumanMessage actions to eliminate blank space and tighten the chat UI layout. Copy/Edit buttons now render only on hover; no behavior changes.

<sup>Written for commit 2f3457c86e70b787729c9467341fb57e02b573aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

