### PR TITLE
chore: bump limits on cloud LLM usage

### DIFF
--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -228,10 +228,10 @@ USAGE_LIMIT_WINDOW_SECONDS = int(os.environ.get("USAGE_LIMIT_WINDOW_SECONDS", "6
 # Per-week LLM usage cost limits in cents (e.g., 1000 = $10.00)
 # Trial users get lower limits than paid users
 USAGE_LIMIT_LLM_COST_CENTS_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_TRIAL", "200")  # $2.00 default
+    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_TRIAL", "800")  # $8.00 default
 )
 USAGE_LIMIT_LLM_COST_CENTS_PAID = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_PAID", "400")  # $4.00 default
+    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_PAID", "1600")  # $16.00 default
 )
 
 # Per-week chunks indexed limits


### PR DESCRIPTION
## Description

change the defaults since this is more consistent with what we want long term

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase default weekly cloud LLM usage limits to better match expected workloads. Trial limit moves from $2 to $8 and paid from $4 to $16 (USAGE_LIMIT_LLM_COST_CENTS_TRIAL and USAGE_LIMIT_LLM_COST_CENTS_PAID), still overridable via environment variables.

<sup>Written for commit dcc38bcdf091466ba819e5d17f13e33ce662f7ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

