### PR TITLE
feat: per-tenant usage limits

### DIFF
--- a/backend/ee/onyx/server/tenant_usage_limits.py
+++ b/backend/ee/onyx/server/tenant_usage_limits.py
@@ -4,7 +4,7 @@ import requests
 
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
-from onyx.server.tenants.usage_limits import TenantUsageLimitOverrides
+from onyx.server.tenant_usage_limits import TenantUsageLimitOverrides
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/tenant_usage_limits.py
+++ b/backend/onyx/server/tenant_usage_limits.py
@@ -4,7 +4,7 @@ Non-EE version of tenant usage limit overrides.
 In non-EE deployments, there are no tenant-specific overrides - all tenants
 use the default limits from environment variables.
 
-The EE version (ee.onyx.server.tenants.usage_limits) fetches per-tenant
+The EE version (ee.onyx.server.tenant_usage_limits) fetches per-tenant
 overrides from the control plane.
 """
 

--- a/backend/onyx/server/usage_limits.py
+++ b/backend/onyx/server/usage_limits.py
@@ -12,8 +12,8 @@ from onyx.configs.app_configs import OPENROUTER_DEFAULT_API_KEY
 from onyx.db.usage import check_usage_limit
 from onyx.db.usage import UsageLimitExceededError
 from onyx.db.usage import UsageType
-from onyx.server.tenants.usage_limits import TenantUsageLimitKeys
-from onyx.server.tenants.usage_limits import TenantUsageLimitOverrides
+from onyx.server.tenant_usage_limits import TenantUsageLimitKeys
+from onyx.server.tenant_usage_limits import TenantUsageLimitOverrides
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from shared_configs.configs import USAGE_LIMIT_API_CALLS_PAID
@@ -87,7 +87,7 @@ def _get_tenant_override(tenant_id: str, field_name: str) -> int | None:
     try:
         # Try to get EE version that has tenant overrides
         get_overrides_fn = fetch_versioned_implementation(
-            "onyx.server.tenants.usage_limits", "get_tenant_usage_limit_overrides"
+            "onyx.server.tenant_usage_limits", "get_tenant_usage_limit_overrides"
         )
         overrides: TenantUsageLimitOverrides | None = get_overrides_fn(tenant_id)
         if overrides is not None:


### PR DESCRIPTION
## Description

Some of our cloud tenants are customers with which we have explicit agreements about usage limits (or lack thereof). We can now fetch per-tenant limits from the control plane (use defaults when the request fails).

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-tenant usage limits with control-plane overrides. Tenants can now have custom limits or unlimited usage; defaults are used when no override is present or fetch fails.

- **New Features**
  - EE: Fetch tenant override limits from the control plane, cache in memory, and load at server startup via versioned implementation.
  - Override fields for trial/paid: llm_cost_cents_trial/paid, chunks_indexed_trial/paid, api_calls_trial/paid, non_streaming_calls_trial/paid. -1 means unlimited; None falls back to env defaults.
  - Updated limit checks to be tenant-aware and skip enforcement when NO_LIMIT (-1) is set.
  - Non-EE: Stubbed overrides (always None) so non-EE deployments use defaults only.

<sup>Written for commit 5bbd628ea91c0ef6a6caa22544f47c64e4a37c1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

