### PR TITLE
chore(fe): replace js isHovered with css hover effects

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -137,7 +137,6 @@ const HumanMessage = React.memo(function HumanMessage({
   // Fix this later.
   const [content, setContent] = useState(initialContent);
 
-  const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
 
   // Use nodeId for switching (finding position in siblings)
@@ -173,9 +172,7 @@ const HumanMessage = React.memo(function HumanMessage({
   return (
     <div
       id="onyx-human-message"
-      className="flex flex-col justify-end pt-5 pb-1 w-full -mr-6 relative"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className="group flex flex-col justify-end pt-5 pb-1 w-full -mr-6 relative"
     >
       <FileDisplay alignBubble files={files || []} />
       <div className="flex flex-wrap justify-end break-words">
@@ -207,49 +204,40 @@ const HumanMessage = React.memo(function HumanMessage({
                 </Text>
               </div>
             </div>
-            {onEdit &&
-              isHovered &&
-              !isEditing &&
-              (!files || files.length === 0) && (
-                <div className="flex flex-row gap-1 p-1">
-                  <CopyIconButton
-                    getCopyText={() => content}
-                    tertiary
-                    data-testid="HumanMessage/copy-button"
-                  />
-                  <IconButton
-                    icon={SvgEdit}
-                    tertiary
-                    tooltip="Edit"
-                    onClick={() => {
-                      setIsEditing(true);
-                      setIsHovered(false);
-                    }}
-                    data-testid="HumanMessage/edit-button"
-                  />
-                </div>
-              )}
+            {onEdit && !isEditing && (!files || files.length === 0) && (
+              <div className="flex flex-row gap-1 p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <CopyIconButton
+                  getCopyText={() => content}
+                  tertiary
+                  data-testid="HumanMessage/copy-button"
+                />
+                <IconButton
+                  icon={SvgEdit}
+                  tertiary
+                  tooltip="Edit"
+                  onClick={() => setIsEditing(true)}
+                  data-testid="HumanMessage/edit-button"
+                />
+              </div>
+            )}
           </>
         ) : (
           <>
-            {onEdit &&
-            isHovered &&
-            !isEditing &&
-            (!files || files.length === 0) ? (
-              <div className="my-auto">
-                <IconButton
-                  icon={SvgEdit}
-                  onClick={() => {
-                    setIsEditing(true);
-                    setIsHovered(false);
-                  }}
-                  tertiary
-                  tooltip="Edit"
-                />
-              </div>
-            ) : (
-              <div className="h-[27px]" />
-            )}
+            <div
+              className={cn(
+                "my-auto",
+                onEdit && !isEditing && (!files || files.length === 0)
+                  ? "opacity-0 group-hover:opacity-100 transition-opacity"
+                  : "invisible"
+              )}
+            >
+              <IconButton
+                icon={SvgEdit}
+                onClick={() => setIsEditing(true)}
+                tertiary
+                tooltip="Edit"
+              />
+            </div>
             <div className="ml-auto rounded-lg p-1">{content}</div>
           </>
         )}


### PR DESCRIPTION
## Description

Prefer CSS for hover effects. Simplifies the code plus is more accessible as these buttons are now always present which means they can be read by screen readers or activated with tabbing the keyboard. 

## How Has This Been Tested?

<img width="1536" height="1820" alt="20260105_08h57m03s_grim" src="https://github.com/user-attachments/assets/d641caa6-4fd4-405c-b3c0-0c9975512763" />

(need to work on the visibility of buttons when focused, but at least they're accessible)

## Additional Options

- [x] Override Linear Check
