### PR TITLE
feat(braintrust): Cost Tracking

### DIFF
--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -134,14 +134,15 @@ class BraintrustTracingProcessor(TracingProcessor):
         usage = span.span_data.usage or {}
         prompt_tokens = None
         completion_tokens = None
-        if (
-            prompt_tokens := usage.get("prompt_tokens") or usage.get("input_tokens")
-        ) is not None:
+        prompt_tokens = usage.get("prompt_tokens")
+        if prompt_tokens is None:
+            prompt_tokens = usage.get("input_tokens")
+        if prompt_tokens is not None:
             metrics["prompt_tokens"] = int(prompt_tokens)
-        if (
-            completion_tokens := usage.get("completion_tokens")
-            or usage.get("output_tokens")
-        ) is not None:
+        completion_tokens = usage.get("completion_tokens")
+        if completion_tokens is None:
+            completion_tokens = usage.get("output_tokens")
+        if completion_tokens is not None:
             metrics["completion_tokens"] = int(completion_tokens)
 
         if "total_tokens" in usage:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Reusing the LLM cost framework to ingest costs into Braintrust

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LLM cost tracking to Braintrust tracing by computing cost_cents per generation from model and token usage. Improves token metric handling for accurate totals.

- **New Features**
  - Calculates cost_cents via calculate_llm_cost_cents when model, prompt_tokens, and completion_tokens are present; adds to metrics only if positive.

- **Refactors**
  - Normalizes usage fields (prompt/input, completion/output), casts to ints, and derives total_tokens when missing to ensure accurate metrics.

<sup>Written for commit 8c8ac2cf62e6ffcfe025ce66c76688017c286d14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

