### PR TITLE
fix(ui): Remove Open URL Filter for Agents

### DIFF
--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -23,6 +23,8 @@ import Button from "@/refresh-components/buttons/Button";
 import {
   SEARCH_TOOL_ID,
   IMAGE_GENERATION_TOOL_ID,
+  OPEN_URL_TOOL_ID,
+  OPEN_URL_TOOL_NAME,
   WEB_SEARCH_TOOL_ID,
   SYSTEM_TOOL_ICONS,
 } from "@/app/chat/components/tools/constants";
@@ -193,6 +195,13 @@ export default function AgentsNavigationPage() {
     >();
     agents.forEach((agent) => {
       agent.tools.forEach((tool) => {
+        if (
+          tool.in_code_tool_id === OPEN_URL_TOOL_ID ||
+          tool.name === OPEN_URL_TOOL_ID ||
+          tool.name === OPEN_URL_TOOL_NAME
+        ) {
+          return;
+        }
         actionsMap.set(tool.id, {
           id: tool.id,
           name: tool.name,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Remove the OpenURL Filter in the Agent view

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

<img width="873" height="621" alt="Screenshot 2026-01-05 at 1 00 21 PM" src="https://github.com/user-attachments/assets/c8aec96f-53d0-450b-a1f1-0c12dc5c72cb" />

## Additional Options
Partially closes https://linear.app/onyx-app/issue/ENG-3261/this-filter-doesnt-work-as-it-should

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Open URL" filter from the Agents view to prevent a broken filter from appearing. Partially addresses ENG-3261 by skipping Open URL tools (by id and name) when building filter options.

<sup>Written for commit da2622f37f830e006a418c245d1a422147448235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

