### PR TITLE
fix(ui): Update coloring for Doc Set Tooltip

### DIFF
--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         side={side}
         className={cn(
-          "z-tooltip rounded-08 px-3 py-2 text-text-inverted-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-tooltip rounded-08 px-3 py-2 text-text-light-05 animate-in fade-in-0 zoom-in-95 bg-background-neutral-dark-03 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           width,
           className
         )}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing the coloring for the Tooltip in the document sets page

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

Before:
<img width="1296" height="242" alt="Screenshot 2026-01-05 at 1 54 36 PM" src="https://github.com/user-attachments/assets/27df4128-ddf7-4004-aa05-46be649525db" />
<img width="1297" height="247" alt="Screenshot 2026-01-05 at 1 54 44 PM" src="https://github.com/user-attachments/assets/45bd1d85-611e-4281-9a2f-c53962fbc700" />

After:
<img width="1284" height="188" alt="Screenshot 2026-01-05 at 1 55 28 PM" src="https://github.com/user-attachments/assets/a2ae3ecb-325c-4564-8ef6-633229fd260e" />
<img width="1273" height="243" alt="Screenshot 2026-01-05 at 1 55 10 PM" src="https://github.com/user-attachments/assets/c24fa36f-1828-43ce-a8bf-daf103bb00cb" />

## Additional Options

- [x] [Optional] Override Linear Check

Closes: https://linear.app/onyx-app/issue/ENG-3266/bad-info-component

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated tooltip text color from text-text-inverted-05 to text-text-light-05 to improve contrast and readability on dark tooltips. Aligns tooltip styling with our design tokens for light text on neutral-dark backgrounds.

<sup>Written for commit 7dc566c69390ceb40f7f8e7718e26a0a906d80eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
