### PR TITLE
fix(ui): Image Gen Tooltip for Agent Workflow

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -38,6 +38,7 @@ import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import InputSelectField from "@/refresh-components/form/InputSelectField";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
+import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { useDocumentSets } from "@/app/admin/documents/sets/hooks";
 import { useProjectsContext } from "@/app/chat/projects/ProjectsContext";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
@@ -522,6 +523,10 @@ export default function AgentEditorPage({
   const codeInterpreterTool = availableTools?.find(
     (t) => t.in_code_tool_id === PYTHON_TOOL_ID
   );
+  const isImageGenerationAvailable = !!imageGenTool;
+  const imageGenerationDisabledTooltip = isImageGenerationAvailable
+    ? undefined
+    : "Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin.";
 
   // Group MCP server tools from availableTools by server ID
   const mcpServersWithTools = mcpServers.map((server) => {
@@ -1241,18 +1246,38 @@ export default function AgentEditorPage({
                         }
                       >
                         <Section className="gap-2">
-                          <Card>
-                            <InputLayouts.Horizontal
-                              name="image_generation"
-                              label="Image Generation"
-                              description="Generate and manipulate images using AI-powered tools."
+                          <SimpleTooltip
+                            tooltip={imageGenerationDisabledTooltip}
+                            side="top"
+                          >
+                            <div
+                              className={cn(
+                                "w-full",
+                                !isImageGenerationAvailable &&
+                                  "cursor-not-allowed"
+                              )}
                             >
-                              <SwitchField
-                                name="image_generation"
-                                disabled={!imageGenTool}
-                              />
-                            </InputLayouts.Horizontal>
-                          </Card>
+                              <div
+                                className={cn(
+                                  !isImageGenerationAvailable &&
+                                    "pointer-events-none opacity-50"
+                                )}
+                              >
+                                <Card>
+                                  <InputLayouts.Horizontal
+                                    name="image_generation"
+                                    label="Image Generation"
+                                    description="Generate and manipulate images using AI-powered tools."
+                                  >
+                                    <SwitchField
+                                      name="image_generation"
+                                      disabled={!isImageGenerationAvailable}
+                                    />
+                                  </InputLayouts.Horizontal>
+                                </Card>
+                              </div>
+                            </div>
+                          </SimpleTooltip>
 
                           <Card>
                             <InputLayouts.Horizontal


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding a new tooltip to show that you must configure an image model in order to add the image tool to an agent.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally.

Before:
<img width="808" height="228" alt="Screenshot 2026-01-05 at 2 08 36 PM" src="https://github.com/user-attachments/assets/458ff424-3dc4-4128-a545-cd3251106ab5" />

After:
<img width="820" height="275" alt="Screenshot 2026-01-05 at 2 08 03 PM" src="https://github.com/user-attachments/assets/6491cda6-5ceb-45df-a020-bfd4f3b81229" />

## Additional Options

- [x] [Optional] Override Linear Check

Closes https://linear.app/onyx-app/issue/ENG-3310/image-gen-tooltip-for-agent-creation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a tooltip and disabled state to the Image Generation toggle in the Agent editor when no image model is configured. This guides users to Settings > Image Generation or to ask an admin, reducing confusion.

<sup>Written for commit c79c84a48d3b2b0a958b0d1df63bd89015d116a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

