### PR TITLE
fix(chat): Thinking in Regen Chat

### DIFF
--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -355,6 +355,7 @@ def translate_assistant_message_to_packets(
                 tool_calls_by_turn[turn_num] = []
             tool_calls_by_turn[turn_num].append(tool_call)
 
+        tool_call_turns = set(tool_calls_by_turn.keys())
         # Process each turn in order
         for turn_num in sorted(tool_calls_by_turn.keys()):
             tool_calls_in_turn = tool_calls_by_turn[turn_num]
@@ -369,7 +370,10 @@ def translate_assistant_message_to_packets(
                 None,
             )
             if turn_reasoning:
-                reasoning_turn_index = turn_num - 1 if turn_num > 0 else 0
+                # Use the previous turn slot when free to preserve reasoning-before-tool ordering.
+                reasoning_turn_index = turn_num
+                if turn_num > 0 and (turn_num - 1) not in tool_call_turns:
+                    reasoning_turn_index = turn_num - 1
                 packet_list.extend(
                     create_reasoning_packets(
                         reasoning_text=turn_reasoning,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
We don't show the initial Thinking blocks when the chat is regenerated. 

This PR aims to properly address this by making sure we don't drop the reasoning tokens.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally with regenerated chats showing the thinking blocks properly.
<img width="922" height="786" alt="Screenshot 2026-01-05 at 3 37 29 PM" src="https://github.com/user-attachments/assets/0e4e9321-423b-4787-9f28-a44cb6351a6d" />

## Additional Options
Should close https://linear.app/onyx-app/issue/ENG-3131/need-to-make-the-reasoning-tokens-show-on-replays
and close https://linear.app/onyx-app/issue/ENG-3243/deep-research-replay
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show initial Thinking blocks in regenerated chats by keeping and emitting reasoning tokens in the packet stream. Addresses Linear ENG-3131 (show reasoning tokens on replays) and fixes turn ordering with tool calls, messages, and citations.

- **Bug Fixes**
  - Insert pre-tool reasoning packets once per turn when available.
  - Emit assistant-level reasoning before the final message turn.
  - Update turn_index calculations to account for reasoning and maintain correct citation ordering.

<sup>Written for commit fd28da0a9c8aed6ee4adec41efe4ddddf816c082. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



