### PR TITLE
fix: serper api key errors when adding

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/clients/serper_client.py
+++ b/backend/onyx/tools/tool_implementations/web_search/clients/serper_client.py
@@ -49,6 +49,8 @@ class SerperClient(WebSearchProvider, WebContentProvider):
         results = response.json()
         organic_results = results["organic"]
 
+        organic_results = filter(lambda result: "link" in result, organic_results)
+
         return [
             WebSearchResult(
                 title=result.get("title", ""),


### PR DESCRIPTION
When we try to add an api key to serper it currently crashes and returns an error, 'snippet'.

When we attach a new key for a web provider, we run the test_connection() function to test that the key works. In Serper, this currently works by running self.search("test") and checking that it gets valid results. One of the results that emerges is www.test.com, which notably has no snippet. This leads to an error as there is no 'snippet' key on the dictionary.

Solution: Replace key lookup with .get and use a default empty string if it does not exist.

Linear: closes https://linear.app/onyx-app/issue/ENG-3312/serper-key-in-ui-fails


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when adding a Serper API key by handling missing fields in search results during test_connection. Filter out results without a link, and use result.get for title/link with default title/snippet to '' so missing fields no longer error.

<sup>Written for commit 9d9cc83d5b1a4afc50ea16fc8b6f4b69adb176d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



