### PR TITLE
fix(projects): projct folder button not expandable 

### DIFF
--- a/web/src/refresh-components/buttons/SidebarTab.tsx
+++ b/web/src/refresh-components/buttons/SidebarTab.tsx
@@ -66,7 +66,7 @@ export default function SidebarTab({
         )}
       >
         {LeftIcon && (
-          <div className="w-[1rem] h-[1rem] flex flex-col items-center justify-center">
+          <div className="w-[1rem] h-[1rem] flex items-center justify-center pointer-events-auto">
             <LeftIcon
               data-state={state}
               className={`h-[1rem] w-[1rem] sidebar-tab-icon-${variant}`}
@@ -87,7 +87,11 @@ export default function SidebarTab({
             children
           ))}
       </div>
-      {!folded && <div className="relative">{rightChildren}</div>}
+      {!folded && (
+        <div className="relative h-[1.5rem] flex items-center">
+          {rightChildren}
+        </div>
+      )}
     </div>
   );
 


### PR DESCRIPTION
## Description
This pull request fixes the non expandable project button issue.

ticket -> https://linear.app/onyx-app/issue/ENG-3283/projects-are-no-longer-expandable

https://github.com/user-attachments/assets/881a4e7d-876a-4981-a10e-a9a563def6da



## How Has This Been Tested?
Tested from UI

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Projects sidebar button so folders expand/collapse as expected. Addresses Linear ENG-3283.

- **Bug Fixes**
  - Made the icon clickable by adding pointer-events-auto to the LeftIcon wrapper.
  - Adjusted the right-side container height and alignment for a consistent hit area and layout.

<sup>Written for commit ede047fc2ceb4563649cfb136de0f4fb0c7384bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

