### PR TITLE
fix: json serialize tool calls and other types in prompt cache

### DIFF
--- a/backend/onyx/llm/prompt_cache/cache_manager.py
+++ b/backend/onyx/llm/prompt_cache/cache_manager.py
@@ -172,10 +172,10 @@ def _make_json_serializable(obj: object) -> object:
     """
     if hasattr(obj, "model_dump"):
         # Pydantic v2 model
-        return obj.model_dump()
+        return obj.model_dump(mode="json")
     elif hasattr(obj, "dict"):
         # Pydantic v1 model or similar
-        return obj.dict()
+        return _make_json_serializable(obj.dict())
     elif isinstance(obj, dict):
         return {k: _make_json_serializable(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):


### PR DESCRIPTION
## Description

for caching chats we don't serialize tool calls and other pydantic v2 models properly

## Testing

locally verified that we serialize tool calls properly

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache key generation by making chat messages and tool call payloads JSON-serializable. Prevents hashing errors and inconsistent cache entries when messages include Pydantic models or nested types.

- **Bug Fixes**
  - Added _make_json_serializable to recursively convert Pydantic v1/v2 models, dicts, lists, tuples, and primitives; fallback to string.
  - Used this in generate_cache_key_hash to serialize normalized messages deterministically.

<sup>Written for commit 0e14f484f131d567b06e34135418ad8d44d207ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

