### PR TITLE
fix(fe): move Text horizontal padding to pseudo-element

### DIFF
--- a/web/src/refresh-components/texts/Text.tsx
+++ b/web/src/refresh-components/texts/Text.tsx
@@ -201,7 +201,7 @@ export default function Text({
         // complement the white-space implicit with line-height. We apply to the before and after
         // pseudo-elements such that padding applied to the tag directly is additive making the
         // likelihood of 2px offsets with other text elements much lower.
-        "before:content-[''] before:pl-[2px] after:content-[''] after:pr-[2px]",
+        "before:content-[''] before:inline-block before:pl-[2px] after:content-[''] after:inline-block after:pr-[2px]",
         className
       )}
     >


### PR DESCRIPTION
## Description

Applies the default Text padding (visual) to a psuedo-element such that it is additive with any layout-specific padding reducing the likelihood of small 2px offsets between text elements.

See also, https://onyx-company.slack.com/archives/C09BHKH5PML/p1767657622160989

## How Has This Been Tested?

**before**
<img width="1416" height="1820" alt="image" src="https://github.com/user-attachments/assets/fed41aac-1b0f-427e-8dbc-d5746ac97370" />

**after**
<img width="1416" height="1820" alt="image" src="https://github.com/user-attachments/assets/f3528345-4d3b-4084-9d64-2127c0610eaa" />

## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Text component’s 2px horizontal padding to ::before and ::after pseudo-elements so it’s additive with layout padding and avoids small misalignments between text elements. Improves visual alignment and consistency across layouts.

<sup>Written for commit ce4d4abe3dd1cffeb2bd2fca92f4ac0c0ab177fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



