### PR TITLE
fix(chat): Math Formatting

### DIFF
--- a/web/src/app/chat/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/chat/message/messageComponents/markdownUtils.tsx
@@ -140,7 +140,7 @@ export const renderMarkdown = (
         components={markdownComponents}
         remarkPlugins={[
           remarkGfm,
-          [remarkMath, { singleDollarTextMath: false }],
+          [remarkMath, { singleDollarTextMath: true }],
         ]}
         rehypePlugins={[rehypeHighlight, rehypeKatex]}
         urlTransform={transformLinkUri}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
We had some weird oddities with formatting in the product. There is a video in the linear link.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally and validated that the formatting was properly handled now.
<img width="902" height="1456" alt="Screenshot 2026-01-06 at 11 40 14 AM" src="https://github.com/user-attachments/assets/1e22f485-12a1-4070-bc1c-c3ac40418707" />

## Additional Options
Closes https://linear.app/onyx-app/issue/ENG-3258/some-rendering-issues-in-the-response

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable single-dollar inline math in chat messages so $...$ renders correctly. Addresses the formatting issues in Linear ENG-3258 by turning on remark-math’s singleDollarTextMath option.

<sup>Written for commit c14e892b5a0c304cab682c9e8fdb484ec0548d68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

