### PR TITLE
chore(devtools): ods with no args outputs help

### DIFF
--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -50,5 +50,5 @@ func NewRootCommand() *cobra.Command {
 }
 
 func rootCmd(cmd *cobra.Command, args []string) {
-	log.Debug("Debug log in rootCmd")
+	_ = cmd.Help()
 }


### PR DESCRIPTION
## Description



## How Has This Been Tested?

```
cd tools/ods/
go build .
./ods
```

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running ods with no arguments now prints the CLI help instead of a debug log. This improves usability and matches common Cobra CLI behavior.

<sup>Written for commit 7246b595b2ff1642863bd7634183e86e2f7478af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

