### PR TITLE
chore(gha): pin uv version w/ chart-testing-action

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -41,7 +41,10 @@ jobs:
           version: v3.19.0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # ratchet:helm/chart-testing-action@v2.8.0
+        # NOTE: This is Jamison's patch from https://github.com/helm/chart-testing-action/pull/194
+        uses: helm/chart-testing-action@8958a6ac472cbd8ee9a8fbb6f1acbc1b0e966e44 # zizmor: ignore[impostor-commit]
+        with:
+          uv_version: "0.9.9"
 
       # even though we specify chart-dirs in ct.yaml, it isn't used by ct for the list-changed command...
       - name: Run chart-testing (list-changed)


### PR DESCRIPTION
## Description

Standardizes the version of `uv` across our actions and avoids rate-limiting like https://github.com/onyx-dot-app/onyx/actions/runs/20764104130/job/59626268811#step:5:377

## How Has This Been Tested?

No

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned uv to 0.9.9 in the Helm chart testing workflow to standardize the environment and prevent rate-limit errors during chart tests. Switched to a patched chart-testing-action that supports uv_version.

- **Dependencies**
  - Use chart-testing-action version with uv_version support.
  - Set uv_version to 0.9.9 in the setup step.

<sup>Written for commit 77b5cde4d13dcc02ad7430faf9b3f729df9ef081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

