### PR TITLE
chore(gha): conditionally run zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,7 +27,16 @@ jobs:
           enable-cache: false
           version: "0.9.9"
 
+      - name: Detect changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        with:
+          filters: |
+            zizmor:
+              - '.github/**'
+
       - name: Run zizmor
+        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
         run: uv run --no-sync --with zizmor zizmor --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

I suspect a lot of Github API usage is coming from Zizmor which cannot be avoided while preserving the utility of the test, so instead implement test selection so we only run it when we have to.

## How Has This Been Tested?

Should still run on this PR, https://github.com/onyx-dot-app/onyx/actions/runs/20766281831/job/59632991939?pr=7240

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally run Zizmor in CI to reduce unnecessary GitHub API usage. It now runs only when .github/** files change or on the main branch, using dorny/paths-filter for detection.

<sup>Written for commit 3434b70caec080de7e1c1ed60a6646a06186457a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

