### PR TITLE
fix(sidebar): Allow unpinning all agents and fix icon flicker

### DIFF
--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -107,22 +107,27 @@ export function usePinnedAgents() {
   const serverPinnedAgents = useMemo(() => {
     if (agents.length === 0) return [];
 
-    const pinned = (user?.preferences.pinned_assistants ?? [])
+    // If pinned_assistants is null/undefined (never set), show default personas
+    // If it's an empty array (user explicitly unpinned all), show nothing
+    const pinnedIds = user?.preferences.pinned_assistants;
+    if (pinnedIds === null || pinnedIds === undefined) {
+      return agents.filter(
+        (agent) => agent.is_default_persona && agent.id !== 0
+      );
+    }
+
+    return pinnedIds
       .map((id) => agents.find((agent) => agent.id === id))
       .filter((agent): agent is MinimalPersonaSnapshot => !!agent);
-
-    // Fallback to default personas if no pinned agents
-    return pinned.length > 0
-      ? pinned
-      : agents.filter((agent) => agent.is_default_persona && agent.id !== 0);
   }, [agents, user?.preferences.pinned_assistants]);
 
   // Sync server data → local state when server data changes
+  // Only sync when agents have loaded (to avoid syncing empty during initial load)
   useEffect(() => {
-    if (serverPinnedAgents.length > 0) {
+    if (agents.length > 0) {
       setLocalPinnedAgents(serverPinnedAgents);
     }
-  }, [serverPinnedAgents]);
+  }, [serverPinnedAgents, agents.length]);
 
   // Toggle pin status - updates local state AND persists to server
   const togglePinnedAgent = useCallback(

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -51,6 +51,7 @@ import {
   SvgTrash,
 } from "@opal/icons";
 import useOnMount from "@/hooks/useOnMount";
+import { useAgents, usePinnedAgents } from "@/hooks/useAgents";
 
 export interface PopoverSearchInputProps {
   setShowMoveOptions: (show: boolean) => void;
@@ -137,6 +138,8 @@ const ChatButton = memo(
       createProject,
     } = useProjectsContext();
     const { popup, setPopup } = usePopup();
+    const { agents } = useAgents();
+    const { pinnedAgents, togglePinnedAgent } = usePinnedAgents();
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [pendingMoveProjectId, setPendingMoveProjectId] = useState<
       number | null
@@ -292,6 +295,18 @@ const ChatButton = memo(
       createProject,
     ]);
 
+    // Pin the chat's agent when clicking on the conversation
+    async function handleClick() {
+      const agent = agents.find((a) => a.id === chatSession.persona_id);
+      if (agent) {
+        const isAlreadyPinned = pinnedAgents.some((a) => a.id === agent.id);
+        if (!isAlreadyPinned) {
+          await togglePinnedAgent(agent, true);
+        }
+      }
+      route({ chatSessionId: chatSession.id });
+    }
+
     async function handleRename(newName: string) {
       setDisplayName(newName);
       await renameChatSession(chatSession.id, newName);
@@ -434,7 +449,7 @@ const ChatButton = memo(
       >
         <PopoverAnchor>
           <SidebarTab
-            href={`/chat?chatId=${chatSession.id}`}
+            onClick={handleClick}
             transient={active}
             rightChildren={rightMenu}
             focused={renaming}


### PR DESCRIPTION
## Description

Fixes agent pinning issues in the sidebar:
- Allow unpinning all agents (distinguish `null` vs `[]` for pinned preferences)
- Prevent icon flicker when unpinning
- Persist pins when clicking sidebar agents or chat sessions
- Hide unpin button for current agent

## How Has This Been Tested?

![2026-01-09 10 54 59](https://github.com/user-attachments/assets/34b536cd-a9d5-495a-9900-db2b056ee717)


Closes https://linear.app/onyx-app/issue/ENG-3311/cant-unpin-agent