### PR TITLE
fix(ci): Add missing conditional to zizmor SARIF upload step

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -42,6 +42,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
+        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
         uses: github/codeql-action/upload-sarif@ba454b8ab46733eb6145342877cd148270bb77ab # ratchet:github/codeql-action/upload-sarif@codeql-bundle-v2.23.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Description

The zizmor workflow was failing on all PRs that don't modify `.github/**` files with:

```
Path does not exist: results.sarif
```

The "Run zizmor" step has a conditional that skips it when no workflow files are changed:
```yaml
if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
```

But the "Upload SARIF file" step was missing this same conditional, so it would still try to upload `results.sarif` even when the file was never created.

Added the same `if` conditional to the "Upload SARIF file" step.

## How Has This Been Tested?

- This PR modifies `.github/**` so zizmor will run and validate the workflow syntax
- The fix ensures that for PRs that don't touch workflow files, both steps are skipped together

## Additional Options

- [x] Override Linear Check