### PR TITLE
chore(gha): skip all of zizmor when applicable

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,17 +16,6 @@ jobs:
     permissions:
       security-events: write # needed for SARIF uploads
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-          version: "0.9.9"
-
       - name: Detect changes
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
@@ -35,6 +24,19 @@ jobs:
             zizmor:
               - '.github/**'
 
+      - name: Checkout repository
+        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
+        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          version: "0.9.9"
+
       - name: Run zizmor
         if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
         run: uv run --no-sync --with zizmor zizmor --format=sarif . > results.sarif
@@ -42,6 +44,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
+        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
         uses: github/codeql-action/upload-sarif@ba454b8ab46733eb6145342877cd148270bb77ab # ratchet:github/codeql-action/upload-sarif@codeql-bundle-v2.23.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Description

Let's just skip all steps if not matched.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the entire zizmor workflow unless .github/** changes, while still running on main. This avoids unnecessary checkout/setup and speeds up CI.

- **Refactors**
  - Moved paths-filter to the start of the job.
  - Added the same condition to checkout, setup-uv, run, and SARIF upload steps.
  - Workflow now runs only on .github/** changes or on main.

<sup>Written for commit 969071f5642cc04a54deaaaa2506ec9de671c354. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

