### PR TITLE
chore(gha): paths-filter depends on actions/checkout

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,6 +16,11 @@ jobs:
     permissions:
       security-events: write # needed for SARIF uploads
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
+
       - name: Detect changes
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
@@ -23,12 +28,6 @@ jobs:
           filters: |
             zizmor:
               - '.github/**'
-
-      - name: Checkout repository
-        if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ratchet:actions/checkout@v6.0.1
-        with:
-          persist-credentials: false
 
       - name: Install the latest version of uv
         if: steps.filter.outputs.zizmor == 'true' || github.ref_name == 'main'


### PR DESCRIPTION
## Description

https://github.com/onyx-dot-app/onyx/commit/596b3d9f3e63b480c4342933c2a729205c90a8d6 broke HEAD now

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run actions/checkout at the start of the zizmor workflow so dorny/paths-filter can read the repo. This fixes HEAD failures and removes the redundant conditional checkout step.

<sup>Written for commit adfaaf43c5f356fb47e550f35c5a2eecb1261721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

