### PR TITLE
feat: Fix last cycle LLM did not return an answer

### DIFF
--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -10,6 +10,7 @@ from onyx.file_store.models import FileDescriptor
 from onyx.prompts.chat_prompts import CITATION_REMINDER
 from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN
 from onyx.prompts.chat_prompts import DEFAULT_SYSTEM_PROMPT
+from onyx.prompts.chat_prompts import LAST_CYCLE_CITATION_REMINDER
 from onyx.prompts.chat_prompts import REQUIRE_CITATION_GUIDANCE
 from onyx.prompts.chat_prompts import USER_INFO_HEADER
 from onyx.prompts.prompt_utils import get_company_context
@@ -115,8 +116,11 @@ def calculate_reserved_tokens(
 def build_reminder_message(
     reminder_text: str | None,
     include_citation_reminder: bool,
+    is_last_cycle: bool,
 ) -> str | None:
     reminder = reminder_text.strip() if reminder_text else ""
+    if is_last_cycle:
+        reminder += "\n\n" + LAST_CYCLE_CITATION_REMINDER
     if include_citation_reminder:
         reminder += "\n\n" + CITATION_REMINDER
     reminder = reminder.strip()

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -51,6 +51,10 @@ Remember to provide inline citations in the format [1], [2], [3], etc. based on 
 Do not acknowledge this hint in your response.
 """.strip()
 
+LAST_CYCLE_CITATION_REMINDER = """
+You are on your last cycle and no longer have any tool calls available. You must answer the query now to the best of your ability.
+""".strip()
+
 
 # Reminder message that replaces the usual reminder if web_search was the last tool call
 OPEN_URL_REMINDER = """


### PR DESCRIPTION
## Description

For meh/bad LLMs, even if it's the last cycle and we have removed all tools, it will still see the format of tool calls in the history and attempt to call a tool sometimes. In this case GPT OSS 120B does this.

addresses: https://linear.app/onyx-app/issue/ENG-3348/llm-did-not-return-an-answer

## How Has This Been Tested?
Same prompt now fairly reliably gives an answer on the last cycle

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the LLM always produces a final answer on the last cycle by disabling tools and adding a clear last-cycle reminder. Prevents models from attempting tool calls due to history and failing to answer.

- **Bug Fixes**
  - Explicitly mark the last cycle (out_of_cycles) and set tool_choice to NONE.
  - Add a last-cycle prompt reminder and pass is_last_cycle to the reminder builder.
  - Skip the web search reminder on the last cycle to avoid tool call hints.
  - Last-cycle answers are now reliable for models like GPT OSS 120B.

<sup>Written for commit 5aadfbb103955d3a6ab4bb65ae736fa3da9bd1aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

