### PR TITLE
fix: don't pass tool_choice for mistral provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -22,6 +22,7 @@ class LlmProviderNames(str, Enum):
     OPENROUTER = "openrouter"
     AZURE = "azure"
     OLLAMA_CHAT = "ollama_chat"
+    MISTRAL = "mistral"
     LITELLM_PROXY = "litellm_proxy"
 
     def __str__(self) -> str:
@@ -59,7 +60,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",
     "xai": "xAI",
-    "mistral": "Mistral",
+    LlmProviderNames.MISTRAL: "Mistral",
     "mistralai": "Mistral",  # Alias used by some providers
     "cohere": "Cohere",
     "perplexity": "Perplexity",

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -296,6 +296,7 @@ class LitellmLLM(LLM):
             self.config.model_provider, self.config.model_name
         )
         is_ollama = self._model_provider == LlmProviderNames.OLLAMA_CHAT
+        is_mistral = self._model_provider == LlmProviderNames.MISTRAL
 
         #########################
         # Build arguments
@@ -353,9 +354,10 @@ class LitellmLLM(LLM):
         if structured_response_format:
             optional_kwargs["response_format"] = structured_response_format
 
-        if not (is_claude_model or is_ollama):
+        if not (is_claude_model or is_ollama or is_mistral):
             # Litellm bug: tool_choice is dropped silently if not specified here for OpenAI
-            # However, this param breaks Anthropic models, so it must be conditionally included
+            # However, this param breaks Anthropic and Mistral models,
+            # so it must be conditionally included.
             # Additionally, tool_choice is not supported by Ollama and causes warnings if included.
             # See also, https://github.com/ollama/ollama/issues/11171
             optional_kwargs["allowed_openai_params"] = ["tool_choice"]


### PR DESCRIPTION
## Description

- Mistral API giving errors when we pass `tool_choice` in `allowed_openai_params`

## How Has This Been Tested?

locally with mistral api

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop passing tool_choice to Mistral models to prevent call failures and warnings. Added a dedicated Mistral provider for accurate detection and labeling.

- **Bug Fixes**
  - Skip tool_choice when the provider is Mistral, consistent with Anthropic and Ollama handling.

- **Refactors**
  - Introduced LlmProviderNames.MISTRAL and updated the provider display mapping to use the enum.

<sup>Written for commit c6e619aa2ec7581a7cf2c0fdbdabde838650face. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

