### PR TITLE
chore(deployments): dont treat ad-hoc releases as dry-runs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -258,9 +258,11 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: ./desktop
         shell: pwsh
+        env:
+          IS_TEST_RUN: ${{ needs.determine-builds.outputs.is-test-run }}
         run: |
           # Windows MSI requires numeric-only build metadata, so we skip the SHA suffix
-          if ("${{ needs.determine-builds.outputs.is-test-run }}" -eq "true") {
+          if ($env:IS_TEST_RUN -eq "true") {
             $VERSION = "0.0.0"
           } else {
             # Strip 'v' prefix and any pre-release suffix (e.g., -beta.13) for MSI compatibility


### PR DESCRIPTION
## Description

I want ad-hoc, user-distached deployments to be treated as real deployments. Only clearly testing changes (i.e non-default branches) should be treated as dry-runs. This way, if you dispatch a run matching a real deployment (re-running nightly), it actually deploys.

## How Has This Been Tested?

Hmmm

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ad-hoc workflow_dispatch runs on production refs now perform real deployments; only non-production dispatches are treated as test runs. This makes re-running nightly or version tags deploy for real.

- **Refactors**
  - Added is-test-run flag based on event type and tag (vX.Y.Z*, nightly* are production).
  - Removed IS_DRY_RUN env and unified logic across web, cloud, backend, and model-server.
  - Switched image repo, tags, and release versions to depend on is-test-run.
  - Adjusted desktop versioning for test runs (0.0.0[-dev+SHA]) and real releases (v tag).
  - Updated image scan targets and Slack failure notifications to respect is-test-run.

<sup>Written for commit f5bd2c6549c5afc8bb40cdfabb7b08aaf9f9d558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

