### PR TITLE
feat(chat): add custom copy behavior for HumanMessage component

### DIFF
--- a/web/src/app/chat/message/HumanMessage.tsx
+++ b/web/src/app/chat/message/HumanMessage.tsx
@@ -199,9 +199,9 @@ const HumanMessage = React.memo(function HumanMessage({
                   "max-w-[25rem] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
                 }
                 onCopy={(e) => {
-                  e.preventDefault();
                   const selection = window.getSelection();
                   if (selection) {
+                    e.preventDefault();
                     const text = selection
                       .toString()
                       .replace(/\n{2,}/g, "\n")


### PR DESCRIPTION
## Description
This pull request introduces a small but useful enhancement to the chat interface. It customizes the copy behavior for user messages, ensuring that copied text is cleaned up by removing multiple newlines because of triple click selection which introduces new lines.

ticket -> https://linear.app/onyx-app/issue/ENG-3349/tripple-click-copy-of-the-user-message-in-the-ui-copies-a-bunch-of
## How Has This Been Tested?
From UI

## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Customize copy behavior in HumanMessage to clean copied text by collapsing multiple newlines and trimming whitespace. Addresses Linear ENG-3349 to prevent messy clipboard content from triple-click selections.

<sup>Written for commit 7550c76c29c513139cccaead6be0c5a5247a646e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

