### PR TITLE
feat(projects): enhance FileCard component with className prop to fix width issue

### DIFF
--- a/web/src/app/chat/components/input/FileCard.tsx
+++ b/web/src/app/chat/components/input/FileCard.tsx
@@ -108,12 +108,14 @@ export function FileCard({
   hideProcessingState = false,
   onFileClick,
   compactImages = false,
+  className,
 }: {
   file: ProjectFile;
   removeFile: (fileId: string) => void;
   hideProcessingState?: boolean;
   onFileClick?: (file: ProjectFile) => void;
   compactImages?: boolean;
+  className?: string;
 }) {
   const typeLabel = useMemo(() => {
     const name = String(file.name || "");
@@ -163,13 +165,15 @@ export function FileCard({
 
   return (
     <div
-      className={`relative group flex items-center gap-1 border border-border-01 rounded-08 ${
-        isProcessing ? "bg-background-neutral-02" : "bg-background-tint-00"
-      } p-1 h-11 min-w-[120px] max-w-[240px] ${
-        onFileClick && !isProcessing
-          ? "cursor-pointer hover:bg-accent-background"
-          : ""
-      }`}
+      className={cn(
+        "relative group flex items-center gap-1 border border-border-01 rounded-08",
+        isProcessing ? "bg-background-neutral-02" : "bg-background-tint-00",
+        "p-1 h-11 min-w-[120px] max-w-[240px]",
+        onFileClick &&
+          !isProcessing &&
+          "cursor-pointer hover:bg-accent-background",
+        className
+      )}
       onClick={() => {
         if (onFileClick && !isProcessing) {
           onFileClick(file);

--- a/web/src/app/chat/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/chat/components/projects/ProjectContextPanel.tsx
@@ -271,7 +271,7 @@ export default function ProjectContextPanel({
               </div>
 
               {/* Desktop / larger screens: show previews with optional View All */}
-              <div className="hidden sm:flex gap-1 relative">
+              <div className="hidden sm:flex gap-1 relative items-center">
                 {(() => {
                   return allCurrentProjectFiles.slice(0, 4).map((f) => (
                     <div key={f.id}>
@@ -283,6 +283,7 @@ export default function ProjectContextPanel({
                         }}
                         onFileClick={handleOnView}
                         compactImages={shouldCompactImages}
+                        className="w-40"
                       />
                     </div>
                   ));


### PR DESCRIPTION
## Description
This pull request introduces fix for filecard overflow in project panel.
<img width="1236" height="825" alt="Screenshot 2026-01-07 at 8 32 26 PM" src="https://github.com/user-attachments/assets/44375cd0-82b4-4aa2-af26-4591916588ed" />


## How Has This Been Tested?
Tested from UI
<img width="961" height="635" alt="Screenshot 2026-01-07 at 8 32 57 PM" src="https://github.com/user-attachments/assets/cdd01990-4195-4907-b60e-e568c439086a" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed FileCard overflow in the project panel by adding a className prop and constraining width in ProjectContextPanel. This keeps file previews consistent on desktop and prevents layout issues.

- **Bug Fixes**
  - FileCard: added optional className and used cn to merge styles safely.
  - ProjectContextPanel: aligned preview row with items-center and passed className="w-40" to FileCard to enforce width.

<sup>Written for commit b28a5dd363804bdbd16ef80ec877f7985c718367. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

