### PR TITLE
fix(fe): Failed indexing colors support dark theme

### DIFF
--- a/web/src/components/embedding/FailedReIndexAttempts.tsx
+++ b/web/src/components/embedding/FailedReIndexAttempts.tsx
@@ -73,10 +73,10 @@ export function FailedReIndexAttempts({
         />
       )}
 
-      <Text className="text-red-700 font-semibold mb-2">
+      <Text className="text-status-error-05 font-semibold mb-2">
         Failed Re-indexing Attempts
       </Text>
-      <Text className="text-red-600 mb-4">
+      <Text className="text-status-error-05 mb-4">
         The table below shows only the failed re-indexing attempts for existing
         connectors. These failures require immediate attention. Once all
         connectors have been re-indexed successfully, the new model will be used


### PR DESCRIPTION
## How Has This Been Tested?

before and after:
<img width="3840" height="2109" alt="20260107_10h28m17s_grim" src="https://github.com/user-attachments/assets/9950a891-18c3-4613-9fe7-9b3e41d19292" />


## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the failed reindex attempts alert to use proper dark mode colors, improving contrast and readability.

<sup>Written for commit 82f26c96c7c43a433b0b1e2c234533604ea58ce1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



