### PR TITLE
fix(fe): fix InputComboBox shrinking when disabled

### DIFF
--- a/web/src/app/css/inputs.css
+++ b/web/src/app/css/inputs.css
@@ -22,6 +22,6 @@
 
 .input-disabled {
   background-color: var(--background-neutral-03);
-  border: none;
+  border: 1px solid transparent;
   cursor: not-allowed;
 }

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
@@ -364,7 +364,7 @@ const InputComboBox = ({
 
   return (
     <div ref={refs.setReference} className={cn("relative w-full", className)}>
-      <div className="relative">
+      <>
         <InputTypeIn
           ref={inputRef}
           placeholder={placeholder}
@@ -438,7 +438,7 @@ const InputComboBox = ({
           allowCreate={!strict}
           showCreateOption={showCreateOption}
         />
-      </div>
+      </>
 
       {/* Error message - only show internal error messages when not using external isError */}
       {!isValid && errorMessage && externalIsError === undefined && (


### PR DESCRIPTION
## Description

Closes (part 1) of https://linear.app/onyx-app/issue/ENG-3271/minor-onboarding-nits

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes InputComboBox shrinking when disabled so the field size stays consistent in forms. Addresses ENG-3271 (onboarding nits).

- Bug Fixes
  - Keep disabled inputs the same size by using a transparent 1px border instead of removing the border.
  - Remove an extra relative wrapper around the input to prevent layout side effects.

<sup>Written for commit adac241274883da283a2abf38d65d56db774e978. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

