### PR TITLE
feat(web): allow copy-pasting of sources and fix miscounting bug - #6941 and #6942

### DIFF
--- a/web/src/app/chat/message/messageComponents/CitedSourcesToggle.tsx
+++ b/web/src/app/chat/message/messageComponents/CitedSourcesToggle.tsx
@@ -59,8 +59,7 @@ export default function CitedSourcesToggle({
     return { sourceKey, iconElement };
   };
 
-  // Get unique icons by creating a unique identifier for each source
-  const getUniqueIcons = () => {
+  const getSourceData = () => {
     const seenSources = new Set<string>();
     const uniqueIcons: Array<{
       id: string;
@@ -71,17 +70,15 @@ export default function CitedSourcesToggle({
     const documentsToProcess =
       citations.length > 0
         ? citations.map((citation) => ({
-            documentId: citation.document_id,
-            doc: documentMap.get(citation.document_id),
-          }))
+          documentId: citation.document_id,
+          doc: documentMap.get(citation.document_id),
+        }))
         : Array.from(documentMap.entries()).map(([documentId, doc]) => ({
-            documentId,
-            doc,
-          }));
+          documentId,
+          doc,
+        }));
 
     for (const { documentId, doc } of documentsToProcess) {
-      if (uniqueIcons.length >= 2) break;
-
       let sourceKey: string;
       let iconElement: React.ReactNode;
 
@@ -97,20 +94,27 @@ export default function CitedSourcesToggle({
 
       if (!seenSources.has(sourceKey)) {
         seenSources.add(sourceKey);
-        uniqueIcons.push({
-          id: sourceKey,
-          element: iconElement,
-        });
+        // Show up to 3 icons (as supported by Tag)
+        if (uniqueIcons.length < 3) {
+          uniqueIcons.push({
+            id: sourceKey,
+            element: iconElement,
+          });
+        }
       }
     }
 
-    return uniqueIcons;
+    return { uniqueIcons, totalCount: seenSources.size };
   };
 
-  const uniqueIcons = getUniqueIcons();
+  const { uniqueIcons, totalCount } = getSourceData();
 
   return (
-    <Tag label="Sources" onClick={() => onToggle(nodeId)}>
+    <Tag
+      label="Sources"
+      onClick={() => onToggle(nodeId)}
+      count={totalCount}
+    >
       {uniqueIcons.map((icon) => (() => icon.element) as any)}
     </Tag>
   );

--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -17,12 +17,14 @@ export interface TagProps {
   // Tag content:
   label: string;
   className?: string;
+  count?: number;
   children: React.FunctionComponent<SVGProps<SVGSVGElement>>[];
   onClick?: React.MouseEventHandler;
 }
 
 export default function Tag({
   active,
+  count,
 
   label,
   className,
@@ -63,7 +65,7 @@ export default function Tag({
           active ? "max-w-[10rem] opacity-100" : "max-w-0 opacity-0"
         )}
       >
-        <Text as="p">{children.length}</Text>
+        <Text as="p">{count !== undefined ? count : children.length}</Text>
       </div>
 
       <Text as="p">{label}</Text>

--- a/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
+++ b/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
@@ -11,6 +11,7 @@ import { ValidSources } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import Truncated from "@/refresh-components/texts/Truncated";
 import Text from "@/refresh-components/texts/Text";
+import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 
 interface DocumentMetadataBlockProps {
   modal?: boolean;
@@ -82,11 +83,11 @@ export default function ChatDocumentDisplay({
     <div
       onClick={() => openDocument(document, setPresentingDocument)}
       className={cn(
-        "flex w-full flex-col p-3 gap-2 rounded-12 hover:bg-background-tint-00 cursor-pointer",
+        "group flex w-full flex-col p-3 gap-2 rounded-12 hover:bg-background-tint-00 cursor-pointer relative",
         isSelected && "bg-action-link-02"
       )}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 pr-8">
         {document.is_internet || document.source_type === ValidSources.Web ? (
           <WebResultIcon url={document.link} />
         ) : (
@@ -95,6 +96,16 @@ export default function ChatDocumentDisplay({
         <Truncated className="line-clamp-2" side="left">
           {title}
         </Truncated>
+      </div>
+
+      <div
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CopyIconButton
+          getCopyText={() => document.link || title}
+          tooltip="Copy Link"
+        />
       </div>
 
       {hasMetadata && (


### PR DESCRIPTION
**Description**
This PR implements the requested "Copy-Paste" functionality for sources and fixes a bug where source icons were miscounting the total number of references.

**Key Changes:**

Copy Sources UI: Added a "Copy Link" button to individual source cards in the document sidebar (visible on hover) and a "Copy All" button to sidebar section headers (Cited Sources, Found Sources, User Files).
Source Count Accuracy: Decoupled the numeric count displayed on the "Sources" tag from the number of child icons passed to it. The Tag component now accepts an optional count prop.
Enhanced Icons: Increased the number of visible source icons from 2 to 3 for better visual feedback.
Robustness: Handled event propagation and positioning to ensure copy buttons don't interfere with existing sidebar interactions.

**How Has This Been Tested?**
**Manual Verification:**
Verified that the "Sources" tag count correctly matches the unique number of documents cited.
Verified that clicking "Copy All" in the sidebar aggregates all document names and links into the clipboard.
Verified that clicking individual "Copy" buttons on source cards captures the specific document link.
Verified hover-based visibility for copy buttons on both mobile-responsive and desktop layouts.
**Regression Testing:** Ensured that clicking a source card still opens the document viewer as expected.

Additional Options
[Optional] Override Linear Check

Issue Tag: #6941 and #6942 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables copying sources from the sidebar and fixes the Sources tag count to reflect unique references. Addresses Linear #6941.

- **New Features**
  - Added “Copy Link” on each source card (shown on hover).
  - Added “Copy All” on section headers (Cited Sources, Found Sources, User Files) to copy titles and links.
  - Tag now shows up to 3 source icons and supports an explicit count prop.

- **Bug Fixes**
  - Decoupled visible icon count from the Sources tag count; the tag now shows the number of unique sources (Linear #6941).

<sup>Written for commit 090f7120931ac293b6cc7c22ab869f0fd330b186. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

