### PR TITLE
chore: exa prompt fix

### DIFF
--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -23,6 +23,7 @@ from onyx.prompts.tool_prompts import PYTHON_TOOL_GUIDANCE
 from onyx.prompts.tool_prompts import TOOL_DESCRIPTION_SEARCH_GUIDANCE
 from onyx.prompts.tool_prompts import TOOL_SECTION_HEADER
 from onyx.prompts.tool_prompts import WEB_SEARCH_GUIDANCE
+from onyx.prompts.tool_prompts import WEB_SEARCH_SITE_DISABLED_GUIDANCE
 from onyx.tools.interface import Tool
 from onyx.tools.tool_implementations.images.image_generation_tool import (
     ImageGenerationTool,
@@ -173,7 +174,9 @@ def build_system_prompt(
             TOOL_SECTION_HEADER
             + TOOL_DESCRIPTION_SEARCH_GUIDANCE
             + INTERNAL_SEARCH_GUIDANCE
-            + WEB_SEARCH_GUIDANCE
+            + WEB_SEARCH_GUIDANCE.format(
+                site_colon_disabled=WEB_SEARCH_SITE_DISABLED_GUIDANCE
+            )
             + OPEN_URLS_GUIDANCE
             + GENERATE_IMAGE_GUIDANCE
             + PYTHON_TOOL_GUIDANCE
@@ -199,7 +202,16 @@ def build_system_prompt(
             system_prompt += INTERNAL_SEARCH_GUIDANCE
 
         if has_web_search or include_all_guidance:
-            system_prompt += WEB_SEARCH_GUIDANCE
+            site_disabled_guidance = ""
+            if has_web_search:
+                web_search_tool = next(
+                    (t for t in tools if isinstance(t, WebSearchTool)), None
+                )
+                if web_search_tool and not web_search_tool.supports_site_filter:
+                    site_disabled_guidance = WEB_SEARCH_SITE_DISABLED_GUIDANCE
+            system_prompt += WEB_SEARCH_GUIDANCE.format(
+                site_colon_disabled=site_disabled_guidance
+            )
 
         if has_open_urls or include_all_guidance:
             system_prompt += OPEN_URLS_GUIDANCE

--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -33,8 +33,12 @@ WEB_SEARCH_GUIDANCE = """
 Use the `web_search` tool to access up-to-date information from the web. Some examples of when to use `web_search` include:
 - Freshness: if up-to-date information on a topic could change or enhance the answer. Very important for topics that are changing or evolving.
 - Niche Information: detailed info not widely known or understood (but that is likely found on the internet).
-- Accuracy: if the cost of outdated information is high, use web sources directly.
+- Accuracy: if the cost of outdated information is high, use web sources directly.{site_colon_disabled}
 """
+
+WEB_SEARCH_SITE_DISABLED_GUIDANCE = """
+Do not use the "site:" operator in your web search queries.
+""".rstrip()
 
 
 OPEN_URLS_GUIDANCE = """

--- a/backend/onyx/tools/tool_implementations/web_search/clients/exa_client.py
+++ b/backend/onyx/tools/tool_implementations/web_search/clients/exa_client.py
@@ -25,6 +25,10 @@ class ExaClient(WebSearchProvider, WebContentProvider):
         self.exa = Exa(api_key=api_key)
         self._num_results = num_results
 
+    @property
+    def supports_site_filter(self) -> bool:
+        return False
+
     @retry_builder(tries=3, delay=1, backoff=2)
     def search(self, query: str) -> list[WebSearchResult]:
         response = self.exa.search_and_contents(

--- a/backend/onyx/tools/tool_implementations/web_search/models.py
+++ b/backend/onyx/tools/tool_implementations/web_search/models.py
@@ -37,6 +37,13 @@ class WebSearchResult(BaseModel):
 
 
 class WebSearchProvider:
+    @property
+    def supports_site_filter(self) -> bool:
+        """Whether this provider supports the site: operator in queries.
+        Override in subclasses that don't support it.
+        """
+        return True
+
     @abstractmethod
     def search(self, query: str) -> Sequence[WebSearchResult]:
         pass

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -81,6 +81,11 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
     def display_name(self) -> str:
         return self.DISPLAY_NAME
 
+    @property
+    def supports_site_filter(self) -> bool:
+        """Whether the underlying provider supports site: operator."""
+        return self._provider.supports_site_filter
+
     @override
     @classmethod
     def is_available(cls, db_session: Session) -> bool:


### PR DESCRIPTION
## Description
Exa fails to search in format site:whatever for sites like reddit, just turning it off with prompt change hopefully.

## How Has This Been Tested?
Checked locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable "site:" usage in web search prompts when using Exa to prevent failed queries (e.g., reddit), and add a provider capability flag to control this behavior. This reduces search errors and makes queries more reliable.

- **Bug Fixes**
  - Conditionally add “Do not use the site: operator” guidance to the system prompt when the provider doesn’t support it (Exa).
  
- **Refactors**
  - Added supports_site_filter capability to WebSearchProvider (defaults to True).
  - Exa client reports supports_site_filter = False; surfaced via WebSearchTool.
  - Updated WEB_SEARCH_GUIDANCE to accept optional site_colon_disabled messaging.

<sup>Written for commit 7041a4711575f24b219c8fc7886734f531698879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

