### PR TITLE
fix(chat): use url when name unknown

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -415,6 +415,7 @@ class SearchDoc(BaseModel):
                 ).document_id,
                 chunk_ind=chunk.chunk_id,
                 semantic_identifier=chunk.semantic_identifier or "Unknown",
+                link=chunk.source_links[0] if chunk.source_links else None,
                 blurb=chunk.blurb,
                 source_type=chunk.source_type,
                 boost=chunk.boost,


### PR DESCRIPTION
## Description
Currently when there is no semantic_identifier, the backup option is 'Unknown'. This changes to use the source link as a backup beforehand.

## How Has This Been Tested?
Visual test

## Additional Options
closes https://linear.app/onyx-app/issue/ENG-3238/should-back-off-to-using-url
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the first source URL as the semantic_identifier when missing, only falling back to "Unknown" if no URL exists. Aligns with Linear ENG-3238’s requirement to back off to the URL, improving chat context labels.

<sup>Written for commit 727c55bd1df80adc0985527935fb365fcb5548da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

