### PR TITLE
fix(layout): absolute chat header for large screens

### DIFF
--- a/web/src/app/css/z-index.css
+++ b/web/src/app/css/z-index.css
@@ -3,6 +3,7 @@
   --z-base: 0;
   --z-content: 1;
   --z-sticky: 10;
+  --z-chat-header: 11;
 
   /* Interactive overlays */
   --z-modal-overlay: 900;
@@ -22,6 +23,9 @@
 }
 .z-sticky {
   z-index: var(--z-sticky);
+}
+.z-chat-header {
+  z-index: var(--z-chat-header);
 }
 
 /* Interactive overlays */

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -305,7 +305,13 @@ function AppHeader() {
       )}
 
       {(isMobile || customHeaderContent || currentChatSessionId) && (
-        <header className="w-full flex flex-row justify-center items-center py-3 px-4 h-16">
+        <header
+          className={cn(
+            "w-full flex flex-row justify-center items-center py-3 px-4 h-16",
+            !customHeaderContent &&
+              "2xl:absolute 2xl:top-0 2xl:left-0 2xl:right-0 2xl:bg-transparent 2xl:z-chat-header"
+          )}
+        >
           {/* Left - contains the icon-button to fold the AppSidebar on mobile */}
           <div className="flex-1">
             <IconButton
@@ -444,7 +450,7 @@ export interface AppRootProps {
 
 function AppRoot({ children }: AppRootProps) {
   return (
-    <div className="flex flex-col h-full w-full">
+    <div className="flex flex-col h-full w-full 2xl:relative">
       <AppHeader />
       <div className="flex-1 overflow-auto h-full w-full">{children}</div>
       <AppFooter />


### PR DESCRIPTION
## Description
This pull request introduces the absolute chat headers for large screens which allows the messages to reach top of the view port.
ticket -> https://linear.app/onyx-app/issue/ENG-3240/no-top-header

## How Has This Been Tested?
Test from UI
https://github.com/user-attachments/assets/b2cdc339-baa5-46f4-9aeb-14eb84854172

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chat header absolute on large (2xl) screens so messages reach the top of the viewport. Addresses Linear ENG-3240 (no top header).

- **Bug Fixes**
  - Added --z-chat-header token and .z-chat-header utility.
  - Made AppHeader 2xl:absolute with transparent background and z-chat-header when no custom header.
  - Set AppRoot to 2xl:relative to anchor the header.

<sup>Written for commit dc45863d67a913e3404dd8625a29a59e8fc3c53b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

