### PR TITLE
chore(fe): remove items-center from onboarding cards

### DIFF
--- a/web/src/refresh-components/onboarding/components/LLMProviderCard.tsx
+++ b/web/src/refresh-components/onboarding/components/LLMProviderCard.tsx
@@ -66,7 +66,7 @@ function LLMProviderCardInner({
         disabled && "opacity-50 cursor-not-allowed"
       )}
     >
-      <div className="flex items-center gap-1 p-1 flex-1 min-w-0">
+      <div className="flex gap-1 p-1 flex-1 min-w-0">
         <div className="flex items-start h-full pt-0.5">
           {providerName ? (
             <ProviderIcon provider={providerName} size={16} className="" />


### PR DESCRIPTION
## Description

On small screens, the Custom LLM Provider wraps and the Ollama card looks odd.

**before**
<img width="1116" height="1820" alt="20260108_08h40m23s_grim" src="https://github.com/user-attachments/assets/77778e72-ab38-4cc7-bc6a-c6ad43fbdcb0" />

**after**
<img width="1116" height="1820" alt="20260108_08h39m54s_grim" src="https://github.com/user-attachments/assets/dc91cc41-38d4-4c71-aedc-cb7f1c7ca0ce" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix small-screen layout of the LLM provider onboarding cards by removing items-center from the container. This lets long provider names wrap and aligns icon/text from the top, fixing the odd look of the Ollama card.

<sup>Written for commit 493b7559252b9718c713b918cea847f028ff536a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

