### PR TITLE
feat(opensearch): More feature parity

### DIFF
--- a/backend/onyx/access/models.py
+++ b/backend/onyx/access/models.py
@@ -105,6 +105,8 @@ class DocExternalAccess:
         )
 
 
+# TODO(andrei): First refactor this into a pydantic model, then get rid of
+# duplicate fields.
 @dataclass(frozen=True, init=False)
 class DocumentAccess(ExternalAccess):
     # User emails for Onyx users, None indicates admin

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -316,6 +316,7 @@ class DocumentQuery:
             {
                 "multi_match": {
                     "query": query_text,
+                    # TODO(andrei): Ask Yuhong do we want this?
                     "fields": [f"{TITLE_FIELD_NAME}^2", f"{TITLE_FIELD_NAME}.keyword"],
                     "type": "best_fields",
                 }


### PR DESCRIPTION
## Description
More feature parity work, pretty simple, same idea as #7252.

## How Has This Been Tested?
It wasn't.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the OpenSearch document schema and converters with app features for better parity: metadata is stored and surfaced, ACLs are indexed, global boost is applied, and the image field is now image_file_id.

- New Features
  - Index access_control_list from DocumentAccess.
  - Persist document metadata (JSON string) and return it in inference chunks.
  - Use chunk.boost as global_boost across indexing and result conversion.

- Refactors
  - Rename image_file_name to image_file_id in schema and converters.
  - Change global_boost to integer in the mapping and model.
  - Tighten DocumentChunk model types; remove nullable defaults where appropriate.

<sup>Written for commit 13974ee7e08826632bacbe021df0403838feb081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
