### PR TITLE
fix: use tag constraint name instead of index elements

### DIFF
--- a/backend/onyx/db/tag.py
+++ b/backend/onyx/db/tag.py
@@ -52,7 +52,7 @@ def create_or_add_document_tag(
         is_list=False,
     )
     insert_stmt = insert_stmt.on_conflict_do_nothing(
-        index_elements=["tag_key", "tag_value", "source", "is_list"]
+        constraint="_tag_key_value_source_list_uc"
     )
     db_session.execute(insert_stmt)
 
@@ -98,7 +98,7 @@ def create_or_add_document_tag_list(
             is_list=True,
         )
         insert_stmt = insert_stmt.on_conflict_do_nothing(
-            index_elements=["tag_key", "tag_value", "source", "is_list"]
+            constraint="_tag_key_value_source_list_uc"
         )
         db_session.execute(insert_stmt)
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched tag insert conflict handling to use the named unique constraint (_tag_key_value_source_list_uc) instead of index elements. This prevents duplicate tags and makes conflict behavior consistent for both single and list tag inserts.

<sup>Written for commit 5392e71e534b229f7ad6f2432993ec7174652d45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

