### PR TITLE
feat: agent deletion

### DIFF
--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -41,9 +41,15 @@ interface AgentsSectionProps {
   title: string;
   description?: string;
   agents: MinimalPersonaSnapshot[];
+  onDeleteAgent?: () => void;
 }
 
-function AgentsSection({ title, description, agents }: AgentsSectionProps) {
+function AgentsSection({
+  title,
+  description,
+  agents,
+  onDeleteAgent,
+}: AgentsSectionProps) {
   if (agents.length === 0) return null;
 
   return (
@@ -60,7 +66,7 @@ function AgentsSection({ title, description, agents }: AgentsSectionProps) {
         {agents
           .sort((a, b) => b.id - a.id)
           .map((agent) => (
-            <AgentCard key={agent.id} agent={agent} />
+            <AgentCard key={agent.id} agent={agent} onDelete={onDeleteAgent} />
           ))}
       </div>
     </div>
@@ -68,7 +74,7 @@ function AgentsSection({ title, description, agents }: AgentsSectionProps) {
 }
 
 export default function AgentsNavigationPage() {
-  const { agents } = useAgents();
+  const { agents, refresh } = useAgents();
   const [creatorFilterOpen, setCreatorFilterOpen] = useState(false);
   const [actionsFilterOpen, setActionsFilterOpen] = useState(false);
   const { user } = useUser();
@@ -659,8 +665,13 @@ export default function AgentsNavigationPage() {
               title="Featured Agents"
               description="Curated by your team"
               agents={featuredAgents}
+              onDeleteAgent={refresh}
             />
-            <AgentsSection title="All Agents" agents={allAgents} />
+            <AgentsSection
+              title="All Agents"
+              agents={allAgents}
+              onDeleteAgent={refresh}
+            />
             <CounterSeparator
               count={agentCount}
               text={agentCount === 1 ? "Agent" : "Agents"}


### PR DESCRIPTION
## Description

Added a delete button to agent cards that allows users to delete agents they own. When clicked, a confirmation modal appears. Upon confirmation, the agent is deleted from backend API and the agent list is refreshed.
https://linear.app/onyx-app/issue/ENG-3285/agent-deletion

## How Has This Been Tested?

Manual testing locally

## Additional Options

- [ ] [Optional] Override Linear Check
