### PR TITLE
fix(chat): handle message creation in own thread

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -619,7 +619,6 @@ async def handle_send_chat_message(
         """
         try:
             while True:
-                # Await the next item from the buffer
                 item = await buffer.get()
                 if item is None:
                     # End of stream signal


### PR DESCRIPTION
## Description
There is a bug where if we refresh while streaming, the connection becomes lost resulting in fastapi no longer yielding results from the streaming object. This leads to message processing in the 'handle_stream_message_objects' function get blocked (or halting) on the yield from. As such, we don't continue don't the control flow, and don't end up saving the finished chat in the database. 

This thread spins the message creation/processing logic in it's own producer thread and puts the result in a buffer that the consumer can stream to the client.

## How Has This Been Tested?
Manually tested that chats still stream

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat streaming hangs on refresh by moving message creation to a background producer thread and streaming from an async buffer. Ensures chats finish processing and are saved even if the SSE connection drops.

- **Bug Fixes**
  - Converted send-chat-message handler to async and implemented a producer–consumer flow with an asyncio queue.
  - Run message processing in a background thread; consumer streams buffered events to the client.
  - Capture headers before threading, emit error events, and send an explicit end-of-stream signal to prevent blocking.

<sup>Written for commit 5848975679f6ffc653cdb1a80821a9ed8f5fa959. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

