### PR TITLE
chore(perf): remove isEqual memoization check

### DIFF
--- a/web/src/app/chat/message/MemoizedTextComponents.tsx
+++ b/web/src/app/chat/message/MemoizedTextComponents.tsx
@@ -184,10 +184,15 @@ export const MemoizedLink = memo(
   }
 );
 
+interface MemoizedParagraphProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
 export const MemoizedParagraph = memo(function MemoizedParagraph({
   className,
   children,
-}: any) {
+}: MemoizedParagraphProps) {
   return (
     <Text as="p" mainContentBody className={className}>
       {children}


### PR DESCRIPTION
## Description

Claude and I were riffing a bit and he suggested this was unneeded and needlessly heavy. This was added 2 years ago and there's not hint at its necessity.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the isEqual comparator from MemoizedParagraph, relying on React.memo’s default shallow compare to avoid heavy deep checks. This reduces render overhead and removes the lodash/isEqual import from the component.

<sup>Written for commit 5097af00dc60d98038feedd1867da6a8dab6925f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

