### PR TITLE
fix: `Section` layout component fix

### DIFF
--- a/web/src/refresh-components/cards/Card.tsx
+++ b/web/src/refresh-components/cards/Card.tsx
@@ -65,7 +65,7 @@ export default function Card({
 
   return (
     <div className={cn("rounded-16 w-full h-full", classNames[variant])}>
-      <GeneralLayouts.Section padding={padding} {...props} />
+      <GeneralLayouts.Section alignItems="start" padding={padding} {...props} />
     </div>
   );
 }


### PR DESCRIPTION
## Description

This PR makes `Section` align to the start.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set GeneralLayouts.Section alignItems="start" inside Card so card content aligns to the start. Fixes cards that were centering content and causing layout inconsistencies.

<sup>Written for commit c3166fa94f9aa3840ec60dbf7b606546ef29ae8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

