### PR TITLE
fix(chat): newly created chats being marked as failed

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -182,9 +182,9 @@ def get_chat_sessions_by_user(
             .correlate(ChatSession)
         )
 
-        # 5 minute leeway for newly created chats that don't have messages yet
-        five_minutes_ago = datetime.now(timezone.utc) - timedelta(minutes=5)
-        recently_created = ChatSession.time_created >= five_minutes_ago
+        # Leeway for newly created chats that don't have messages yet
+        time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        recently_created = ChatSession.time_created >= time
 
         stmt = stmt.where(or_(non_system_message_exists_subq, recently_created))
 


### PR DESCRIPTION
## Description
There was an earlier PR that described chats with no messages in them as failed. Currently creating a chat session and adding the first message are done in two separate api routes. This leads to there being a period where the new chat is marked as failed. This PR adds leeway for newly created chats so they are no longer instantly marked as failed.

## How Has This Been Tested?
Maual verification

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a 5-minute grace period for newly created chats so sessions without user messages aren’t flagged as failed. The backend query now ORs the “has non-system message” check with “created within last 5 minutes” using a timezone-aware timestamp.

<sup>Written for commit b35df5a5cffc865336e2276f1a95126d8e5154d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

