### PR TITLE
fix(chat): show "User has stopped generation" indicator when user cancels 

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -605,10 +605,10 @@ def handle_stream_message_objects(
             if state_container.answer_tokens:
                 final_answer = (
                     state_container.answer_tokens
-                    + " ... The generation was stopped by the user here."
+                    + " ... \n\nGeneration was stopped by the user."
                 )
             else:
-                final_answer = "The generation was stopped by the user."
+                final_answer = "Generation was stopped by the user."
 
         # Build citation_docs_info from accumulated citations in state container
         citation_docs_info: list[CitationDocInfo] = []

--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -539,9 +539,18 @@ def translate_assistant_message_to_packets(
         if citation_info_list:
             final_turn_index = max(final_turn_index, citation_turn_index)
 
+    # Determine stop reason - check if message indicates user cancelled
+    stop_reason: str | None = None
+    if chat_message.message:
+        if "Generation was stopped" in chat_message.message:
+            stop_reason = "user_cancelled"
+
     # Add overall stop packet at the end
     packet_list.append(
-        Packet(placement=Placement(turn_index=final_turn_index), obj=OverallStop())
+        Packet(
+            placement=Placement(turn_index=final_turn_index),
+            obj=OverallStop(stop_reason=stop_reason),
+        )
     )
 
     return packet_list

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -61,6 +61,7 @@ import FeedbackModal, {
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { useFeedbackController } from "../../hooks/useFeedbackController";
 import { SvgThumbsDown, SvgThumbsUp } from "@opal/icons";
+import Text from "@/refresh-components/texts/Text";
 
 // Type for the regeneration factory function passed from ChatUI
 export type RegenerationFactory = (regenerationRequest: {
@@ -543,8 +544,14 @@ const AIMessage = React.memo(function AIMessage({
             }}
           >
             {groupedPackets.length === 0 ? (
-              // Show blinking dot when no content yet but message is generating
-              <BlinkingDot addMargin />
+              // Show blinking dot when no content yet, or stopped message if user cancelled
+              stopReason === StopReason.USER_CANCELLED ? (
+                <Text as="p" secondaryBody text04>
+                  User has stopped generation
+                </Text>
+              ) : (
+                <BlinkingDot addMargin />
+              )
             ) : (
               (() => {
                 // Simple split: tools vs non-tools
@@ -600,10 +607,18 @@ const AIMessage = React.memo(function AIMessage({
                           }}
                           animate={false}
                           stopPacketSeen={stopPacketSeen}
+                          stopReason={stopReason}
                         >
                           {({ content }) => <div>{content}</div>}
                         </RendererComponent>
                       ))}
+                      {/* Show stopped message when user cancelled and no display content */}
+                      {displayGroups.length === 0 &&
+                        stopReason === StopReason.USER_CANCELLED && (
+                          <Text as="p" secondaryBody text04>
+                            User has stopped generation
+                          </Text>
+                        )}
                     </div>
                   </>
                 );

--- a/web/src/app/chat/message/messageComponents/interfaces.ts
+++ b/web/src/app/chat/message/messageComponents/interfaces.ts
@@ -1,6 +1,6 @@
 import { JSX } from "react";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
-import { Packet } from "../../services/streamingModels";
+import { Packet, StopReason } from "../../services/streamingModels";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { ProjectFile } from "../../projects/projectsService";
 import { LlmDescriptor } from "@/lib/hooks";
@@ -47,5 +47,6 @@ export type MessageRenderer<
   renderType: RenderType;
   animate: boolean;
   stopPacketSeen: boolean;
+  stopReason?: StopReason;
   children: (result: RendererResult) => JSX.Element;
 }>;

--- a/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
+++ b/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
@@ -4,6 +4,7 @@ import {
   Packet,
   PacketType,
   ReasoningPacket,
+  StopReason,
 } from "../../services/streamingModels";
 import {
   FullChatState,
@@ -128,6 +129,7 @@ export function RendererComponent({
   onComplete,
   animate,
   stopPacketSeen,
+  stopReason,
   useShortRenderer = false,
   children,
 }: {
@@ -136,6 +138,7 @@ export function RendererComponent({
   onComplete: () => void;
   animate: boolean;
   stopPacketSeen: boolean;
+  stopReason?: StopReason;
   useShortRenderer?: boolean;
   children: (result: RendererResult) => JSX.Element;
 }) {
@@ -154,6 +157,7 @@ export function RendererComponent({
       animate={animate}
       renderType={renderType}
       stopPacketSeen={stopPacketSeen}
+      stopReason={stopReason}
     >
       {children}
     </RendererFn>

--- a/web/src/app/chat/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
+import Text from "@/refresh-components/texts/Text";
 
-import { ChatPacket, PacketType } from "../../../services/streamingModels";
+import {
+  ChatPacket,
+  PacketType,
+  StopReason,
+} from "../../../services/streamingModels";
 import { MessageRenderer, FullChatState } from "../interfaces";
 import { isFinalAnswerComplete } from "../../../services/packetUtils";
 import { useMarkdownRenderer } from "../markdownUtils";
@@ -19,6 +24,7 @@ export const MessageTextRenderer: MessageRenderer<
   renderType,
   animate,
   stopPacketSeen,
+  stopReason,
   children,
 }) => {
   // If we're animating and the final answer is already complete, show more packets initially
@@ -115,12 +121,21 @@ export const MessageTextRenderer: MessageRenderer<
     "font-main-content-body"
   );
 
+  const wasUserCancelled = stopReason === StopReason.USER_CANCELLED;
+
   return children({
     icon: null,
     status: null,
     content:
       content.length > 0 || packets.length > 0 ? (
-        renderedContent
+        <>
+          {renderedContent}
+          {wasUserCancelled && (
+            <Text as="p" secondaryBody text04>
+              User has stopped generation
+            </Text>
+          )}
+        </>
       ) : (
         <BlinkingDot addMargin />
       ),


### PR DESCRIPTION
## Description

Shows "User has stopped generation" indicator when user clicks the stop button during chat generation. The indicator persists when navigating away and back to the conversation.

  Changes

  - Pass stopReason through message component rendering pipeline
  - Display indicator in MessageTextRenderer when generation was user-cancelled
  - Backend: detect user-stopped messages when loading saved conversations and set stop_reason in packets



## How Has This Been Tested?

  - Stop generation during streaming → indicator appears
  - Stop during deep research → indicator appears
  - Navigate away and back → indicator persists

<img width="924" height="409" alt="Screenshot 2026-01-09 at 9 43 58 AM" src="https://github.com/user-attachments/assets/d67b80c8-e56f-4145-aa5e-cd07339b2cb1" />


text below is italicized but that has been removed
![2026-01-09 09 23 22](https://github.com/user-attachments/assets/898f9c52-f627-442f-8d24-4b4ff01baa84)

## Additional Options

Closes https://linear.app/onyx-app/issue/ENG-3192/show-correct-killed-state-for-user-stopping-generation

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear “User has stopped generation” indicator when a user cancels a chat response, and persist it when returning to the conversation. Addresses ENG-3192.

- **Bug Fixes**
  - Backend sets stop_reason=user_cancelled on OverallStop when loading saved conversations.
  - UI passes stopReason to renderers and shows “User has stopped generation” instead of the blinking dot when cancelled.
  - Indicator persists across navigation and during deep research streaming.

<sup>Written for commit 3624763cf7129a8629ca1d1bb908fbd749b7a77c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

