### PR TITLE
chore(fe): fix `undefined` className in tooltip

### DIFF
--- a/web/src/components/tooltip/CustomTooltip.tsx
+++ b/web/src/components/tooltip/CustomTooltip.tsx
@@ -146,7 +146,8 @@ export const CustomTooltip = ({
               large ? (medium ? "w-88" : "w-96") : line && "max-w-64 w-auto",
               light
                 ? "bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-50"
-                : "bg-neutral-900 dark:bg-neutral-200 text-neutral-50 dark:text-neutral-900"
+                : "bg-neutral-900 dark:bg-neutral-200 text-neutral-50 dark:text-neutral-900",
+              className
             )}
             style={{
               top: `${tooltipPosition.top}px`,


### PR DESCRIPTION
## Description

`gap` is optional, so this can resolve to `undefined`,
<img width="1572" height="2047" alt="20260109_14h44m32s_grim" src="https://github.com/user-attachments/assets/a885eca1-468e-415a-b020-05ce08fa43f3" />

## How Has This Been Tested?

Should be a no-op

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use cn() for className composition across TooltipGroup and CustomTooltip to prevent rendering "undefined" when optional props are absent, ensuring consistent styles and a clean DOM.

<sup>Written for commit 9544783d170c1b4eda731ff810ef017b86301511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

