### PR TITLE
Opensearch README

### DIFF
--- a/backend/onyx/document_index/opensearch/README.md
+++ b/backend/onyx/document_index/opensearch/README.md
@@ -34,11 +34,20 @@ Same logic applies to additive boosting.
 
 So these boosts can only be applied after normalization. Unfortunately with Opensearch, the normalization processor runs last
 and only applies to the results of the completely independent `Search` phase queries. So if a time based boost (a separate
-query which filters/ranks on the most recently updated documents) is added, it would not be able to introduce any new documents
+query which filters on recently updated documents) is added, it would not be able to introduce any new documents
 to the set (since the new documents would have no keyword/vector score or already be present) since the 0 scores on keyword
 and vector would make the docs which only came because of time filter very low scoring. This can however make some of the lower
 scored documents from the union of all the `Search` phase documents to show up higher and potentially not get dropped before
-being fetched and returned to the user.
+being fetched and returned to the user. But there are other issues of including these:
+- There is no way to sort by this field, only a filter, so there's no way to guarantee the best docs even irrespective of the
+contents. If there are lots of updates, this may miss
+- There is not a good way to normalize this field, the best is to clip it on the bottom.
+- This would require using min-max norm but z-score norm is better for the other functions due to things like it being less
+sensitive to outliers, better handles distribution drifts (min-max assumes stable meaningful ranges), better for comparing
+"unusual-ness" across distributions.
+
+So while it is possible to apply time based boosting at the normalization stage (or specifically to the keyword score), we have
+decided it is better to not apply it during the OpenSearch query.
 
 Because of these limitations, Onyx in code applies further refinements, boostings, etc. based on OpenSearch providing an initial
 filtering. The impact of time decay and boost should not be so big that we would need orders of magnitude more results back


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the OpenSearch README on time-based boosting and normalization. Explains why we won’t apply time-based boosts in the OpenSearch query (no sort support, normalization challenges, min–max vs z-score) and that boosts happen later in Onyx post-processing.

<sup>Written for commit 5301a33ca18bbc41c560bb6fd5b0796286528d1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

