### PR TITLE
fix(fe): Tags have consistent height on hover

### DIFF
--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -58,7 +58,7 @@ export default function Tag({
       {/* Count display - only shows on hover/active */}
       <Text
         className={cn(
-          "flex transition-all duration-200 ease-in-out overflow-hidden",
+          "inline-flex transition-all duration-200 ease-in-out overflow-hidden",
           "group-hover:max-w-8 group-hover:opacity-100",
           active ? "max-w-[10rem] opacity-100" : "max-w-0 opacity-0"
         )}


### PR DESCRIPTION
## Description

For some reason, the pseudo-elements applying 2px padding to the `Text` element inside of a `Tag` was wrapping causing this element to have a height of 60px even though the visible content was <32px. On hover, the padding was moving correctly to the side and the button was shrinking causing https://onyx-company.slack.com/archives/C09BHKH5PML/p1767997474019149

<img width="1572" height="2047" alt="20260109_16h09m21s_grim" src="https://github.com/user-attachments/assets/ee33f5d0-10f6-49a3-bdc4-b7dd42741aa7" />

<img width="1572" height="2047" alt="20260109_16h09m31s_grim" src="https://github.com/user-attachments/assets/9341b37c-e633-4147-ac80-366fe8668676" />

## How Has This Been Tested?

<img width="1572" height="2047" alt="20260109_16h16m55s_grim" src="https://github.com/user-attachments/assets/f7bbad1d-9837-4838-a038-8221a5b2e3a7" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tag height so it stays consistent on hover and active. The count now renders inline without wrapping, preventing vertical resize.

- **Bug Fixes**
  - Render count with Text using inline-flex to prevent wrapping and height jumps.
  - Keep smooth max-width/opacity transitions for the count without shifting the layout.

<sup>Written for commit 467242395e30dcd7a5d7725b3e87b730fa7d9602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

