### PR TITLE
fix(fe): `html` and `body` tags set `height: 100%;`

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,6 +40,12 @@
     @apply border-border;
   }
 
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
+
   body {
     @apply bg-background text-foreground;
     overscroll-behavior-y: none;


### PR DESCRIPTION
## Description

I don't fully understand this, but for some reason, enabling `katex` styling (340e93862) causes the `html` tag overflow on both the chat[1] and shared chat[2] pages.

This seems like a fairly sane style to set, but I'm not entirely confident and it's obviously very systemic.

Closes https://linear.app/onyx-app/issue/ENG-3361/no-lower-bound-for-scroll-behavior

<img width="1572" height="2047" alt="20260109_16h19m00s_grim" src="https://github.com/user-attachments/assets/25207c4f-b3c8-4b18-96cb-1a5e5acbbd31" />
<img width="1572" height="2047" alt="20260109_13h58m50s_grim" src="https://github.com/user-attachments/assets/eeb6eac0-781f-4418-ac63-f08aa4aed1ab" />


## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes page overflow on chat and shared chat when KaTeX styles are enabled. Sets html and body to height: 100% and overflow: hidden in globals.css to keep scrolling within app containers.

<sup>Written for commit 6259272920e7d9a7314bc4fc5330813bca0d6774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

