### PR TITLE
fix: auto-sync

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -671,7 +671,7 @@ def sync_auto_mode_models(
             changes += 1
 
     # In Auto mode, default model is always set from GitHub config
-    default_model = llm_recommendations.get_default_model(provider.name)
+    default_model = llm_recommendations.get_default_model(provider.provider)
     if default_model and provider.default_model_name != default_model.name:
         provider.default_model_name = default_model.name
         changes += 1


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-sync of LLM models by using the provider key instead of the display name when fetching visible and default models. Ensures Vertex and other providers sync the correct visible models and set the right default model.

<sup>Written for commit 5a1050642df84ef95918951191992ad712502f54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

