### PR TITLE
feat: Deep Research Replay

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -609,7 +609,6 @@ def run_deep_research_llm_loop(
                         continue
 
                     current_tool_call = research_agent_calls[tab_index]
-                    # Get per-agent cited docs for persistence
                     tool_call_info = ToolCallInfo(
                         parent_tool_call_id=None,
                         turn_index=orchestrator_start_turn_index


### PR DESCRIPTION
## Description

Deep Research to provide citations on replay. https://linear.app/onyx-app/issue/ENG-3243/deep-research-replay

## How Has This Been Tested?
Tested locally

## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show citations in Deep Research replay. Persists citation mapping and per‑agent cited docs and reconstructs them in the replay stream to meet ENG-3243.

- **New Features**
  - Persist citation mapping in state and attach per-agent cited docs to research tool calls.
  - Add per_agent_cited_docs to CombinedResearchAgentCallResult and collect cited docs from each agent.
  - Reconstruct replay packets: emit IntermediateReportStart, IntermediateReportDelta, and IntermediateReportCitedDocs; add TopLevelBranching when multiple agents; translate saved DB docs to SearchDoc for rendering.

<sup>Written for commit b2900470a53111b82ecf85266b5a99ba209e5d54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

