### PR TITLE
fix(fe): avoid internal table scroll on query history page

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -61,14 +61,14 @@ function QueryHistoryTableRow({
       className="hover:bg-accent-background cursor-pointer relative select-none"
     >
       <TableCell>
-        <Text as="p" className="whitespace-normal line-clamp-5">
+        <Text className="whitespace-normal line-clamp-5">
           {chatSessionMinimal.first_user_message ||
             chatSessionMinimal.name ||
             "-"}
         </Text>
       </TableCell>
       <TableCell>
-        <Text as="p" className="whitespace-normal line-clamp-5">
+        <Text className="whitespace-normal line-clamp-5">
           {chatSessionMinimal.first_ai_message || "-"}
         </Text>
       </TableCell>
@@ -86,7 +86,7 @@ function QueryHistoryTableRow({
           href={
             `/ee/admin/performance/query-history/${chatSessionMinimal.id}` as Route
           }
-          className="absolute w-full h-full left-0"
+          className="absolute w-full h-full left-0 top-0"
         ></Link>
       </td>
     </TableRow>


### PR DESCRIPTION
## Description

**before**
<img width="1920" height="1080" alt="20260110_20h34m08s_grim" src="https://github.com/user-attachments/assets/c05c22a5-16cc-45cf-b5c6-990dffd8f762" />

**after**
<img width="1920" height="1080" alt="20260110_20h33m46s_grim" src="https://github.com/user-attachments/assets/c05638c7-18d5-4d49-9bad-912d6d40a599" />

## Additional Options

Closes https://linear.app/onyx-app/issue/ENG-3249/query-history-table-has-2-scroll-bars


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminated the extra internal scrollbar on the Query History page so the table scrolls with the page. Addresses Linear ENG-3249.

- **Bug Fixes**
  - Removed block-level Text (`as="p"`) in table cells to prevent nested overflow.
  - Positioned the full-row Link overlay with `top-0` to align correctly and avoid internal scroll.

<sup>Written for commit e243659953b442bbdf9b83da2bd405214af9f2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

