### PR TITLE
fix(fe): "Pick a date range" button wrapping

### DIFF
--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -30,10 +30,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { CalendarIcon } from "lucide-react";
 import Calendar from "@/refresh-components/Calendar";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/Spinner";
+import { SvgCalendar } from "@opal/icons";
 
 function GenerateReportInput({
   onReportGenerated,
@@ -112,7 +112,7 @@ function GenerateReportInput({
                 "w-[300px] justify-start text-left font-normal",
                 !dateRange && "text-muted-foreground"
               )}
-              leftIcon={CalendarIcon}
+              leftIcon={SvgCalendar}
             >
               {dateRange?.from ? (
                 dateRange.to ? (


### PR DESCRIPTION
## Description

Prefers the `Button`'s `leftIcon` prop which handles layout properly.

## How Has This Been Tested?

**before**
<img width="798" height="1030" alt="20260110_21h01m07s_grim" src="https://github.com/user-attachments/assets/b7e8ad15-4f0a-49c4-9142-ae98d9cfe01e" />

**after**
<img width="798" height="1030" alt="20260110_21h00m49s_grim" src="https://github.com/user-attachments/assets/d83e280e-c83b-4636-b863-e9af26077fe7" />

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Pick a date range” button layout by using the Button’s leftIcon for the calendar icon. Prevents text wrapping and keeps spacing consistent with other buttons.

<sup>Written for commit 8ec21f15636939007a8802e5c3e2b1124310a1ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

