### PR TITLE
fix(tools): persist enabled tools in ui

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -1021,21 +1021,15 @@ export function useSourcePreferences({
           Object.prototype.hasOwnProperty.call(sourcePreferences, key);
 
         // Get sources with no preference
-        const newSources = configuredSources.filter(
-          (source: SourceMetadata) => {
-            if (!source.uniqueKey) return true;
-            return !hasPref(source.uniqueKey);
-          }
-        );
+        const newSources = configuredSources.filter((source) => {
+          return !hasPref(source.uniqueKey);
+        });
 
-        const enabledSources = configuredSources.filter(
-          (source: SourceMetadata) => {
-            if (!source.uniqueKey) return true;
-            return (
-              hasPref(source.uniqueKey) && sourcePreferences[source.uniqueKey]
-            );
-          }
-        );
+        const enabledSources = configuredSources.filter((source) => {
+          return (
+            hasPref(source.uniqueKey) && sourcePreferences[source.uniqueKey]
+          );
+        });
 
         // Merge valid saved sources with new sources (enable new sources by default)
         const mergedSources = [...enabledSources, ...newSources];


### PR DESCRIPTION
## Description
There is a bug in the current persistence of tools in the UI where we merge validSavedSources and newSources. validSavedSources are tools that we saved in the last iteration, and newSources are sources that were not in the savedSources. This leads to mergedSources being every source and us setting the default as every source across mounts.

This PR adds boolean state tracking to the sources so that we can determine explicitly whether a source should be enabled or disabled, and explicitly determine what the new sources are.

## How Has This Been Tested?
Manual frontend testing.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes source/tool selection persistence so the UI correctly remembers enabled tools and only auto-enables new ones. Prevents all sources being set as default on each mount.

- **Bug Fixes**
  - Persist a snapshot in localStorage: sourcePreferences (uniqueKey → enabled) for all known sources.
  - Restore only previously enabled sources; enable truly new sources by default.
  - Validate snapshot structure and filter against the current configuration.
  - Always persist on init and on enableAll/disableAll/toggle.

<sup>Written for commit 032d66d8ada993a911e6646d25c00e9b3ae74ea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

