### PR TITLE
feat: Exclude image generation providers from LLM fetch in API calls

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -374,7 +374,7 @@ def fetch_existing_tools(db_session: Session, tool_ids: list[int]) -> list[ToolM
 def fetch_existing_llm_providers(
     db_session: Session,
     only_public: bool = False,
-    exclude_image_generation_providers: bool = False,
+    exclude_image_generation_providers: bool = True,
 ) -> list[LLMProviderModel]:
     """Fetch all LLM providers with optional filtering.
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -408,9 +408,7 @@ def list_llm_provider_basics(
     start_time = datetime.now(timezone.utc)
     logger.debug("Starting to fetch user-accessible LLM providers")
 
-    all_providers = fetch_existing_llm_providers(
-        db_session, exclude_image_generation_providers=True
-    )
+    all_providers = fetch_existing_llm_providers(db_session)
     user_group_ids = fetch_user_group_ids(db_session, user) if user else set()
     is_admin = user and user.role == UserRole.ADMIN
 
@@ -506,9 +504,7 @@ def list_llm_providers_for_persona(
         )
 
     is_admin = user is not None and user.role == UserRole.ADMIN
-    all_providers = fetch_existing_llm_providers(
-        db_session, exclude_image_generation_providers=True
-    )
+    all_providers = fetch_existing_llm_providers(db_session)
     user_group_ids = set() if is_admin else fetch_user_group_ids(db_session, user)
 
     llm_provider_list: list[LLMProviderDescriptor] = []


### PR DESCRIPTION
## Description
This pull request introduces a targeted update to both backend code, mainly to ensure that image generation providers are excluded from chat llmpopover.

## How Has This Been Tested?
Tested it in UI

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude image generation providers from LLM API fetches so the chat model picker only shows text models. Also fixes the ImageGen form width.

- **Bug Fixes**
  - Default exclude_image_generation_providers=True in fetch_existing_llm_providers to hide image-only providers in chat.
  - Set ImageGenFormWrapper form to w-full for consistent layout.

<sup>Written for commit 7f00428b1130a5d1b0a6ca42e57ec38d2dd038ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

