### PR TITLE
fix: update docs link

### DIFF
--- a/backend/onyx/connectors/README.md
+++ b/backend/onyx/connectors/README.md
@@ -93,7 +93,7 @@ if __name__ == "__main__":
 #### Docs Changes
 
 Create the new connector page (with guiding images!) with how to get the connector credentials and how to set up the
-connector in Onyx. Then create a Pull Request in [https://github.com/onyx-dot-app/onyx-docs](https://github.com/onyx-dot-app/documentation).
+connector in Onyx. Then create a Pull Request in [https://github.com/onyx-dot-app/documentation](https://github.com/onyx-dot-app/documentation).
 
 ### Before opening PR
 


### PR DESCRIPTION
## Description
Update 404 link with the correct link


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken docs link in the connectors README to point to https://github.com/onyx-dot-app/documentation, preventing a 404 and directing contributors to the correct repository.

<sup>Written for commit ac94bfb67a271ccb35896c317fb913db3566177a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

