### PR TITLE
perf: switch BeautifulSoup parser from html.parser to lxml for web crawler

### DIFF
--- a/backend/onyx/file_processing/html_utils.py
+++ b/backend/onyx/file_processing/html_utils.py
@@ -164,7 +164,7 @@ def format_document_soup(
 
 
 def parse_html_page_basic(text: str | BytesIO | IO[bytes]) -> str:
-    soup = bs4.BeautifulSoup(text, "html.parser")
+    soup = bs4.BeautifulSoup(text, "lxml")
     return format_document_soup(soup)
 
 
@@ -174,7 +174,7 @@ def web_html_cleanup(
     additional_element_types_to_discard: list[str] | None = None,
 ) -> ParsedHTML:
     if isinstance(page_content, str):
-        soup = bs4.BeautifulSoup(page_content, "html.parser")
+        soup = bs4.BeautifulSoup(page_content, "lxml")
     else:
         soup = page_content
 


### PR DESCRIPTION
## Description

Switch BeautifulSoup's HTML parser from `html.parser` to `lxml`.

**Why:**
- 5-10x faster parsing
- More tolerant of malformed HTML fragments
- Lower memory usage
- `lxml` is already a dependency (`lxml==5.3.0`)

**Changes:**
- `parse_html_page_basic()`: use `lxml` parser
- `web_html_cleanup()`: use `lxml` parser

## How Has This Been Tested?

- Verified `lxml` parses HTML correctly via manual testing (running a web search)
- Existing tests pass

## Additional Options

- [x] [Optional] Override Linear Check