### PR TITLE
fix: Fix actions cards

### DIFF
--- a/web/src/layouts/actions-layouts.tsx
+++ b/web/src/layouts/actions-layouts.tsx
@@ -71,6 +71,7 @@ import { WithoutStyles } from "@/types";
 import Text from "@/refresh-components/texts/Text";
 import { SvgMcp } from "@opal/icons";
 import ShadowDiv from "@/refresh-components/ShadowDiv";
+import { Section, SectionProps } from "@/layouts/general-layouts";
 
 /**
  * Actions Layout Context
@@ -163,12 +164,10 @@ function useActionsLayoutContext() {
  * </ActionsLayouts.Root>
  * ```
  */
-export type ActionsRootProps = WithoutStyles<
-  React.HTMLAttributes<HTMLDivElement>
->;
+export type ActionsRootProps = SectionProps;
 
 function ActionsRoot(props: ActionsRootProps) {
-  return <div className="flex flex-col" {...props} />;
+  return <Section gap={0} padding={0} {...props} />;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes cards for actions during agent-creation.

## Screenshots

### Before

<img width="839" height="495" alt="image" src="https://github.com/user-attachments/assets/afcbcb9e-43f7-4e76-909d-2852604511aa" />

### After

<img width="813" height="521" alt="image" src="https://github.com/user-attachments/assets/54b017a1-0352-4a67-8a90-d39d50adf10b" />

## How Has This Been Tested?

Through the UI.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes action card layout in the agent creation flow. Cards now render with correct spacing and alignment.

- **Bug Fixes**
  - Replaced ActionsRoot div with shared Section (gap=0, padding=0) and updated props to SectionProps to standardize layout.

<sup>Written for commit 88c79046f80d690cc94bd984aa11083678300cb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

