### PR TITLE
fix: More actions cards fixes

### DIFF
--- a/web/src/layouts/actions-layouts.tsx
+++ b/web/src/layouts/actions-layouts.tsx
@@ -235,30 +235,28 @@ function ActionsHeader({
         isFolded ? "rounded-16" : "rounded-t-16"
       )}
     >
-      <div className="px-4">
-        <label
-          className="flex items-start justify-between gap-2 cursor-pointer"
-          htmlFor={name}
-        >
-          {/* Left: Icon, Title, Description */}
-          <div className="flex flex-col items-start">
-            <div className="flex items-center justify-center gap-2">
-              <div className="min-w-[18px]">
-                <Icon className="stroke-text-04" size={18} />
-              </div>
-              <Truncated mainContentEmphasis text04>
-                {title}
-              </Truncated>
+      <label
+        className="flex items-start justify-between gap-2 cursor-pointer px-4"
+        htmlFor={name}
+      >
+        {/* Left: Icon, Title, Description */}
+        <Section alignItems="start" gap={0} fit>
+          <Section flexDirection="row" gap={0.5}>
+            <div className="min-w-[18px]">
+              <Icon className="stroke-text-04" size={18} />
             </div>
-            <Truncated secondaryBody text03 className="pl-7">
-              {description}
+            <Truncated mainContentEmphasis text04>
+              {title}
             </Truncated>
-          </div>
+          </Section>
+          <Truncated secondaryBody text03 className="pl-7">
+            {description}
+          </Truncated>
+        </Section>
 
-          {/* Right: Actions */}
-          {rightChildren}
-        </label>
-      </div>
+        {/* Right: Actions */}
+        <Section fit>{rightChildren}</Section>
+      </label>
       <div {...props} className="px-2" />
     </div>
   );


### PR DESCRIPTION
## Description

Fixes the `EnabledCount` layout in the action card.

## How Has This Been Tested?

Through the UI.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the EnabledCount and header layout in action cards. Replaces the div-based layout with our shared Section component and adjusts padding to align left content and right actions consistently.

<sup>Written for commit 070a726317ef1ce2bfc91bf75328e7cf970be9b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

