### PR TITLE
fix: onboarding modal styling

### DIFF
--- a/web/src/refresh-components/onboarding/forms/OnboardingFormWrapper.tsx
+++ b/web/src/refresh-components/onboarding/forms/OnboardingFormWrapper.tsx
@@ -328,8 +328,8 @@ export function OnboardingFormWrapper<T extends Record<string, any>>({
             submitDisabled={!formikProps.isValid || !formikProps.dirty}
             isSubmitting={isSubmitting}
           >
-            <Form className="flex flex-col gap-0">
-              <div className="flex flex-col p-4 gap-4 bg-background-tint-01 w-full">
+            <Form className="w-full">
+              <div className="flex flex-col gap-4 w-full">
                 {children(childProps)}
               </div>
             </Form>


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/b784b08e-3bbf-49c6-bdc2-ac7349cf4831

- make forms stretch and minimize tailwind

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the onboarding modal layout by removing extra padding and background tint from the form container and making the form full-width. This aligns the content with modal styling and prevents awkward spacing or double backgrounds.

<sup>Written for commit 5895515716916cad46fa02a8a98efa889ee18da3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

