### PR TITLE
fix: Editing First Message

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -401,7 +401,10 @@ def handle_stream_message_objects(
         if new_msg_req.parent_message_id == AUTO_PLACE_AFTER_LATEST_MESSAGE:
             # Auto-place after the latest message in the chain
             parent_message = chat_history[-1] if chat_history else root_message
-        elif new_msg_req.parent_message_id is None:
+        elif (
+            new_msg_req.parent_message_id is None
+            or new_msg_req.parent_message_id == root_message.id
+        ):
             # None = regeneration from root
             parent_message = root_message
             # Truncate history since we're starting from root


### PR DESCRIPTION
## Description
Edge case bug with editing the first message after having refreshed the browser. Usually with the first message sent, the frontend does not know about the root node. After a refresh though, it passes the root node id to the backend as the parent. Which is fine honestly and the logic should handle that. So added a handling for that.

## How Has This Been Tested?
Works for sure

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes editing the first message after a browser refresh by treating a root-message parent as a root regeneration. If parent_message_id is None or equals the root id, we start from the root and correctly truncate history to prevent misplacement.

<sup>Written for commit f7bf61251c927fb06b235ed04f6f5747137e4e82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

