### PR TITLE
chore(deps): fix `uv-lock` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: uv-sync
         args: ["--locked", "--all-extras"]
       - id: uv-lock
-        files: ^pyproject\.toml$
       - id: uv-export
         name: uv-export default.txt
         args:


### PR DESCRIPTION
## Description

[chore(deps): remove requires-python < 3.13](https://github.com/onyx-dot-app/onyx/pull/7367) is not actually obsolete and CI should be failing, but the pre-commit hook which validates it is broken. 

## How Has This Been Tested?

Confirmed `prek run` fails on that branch.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the uv-lock pre-commit hook so it runs in CI and correctly fails when pyproject changes require an updated lock or violate requires-python rules. Removed the files filter in .pre-commit-config.yaml to let uv-lock execute without file matching.

<sup>Written for commit 605a1adfc790f4f1713a99ff8b46047fa2445a27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

