### PR TITLE
chore(pre-commit): run `npm install` after `web/package.json` changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,16 +149,16 @@ repos:
       - id: npm-install
         name: npm install
         description: "Automatically run 'npm install' after a checkout, pull or rebase"
-        language: node
-        entry: bash -c 'cd web && npm install'
+        language: system
+        entry: bash -c 'cd web && npm install --no-save'
         always_run: true
         pass_filenames: false
         stages: [post-checkout, post-merge, post-rewrite]
       - id: npm-install-check
         name: npm install --package-lock-only
         description: "Check the 'web/package-lock.json' is updated"
-        language: node
-        entry: bash -c 'cd web && npm install'
+        language: system
+        entry: bash -c 'cd web && npm install --package-lock-only'
         pass_filenames: false
         files: ^web/package(-lock)?\.json$
 

--- a/web/README.md
+++ b/web/README.md
@@ -5,22 +5,21 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 ## Getting Started
 
 Install node / npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
-Install all dependencies: `npm i`
+Install all dependencies: `npm i`.
 
 Then, run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 _Note:_ if you are having problems accessing the ^, try setting the `WEB_DOMAIN` env variable to
 `http://127.0.0.1:3000` and accessing it there.
+
+> [!TIP]
+> Packages are installed automatically when changing branches with [pre-commit](https://github.com/onyx-dot-app/onyx/blob/main/CONTRIBUTING.md#formatting-and-linting) configured.
 
 ### Connecting to a Cloud Backend
 
@@ -48,7 +47,6 @@ may need to delete the cookies for the `localhost` domain.
 **Important notes:**
 
 - The `.env.local` file should be created in the `web/` directory (same level as `package.json`)
-- After creating or modifying `.env.local`, restart your development server for changes to take effect
 - The `DEBUG_AUTH_COOKIE` is only used in development mode (`NODE_ENV=development`)
 - If `INTERNAL_URL` is not set, the frontend will connect to the local backend at `http://127.0.0.1:8080`
 - Keep your `.env.local` file secure and never commit it to version control (it should already be in `.gitignore`)


### PR DESCRIPTION
## Description

This fixes two issues:

1. Devs no longer need to install packages manually. When a new package is added, the dev server/type-checker just breaks and it's not immediately obvious the issue is a missing package.
2. Standardizes handling the `package-lock.json`. With CI being the source of truth, we minimize the likelihood of these useless deltas, https://github.com/onyx-dot-app/onyx/pull/7339/changes#r2679104205

## How Has This Been Tested?

Captured by `quality-checks`: https://github.com/onyx-dot-app/onyx/actions/runs/20939373691/job/60169381659?pr=7373#step:7:165

## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds post-checkout/merge/rewrite hooks to auto-run npm install in web and keep package-lock in sync when web/package.json changes. Adds a pre-commit check to ensure web/package-lock.json is updated.

<sup>Written for commit 629073da284761b23adbf210b1f534ec9933d487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





