### PR TITLE
fix(chat): prevent adding chat sessions to recents that belong to a project

### DIFF
--- a/web/src/hooks/useChatSessions.ts
+++ b/web/src/hooks/useChatSessions.ts
@@ -164,7 +164,7 @@ export default function useChatSessions(): UseChatSessionsOutput {
   const addPendingChatSession = useCallback(
     ({ chatSessionId, personaId, projectId }: PendingChatSessionParams) => {
       // Don't add sessions that belong to a project
-      if (projectId) {
+      if (projectId != null) {
         return;
       }
 


### PR DESCRIPTION
## Description
This pull request introduces a small but important change to the `useChatSessions` hook. Now, when adding a pending chat session, any session associated with a project (i.e., where `projectId` is set) will be ignored and not added under Recent section.

ticket->https://linear.app/onyx-app/issue/ENG-3402/new-project-chats-appear-incorrectly-in-sidebar

## How Has This Been Tested?
From UI

https://github.com/user-attachments/assets/cddd7bbf-7d75-43ea-9147-caab472febc0



## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent adding pending chat sessions that belong to a project to the Recent section in the sidebar. Addresses Linear ENG-3402 where new project chats appeared in the wrong place.

<sup>Written for commit 30243ec97419665cb4e1e6fae741cfd0fa06fcae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

