### PR TITLE
chore(pre-commit): run `npm install` after `web/package.json` changes 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,22 @@ repos:
         pass_filenames: false
         files: \.tf$
 
+      - id: npm-install
+        name: npm install
+        description: "Automatically run 'npm install' after a checkout, pull or rebase"
+        language: system
+        entry: bash -c 'cd web && npm install --no-save'
+        pass_filenames: false
+        files: ^web/package(-lock)?\.json$
+        stages: [post-checkout, post-merge, post-rewrite]
+      - id: npm-install-check
+        name: npm install --package-lock-only
+        description: "Check the 'web/package-lock.json' is updated"
+        language: system
+        entry: bash -c 'cd web && npm install --package-lock-only'
+        pass_filenames: false
+        files: ^web/package(-lock)?\.json$
+
       # Uses tsgo (TypeScript's native Go compiler) for ~10x faster type checking.
       # This is a preview package - if it breaks:
       #   1. Try updating: cd web && npm update @typescript/native-preview

--- a/web/README.md
+++ b/web/README.md
@@ -5,22 +5,21 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 ## Getting Started
 
 Install node / npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
-Install all dependencies: `npm i`
+Install all dependencies: `npm i`.
 
 Then, run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 _Note:_ if you are having problems accessing the ^, try setting the `WEB_DOMAIN` env variable to
 `http://127.0.0.1:3000` and accessing it there.
+
+> [!TIP]
+> Packages are installed automatically when switching branches after `package.json` changes with [pre-commit](https://github.com/onyx-dot-app/onyx/blob/main/CONTRIBUTING.md#formatting-and-linting) configured.
 
 ### Connecting to a Cloud Backend
 


### PR DESCRIPTION
## Description

This fixes two issues:

1. Devs no longer need to install packages manually. When a new package is added, the dev server/type-checker just breaks and it's not immediately obvious the issue is a missing package.
2. Standardizes handling the `package-lock.json`. With CI being the source of truth, we minimize the likelihood of these useless deltas, https://github.com/onyx-dot-app/onyx/pull/7339/changes#r2679104205

## How Has This Been Tested?

Captured by `quality-checks`: https://github.com/onyx-dot-app/onyx/actions/runs/20939373691/job/60169381659?pr=7373#step:7:165

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically runs npm install when switching branches and ensures package-lock.json stays in sync to prevent broken dev environments and reduce lockfile noise.

- **New Features**
  - Added post-checkout, post-merge, and post-rewrite hooks to run npm install in web/.
  - Added a check to update web/package-lock.json via npm install --package-lock-only when web/package.json changes.
  - Updated web/README with a tip about auto installs and simplified dev commands.

<sup>Written for commit 0fc07454a76ae0df03547f7c00db90872b116b46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

