### PR TITLE
revert: "chore(playwright): skip dall-e test (#7395)"

### DIFF
--- a/web/tests/e2e/admin/image-generation/image-generation-content.spec.ts
+++ b/web/tests/e2e/admin/image-generation/image-generation-content.spec.ts
@@ -100,7 +100,7 @@ test.describe("Image Generation Provider Configuration", () => {
       }
     });
 
-    test.skip("should configure DALL-E 3 with API key", async ({ page }) => {
+    test("should configure DALL-E 3 with API key", async ({ page }) => {
       // Click Connect on DALL-E 3 card using aria-label
       await openProviderModal(page, "openai_dalle_3");
 


### PR DESCRIPTION
This reverts commit 037c2aee3adbdbc86b5265edb8cbeba6261d7bc7.

## Description

So we don't forget to reclaim coverage.

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the DALL-E 3 configuration Playwright test to restore coverage for the admin image generation provider setup. This reverts the earlier skip so the test runs and validates API key configuration.

<sup>Written for commit a2b95c9e51a978ed66357e83ee2d820b8fcd8048. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

