### PR TITLE
fix: LLM failing to give answer on tool call

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -591,7 +591,7 @@ def run_llm_step_pkt_generator(
                 and delta.tool_calls is None
             ):
                 logger.warning(
-                    f"Useful contents from LLM packet are empty, skipping packet: {packet}"
+                    f"LLM packet is empty (no contents, reasoning or tool calls). Skipping: {packet}"
                 )
                 continue
 


### PR DESCRIPTION
## Description
Some LLM inference providers do not give an id along with tool calls. We assume that will be there which can cause tool calls to get dropped. If there are dropped tool calls and no answer/reasoning, then the flow fails because we have gotten nothing from the LLM https://linear.app/onyx-app/issue/ENG-3403/vllm-issue-likely-empty-packet

## How Has This Been Tested?
tested locally with mlx inference, wanted to use VLLM but didn't get around to deploying it on the cloud with GPU so just did a local replacement. Still repros the issue though.

## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLM stream handling so tool calls aren’t dropped and runs don’t fail when providers omit tool_call IDs or send empty packets. Addresses Linear ENG-3403 (vLLM empty packet issue).

- **Bug Fixes**
  - Generate a fallback UUID for tool_call.id when the provider doesn’t send one.
  - Skip and log delta packets with no content, reasoning, or tool_calls.

<sup>Written for commit 26e3fa7d1924d70d266916a3f9f13f1b2584cfea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

