### PR TITLE
fix(mcp): per-user auth

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -697,7 +697,7 @@ def save_user_credentials(
             # TODO: fix and/or type correctly w/base model
             config_data = MCPConnectionData(
                 headers=auth_template.config.get("headers", {}),
-                header_substitutions=auth_template.config.get(HEADER_SUBSTITUTIONS, {}),
+                header_substitutions=request.credentials,
             )
             for oauth_field_key in MCPOAuthKeys:
                 field_key: Literal["client_info", "tokens", "metadata"] = (

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -41,6 +41,12 @@ API_KEY_RECORDS: Dict[str, Dict[str, Any]] = {
     },
 }
 
+# These are inferrable from the file anyways, no need to obfuscate.
+# use them to test your auth with this server
+#
+# mcp_live-kid_alice_001-S3cr3tAlice
+# mcp_live-kid_bob_001-S3cr3tBob
+
 
 # ---- verifier ---------------------------------------------------------------
 class ApiKeyVerifier(TokenVerifier):

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -438,7 +438,17 @@ export default function ActionsPopover({
         serverId: server.id,
         serverName: server.name,
         authTemplate: server.auth_template,
-        onSuccess: undefined,
+        onSuccess: () => {
+          // Update the authentication state after successful credential submission
+          setMcpServerData((prev) => ({
+            ...prev,
+            [server.id]: {
+              ...prev[server.id],
+              isAuthenticated: true,
+              isLoading: false,
+            },
+          }));
+        },
         isAuthenticated: server.user_authenticated,
         existingCredentials: server.user_credentials,
       });


### PR DESCRIPTION
## Description

Fixes https://linear.app/onyx-app/issue/ENG-3412/mcp-per-user-auth-not-working

There was a pretty bad bug where we weren't correctly saving/using the per-user API keys users submitted. This fixes that and ensures that the auth status of the server is updated when a user finishes submitting the api key form

## How Has This Been Tested?

Tested in UI, and the automated tests already cover the basic behavior here. We just didn't catch the aforementioned issue because the flow still worked, just not with the right API key...

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user MCP authentication so the API key a user submits is correctly saved and used, and the UI updates to show the authenticated state right away.

- **Bug Fixes**
  - Use user-submitted credentials for header_substitutions when saving MCP connection data.
  - Update ActionsPopover to set isAuthenticated and stop loading after a successful submit.
  - Add clear test keys to the mock MCP server to verify per-user auth locally.

<sup>Written for commit 31a26456f6ce5db62ad3fc6087f0f263b6721789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

