### PR TITLE
feat: Deep Research Multilingual

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -854,14 +854,14 @@ def run_llm_step_pkt_generator(
         logger.debug(f"Accumulated reasoning: {accumulated_reasoning}")
         logger.debug(f"Accumulated answer: {accumulated_answer}")
 
-    if tool_calls:
-        tool_calls_str = "\n".join(
-            f"  - {tc.tool_name}: {json.dumps(tc.tool_args, indent=4)}"
-            for tc in tool_calls
-        )
-        logger.debug(f"Tool calls:\n{tool_calls_str}")
-    else:
-        logger.debug("Tool calls: []")
+        if tool_calls:
+            tool_calls_str = "\n".join(
+                f"  - {tc.tool_name}: {json.dumps(tc.tool_args, indent=4)}"
+                for tc in tool_calls
+            )
+            logger.debug(f"Tool calls:\n{tool_calls_str}")
+        else:
+            logger.debug("Tool calls: []")
 
     return (
         LlmStepResult(

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -19,6 +19,7 @@ If you need to ask questions, follow these guidelines:
 - Be concise and do not ask more than 5 questions.
 - If there are ambiguous terms or questions, ask the user to clarify.
 - Your questions should be a numbered list for clarity.
+- Respond in the user's language.
 - Make sure to gather all the information needed to carry out the research task in a concise, well-structured manner.{{internal_search_clarification_guidance}}
 - Wrap up with a quick sentence on what the clarification will help with, it's ok to reference the user query closely here.
 """.strip()
@@ -45,7 +46,7 @@ The research plan should be formatted as a numbered list of steps and have 6 or 
 
 Each step should be a standalone exploration question or topic that can be researched independently but may build on previous steps.
 
-Output only the numbered list of steps with no additional prefix or suffix.
+Output only the numbered list of steps with no additional prefix or suffix. Respond in the user's language.
 """.strip()
 
 
@@ -78,7 +79,7 @@ The research task provided to the {RESEARCH_AGENT_TOOL_NAME} should be reasonabl
 It should not be a single short query, rather it should be 1 (or 2 if necessary) descriptive sentences that outline the direction of the investigation.
 
 CRITICAL - the {RESEARCH_AGENT_TOOL_NAME} only receives the task and has no additional context about the user's query, research plan, other research agents, or message history. \
-You absolutely must provide all of the context needed to complete the task in the argument to the {RESEARCH_AGENT_TOOL_NAME}.{{internal_search_research_task_guidance}}
+You absolutely must provide all of the context needed to complete the task in the argument to the {RESEARCH_AGENT_TOOL_NAME}. The research task should be in the user's language.{{internal_search_research_task_guidance}}
 
 You should call the {RESEARCH_AGENT_TOOL_NAME} MANY times before completing with the {GENERATE_REPORT_TOOL_NAME} tool.
 
@@ -128,7 +129,7 @@ For context, the date is {current_datetime}.
 
 Users have explicitly selected the deep research mode and will expect a long and detailed answer. It is ok and encouraged that your response is several pages long.
 
-You use different text styles and formatting to make the response easier to read. You may use markdown rarely when necessary to make the response more digestible.
+You use different text styles and formatting to make the response easier to read. You may use markdown rarely when necessary to make the response more digestible. Respond in the user's language.
 
 Not every fact retrieved will be relevant to the user's query.
 
@@ -167,7 +168,7 @@ The research task provided to the {RESEARCH_AGENT_TOOL_NAME} should be reasonabl
 It should not be a single short query, rather it should be 1 (or 2 if necessary) descriptive sentences that outline the direction of the investigation.
 
 CRITICAL - the {RESEARCH_AGENT_TOOL_NAME} only receives the task and has no additional context about the user's query, research plan, or message history. \
-You absolutely must provide all of the context needed to complete the task in the argument to the {RESEARCH_AGENT_TOOL_NAME}.{{internal_search_research_task_guidance}}
+You absolutely must provide all of the context needed to complete the task in the argument to the {RESEARCH_AGENT_TOOL_NAME}. The research task should be in the user's language.{{internal_search_research_task_guidance}}
 
 You should call the {RESEARCH_AGENT_TOOL_NAME} MANY times before completing with the {GENERATE_REPORT_TOOL_NAME} tool.
 

--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -51,6 +51,8 @@ Remove any obviously irrelevant or duplicative information.
 
 If a statement seems not trustworthy or is contradictory to other statements, it is important to flag it.
 
+Write the report in the same language as the provided task.
+
 Cite all sources INLINE using the format [1], [2], [3], etc. based on the `document` field of the source. \
 Cite inline as opposed to leaving all citations until the very end of the response.
 """
@@ -61,7 +63,8 @@ Please write me a comprehensive report on the research topic given the context a
 {research_topic}
 
 Remember to include AS MUCH INFORMATION AS POSSIBLE and as faithful to the original sources as possible. \
-Keep it free of formatting and focus on the facts only. Be sure to include all context for each fact to avoid misinterpretation or misattribution.
+Keep it free of formatting and focus on the facts only. Be sure to include all context for each fact to avoid misinterpretation or misattribution. \
+Respond in the same language as the topic provided above.
 
 Cite every fact INLINE using the format [1], [2], [3], etc. based on the `document` field of the source.
 

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -434,6 +434,10 @@ def run_research_agent_call(
                             tool_calls[0], token_counter
                         )
                         msg_history.extend(failure_messages)
+
+                        # If there is a failure like this, we still increment to avoid potential infinite loops
+                        research_cycle_count += 1
+                        llm_cycle_count += 1
                         continue
 
                     for tool_response in tool_responses:


### PR DESCRIPTION
## Description
Tune it for queries not in English

## How Has This Been Tested?
Works for sure

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multilingual Deep Research so clarifications, plans, tasks, and reports respond in the user's language. Adds query validation and loop safeguards for more reliable runs.

- New Features
  - Orchestration prompts instruct all steps to respond in the user’s language; research tasks are authored in that language; reports are written in the task language.

- Bug Fixes
  - Normalize web search queries (trim, drop empty) and return a clear error when none are valid.
  - Prevent potential infinite loops by incrementing cycle counters after tool failures; limit tool call logging to debug-only paths.

<sup>Written for commit b9a1b43d4fac3bb9b6b149784865cecc40eacee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

