### PR TITLE
fix(tests): increase timeout for modal dialog visibility in image generation tests

### DIFF
--- a/web/tests/e2e/admin/image-generation/image-generation-content.spec.ts
+++ b/web/tests/e2e/admin/image-generation/image-generation-content.spec.ts
@@ -132,7 +132,7 @@ test.describe("Image Generation Provider Configuration", () => {
       );
 
       // Wait for modal to close (indicates success)
-      await expect(modalDialog).not.toBeVisible({ timeout: 30000 });
+      await expect(modalDialog).not.toBeVisible({ timeout: 60000 });
 
       console.log(
         "[image-gen-test] Modal closed, verifying provider is configured..."


### PR DESCRIPTION
## Description
Image generation tests flakiness fix.

## How Has This Been Tested?
Running the tests

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the wait timeout for the image generation provider config modal to close from 30s to 60s. This reduces e2e test flakiness, especially in slower CI environments.

<sup>Written for commit f4743c5070edb6f9bcf8472282c45196d763fe63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

