### PR TITLE
chore(docs): fix `is_creation` description

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -196,7 +196,7 @@ def put_llm_provider(
     llm_provider_upsert_request: LLMProviderUpsertRequest,
     is_creation: bool = Query(
         False,
-        description="True if updating an existing provider, False if creating a new one",
+        description="True if creating a new one, False if updating an existing provider",
     ),
     _: User | None = Depends(current_admin_user),
     db_session: Session = Depends(get_session),


### PR DESCRIPTION
## Description

Closes https://github.com/onyx-dot-app/onyx/issues/7408

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the is_creation query parameter description in put_llm_provider to reflect the correct behavior: True creates a new provider, False updates an existing one. This clarifies the API docs and prevents confusion when using the endpoint.

<sup>Written for commit eac185fa6f902f80c20efd27bd69bdf1b332ce81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

