### PR TITLE
fix: Chat naming for long messages

### DIFF
--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -1,5 +1,3 @@
-from onyx.prompts.constants import GENERAL_SEP_PAT
-
 # ruff: noqa: E501, W605 start
 
 DATETIME_REPLACEMENT_PAT = "{{CURRENT_DATETIME}}"
@@ -93,17 +91,18 @@ This tool call completed but the results are no longer accessible.
 # date and time but the replacement pattern is not present in the prompt.
 ADDITIONAL_INFO = "\n\nAdditional Information:\n\t- {datetime_info}."
 
-CHAT_NAMING = f"""
-Given the following conversation, provide a SHORT name for the conversation.{{language_hint_or_empty}}
-IMPORTANT: TRY NOT TO USE MORE THAN 5 WORDS, MAKE IT AS CONCISE AS POSSIBLE.
-Focus the name on the important keywords to convey the topic of the conversation.
 
-Chat History:
-{GENERAL_SEP_PAT}
-{{chat_history}}
-{GENERAL_SEP_PAT}
+CHAT_NAMING_SYSTEM_PROMPT = """
+Given the conversation history, provide a SHORT name for the conversation. Focus the name on the important keywords to convey the topic of the conversation. \
+Make sure the name is in the same language as the user's language.
 
-Based on the above, what is a short name to convey the topic of the conversation?
+IMPORTANT: DO NOT OUTPUT ANYTHING ASIDE FROM THE NAME. MAKE IT AS CONCISE AS POSSIBLE. NEVER USE MORE THAN 5 WORDS, LESS IS FINE.
 """.strip()
 
+
+CHAT_NAMING_REMINDER = """
+Provide a short name for the conversation. Refer to other messages in the conversation (not including this one) to determine the language of the name.
+
+IMPORTANT: DO NOT OUTPUT ANYTHING ASIDE FROM THE NAME. MAKE IT AS CONCISE AS POSSIBLE. NEVER USE MORE THAN 5 WORDS, LESS IS FINE.
+""".strip()
 # ruff: noqa: E501, W605 end

--- a/backend/onyx/secondary_llm_flows/chat_session_naming.py
+++ b/backend/onyx/secondary_llm_flows/chat_session_naming.py
@@ -1,38 +1,36 @@
-from onyx.chat.chat_utils import combine_message_chain
-from onyx.configs.chat_configs import LANGUAGE_CHAT_NAMING_HINT
-from onyx.db.models import ChatMessage
-from onyx.db.search_settings import get_multilingual_expansion
+from onyx.chat.llm_step import translate_history_to_llm_format
+from onyx.chat.models import ChatMessageSimple
+from onyx.configs.constants import MessageType
 from onyx.llm.interfaces import LLM
 from onyx.llm.utils import llm_response_to_string
-from onyx.prompts.chat_prompts import CHAT_NAMING
+from onyx.prompts.chat_prompts import CHAT_NAMING_REMINDER
+from onyx.prompts.chat_prompts import CHAT_NAMING_SYSTEM_PROMPT
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
-def get_renamed_conversation_name(
-    full_history: list[ChatMessage],
+def generate_chat_session_name(
+    chat_history: list[ChatMessageSimple],
     llm: LLM,
 ) -> str:
-    max_context_for_naming = 1000
-    history_str = combine_message_chain(
-        messages=full_history, token_limit=max_context_for_naming
+    system_prompt = ChatMessageSimple(
+        message=CHAT_NAMING_SYSTEM_PROMPT,
+        token_count=100,
+        message_type=MessageType.SYSTEM,
     )
 
-    language_hint = (
-        f"\n{LANGUAGE_CHAT_NAMING_HINT.strip()}"
-        if bool(get_multilingual_expansion())
-        else ""
+    reminder_prompt = ChatMessageSimple(
+        message=CHAT_NAMING_REMINDER,
+        token_count=100,
+        message_type=MessageType.USER,
     )
 
-    prompt = CHAT_NAMING.format(
-        language_hint_or_empty=language_hint, chat_history=history_str
+    complete_message_history = [system_prompt] + chat_history + [reminder_prompt]
+
+    llm_facing_history = translate_history_to_llm_format(
+        complete_message_history, llm.config
     )
+    new_name_raw = llm_response_to_string(llm.invoke(llm_facing_history))
 
-    new_name_raw = llm_response_to_string(llm.invoke(prompt))
-
-    new_name = new_name_raw.strip().strip('"')
-
-    logger.debug(f"New Session Name: {new_name}")
-
-    return new_name
+    return new_name_raw.strip().strip('"')


### PR DESCRIPTION
## Description
There was an issue where if any of the messages were semi long, it would drop the entire history and there would be an "Empty conversation" name given for the chat session. This addresses it in 2 ways:
- Drops singular large messages rather than stopping history construction
- Allows for overall more tokens in the history

Also updates the 2 year old code to use updated interfaces/functions

Addresses: https://linear.app/onyx-app/issue/ENG-3350/no-chat-history-provided

## How Has This Been Tested?
Verified locally, very high confidence this is fine

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat session naming when long messages are present by trimming oversized messages and using structured history, preventing "Empty conversation" titles. Addresses Linear ENG-3350.

- **Bug Fixes**
  - Added convert_chat_history_basic to drop individual large messages and keep only USER/ASSISTANT content.
  - Increased naming context from 1k to 3k tokens and applied a 3k cap per message and total history.
  - Switched naming flow to structured system/user prompts and ensured the name matches the conversation’s language.
  - Replaced string-based history building with translate_history_to_llm_format for safer LLM calls.
  - Updated server endpoint to use model token counter and new naming function.

<sup>Written for commit bf7add5897fb29d5509d6da2299921a7ec4108eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

