### PR TITLE
chore: usage limit defaults to off

### DIFF
--- a/backend/ee/onyx/server/tenant_usage_limits.py
+++ b/backend/ee/onyx/server/tenant_usage_limits.py
@@ -1,10 +1,13 @@
 """Tenant-specific usage limit overrides from the control plane (EE version)."""
 
+import time
+
 import requests
 
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.server.tenant_usage_limits import TenantUsageLimitOverrides
+from onyx.server.usage_limits import NO_LIMIT
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -12,9 +15,12 @@ logger = setup_logger()
 
 # In-memory storage for tenant overrides (populated at startup)
 _tenant_usage_limit_overrides: dict[str, TenantUsageLimitOverrides] | None = None
+_last_fetch_time: float = 0.0
+_FETCH_INTERVAL = 60 * 60 * 24  # 24 hours
+_ERROR_FETCH_INTERVAL = 30 * 60  # 30 minutes (if the last fetch failed)
 
 
-def fetch_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides]:
+def fetch_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides] | None:
     """
     Fetch tenant-specific usage limit overrides from the control plane.
 
@@ -45,26 +51,31 @@ def fetch_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides]:
                     f"Failed to parse usage limit overrides for tenant {tenant_id}: {e}"
                 )
 
-        return result
+        return (
+            result or None
+        )  # if empty dictionary, something went wrong and we shouldn't enforce limits
 
     except requests.exceptions.RequestException as e:
         logger.warning(f"Failed to fetch usage limit overrides from control plane: {e}")
-        return {}
+        return None
     except Exception as e:
         logger.error(f"Error parsing usage limit overrides: {e}")
-        return {}
+        return None
 
 
-def load_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides]:
+def load_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides] | None:
     """
     Load tenant usage limit overrides from the control plane.
 
     Called at server startup to populate the in-memory cache.
     """
     global _tenant_usage_limit_overrides
+    global _last_fetch_time
 
     logger.info("Loading tenant usage limit overrides from control plane...")
     overrides = fetch_usage_limit_overrides()
+
+    _last_fetch_time = time.time()
     _tenant_usage_limit_overrides = overrides
 
     if overrides:
@@ -72,6 +83,20 @@ def load_usage_limit_overrides() -> dict[str, TenantUsageLimitOverrides]:
     else:
         logger.info("No tenant-specific usage limit overrides found")
     return overrides
+
+
+def unlimited(tenant_id: str) -> TenantUsageLimitOverrides:
+    return TenantUsageLimitOverrides(
+        tenant_id=tenant_id,
+        llm_cost_cents_trial=NO_LIMIT,
+        llm_cost_cents_paid=NO_LIMIT,
+        chunks_indexed_trial=NO_LIMIT,
+        chunks_indexed_paid=NO_LIMIT,
+        api_calls_trial=NO_LIMIT,
+        api_calls_paid=NO_LIMIT,
+        non_streaming_calls_trial=NO_LIMIT,
+        non_streaming_calls_paid=NO_LIMIT,
+    )
 
 
 def get_tenant_usage_limit_overrides(
@@ -87,6 +112,16 @@ def get_tenant_usage_limit_overrides(
         TenantUsageLimitOverrides if the tenant has overrides, None otherwise.
     """
     global _tenant_usage_limit_overrides
-    if _tenant_usage_limit_overrides is None:
+    time_since = time.time() - _last_fetch_time
+    if (
+        _tenant_usage_limit_overrides is None and time_since > _ERROR_FETCH_INTERVAL
+    ) or (time_since > _FETCH_INTERVAL):
+        logger.debug(
+            f"Last fetch time: {_last_fetch_time}, time since last fetch: {time_since}"
+        )
         _tenant_usage_limit_overrides = load_usage_limit_overrides()
+
+    # If we have failed to fetch from the control plane, don't usage limit everyone.
+    if _tenant_usage_limit_overrides is None:
+        return unlimited(tenant_id)
     return _tenant_usage_limit_overrides.get(tenant_id)


### PR DESCRIPTION
## Description

If the control plane tenants service is down, we shouldn't start usage limiting all tenants. We now re-load usage limits every 24 hours by default, and every 30 minutes if the control plane fetch has not yet succeeded.

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned usage limiting off by default when the control plane is unavailable. Adds a safe fallback and scheduled refresh so we don’t accidentally limit all tenants during outages.

- **Bug Fixes**
  - Fallback to unlimited limits when overrides cannot be fetched.
  - Refresh overrides every 24 hours; retry every 30 minutes until first success.
  - Track last fetch time and reload on access when intervals elapse.

<sup>Written for commit 87fab8501a72d8ef14b88dbf34869b13039f1726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

