### PR TITLE
chore: Turn off reasoning for chat naming

### DIFF
--- a/backend/onyx/secondary_llm_flows/chat_session_naming.py
+++ b/backend/onyx/secondary_llm_flows/chat_session_naming.py
@@ -2,6 +2,7 @@ from onyx.chat.llm_step import translate_history_to_llm_format
 from onyx.chat.models import ChatMessageSimple
 from onyx.configs.constants import MessageType
 from onyx.llm.interfaces import LLM
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.utils import llm_response_to_string
 from onyx.prompts.chat_prompts import CHAT_NAMING_REMINDER
 from onyx.prompts.chat_prompts import CHAT_NAMING_SYSTEM_PROMPT
@@ -31,6 +32,8 @@ def generate_chat_session_name(
     llm_facing_history = translate_history_to_llm_format(
         complete_message_history, llm.config
     )
-    new_name_raw = llm_response_to_string(llm.invoke(llm_facing_history))
+    new_name_raw = llm_response_to_string(
+        llm.invoke(llm_facing_history, reasoning_effort=ReasoningEffort.OFF)
+    )
 
     return new_name_raw.strip().strip('"')


### PR DESCRIPTION
## Description
Not really any reason why reasoning would be needed for this simple task

## How Has This Been Tested?
Works

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable reasoning for chat session naming by invoking the LLM with ReasoningEffort.OFF. This reduces latency and token usage for a simple task without changing naming behavior.

<sup>Written for commit bda150b20c84573f90dbc8cf8c3403f759e1053e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

