### PR TITLE
docs: enhance send-chat-message docs to also show ChatFullResponse

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -532,7 +532,7 @@ def handle_new_chat_message(
 
 @router.post(
     "/send-chat-message",
-    response_model=None,
+    response_model=ChatFullResponse,
     tags=PUBLIC_API_TAGS,
     responses={
         200: {
@@ -549,9 +549,6 @@ def handle_new_chat_message(
                             "value": "string",
                         }
                     },
-                },
-                "application/json": {
-                    "schema": ChatFullResponse.model_json_schema(),
                 },
             },
         }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

When developing integrations with the new `send-chat-message` endpoint, I noticed that currently, the Swagger docs only display the stream example (`"string"`) whereas it can return a `StreamingResponse` _or_ a `ChatFullResponse` when `stream=false` - It'd be useful to have this model in the docs for clarity.

I updated the `responses` field in the method definition to include both examples, for stream and not.

## How Has This Been Tested?

- Fresh clone of repo
- Stood up services following `CONTRIBUTING_VSCODE.md`
- Found: `<api-url>/docs#/public/handle_send_chat_message`
- Identified missing examples:
<img width="605" height="414" alt="image" src="https://github.com/user-attachments/assets/f3054fe9-f67f-4bef-82a8-0e0e9571bedc" />


- Made changes to method definition
- Observed updated examples:
<img width="996" height="450" alt="image" src="https://github.com/user-attachments/assets/960a3e1f-04d9-42d5-9d74-9db87e141000" />
<img width="1003" height="609" alt="image" src="https://github.com/user-attachments/assets/f2143651-98ce-457d-b6f9-2c516a4c6e82" />



## Additional Options

- [x] [Optional] Override Linear Check
