### PR TITLE
chore(devtools): upgrade `ods` -> v0.3.2

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -295,7 +295,7 @@ numpy==2.4.1
     #   pandas-stubs
     #   shapely
     #   voyageai
-onyx-devtools==0.3.1
+onyx-devtools==0.3.2
     # via onyx
 openai==2.14.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ dev = [
     "matplotlib==3.10.8",
     "mypy-extensions==1.0.0",
     "mypy==1.13.0",
-    "onyx-devtools==0.3.1",
+    "onyx-devtools==0.3.2",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4759,7 +4759,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==2.4.1" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.3.1" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.3.2" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "openapi-generator-cli", marker = "extra == 'dev'", specifier = "==7.17.0" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
@@ -4862,20 +4862,20 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/31/1bfaed028ae4673676b4ba511852d82aa91c866745a5995f729f7638fdf0/onyx_devtools-0.3.1-py3-none-any.whl", hash = "sha256:dfc533485c732cfc0ace5e5aea4ce3dd90c6dbc48d51aef6cf2378e15f6c45eb", size = 1348300, upload-time = "2026-01-15T19:51:10.449Z" },
-    { url = "https://files.pythonhosted.org/packages/09/a6/79254b30a9111555607b25544d1c9b419a8cb08dd3915f16aa47c5b036fe/onyx_devtools-0.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c3b98aac8b239836b7204fc08245b303d6e1b53172071c38534866d096588ef9", size = 1350983, upload-time = "2026-01-15T19:51:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/33/2fa4899839aa202bd22506eff31a2139a6c11f96e22c77ad759d8e3238a4/onyx_devtools-0.3.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8b9013e44210eb6f25ffa17e46b751b8796824daa8e76a87f820d566a2e0e5ab", size = 1273048, upload-time = "2026-01-15T19:51:06.992Z" },
-    { url = "https://files.pythonhosted.org/packages/58/23/9e9591d9511dd519e4245cd5901650e8685ec0b747c5a6515b4ae79017f7/onyx_devtools-0.3.1-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:a25d1812fab443c94a0c32b90d3408a47ebed8853e1e0cc8b63f8de6264e57e8", size = 1240853, upload-time = "2026-01-15T19:51:14.955Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/9b/c8cb7f692950e66845368bf2769345e10d30bc2e3b236c170f37a87f2b53/onyx_devtools-0.3.1-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:180ef4373358078c13d38d55bc8494be897d9ab7a540c97addbcdbae1245367e", size = 1348320, upload-time = "2026-01-15T19:51:08.837Z" },
-    { url = "https://files.pythonhosted.org/packages/71/96/fef7f520ebd84b7eb5ac1a8ffd67d3c1ea58c6d27aca9f5b11a87280e512/onyx_devtools-0.3.1-py3-none-win_amd64.whl", hash = "sha256:ac6154b37b8fa92f3efee3953becd9750d30e986db6647695a0e44e950236c5d", size = 1424253, upload-time = "2026-01-15T19:51:11.921Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7b/e8f72c54303357971024b902be46a06a4f92ab8984d039681011d2804f11/onyx_devtools-0.3.1-py3-none-win_arm64.whl", hash = "sha256:fc07f040d1af1af4baab0482889f9f330fc5f3b76ff1cf1ed911c1a194385f4b", size = 1297947, upload-time = "2026-01-15T19:51:09.098Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/740f0afebfaa2537b9b016b1352f39e750ee282dbfd3b7fd793baebd4e69/onyx_devtools-0.3.2-py3-none-any.whl", hash = "sha256:c8d495fe0701a793acfca10145135314031c9892dc43cc2a146a0bfb56eb4fe5", size = 1348309, upload-time = "2026-01-15T20:28:23.124Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4b/87a79b8a972406a9698b0cb29564d0b1686c074a6b242635ece0fac575b1/onyx_devtools-0.3.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ca1868c64e68d1a129e542e253744d998b316837e8c77fe1ab69693a65efb36c", size = 1350995, upload-time = "2026-01-15T20:28:25.721Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ac/8d40e968627a075d127774a62667c42f59ad1866d167542e14897c57eb87/onyx_devtools-0.3.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cfbafbf1fdddc6a2ea9278ba595cc0bf3430f588e09ddcba496d7fa95110c905", size = 1273049, upload-time = "2026-01-15T20:28:26.254Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a4/668b4d32c1534fa591ffbd9873e3b9d3b2fc82988d6ecbb2d3e96f340441/onyx_devtools-0.3.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:52877fdad82f54d24c50bd4f718c77097cc7f6d3944e586cc28d437457b27e6e", size = 1240860, upload-time = "2026-01-15T20:28:22.097Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2e/e58597364c40a2fadccc334f0961edd6caa502777e625ea07bb61a29e2c7/onyx_devtools-0.3.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:f0192f36a9505e16c5cb039f6c4f595471a48434fc539b3d8c0971415b998294", size = 1348326, upload-time = "2026-01-15T20:28:19.941Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/00/a31790f5835f789dc6259a2e467a64407482dca28bf3a86eadb1f6d8dca6/onyx_devtools-0.3.2-py3-none-win_amd64.whl", hash = "sha256:90164068e99abcfc5cb24539e3fe9946e8acb14116ad0f93deebb149851ef22a", size = 1424264, upload-time = "2026-01-15T20:28:23.747Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0c/4d02a6229b333af088a0cfd06f236de221baaf16ebf3806529d2c7dfb0da/onyx_devtools-0.3.2-py3-none-win_arm64.whl", hash = "sha256:a2da66ab167cc2dc612cfbecf1e04a517e3a1d5e9ea121d07a90478a3dc8e307", size = 1297957, upload-time = "2026-01-15T20:28:26.11Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## How Has This Been Tested?

```
source .venv/bin/activate
ods --version
```

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded ODS (onyx-devtools) to v0.3.2 for dev tooling. This updates the local CLI and has no production impact.

<sup>Written for commit 822ccfa0c30354d187e5b43256041c71fae81e7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

