### PR TITLE
refactor: move api server config to shared configs, move api url builder to shared configs, simplify overriding api server url

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -12,16 +12,6 @@ from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_SYSTEM_PROMPT
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT
 
-#####
-# App Configs
-#####
-APP_HOST = "0.0.0.0"
-APP_PORT = 8080
-# API_PREFIX is used to prepend a base path for all API routes
-# generally used if using a reverse proxy which doesn't support stripping the `/api`
-# prefix from requests directed towards the API server. In these cases, set this to `/api`
-APP_API_PREFIX = os.environ.get("API_PREFIX", "")
-
 # Whether to send user metadata (user_id/email and session_id) to the LLM provider.
 # Disabled by default.
 SEND_USER_METADATA_TO_LLM_PROVIDER = (

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -33,9 +33,6 @@ from onyx.auth.schemas import UserUpdate
 from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
 from onyx.auth.users import fastapi_users
-from onyx.configs.app_configs import APP_API_PREFIX
-from onyx.configs.app_configs import APP_HOST
-from onyx.configs.app_configs import APP_PORT
 from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
@@ -141,6 +138,9 @@ from onyx.utils.telemetry import RecordType
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from onyx.utils.variable_functionality import global_version
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
+from shared_configs.configs import APP_API_PREFIX
+from shared_configs.configs import APP_HOST
+from shared_configs.configs import APP_PORT
 from shared_configs.configs import CORS_ALLOWED_ORIGIN
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA

--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -151,8 +151,4 @@ Expected response:
 - `MCP_SERVER_CORS_ORIGINS`: Comma-separated CORS origins (optional)
 
 **API Server Connection:**
-- `API_SERVER_BASE_URL`: Full API base URL (e.g., `https://cloud.onyx.app/api`). If set, overrides protocol/host/port below.
-- `ONYX_URL`: Alternative to `API_SERVER_BASE_URL` (same purpose, either can be used)
-- `API_SERVER_PROTOCOL`: Protocol for internal API calls (default: "http")
-- `API_SERVER_HOST`: Host for internal API calls (default: "127.0.0.1")
-- `API_SERVER_PORT`: Port for internal API calls (default: 8080)
+- `API_SERVER_URL_OVERRIDE`: Full API base URL (e.g., `https://cloud.onyx.app/api`). Use this if you wanted to self-host the MCP server, but not the full Onyx application.

--- a/backend/onyx/mcp_server/auth.py
+++ b/backend/onyx/mcp_server/auth.py
@@ -5,9 +5,9 @@ from typing import Optional
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
 
-from onyx.mcp_server.utils import get_api_server_url
 from onyx.mcp_server.utils import get_http_client
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import get_api_server_url
 
 logger = setup_logger()
 
@@ -19,7 +19,7 @@ class OnyxTokenVerifier(TokenVerifier):
         """Call API /me to verify the token, return minimal AccessToken on success."""
         try:
             response = await get_http_client().get(
-                f"{get_api_server_url()}/me",
+                f"{get_api_server_url(use_env_ovverride_if_set=True)}/me",
                 headers={"Authorization": f"Bearer {token}"},
             )
         except Exception as exc:

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -3,10 +3,10 @@
 from typing import Any
 
 from onyx.mcp_server.api import mcp_server
-from onyx.mcp_server.utils import get_api_server_url
 from onyx.mcp_server.utils import get_http_client
 from onyx.mcp_server.utils import require_access_token
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import get_api_server_url
 
 logger = setup_logger()
 
@@ -119,7 +119,7 @@ logger = setup_logger()
 #     # Call the API server
 #     try:
 #         response = await get_http_client().post(
-#             f"{get_api_server_url()}/query/document-search",
+#             f"{get_api_server_url(use_env_ovverride_if_set=True)}/query/document-search",
 #             json=search_request.model_dump(mode="json"),
 #             headers={"Authorization": f"Bearer {access_token.token}"},
 #         )
@@ -183,7 +183,7 @@ async def search_web(
     try:
         request_payload = {"queries": [query], "max_results": limit}
         response = await get_http_client().post(
-            f"{get_api_server_url()}/web-search/search-lite",
+            f"{get_api_server_url(use_env_ovverride_if_set=True)}/web-search/search-lite",
             json=request_payload,
             headers={"Authorization": f"Bearer {access_token.token}"},
         )
@@ -229,7 +229,7 @@ async def open_urls(
 
     try:
         response = await get_http_client().post(
-            f"{get_api_server_url()}/web-search/open-urls",
+            f"{get_api_server_url(use_env_ovverride_if_set=True)}/web-search/open-urls",
             json={"urls": urls},
             headers={"Authorization": f"Bearer {access_token.token}"},
         )

--- a/backend/onyx/mcp_server/utils.py
+++ b/backend/onyx/mcp_server/utils.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import os
-
 import httpx
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.dependencies import get_access_token
 
-from onyx.configs.app_configs import APP_API_PREFIX
-from onyx.configs.app_configs import APP_PORT
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import get_api_server_url
 
 logger = setup_logger()
 
@@ -34,21 +31,6 @@ def require_access_token() -> AccessToken:
             "MCP Server requires an Onyx access token to authenticate your request"
         )
     return access_token
-
-
-def get_api_server_url() -> str:
-    """Construct the API server base URL for internal or external requests."""
-    override = os.getenv("API_SERVER_BASE_URL") or os.getenv("ONYX_URL")
-    if override:
-        return override.rstrip("/")
-
-    protocol = os.getenv("API_SERVER_PROTOCOL", "http")
-    host = os.getenv("API_SERVER_HOST", "127.0.0.1")
-    port = os.getenv("API_SERVER_PORT", str(APP_PORT))
-    prefix = (APP_API_PREFIX or "").strip("/")
-
-    base = f"{protocol}://{host}:{port}"
-    return f"{base}/{prefix}" if prefix else base
 
 
 def get_http_client() -> httpx.AsyncClient:
@@ -79,7 +61,7 @@ async def get_indexed_sources(
     headers = {"Authorization": f"Bearer {access_token.token}"}
     try:
         response = await get_http_client().get(
-            f"{get_api_server_url()}/manage/indexed-sources",
+            f"{get_api_server_url(use_env_ovverride_if_set=True)}/manage/indexed-sources",
             headers=headers,
         )
         response.raise_for_status()

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -10,8 +10,8 @@ from onyx.auth.users import current_curator_or_admin_user
 from onyx.auth.users import current_limited_user
 from onyx.auth.users import current_user
 from onyx.auth.users import current_user_with_expired_token
-from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.configs import APP_API_PREFIX
 
 
 PUBLIC_ENDPOINT_SPECS = [

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -225,6 +225,39 @@ else:
 # Usage limit window in seconds (default: 1 week = 604800 seconds)
 USAGE_LIMIT_WINDOW_SECONDS = int(os.environ.get("USAGE_LIMIT_WINDOW_SECONDS", "604800"))
 
+
+#####
+# App Configs
+#####
+APP_HOST = "0.0.0.0"
+APP_PORT = 8080
+# API_PREFIX is used to prepend a base path for all API routes
+# generally used if using a reverse proxy which doesn't support stripping the `/api`
+# prefix from requests directed towards the API server. In these cases, set this to `/api`
+APP_API_PREFIX = os.environ.get("API_PREFIX", "")
+API_SERVER_URL_OVERRIDE = os.environ.get("API_SERVER_URL_OVERRIDE")
+
+
+def get_api_server_url(use_env_ovverride_if_set: bool = False) -> str:
+    """Construct the API server base URL for internal or external requests.
+
+    This function is used by services that need to communicate with the
+    Onyx API server (e.g., MCP server, Discord bot).
+
+    use_env_ovverride_if_set can be used to deploy a service against a separate Onyx API server,
+    such as self-hosting the Onyx MCP server with the Onyx Cloud API backend.
+
+    Returns:
+        The base URL for the API server (e.g., "http://127.0.0.1:8080")
+    """
+    override = API_SERVER_URL_OVERRIDE if use_env_ovverride_if_set else None
+    if override:
+        return override.rstrip("/")
+
+    base = f"http://{APP_HOST}:{APP_PORT}"
+    return f"{base}/{APP_API_PREFIX}" if APP_API_PREFIX else base
+
+
 # Per-week LLM usage cost limits in cents (e.g., 1000 = $10.00)
 # Trial users get lower limits than paid users
 USAGE_LIMIT_LLM_COST_CENTS_TRIAL = int(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized API server config in shared_configs and simplified URL overrides via API_SERVER_URL_OVERRIDE. This reduces duplicate config and makes self-hosted services (like MCP) easier to point at a different API server.

- **Refactors**
  - Moved APP_HOST, APP_PORT, and APP_API_PREFIX to shared_configs.
  - Moved get_api_server_url to shared_configs and used it across MCP and server code.
  - Updated MCP README to document the single override var: API_SERVER_URL_OVERRIDE.

- **Migration**
  - Replace API_SERVER_BASE_URL, ONYX_URL, API_SERVER_PROTOCOL/HOST/PORT with API_SERVER_URL_OVERRIDE.
  - If MCP or other services should call a remote Onyx API, set API_SERVER_URL_OVERRIDE to that base URL.

<sup>Written for commit ed5aee70887011549349ac0388d4dabdc7018080. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

