### PR TITLE
chore(devtools): fix `ods` README typo

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -68,7 +68,7 @@ ods db <subcommand>
 
 - `dump` - Create a database dump
 - `restore` - Restore from a dump
-- `migrate` - Run database migrations
+- `upgrade`/`downgrade` - Run database migrations
 - `drop` - Drop a database
 
 Run `ods db --help` for detailed usage.


### PR DESCRIPTION
## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the ods README: the DB migration subcommands are upgrade/downgrade, not migrate. This aligns the docs with the actual CLI usage.

<sup>Written for commit 13656217e65cf6631853003bfb3af80f66b350d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

