### PR TITLE
feat: url builder for api server http requests

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -22,6 +22,14 @@ APP_PORT = 8080
 # prefix from requests directed towards the API server. In these cases, set this to `/api`
 APP_API_PREFIX = os.environ.get("API_PREFIX", "")
 
+# Certain services need to make HTTP requests to the API server, such as the MCP server and Discord bot
+API_SERVER_PROTOCOL = os.environ.get("API_SERVER_PROTOCOL", "http")
+API_SERVER_HOST = os.environ.get("API_SERVER_HOST", "127.0.0.1")
+# This override allows self-hosting the MCP server with Onyx Cloud backend.
+API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS = os.environ.get(
+    "API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS"
+)
+
 # Whether to send user metadata (user_id/email and session_id) to the LLM provider.
 # Disabled by default.
 SEND_USER_METADATA_TO_LLM_PROVIDER = (

--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -151,8 +151,6 @@ Expected response:
 - `MCP_SERVER_CORS_ORIGINS`: Comma-separated CORS origins (optional)
 
 **API Server Connection:**
-- `API_SERVER_BASE_URL`: Full API base URL (e.g., `https://cloud.onyx.app/api`). If set, overrides protocol/host/port below.
-- `ONYX_URL`: Alternative to `API_SERVER_BASE_URL` (same purpose, either can be used)
-- `API_SERVER_PROTOCOL`: Protocol for internal API calls (default: "http")
-- `API_SERVER_HOST`: Host for internal API calls (default: "127.0.0.1")
-- `API_SERVER_PORT`: Port for internal API calls (default: 8080)
+- `API_SERVER_PROTOCOL`: Protocol for API server connection (default: "http")
+- `API_SERVER_HOST`: Hostname for API server connection (default: "127.0.0.1")
+- `API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS`: Optional override URL. If set, takes precedence over the protocol/host variables. Used for self-hosting the MCP server with Onyx Cloud as the backend.

--- a/backend/onyx/mcp_server/auth.py
+++ b/backend/onyx/mcp_server/auth.py
@@ -5,9 +5,9 @@ from typing import Optional
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
 
-from onyx.mcp_server.utils import get_api_server_url
 from onyx.mcp_server.utils import get_http_client
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
 
@@ -19,7 +19,7 @@ class OnyxTokenVerifier(TokenVerifier):
         """Call API /me to verify the token, return minimal AccessToken on success."""
         try:
             response = await get_http_client().get(
-                f"{get_api_server_url()}/me",
+                f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/me",
                 headers={"Authorization": f"Bearer {token}"},
             )
         except Exception as exc:

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -3,10 +3,10 @@
 from typing import Any
 
 from onyx.mcp_server.api import mcp_server
-from onyx.mcp_server.utils import get_api_server_url
 from onyx.mcp_server.utils import get_http_client
 from onyx.mcp_server.utils import require_access_token
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
 
@@ -119,7 +119,7 @@ logger = setup_logger()
 #     # Call the API server
 #     try:
 #         response = await get_http_client().post(
-#             f"{get_api_server_url()}/query/document-search",
+#             f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/query/document-search",
 #             json=search_request.model_dump(mode="json"),
 #             headers={"Authorization": f"Bearer {access_token.token}"},
 #         )
@@ -183,7 +183,7 @@ async def search_web(
     try:
         request_payload = {"queries": [query], "max_results": limit}
         response = await get_http_client().post(
-            f"{get_api_server_url()}/web-search/search-lite",
+            f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/web-search/search-lite",
             json=request_payload,
             headers={"Authorization": f"Bearer {access_token.token}"},
         )
@@ -229,7 +229,7 @@ async def open_urls(
 
     try:
         response = await get_http_client().post(
-            f"{get_api_server_url()}/web-search/open-urls",
+            f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/web-search/open-urls",
             json={"urls": urls},
             headers={"Authorization": f"Bearer {access_token.token}"},
         )

--- a/backend/onyx/utils/variable_functionality.py
+++ b/backend/onyx/utils/variable_functionality.py
@@ -4,6 +4,12 @@ import inspect
 from typing import Any
 from typing import TypeVar
 
+from onyx.configs.app_configs import API_SERVER_HOST
+from onyx.configs.app_configs import API_SERVER_PROTOCOL
+from onyx.configs.app_configs import API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
+from onyx.configs.app_configs import APP_API_PREFIX
+from onyx.configs.app_configs import APP_PORT
+from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from onyx.utils.logger import setup_logger
 
@@ -158,3 +164,22 @@ def fetch_ee_implementation_or_noop(
     except Exception as e:
         logger.error(f"Failed to fetch implementation for {module}.{attribute}: {e}")
         raise
+
+
+def build_api_server_url_for_http_requests(
+    respect_env_override_if_set: bool = False,
+) -> str:
+    """
+    Builds the API server URL for HTTP requests.
+    """
+    if DEV_MODE:
+        url = f"http://127.0.0.1:{APP_PORT}"
+    elif respect_env_override_if_set and API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS:
+        url = API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS.rstrip("/")
+    else:
+        url = f"{API_SERVER_PROTOCOL}://{API_SERVER_HOST}:{APP_PORT}"
+
+    if APP_API_PREFIX:
+        url += f"/{APP_API_PREFIX.strip('/')}"
+
+    return url

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -326,7 +326,6 @@ services:
   #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
   #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
   #     - API_SERVER_HOST=api_server
-  #     - API_SERVER_PORT=8080
   #   extra_hosts:
   #     - "host.docker.internal:host-gateway"
   #   logging:

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -126,7 +126,6 @@ services:
   #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
   #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
   #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
   #   extra_hosts:
   #     - "host.docker.internal:host-gateway"
   #   logging:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -145,7 +145,6 @@ services:
   #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
   #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
   #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
   #   extra_hosts:
   #     - "host.docker.internal:host-gateway"
   #   logging:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -158,7 +158,6 @@ services:
   #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
   #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
   #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
   #   extra_hosts:
   #     - "host.docker.internal:host-gateway"
   #   logging:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -204,7 +204,6 @@ services:
   #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
   #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
   #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #     - API_SERVER_PORT=${API_SERVER_PORT:-8080}
   #   extra_hosts:
   #     - "host.docker.internal:host-gateway"
   #   logging:

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -93,7 +93,8 @@ spec:
               value: "{{ .Values.mcpServer.corsOrigins }}"
             {{- end }}
             # API server connection for authentication and proxying
-            - name: API_SERVER_BASE_URL
+            # Uses full override variable to set the port instead of using default 8080
+            - name: API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
               value: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }}"
             {{- include "onyx.envSecrets" . | nindent 12 }}
           {{- with .Values.mcpServer.volumeMounts }}


### PR DESCRIPTION
## Description

- Certain services need to make HTTP requests to the API server, such as the MCP server and the Discord bot.
- Deleted old MCP server URL builder and created a new shared one

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check
