### PR TITLE
fix(fe): fix Text padding with wrapping

### DIFF
--- a/web/src/refresh-components/texts/Text.tsx
+++ b/web/src/refresh-components/texts/Text.tsx
@@ -200,7 +200,12 @@ export default function Text({
         className
       )}
     >
-      {children}
+      {/* NOTE: We want a small, horizontal padding applied to text components to visually
+        complement the white-space implicit with line-height. We apply it internally such that
+        padding applied to the tag directly is additive making the likelihood of 2px offsets with
+        other text elements much lower.
+        */}
+      <span className="px-[2px] box-decoration-clone">{children}</span>
     </Tag>
   );
 }


### PR DESCRIPTION
## Description

The pseudo-element approach worked to make padding on the element addative, but it was only applied to the first line (before) and last line (after), so text which wrapped had a 2px indentation.

## How Has This Been Tested?

Before and After (with 16px padding instead of 2px for exaggeration)

<img width="1215" height="958" alt="20260115_18h09m33s_grim" src="https://github.com/user-attachments/assets/591d08b5-cfd1-4bf3-98b7-f7218bd3b8f3" />


<img width="1209" height="1003" alt="20260115_18h08m02s_grim" src="https://github.com/user-attachments/assets/cd7da31f-f997-4f34-9747-8d53d187ba11" />


Confirmed motivator for the pseudo-element change is un-regressed:
<img width="1512" height="2085" alt="20260115_18h06m34s_grim" src="https://github.com/user-attachments/assets/47ebdfb6-7aea-48b4-94ae-54ef6b679de6" />


## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Text component padding so wrapped lines no longer indent by 2px. Replace before/after pseudo-elements with an internal span (px-[2px] + box-decoration-clone) to apply consistent horizontal padding on each line while keeping outer padding additive.

<sup>Written for commit 5e23065a93d74393989005e2303a1e05adf33476. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



