### PR TITLE
fix: delete old notifications first in migration

### DIFF
--- a/backend/alembic/versions/8405ca81cc83_notifications_constraint.py
+++ b/backend/alembic/versions/8405ca81cc83_notifications_constraint.py
@@ -24,6 +24,9 @@ def upgrade() -> None:
     # in unique constraints, but we want NULL == NULL for deduplication).
     # The '{}' represents an empty JSONB object as the NULL replacement.
 
+    # Clean up legacy notifications first
+    op.execute("DELETE FROM notification WHERE title = 'New Notification'")
+
     op.execute(
         """
         CREATE UNIQUE INDEX IF NOT EXISTS ix_notification_user_type_data
@@ -39,9 +42,6 @@ def upgrade() -> None:
         ON notification (user_id, dismissed, first_shown DESC)
         """
     )
-
-    # Clean up legacy 'reindex' notifications that are no longer needed
-    op.execute("DELETE FROM notification WHERE title = 'New Notification'")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete legacy "New Notification" rows before creating the unique index to avoid conflicts during migration. Remove the duplicate cleanup at the end to keep the migration safe and idempotent.

<sup>Written for commit b491a160d1171661a2661c0245e2189cca03b120. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

