### PR TITLE
enhancement: prompt tuning

### DIFF
--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -10,7 +10,9 @@ ALT_CITATION_GUIDANCE_REPLACEMENT_PAT = "[[CITATION_GUIDANCE]]"
 # This is editable by the user in the admin UI.
 # The first line is intended to help guide the general feel/behavior of the system.
 DEFAULT_SYSTEM_PROMPT = f"""
-You are a highly capable, thoughtful, and precise assistant. Your goal is to deeply understand the user's intent, ask clarifying questions when needed, think step-by-step through complex problems, provide clear and accurate answers, and proactively anticipate helpful follow-up information. Always prioritize being truthful, nuanced, insightful, and efficient.
+You are an expert assistant who is truthful, nuanced, insightful, and efficient. \
+Your goal is to deeply understand the user's intent, think step-by-step through complex problems, provide clear and accurate answers, and proactively anticipate helpful follow-up information. \
+Whenever there is any ambiguity around the user's query (or more information would be helpful), you use available tools (if any) to get more context.
 
 The current date is {DATETIME_REPLACEMENT_PAT}.{CITATION_GUIDANCE_REPLACEMENT_PAT}
 

--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -5,11 +5,15 @@ TOOL_SECTION_HEADER = "\n\n# Tools\n"
 
 # This section is included if there are search type tools, currently internal_search and web_search
 TOOL_DESCRIPTION_SEARCH_GUIDANCE = """
-For questions that can be answered from existing knowledge, answer the user directly without using any tools. If you suspect your knowledge is outdated or for topics where things are rapidly changing, use search tools to get more context.
+For questions that can be answered from existing knowledge, answer the user directly without using any tools. \
+If you suspect your knowledge is outdated or for topics where things are rapidly changing, use search tools to get more context. \
+For statements that may be describing or referring to a document, run a search for the document. \
+In ambiguous cases, favor searching to get more context.
 
 When using any search type tool, do not make any assumptions and stay as faithful to the user's query as possible. \
 Between internal and web search (if both are available), think about if the user's query is likely better answered by team internal sources or online web pages. \
-When searching for information, if the initial results cannot fully answer the user's query, try again with different tools or arguments. Do not repeat the same or very similar queries if it already has been run in the chat history.
+When searching for information, if the initial results cannot fully answer the user's query, try again with different tools or arguments. \
+Do not repeat the same or very similar queries if it already has been run in the chat history.
 
 If it is unclear which tool to use, consider using multiple in parallel to be efficient with time.
 """


### PR DESCRIPTION
## Description
Make it use tools more when ambiguous

## How Has This Been Tested?
Ran like 15 queries, seemed good

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tune chat and tool prompts to favor using tools/search when queries are ambiguous, improving context gathering and answer accuracy.
System prompt now explicitly prefers tool use when more context is needed; tool guidance favors searching in ambiguous cases, searches for referenced documents, avoids repeating similar queries, and chooses internal vs web sources appropriately.

<sup>Written for commit c1f4b7abab3aa349b2b4bf579a4c90168001a987. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

