### PR TITLE
chore(fe): enable reactStrictMode

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -16,6 +16,7 @@ const cspHeader = `
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true,
   productionBrowserSourceMaps: false,
   output: "standalone",
   transpilePackages: ["@onyx/opal"],


### PR DESCRIPTION
## Description

Seems simple enough and useful, https://nextjs.org/docs/pages/api-reference/config/next-config-js/reactStrictMode

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled React Strict Mode by setting reactStrictMode: true in next.config.js to catch side-effect bugs and unsafe patterns during development. This impacts only dev; production behavior is unchanged.

<sup>Written for commit 576386cee02b10ffde6c1c34b25908ebdf7cd9af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

