### PR TITLE
refactor(fe): remove redundant `as="span"` usage

### DIFF
--- a/web/src/app/chat/components/ChatPopup.tsx
+++ b/web/src/app/chat/components/ChatPopup.tsx
@@ -95,7 +95,7 @@ export function ChatPopup() {
                   <Text as="p" mainUiBody text03 {...props} />
                 ),
                 strong: ({ node, ...props }) => (
-                  <Text as="span" mainUiBody text03 {...props} />
+                  <Text mainUiBody text03 {...props} />
                 ),
                 h1: ({ node, ...props }) => (
                   <Text as="p" headingH1 text03 {...props} />
@@ -155,7 +155,7 @@ export function ChatPopup() {
                           />
                         ),
                         strong: ({ node, ...props }) => (
-                          <Text as="span" mainUiBody text04 {...props} />
+                          <Text mainUiBody text04 {...props} />
                         ),
                         li: ({ node, ...props }) => (
                           <Text as="li" mainUiBody text04 {...props} />

--- a/web/src/app/ee/admin/theme/Preview.tsx
+++ b/web/src/app/ee/admin/theme/Preview.tsx
@@ -24,7 +24,7 @@ const previewMarkdownComponents = {
         {...rest}
         className={cn(className, "underline underline-offset-2")}
       >
-        <Text as="span" text03 figureSmallValue>
+        <Text text03 figureSmallValue>
           {children}
         </Text>
       </a>

--- a/web/src/components/modals/ExceptionTraceModal.tsx
+++ b/web/src/components/modals/ExceptionTraceModal.tsx
@@ -34,12 +34,12 @@ export default function ExceptionTraceModal({
                 }}
                 className="flex w-fit items-center hover:bg-accent-background p-2 border-border border rounded"
               >
-                <Text as="span">Copy full trace</Text>
+                <Text>Copy full trace</Text>
                 <SvgCopy className="stroke-text-04 ml-2 h-4 w-4 flex flex-shrink-0" />
               </button>
             ) : (
               <div className="flex w-fit items-center hover:bg-accent-background p-2 border-border border rounded cursor-default">
-                <Text as="span">Copied to clipboard</Text>
+                <Text>Copied to clipboard</Text>
                 <SvgCheck className="stroke-text-04 my-auto ml-2 h-4 w-4 flex flex-shrink-0" />
               </div>
             )}

--- a/web/src/components/search/results/Citation.tsx
+++ b/web/src/components/search/results/Citation.tsx
@@ -90,7 +90,7 @@ export function Citation({
                          hover:bg-background-tint-04 shadow-sm"
               style={{ transform: "translateY(-10%)", lineHeight: "1" }}
             >
-              <Text figureSmallValue as="span" className="truncate">
+              <Text figureSmallValue className="truncate">
                 {citationText}
               </Text>
             </span>

--- a/web/src/components/tools/ExpandableContentWrapper.tsx
+++ b/web/src/components/tools/ExpandableContentWrapper.tsx
@@ -65,12 +65,7 @@ export default function ExpandableContentWrapper({
     >
       <CardHeader className="w-full bg-background-tint-02 top-0 p-3">
         <div className="flex justify-between items-center">
-          <Text
-            as="span"
-            className="text-ellipsis line-clamp-1"
-            text03
-            mainUiAction
-          >
+          <Text className="text-ellipsis line-clamp-1" text03 mainUiAction>
             {fileDescriptor.name || "Untitled"}
           </Text>
           <div className="flex flex-row items-center justify-end gap-1">

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -81,7 +81,7 @@ const footerMarkdownComponents = {
         {...rest}
         className={cn(className, "underline underline-offset-2")}
       >
-        <Text as="span" text03 secondaryAction>
+        <Text text03 secondaryAction>
           {children}
         </Text>
       </a>

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -200,7 +200,7 @@ function LabelLayout({
           {label}
         </Text>
         {optional && (
-          <Text text03 mainContentMuted as="span">
+          <Text text03 mainContentMuted>
             {" (Optional)"}
           </Text>
         )}

--- a/web/src/refresh-components/EnabledCount.tsx
+++ b/web/src/refresh-components/EnabledCount.tsx
@@ -13,7 +13,7 @@ const EnabledCount = memo(
   ({ name, enabledCount, totalCount }: EnabledCountProps) => {
     return (
       <Text as="p" text03 mainUiBody>
-        <Text mainUiBody className="text-action-link-05" as="span">
+        <Text mainUiBody className="text-action-link-05">
           {enabledCount}
         </Text>
         {` of ${totalCount} ${name ?? ""}${

--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -357,7 +357,7 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
           </DialogPrimitive.Title>
           {description && (
             <DialogPrimitive.Description asChild>
-              <Text secondaryBody text03 as="span">
+              <Text secondaryBody text03>
                 {description}
               </Text>
             </DialogPrimitive.Description>

--- a/web/src/refresh-components/Pagination.tsx
+++ b/web/src/refresh-components/Pagination.tsx
@@ -81,7 +81,6 @@ export default function Pagination({
           return (
             <Text
               key={`ellipsis-${index}`}
-              as="span"
               secondaryBody
               text03
               className={cn("px-3 py-2")}

--- a/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
@@ -139,9 +139,7 @@ export default function CustomAgentAvatar({
   if (validFirstLetter) {
     return (
       <SvgOctagonWrapper size={size}>
-        <Text as="span" style={{ fontSize: size * 0.5 }}>
-          {firstLetter}
-        </Text>
+        <Text style={{ fontSize: size * 0.5 }}>{firstLetter}</Text>
       </SvgOctagonWrapper>
     );
   }

--- a/web/src/refresh-components/buttons/Button.tsx
+++ b/web/src/refresh-components/buttons/Button.tsx
@@ -107,7 +107,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           )}
         >
           {typeof children === "string" ? (
-            <Text className={cn("whitespace-nowrap", textClass)} as="span">
+            <Text className={cn("whitespace-nowrap", textClass)}>
               {children}
             </Text>
           ) : (

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -119,11 +119,11 @@ export function PerUserAuthConfig({
         <FormField.Description>
           Format headers for each user to fill in their individual credentials.
           Use placeholders like{" "}
-          <Text text03 secondaryMono className="inline" as="span">
+          <Text text03 secondaryMono className="inline">
             {"{api_key}"}
           </Text>{" "}
           or{" "}
-          <Text text03 secondaryMono className="inline" as="span">
+          <Text text03 secondaryMono className="inline">
             {"{user_email}"}
           </Text>
           . Users will be prompted to provide values for placeholders (except


### PR DESCRIPTION
## Description

This is now the default, so these are unnecessary.

## How Has This Been Tested?

no-op

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant as="span" props from Text usages now that span is the default. No UI or behavior changes—just cleaner JSX across chat, admin preview, modals, search citations, pagination, avatars, buttons, and layouts.

<sup>Written for commit 34f4d368b3a1f585f1dd914ae010a56161c75310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

