### PR TITLE
fix(vespa): Make ID retrieval always check for tenant ID; Add additional tenant ID checks in the new interface

### DIFF
--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -484,13 +484,16 @@ class VespaIndex(DocumentIndex):
             tenant_id=get_current_tenant_id(),
             multitenant=MULTI_TENANT,
         )
-        if tenant_state.tenant_id != index_batch_params.tenant_id:
-            raise ValueError(
-                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {index_batch_params.tenant_id}."
-            )
         if tenant_state.multitenant != self.multitenant:
             raise ValueError(
                 f"Bug: Multitenant mismatch. Expected {tenant_state.multitenant}, got {self.multitenant}."
+            )
+        if (
+            tenant_state.multitenant
+            and tenant_state.tenant_id != index_batch_params.tenant_id
+        ):
+            raise ValueError(
+                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {index_batch_params.tenant_id}."
             )
         vespa_document_index = VespaDocumentIndex(
             index_name=self.index_name,
@@ -670,13 +673,13 @@ class VespaIndex(DocumentIndex):
             tenant_id=get_current_tenant_id(),
             multitenant=MULTI_TENANT,
         )
-        if tenant_state.tenant_id != tenant_id:
-            raise ValueError(
-                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {tenant_id}."
-            )
         if tenant_state.multitenant != self.multitenant:
             raise ValueError(
                 f"Bug: Multitenant mismatch. Expected {tenant_state.multitenant}, got {self.multitenant}."
+            )
+        if tenant_state.multitenant and tenant_state.tenant_id != tenant_id:
+            raise ValueError(
+                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {tenant_id}."
             )
 
         vespa_document_index = VespaDocumentIndex(
@@ -714,13 +717,13 @@ class VespaIndex(DocumentIndex):
             tenant_id=get_current_tenant_id(),
             multitenant=MULTI_TENANT,
         )
-        if tenant_state.tenant_id != tenant_id:
-            raise ValueError(
-                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {tenant_id}."
-            )
         if tenant_state.multitenant != self.multitenant:
             raise ValueError(
                 f"Bug: Multitenant mismatch. Expected {tenant_state.multitenant}, got {self.multitenant}."
+            )
+        if tenant_state.multitenant and tenant_state.tenant_id != tenant_id:
+            raise ValueError(
+                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {tenant_id}."
             )
         vespa_document_index = VespaDocumentIndex(
             index_name=self.index_name,
@@ -776,24 +779,10 @@ class VespaIndex(DocumentIndex):
         offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunk]:
-        # This function will break if callers do not supply tenant ID, which we
-        # were seeing for id_based_retrieval. In practice callers always supply
-        # tenant ID for this function as of the time of this writing so this
-        # should not break, and the extra check below is good. In practice
-        # callers were not supplying tenant ID for id_based_retrieval.
-        tenant_id = filters.tenant_id if filters.tenant_id is not None else ""
         tenant_state = TenantState(
             tenant_id=get_current_tenant_id(),
             multitenant=MULTI_TENANT,
         )
-        if tenant_state.tenant_id != tenant_id:
-            raise ValueError(
-                f"Bug: Tenant ID mismatch. Expected {tenant_state.tenant_id}, got {tenant_id}."
-            )
-        if tenant_state.multitenant != self.multitenant:
-            raise ValueError(
-                f"Bug: Multitenant mismatch. Expected {tenant_state.multitenant}, got {self.multitenant}."
-            )
         vespa_document_index = VespaDocumentIndex(
             index_name=self.index_name,
             tenant_state=tenant_state,


### PR DESCRIPTION
## Description
We're seeing that tenant ID is not being set for ID retrieval, and this is causing issues with the more restrictive document index interface. This PR gets tenant ID from the context and supplies this for document index endpoints that never supplied it. For endpoints that do supply it, this PR just adds an additional check that the supplied ID matches the context ID.

When we get rid of the old interface entirely all this logic will become simpler.

## How Has This Been Tested?
Testing locally now.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure all Vespa index operations use the context tenant ID and validate it, fixing ID-based retrieval failures and preventing cross-tenant access with the new interface.

- **Bug Fixes**
  - Build TenantState from get_current_tenant_id() + MULTI_TENANT across index, update_single, delete_single, id_based_retrieval, hybrid_retrieval, and random_retrieval.
  - Validate provided tenant_id against context; raise on mismatch. Also check multitenant flag.
  - Stop relying on filters.tenant_id; retrieval always uses context tenant.
  - Pass a consistent TenantState to VespaDocumentIndex.

<sup>Written for commit 1e0652bd687f7714d843ee9b3c5f8fdd61481e32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



