### PR TITLE
feat: Doc search optionally returns contents

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/models.py
+++ b/backend/ee/onyx/server/query_and_chat/models.py
@@ -1,9 +1,11 @@
+from collections.abc import Sequence
 from datetime import datetime
 
 from pydantic import BaseModel
 from pydantic import Field
 
 from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import SearchDoc
 from onyx.server.manage.models import StandardAnswer
 
@@ -30,12 +32,62 @@ class SendSearchQueryRequest(BaseModel):
     filters: BaseFilters | None = None
     num_docs_fed_to_llm_selection: int | None = None
     run_query_expansion: bool = False
+
+    include_content: bool = False
     stream: bool = False
+
+
+class SearchDocWithContent(SearchDoc):
+    # Allows None because this is determined by a flag but the object used in code
+    # of the search path uses this type
+    content: str | None
+
+    @classmethod
+    def from_inference_sections(
+        cls,
+        sections: Sequence[InferenceSection],
+        include_content: bool = False,
+        is_internet: bool = False,
+    ) -> list["SearchDocWithContent"]:
+        """Convert InferenceSections to SearchDocWithContent objects.
+
+        Args:
+            sections: Sequence of InferenceSection objects
+            include_content: If True, populate content field with combined_content
+            is_internet: Whether these are internet search results
+
+        Returns:
+            List of SearchDocWithContent with optional content
+        """
+        if not sections:
+            return []
+
+        return [
+            cls(
+                document_id=(chunk := section.center_chunk).document_id,
+                chunk_ind=chunk.chunk_id,
+                semantic_identifier=chunk.semantic_identifier or "Unknown",
+                link=chunk.source_links[0] if chunk.source_links else None,
+                blurb=chunk.blurb,
+                source_type=chunk.source_type,
+                boost=chunk.boost,
+                hidden=chunk.hidden,
+                metadata=chunk.metadata,
+                score=chunk.score,
+                match_highlights=chunk.match_highlights,
+                updated_at=chunk.updated_at,
+                primary_owners=chunk.primary_owners,
+                secondary_owners=chunk.secondary_owners,
+                is_internet=is_internet,
+                content=section.combined_content if include_content else None,
+            )
+            for section in sections
+        ]
 
 
 class SearchFullResponse(BaseModel):
     all_executed_queries: list[str]
-    search_docs: list[SearchDoc]
+    search_docs: list[SearchDocWithContent]
     # Reasoning tokens output by the LLM for the document selection
     doc_selection_reasoning: str | None = None
     # This a list of document ids that are in the search_docs list

--- a/backend/ee/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/ee/onyx/server/query_and_chat/streaming_models.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import BaseModel
 from pydantic import ConfigDict
 
-from onyx.context.search.models import SearchDoc
+from ee.onyx.server.query_and_chat.models import SearchDocWithContent
 
 
 class SearchQueriesPacket(BaseModel):
@@ -17,7 +17,7 @@ class SearchDocsPacket(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     type: Literal["search_docs"] = "search_docs"
-    search_docs: list[SearchDoc]
+    search_docs: list[SearchDocWithContent]
 
 
 class SearchErrorPacket(BaseModel):


### PR DESCRIPTION
## Description
^

## How Has This Been Tested?
Works locally hitting the API

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make document search optionally return section content. Adds a new response model and threads the content flag through the API and MCP tool.

- **New Features**
  - Added include_content flag to SendSearchQueryRequest to return combined section content when true.
  - Introduced SearchDocWithContent and updated SearchFullResponse and streaming packets to use it.
  - Converted InferenceSection objects to SearchDocWithContent, populating content based on the flag.
  - Re-enabled and updated MCP search_indexed_documents to call /search/send-search-message, support source_types/time_cutoff filters, and return simplified results with content.

<sup>Written for commit 2cc8b4bceb086aa599ae29d99a2960047daf21de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

