### PR TITLE
Fix auto-scroll setting persistence in Workspace Settings

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -412,6 +412,7 @@ class OnyxRedisLocks:
     SLACK_BOT_LOCK = "da_lock:slack_bot"
     SLACK_BOT_HEARTBEAT_PREFIX = "da_heartbeat:slack_bot"
     ANONYMOUS_USER_ENABLED = "anonymous_user_enabled"
+    AUTO_SCROLL = "auto_scroll"
 
     CLOUD_BEAT_TASK_GENERATOR_LOCK = "da_lock:cloud_beat_task_generator"
     CLOUD_CHECK_ALEMBIC_BEAT_LOCK = "da_lock:cloud_check_alembic"


### PR DESCRIPTION
**What changed**

* Load auto-scroll preference from Redis
* Persist default value when missing
* Include auto_scroll in returned Settings so UI reflects saved state

**Testing**

* Verified toggle persists after revisiting Workspace Settings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persistence of the auto-scroll setting in Workspace Settings. The setting is now loaded and saved in Redis (defaulting to off when missing), and included in returned Settings so the UI consistently shows the saved state.

<sup>Written for commit 1cc903187e74ced40fb6b80aa870b853f71575f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

