### PR TITLE
feat(ee): enforce seat limits on user operations

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -322,7 +322,9 @@ def check_seat_availability(
     current_used = get_used_seats(tenant_id)
     total_seats = metadata.seats
 
-    if current_used + seats_needed > total_seats:
+    # Use > (not >=) to allow filling to exactly 100% capacity
+    would_exceed_limit = current_used + seats_needed > total_seats
+    if would_exceed_limit:
         return SeatAvailabilityResult(
             available=False,
             error_message=f"Seat limit would be exceeded: {current_used} of {total_seats} seats used, "

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -388,20 +388,20 @@ def bulk_invite_users(
             detail=f"Invalid email address: {email} - {str(e)}",
         )
 
-    # Count only truly new users (not already invited or existing)
+    # Count only new users (not already invited or existing) that need seats
     existing_users = {user.email for user in get_all_users(db_session)}
     already_invited = set(get_invited_users())
-    truly_new_emails = [
+    emails_needing_seats = [
         e
         for e in new_invited_emails
         if e not in existing_users and e not in already_invited
     ]
 
     # Check seat availability for new users
-    if truly_new_emails:
+    if emails_needing_seats:
         result = fetch_ee_implementation_or_noop(
             "onyx.db.license", "check_seat_availability", None
-        )(db_session, seats_needed=len(truly_new_emails))
+        )(db_session, seats_needed=len(emails_needing_seats))
         if result is not None and not result.available:
             raise HTTPException(status_code=402, detail=result.error_message)
 


### PR DESCRIPTION
## Description

Enforce license seat limits on user invite/add operations with proper concurrency handling.

**Seat enforcement:**
- `check_seat_availability()` validates seats before invite/add operations
- Returns 402 "Seat limit exceeded" when at capacity
- Self-hosted without license = unlimited (no enforcement)

**Cross-tenant invitations:**
- Users with active mappings to other tenants receive INACTIVE mappings (invitations)
- Invitations don't consume seats until accepted
- Only users without existing active mappings consume seats immediately

**Race condition prevention:**
- Row locking (`SELECT FOR UPDATE`) prevents concurrent bulk invites from exceeding limits
- Seat checks run inside transactions to ensure atomicity

**Performance:**
- Batched queries in `add_users_to_tenant` (2 queries instead of 2N)

## How Has This Been Tested?

full e2e test locally. verified that adding/inviting new users fails and surfaces a popup notification to the user

## Additional Options

- [x] [Optional] Override Linear Check
closes https://linear.app/onyx-app/issue/ENG-3394/enforce-seat-limits-on-user-invite