### PR TITLE
feat(billing): add seat management endpoint to data plane

### DIFF
--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -113,7 +113,7 @@ def update_seat_count(tenant_id: str, new_seat_count: int) -> SeatUpdateResponse
         "tenant_id": tenant_id,
         "new_seat_count": new_seat_count,
     }
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
     response.raise_for_status()
 
     data = response.json()

--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -131,6 +131,8 @@ async def update_seats(
 
     try:
         return update_seat_count(tenant_id, request.new_seat_count)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Failed to update seats")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/ee/onyx/server/tenants/models.py
+++ b/backend/ee/onyx/server/tenants/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.server.settings.models import ApplicationStatus
 
@@ -103,7 +104,7 @@ class ApproveUserRequest(BaseModel):
 class SeatUpdateRequest(BaseModel):
     """Request to update seat count for a tenant."""
 
-    new_seat_count: int
+    new_seat_count: int = Field(gt=0)
 
 
 class SeatUpdateResponse(BaseModel):


### PR DESCRIPTION
## Description

Add `POST /tenants/seats/update` endpoint that allows admins to update the seat count for their tenant. This endpoint calls the control plane's `/seats/update` API which handles Stripe proration and license regeneration.

Changes:
- Add `SeatUpdateRequest` and `SeatUpdateResponse` models
- Add `update_seat_count()` function to call control plane API
- Add `/tenants/seats/update` endpoint requiring admin auth

## How Has This Been Tested?

- [ ] Verify endpoint accepts valid seat count and returns response
- [ ] Verify non-admin users cannot access endpoint (401/403)
- [ ] Verify control plane integration works end-to-end

## Linear

Part of https://linear.app/onyx-app/issue/ENG-3393/seat-management-api-with-stripe-proration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an admin-only endpoint POST /tenants/seats/update to change a tenant’s seat count. It proxies to the control plane for Stripe proration and license regeneration, meeting ENG-3393.

- **New Features**
  - Added /tenants/seats/update (admin-only for current tenant); preserves control-plane status codes.
  - Implemented billing.update_seat_count to call CONTROL_PLANE_API_BASE_URL/seats/update with a data-plane token and a 30s timeout.
  - Added models: SeatUpdateRequest (new_seat_count > 0) and SeatUpdateResponse (success, current_seats, used_seats, message).

<sup>Written for commit 151eb6bf0e7977cc0a46f5c0271f37a325a311d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

