### PR TITLE
feat: init configs file and move simple_cli_client configs

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -22,9 +22,6 @@ APP_PORT = 8080
 # prefix from requests directed towards the API server. In these cases, set this to `/api`
 APP_API_PREFIX = os.environ.get("API_PREFIX", "")
 
-# URL for the build webapp proxy endpoint
-BUILD_WEBAPP_URL = os.environ.get("BUILD_WEBAPP_URL", "")
-
 # Whether to send user metadata (user_id/email and session_id) to the LLM provider.
 # Disabled by default.
 SEND_USER_METADATA_TO_LLM_PROVIDER = (
@@ -1004,16 +1001,4 @@ INSTANCE_TYPE = (
     "managed"
     if os.environ.get("IS_MANAGED_INSTANCE", "").lower() == "true"
     else "cloud" if AUTH_TYPE == AuthType.CLOUD else "self_hosted"
-)
-
-# Persistent Document Storage Configuration
-# When enabled, indexed documents are written to local filesystem with hierarchical structure
-PERSISTENT_DOCUMENT_STORAGE_ENABLED = (
-    os.environ.get("PERSISTENT_DOCUMENT_STORAGE_ENABLED", "").lower() == "true"
-)
-
-# Base directory path for persistent document storage (local filesystem)
-# Example: /var/onyx/indexed-docs or /app/indexed-docs
-PERSISTENT_DOCUMENT_STORAGE_PATH = os.environ.get(
-    "PERSISTENT_DOCUMENT_STORAGE_PATH", "/app/indexed-docs"
 )

--- a/backend/onyx/indexing/adapters/document_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/document_indexing_adapter.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 
 from onyx.access.access import get_access_for_documents
 from onyx.access.models import DocumentAccess
-from onyx.configs.app_configs import PERSISTENT_DOCUMENT_STORAGE_ENABLED
 from onyx.configs.constants import DEFAULT_BOOST
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexAttemptMetadata
@@ -24,6 +23,7 @@ from onyx.indexing.models import BuildMetadataAwareChunksResult
 from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.indexing.models import IndexChunk
 from onyx.indexing.models import UpdatableChunkData
+from onyx.server.features.build.configs import PERSISTENT_DOCUMENT_STORAGE_ENABLED
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/indexing/persistent_document_writer.py
+++ b/backend/onyx/indexing/persistent_document_writer.py
@@ -134,7 +134,7 @@ class PersistentDocumentWriter:
 
 def get_persistent_document_writer() -> PersistentDocumentWriter:
     """Factory function to create a PersistentDocumentWriter with default configuration"""
-    from onyx.configs.app_configs import PERSISTENT_DOCUMENT_STORAGE_PATH
+    from onyx.server.features.build.configs import PERSISTENT_DOCUMENT_STORAGE_PATH
 
     return PersistentDocumentWriter(
         base_path=PERSISTENT_DOCUMENT_STORAGE_PATH,

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -9,8 +9,8 @@ from fastapi import Response
 from fastapi.responses import StreamingResponse
 
 from onyx.auth.users import current_user
-from onyx.configs.app_configs import BUILD_WEBAPP_URL
 from onyx.db.models import User
+from onyx.server.features.build.configs import BUILD_WEBAPP_URL
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -1,0 +1,20 @@
+import os
+
+# Persistent Document Storage Configuration
+# When enabled, indexed documents are written to local filesystem with hierarchical structure
+PERSISTENT_DOCUMENT_STORAGE_ENABLED = (
+    os.environ.get("PERSISTENT_DOCUMENT_STORAGE_ENABLED", "").lower() == "true"
+)
+
+# Base directory path for persistent document storage (local filesystem)
+# Example: /var/onyx/indexed-docs or /app/indexed-docs
+PERSISTENT_DOCUMENT_STORAGE_PATH = os.environ.get(
+    "PERSISTENT_DOCUMENT_STORAGE_PATH", ""
+)
+
+SANDBOX_BASE_PATH = os.environ.get("SANDBOX_BASE_PATH", "")
+OUTPUTS_TEMPLATE_PATH = os.environ.get("OUTPUTS_TEMPLATE_PATH", "")
+VENV_TEMPLATE_PATH = os.environ.get("VENV_TEMPLATE_PATH", "")
+
+# URL for the build webapp proxy endpoint
+BUILD_WEBAPP_URL = os.environ.get("BUILD_WEBAPP_URL", "")

--- a/backend/onyx/server/features/build/simple_cli_client.py
+++ b/backend/onyx/server/features/build/simple_cli_client.py
@@ -26,12 +26,12 @@ from claude_agent_sdk.types import ToolUseBlock
 from pydantic import BaseModel
 from pydantic import ConfigDict
 
-from onyx.configs.app_configs import PERSISTENT_DOCUMENT_STORAGE_PATH
+from onyx.server.features.build.configs import OUTPUTS_TEMPLATE_PATH
+from onyx.server.features.build.configs import PERSISTENT_DOCUMENT_STORAGE_PATH
+from onyx.server.features.build.configs import SANDBOX_BASE_PATH
+from onyx.server.features.build.configs import VENV_TEMPLATE_PATH
 from onyx.utils.logger import setup_logger
 
-SANDBOX_BASE_PATH = "/Users/chrisweaver/data/sandboxes"
-OUTPUTS_TEMPLATE_PATH = "/Users/chrisweaver/data/outputs_template/outputs"
-VENV_TEMPLATE_PATH = "/Users/chrisweaver/data/venv_template"
 OUTPUTS_DIR = "outputs"
 VENV_DIR = ".venv"
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes build and persistent storage configuration into a new build configs module, and replaces hardcoded paths in the simple CLI client with environment variables. Updates imports across build and indexing code to use the new module.

- **Refactors**
  - Added backend/onyx/server/features/build/configs.py for build and storage env vars (persistent storage, BUILD_WEBAPP_URL, SANDBOX_BASE_PATH, OUTPUTS_TEMPLATE_PATH, VENV_TEMPLATE_PATH).
  - Removed related settings from app_configs.py and updated imports in indexing adapter, persistent document writer, build API, and simple_cli_client.
  - simple_cli_client now reads paths from env instead of hardcoded values.

- **Migration**
  - Set SANDBOX_BASE_PATH, OUTPUTS_TEMPLATE_PATH, and VENV_TEMPLATE_PATH for the CLI to run.
  - Set PERSISTENT_DOCUMENT_STORAGE_PATH explicitly if you relied on the previous default (/app/indexed-docs), as the default is now empty.

<sup>Written for commit 40972f40d75107c18f054ff71a67e8ff3c000981. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

