### PR TITLE
fix: add explicit cleanup for accumulated state in LLM loops

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -623,3 +623,20 @@ class DynamicCitationProcessor:
         if not self.citation_to_doc:
             return 1
         return max(self.citation_to_doc.keys()) + 1
+
+    def clear(self) -> None:
+        """Clear all accumulated state to release memory.
+
+        Call this after processing is complete and the citation data has been
+        used/saved. This allows garbage collection of SearchDoc instances and
+        the accumulated LLM output string.
+        """
+        self.citation_to_doc.clear()
+        self.seen_citations.clear()
+        self.cited_documents_in_order.clear()
+        self.cited_document_ids.clear()
+        self.recent_cited_documents.clear()
+        self.llm_out = ""
+        self.curr_segment = ""
+        self.hold = ""
+        self.non_citation_count = 0

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -653,3 +653,12 @@ def run_llm_loop(
                 obj=OverallStop(type="stop"),
             )
         )
+
+        # Clear accumulated state to release memory after processing is complete.
+        # The state_container holds the data needed for saving, and the completion_callback
+        # in run_chat_loop_with_state_containers will handle persistence.
+        citation_processor.clear()
+        simple_chat_history.clear()
+        if gathered_documents:
+            gathered_documents.clear()
+        citation_mapping.clear()

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -675,3 +675,9 @@ def run_deep_research_llm_loop(
                 obj=OverallStop(type="stop"),
             )
         )
+
+        # Clear accumulated state to release memory after processing is complete.
+        # The state_container holds the data needed for saving, and the completion_callback
+        # in run_chat_loop_with_state_containers will handle persistence.
+        citation_mapping.clear()
+        simple_chat_history.clear()

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -386,9 +386,15 @@ def run_research_agent_call(
                         ),
                     )
                     span.span_data.output = final_report if final_report else None
+                    # Extract seen citations before clearing (copy to avoid clearing the reference)
+                    seen_citations = dict(citation_processor.get_seen_citations())
+                    # Clear accumulated state to release memory
+                    citation_processor.clear()
+                    msg_history.clear()
+                    citation_mapping.clear()
                     return ResearchAgentCallResult(
                         intermediate_report=final_report,
-                        citation_mapping=citation_processor.get_seen_citations(),
+                        citation_mapping=seen_citations,
                     )
                 elif special_tool_calls.think_tool_call:
                     think_tool_call = special_tool_calls.think_tool_call
@@ -548,9 +554,15 @@ def run_research_agent_call(
                 ),
             )
             span.span_data.output = final_report if final_report else None
+            # Extract seen citations before clearing (copy to avoid clearing the reference)
+            seen_citations = dict(citation_processor.get_seen_citations())
+            # Clear accumulated state to release memory
+            citation_processor.clear()
+            msg_history.clear()
+            citation_mapping.clear()
             return ResearchAgentCallResult(
                 intermediate_report=final_report,
-                citation_mapping=citation_processor.get_seen_citations(),
+                citation_mapping=seen_citations,
             )
 
         except Exception as e:


### PR DESCRIPTION
## Description

Addresses memory leak in deep research/LLM loop where objects accumulated during request processing were never explicitly cleaned up. This caused memory to remain allocated even after requests completed.

Changes:
- Add `clear()` method to `ChatStateContainer` to reset accumulated tool_calls, tokens, and citation mappings
- Add `clear()` method to `DynamicCitationProcessor` to reset all tracked citations and output buffers
- Add cleanup calls at end of `run_llm_loop`, `run_deep_research_llm_loop`, and `run_research_agent_call`
- Add cleanup in `run_chat_loop_with_state_containers` finally block (after completion callback saves data)

## How Has This Been Tested?

- [ ] Verify syntax with `python -m py_compile` on all modified files
- [ ] Manual testing of chat and deep research flows
- [ ] Monitor memory usage under load to confirm cleanup effectiveness

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit cleanup of accumulated state in chat and deep research LLM loops to stop memory growth after requests complete. This prevents leaks and reduces memory usage once data is saved.

- **Bug Fixes**
  - Added clear() to ChatStateContainer and DynamicCitationProcessor to reset collections and buffers.
  - Call cleanup at the end of run_llm_loop and run_deep_research_llm_loop; also clear state in run_chat_loop_with_state_containers finally block and drain the emitter queue.
  - In research_agent, copy seen citations before clearing; then clear the citation processor, message history, and citation mapping.

<sup>Written for commit 6bc31e2410852673815a839735329e242d77106c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

