### PR TITLE
fix(chrome extension): make new tab page not scrollable

### DIFF
--- a/web/src/app/css/nrf.css
+++ b/web/src/app/css/nrf.css
@@ -7,7 +7,6 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Description

make new tab page for chrome extension not scrollable

## How Has This Been Tested?

Locally

## Additional Options

- [x] [Optional] Override Linear Check
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent vertical scrolling on the New Tab page by adjusting the container layout so it no longer exceeds the viewport.

- **Bug Fixes**
  - Removed min-height: 100vh from web/src/app/css/nrf.css to eliminate unintended vertical scroll while keeping overflow: hidden.

<sup>Written for commit 770d8bc48daf7f8f8318b6d590064508a1317d19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
