### PR TITLE
fix(chrome extension): auto focus on input bar

### DIFF
--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -110,6 +110,7 @@ export interface ChatInputBarProps {
   setPresentingDocument?: (document: MinimalOnyxDocument) => void;
   toggleDeepResearch: () => void;
   disabled: boolean;
+  tabIndex?: number;
 }
 
 const ChatInputBar = React.memo(
@@ -136,6 +137,7 @@ const ChatInputBar = React.memo(
         toggleDeepResearch,
         setPresentingDocument,
         disabled,
+        tabIndex,
       },
       ref
     ) => {
@@ -511,6 +513,7 @@ const ChatInputBar = React.memo(
                 "pt-3"
               )}
               autoFocus
+              tabIndex={tabIndex}
               style={{ scrollbarWidth: "thin" }}
               role="textarea"
               aria-multiline

--- a/web/src/app/chat/nrf/NRFPage.tsx
+++ b/web/src/app/chat/nrf/NRFPage.tsx
@@ -328,6 +328,7 @@ export default function NRFPage({
             rightIcon={SvgExternalLink}
             onClick={handleOpenInOnyx}
             className="nrf-header-button"
+            tabIndex={0}
           >
             Open in Onyx
           </Button>
@@ -337,6 +338,7 @@ export default function NRFPage({
             tertiary
             tooltip="Open settings"
             className="nrf-header-button"
+            tabIndex={0}
           />
         </div>
       )}
@@ -408,6 +410,7 @@ export default function NRFPage({
                         !llmManager.isLoadingProviders &&
                         !llmManager.hasAnyProvider
                       }
+                      tabIndex={!isSidePanel ? 1 : undefined}
                     />
                   </div>
                 </div>
@@ -456,6 +459,7 @@ export default function NRFPage({
                   disabled={
                     !llmManager.isLoadingProviders && !llmManager.hasAnyProvider
                   }
+                  tabIndex={!isSidePanel ? 1 : undefined}
                 />
               </div>
             )}


### PR DESCRIPTION
## Description

when you open a new tab and click tab, it auto focuses on the chat input bar

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-focuses the chat input and sets tab order so the NRF new tab focuses it first; makes the “Open in Onyx” and settings header buttons focusable via Tab.

<sup>Written for commit 0054adaafe150d9152cdc2172888638014ee0647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"roshan/ce-nits-2","parentHead":"77f287835cf5298ef5e23f2e162862a4e32d87e6","parentPull":7531,"trunk":"main"}
```
-->
