### PR TITLE
fix(chrome extension): remove bottom padding in chrome extension once message is sent

### DIFF
--- a/web/src/app/chat/nrf/NRFPage.tsx
+++ b/web/src/app/chat/nrf/NRFPage.tsx
@@ -374,6 +374,7 @@ export default function NRFPage({
                         stopGenerating={stopGenerating}
                         handleResubmitLastMessage={handleResubmitLastMessage}
                         deepResearchEnabled={deepResearchEnabled}
+                        applyBottomMargin={false}
                       />
                     </div>
                   </div>

--- a/web/src/components/chat/ChatScrollContainer.tsx
+++ b/web/src/components/chat/ChatScrollContainer.tsx
@@ -46,6 +46,9 @@ export interface ChatScrollContainerProps {
 
   /** Session ID - resets scroll state when changed */
   sessionId?: string;
+
+  /** Whether to apply bottom margin for input bar clearance (default: true) */
+  applyBottomMargin?: boolean;
 }
 
 const FadeOverlay = React.memo(
@@ -79,6 +82,7 @@ const ChatScrollContainer = React.memo(
         isStreaming = false,
         onScrollButtonVisibilityChange,
         sessionId,
+        applyBottomMargin = true,
       }: ChatScrollContainerProps,
       ref: ForwardedRef<ChatScrollContainerHandle>
     ) => {
@@ -385,7 +389,11 @@ const ChatScrollContainer = React.memo(
       ]);
 
       return (
-        <div className="flex flex-col flex-1 min-h-0 w-full relative overflow-hidden mb-[7.5rem]">
+        <div
+          className={`flex flex-col flex-1 min-h-0 w-full relative overflow-hidden ${
+            applyBottomMargin ? "mb-[7.5rem]" : ""
+          }`}
+        >
           <FadeOverlay show={hasContentAbove} position="top" />
           <FadeOverlay show={hasContentBelow} position="bottom" />
 

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -49,6 +49,7 @@ export interface ChatUIProps {
   stopGenerating: () => void;
   handleResubmitLastMessage: () => void;
   onScrollButtonVisibilityChange?: (visible: boolean) => void;
+  applyBottomMargin?: boolean;
 }
 
 const ChatUI = React.memo(
@@ -65,6 +66,7 @@ const ChatUI = React.memo(
         stopGenerating,
         handleResubmitLastMessage,
         onScrollButtonVisibilityChange,
+        applyBottomMargin = true,
       }: ChatUIProps,
       ref: ForwardedRef<ChatUIHandle>
     ) => {
@@ -110,6 +112,7 @@ const ChatUI = React.memo(
           autoScroll={autoScrollEnabled}
           isStreaming={isStreaming}
           onScrollButtonVisibilityChange={onScrollButtonVisibilityChange}
+          applyBottomMargin={applyBottomMargin}
         >
           <MessageList
             messages={messages}


### PR DESCRIPTION
## Description

remove bottom padding in chrome extension once message is sent

## How Has This Been Tested?

Fixes
<img width="1236" height="794" alt="image" src="https://github.com/user-attachments/assets/5ed5507a-ab18-45e5-99f9-1c616365afd7" />

Locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove extra bottom spacing in the NRF Chrome extension chat so the content sits flush after sending messages. Makes the input clearance margin configurable and disables it in NRF.

- **Bug Fixes**
  - Disable bottom margin in NRFPage (applyBottomMargin=false) to remove unused space in the extension.

- **Refactors**
  - Add applyBottomMargin prop to ChatScrollContainer and ChatUI (default: true).

<sup>Written for commit 7b40fb9a13bd3839a2b68101cbf6c39114eca036. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"roshan/ce-nits-4","parentHead":"0054adaafe150d9152cdc2172888638014ee0647","parentPull":7533,"trunk":"main"}
```
-->
