### PR TITLE
chore(fe): align assistant icon with chat bar

### DIFF
--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -113,7 +113,7 @@ const MessageList = React.memo(
     );
 
     return (
-      <div className="w-[min(50rem,100%)] px-4">
+      <div className="w-[min(50rem,100%)] px-6">
         <Spacer />
         {messages.map((message, i) => {
           const messageReactComponentKey = `message-${message.nodeId}`;


### PR DESCRIPTION
## Description

Request from Duo, https://onyx-company.slack.com/archives/C09BHKH5PML/p1768850032597989?thread_ts=1768849090.909309&cid=C09BHKH5PML

## How Has This Been Tested?

<img width="748" height="1030" alt="20260119_11h39m54s_grim" src="https://github.com/user-attachments/assets/802a64e6-4692-4d4a-a23b-d643517e5aa1" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the assistant icon with the chat bar by increasing horizontal padding in MessageList (px-4 → px-6) for consistent spacing and visual alignment.

<sup>Written for commit 71fa40cddceb3d5c8bea30f5fb89a4b133cf48cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

