### PR TITLE
refactor: proxy customer portal session through control plane

### DIFF
--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -70,6 +70,26 @@ def fetch_billing_information(
     return BillingInformation(**response_data)
 
 
+def fetch_customer_portal_session(tenant_id: str, return_url: str | None = None) -> str:
+    """
+    Fetch a Stripe customer portal session URL from the control plane.
+    NOTE: This is currently only used for multi-tenant (cloud) deployments.
+    Self-hosted proxy endpoints will be added in a future phase.
+    """
+    token = generate_data_plane_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    url = f"{CONTROL_PLANE_API_BASE_URL}/create-customer-portal-session"
+    payload = {"tenant_id": tenant_id}
+    if return_url:
+        payload["return_url"] = return_url
+    response = requests.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+    return response.json()["url"]
+
+
 def register_tenant_users(tenant_id: str, number_of_users: int) -> stripe.Subscription:
     """
     Send a request to the control service to register the number of users for a tenant.

--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -1,14 +1,12 @@
-import stripe
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
 
 from ee.onyx.auth.users import current_admin_user
-from ee.onyx.configs.app_configs import STRIPE_SECRET_KEY
 from ee.onyx.server.tenants.access import control_plane_dep
 from ee.onyx.server.tenants.billing import fetch_billing_information
+from ee.onyx.server.tenants.billing import fetch_customer_portal_session
 from ee.onyx.server.tenants.billing import fetch_stripe_checkout_session
-from ee.onyx.server.tenants.billing import fetch_tenant_stripe_information
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import ProductGatingFullSyncRequest
 from ee.onyx.server.tenants.models import ProductGatingRequest
@@ -23,7 +21,6 @@ from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import get_current_tenant_id
 
-stripe.api_key = STRIPE_SECRET_KEY
 logger = setup_logger()
 
 router = APIRouter(prefix="/tenants")
@@ -82,21 +79,17 @@ async def billing_information(
 async def create_customer_portal_session(
     _: User = Depends(current_admin_user),
 ) -> dict:
+    """
+    Create a Stripe customer portal session via the control plane.
+    NOTE: This is currently only used for multi-tenant (cloud) deployments.
+    Self-hosted proxy endpoints will be added in a future phase.
+    """
     tenant_id = get_current_tenant_id()
+    return_url = f"{WEB_DOMAIN}/admin/billing"
 
     try:
-        stripe_info = fetch_tenant_stripe_information(tenant_id)
-        stripe_customer_id = stripe_info.get("stripe_customer_id")
-        if not stripe_customer_id:
-            raise HTTPException(status_code=400, detail="Stripe customer ID not found")
-        logger.info(stripe_customer_id)
-
-        portal_session = stripe.billing_portal.Session.create(
-            customer=stripe_customer_id,
-            return_url=f"{WEB_DOMAIN}/admin/billing",
-        )
-        logger.info(portal_session)
-        return {"url": portal_session.url}
+        portal_url = fetch_customer_portal_session(tenant_id, return_url)
+        return {"url": portal_url}
     except Exception as e:
         logger.exception("Failed to create customer portal session")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Description

Remove direct Stripe API calls from data plane for the customer portal session. Portal session is now fetched via the control plane's `/create-customer-portal-session` endpoint.

- Added `fetch_customer_portal_session` to `billing.py` - calls control plane
- Updated `billing_api.py` to use the new function instead of calling Stripe directly
- Removed `stripe` import and `STRIPE_SECRET_KEY` from `billing_api.py`

Note: This is currently only for multi-tenant (cloud) deployments. Self-hosted proxy endpoints will be added in a future phase.

## How Has This Been Tested?

```
nikolas@nikolass-macbook-pro cloud-deployment-yamls % curl -s -X POST http://localhost:3000/api/tenants/create-customer-portal-session \
    -H "Cookie: fastapiusersauth=<READACTED>" \
    -H "Content-Type: application/json" | jq .
{
  "url": "https://billing.stripe.com/p/session/test_YWNjdF8xTndacTJIbGhUWXFSWmliLF9UcDc5d0Jvck1MMUZaQ2NGekYyVVdOeEMydjNaZ2520100Hb1tweFK"
}

# Data plane api server (multi-tenant):
INFO:     01/19/2026 04:35:55 PM                    h11_impl.py  473: [-] ::1:0 - "POST /tenants/create-customer-portal-session HTTP/1.1" 200

Control plane subscription service:
INFO:    01/19/2026 04:38:59 PM                        main.py   71: No metadata
INFO:    01/19/2026 04:38:59 PM             stripe_webhooks.py  258: Processing Stripe event: billing_portal.session.created
WARNING: 01/19/2026 04:38:59 PM             stripe_webhooks.py  270: Unhandled event type: billing_portal.session.created
INFO:    01/19/2026 04:38:59 PM                    h11_impl.py  478: 127.0.0.1:56111 - "POST /webhook HTTP/1.1" 200
```

## Additional Options

- [x] [Optional] Override Linear Check