### PR TITLE
mock router

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -68,6 +68,7 @@ from onyx.server.features.build.api import router as build_router
 from onyx.server.features.build.session_api import (
     session_router as build_session_router,
 )
+from onyx.server.features.build.v1_api import v1_router as build_v1_router
 from onyx.server.features.default_assistant.api import (
     router as default_assistant_router,
 )
@@ -383,6 +384,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, projects_router)
     include_router_with_global_prefix_prepended(application, build_router)
     include_router_with_global_prefix_prepended(application, build_session_router)
+    include_router_with_global_prefix_prepended(application, build_v1_router)
     include_router_with_global_prefix_prepended(application, nextjs_assets_router)
     include_router_with_global_prefix_prepended(application, document_set_router)
     include_router_with_global_prefix_prepended(application, search_settings_router)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the build v1 API router to the FastAPI app so v1 build endpoints are now served behind the global prefix. This enables clients to call /build/v1 routes.

- **New Features**
  - Import build.v1_api.v1_router and register it with include_router_with_global_prefix_prepended.
  - No config changes required.

<sup>Written for commit 4c929efb86c65f2d8c3c80d0a1ac116cc7d1124e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

