### PR TITLE
messages apis + migrations

### DIFF
--- a/backend/alembic/versions/26b589bf8be7_create_build_message_table.py
+++ b/backend/alembic/versions/26b589bf8be7_create_build_message_table.py
@@ -1,0 +1,70 @@
+"""create_build_message_table
+
+Revision ID: 26b589bf8be7
+Revises: df6cbd9a37cc
+Create Date: 2026-01-19 17:51:08.289325
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "26b589bf8be7"
+down_revision = "df6cbd9a37cc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Reuse existing messagetype enum from chat_message table
+    # Build messages only use: USER, ASSISTANT, SYSTEM
+    # Note: The existing enum has uppercase values but MessageType in code uses lowercase
+    # This works because SQLAlchemy handles the conversion when native_enum=False
+
+    # Create build_message table
+    op.create_table(
+        "build_message",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("build_session.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "type",
+            sa.Enum(name="messagetype", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "content",
+            sa.Text(),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create index for build_message
+    op.create_index(
+        "ix_build_message_session_created",
+        "build_message",
+        ["session_id", sa.text("created_at DESC")],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index("ix_build_message_session_created", table_name="build_message")
+
+    # Drop table
+    op.drop_table("build_message")

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -11,11 +11,17 @@ from fastapi.responses import StreamingResponse
 from onyx.auth.users import current_user
 from onyx.db.models import User
 from onyx.server.features.build.configs import BUILD_WEBAPP_URL
+from onyx.server.features.build.messages_api import router as messages_router
+from onyx.server.features.build.sessions_api import router as sessions_router
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 router = APIRouter(prefix="/build")
+
+# Include sub-routers for sessions and messages
+router.include_router(sessions_router, tags=["build"])
+router.include_router(messages_router, tags=["build"])
 
 # Separate router for Next.js static assets at /_next/*
 # This is needed because Next.js apps reference assets with root-relative paths

--- a/backend/onyx/server/features/build/messages_api.py
+++ b/backend/onyx/server/features/build/messages_api.py
@@ -1,0 +1,209 @@
+"""API endpoints for Build Mode message management."""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import current_user
+from onyx.configs.constants import MessageType
+from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.db.build_session import create_message
+from onyx.db.build_session import get_build_session
+from onyx.db.build_session import get_session_messages
+from onyx.db.build_session import update_session_activity
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import User
+from onyx.server.features.build.models import MessageListResponse
+from onyx.server.features.build.models import MessageRequest
+from onyx.server.features.build.models import MessageResponse
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+
+router = APIRouter(prefix="/build/sessions/{session_id}/messages")
+
+
+@router.get("/", tags=PUBLIC_API_TAGS)
+def list_messages(
+    session_id: UUID,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> MessageListResponse:
+    """Get all messages for a build session."""
+    user_id = user.id if user is not None else None
+
+    # Verify session exists and belongs to user
+    session = get_build_session(session_id, user_id, db_session)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Get all messages
+    messages = get_session_messages(session_id, db_session)
+
+    return MessageListResponse(
+        messages=[MessageResponse.from_model(msg) for msg in messages]
+    )
+
+
+async def stream_cli_agent_response(
+    session_id: UUID,
+    user_message_content: str,
+):
+    """
+    Stream the CLI agent's response using SSE format.
+
+    The assistant's response is accumulated during streaming and saved to the
+    database only AFTER the full response is generated. If the user refreshes
+    or disconnects during response generation, that partial response is lost.
+
+    This is a stub implementation. The actual CLI agent communication
+    will be implemented when the CLI agent integration is ready.
+
+    NOTE: Packet types (as defined in plan):
+    - step_start: Begin a logical step (e.g., "Reading requirements")
+    - step_delta: Progress within a step
+    - tool_start: Agent invoking a tool (bash, read, write, etc.)
+    - file_write: File written to sandbox
+    - artifact_created: New artifact generated
+    - output_start: Begin agent's text output
+    - output_delta: Incremental agent text output (accumulated for DB)
+    - done: Signal completion with summary
+
+    Only output_delta content is accumulated and saved to database as MESSAGE.
+    All packets include timestamps.
+    """
+    from datetime import datetime
+
+    # Accumulate the full assistant response (only output_delta packets)
+    full_response = []
+
+    # Get current timestamp
+    def get_timestamp():
+        return datetime.utcnow().isoformat() + "Z"
+
+    # Example step_start packet - agent begins analyzing
+    yield (
+        f'event: message\ndata: {{"type": "step_start", "step_id": "analyze_001", '
+        f'"title": "Analyzing your request", "timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Example step_delta packet - progress update within step
+    yield (
+        f'event: message\ndata: {{"type": "step_delta", "step_id": "analyze_001", '
+        f'"content": "Examining the requirements and context...", '
+        f'"timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Example tool_start packet - agent calling a tool
+    yield (
+        f'event: message\ndata: {{"type": "tool_start", "tool_name": "bash", '
+        f'"tool_input": {{"command": "ls -la /workspace"}}, '
+        f'"timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Example file_write packet - file written to sandbox
+    yield (
+        f'event: message\ndata: {{"type": "file_write", '
+        f'"path": "outputs/web/src/App.tsx", "size_bytes": 1523, '
+        f'"timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Example artifact_created packet
+    yield (
+        f'event: message\ndata: {{"type": "artifact_created", '
+        f'"artifact": {{"id": "uuid-placeholder", "type": "web_app", '
+        f'"name": "Dashboard", "path": "outputs/web/"}}, '
+        f'"timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Example output_start packet - agent begins text output
+    yield f'event: message\ndata: {{"type": "output_start", "timestamp": "{get_timestamp()}"}}\n\n'
+
+    # Example output_delta packets - agent's response text (this gets saved to DB)
+    response_part1 = "I've analyzed your request and created a dashboard application. "
+    full_response.append(response_part1)
+    yield f'event: message\ndata: {{"type": "output_delta", "content": "{response_part1}", "timestamp": "{get_timestamp()}"}}\n\n'
+
+    response_part2 = "The application includes the following features: data visualization, filtering, and export capabilities."
+    full_response.append(response_part2)
+    yield f'event: message\ndata: {{"type": "output_delta", "content": "{response_part2}", "timestamp": "{get_timestamp()}"}}\n\n'
+
+    # Signal completion with summary
+    yield (
+        f'event: message\ndata: {{"type": "done", '
+        f'"summary": "Created a Next.js dashboard with 3 components", '
+        f'"timestamp": "{get_timestamp()}"}}\n\n'
+    )
+
+    # Save the complete assistant response to database
+    # Only output_delta packets are accumulated and saved as the message
+    # We create a new session here because the request-scoped session is closed
+    tenant_id = get_current_tenant_id()
+    with get_session_with_current_tenant(tenant_id) as new_db_session:
+        create_message(
+            session_id=session_id,
+            message_type=MessageType.ASSISTANT,
+            content="".join(full_response),
+            db_session=new_db_session,
+        )
+        logger.info(f"Saved assistant response for session {session_id}")
+
+
+@router.post("/", tags=PUBLIC_API_TAGS)
+async def send_message(
+    session_id: UUID,
+    request: MessageRequest,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+):
+    """
+    Send a message to the CLI agent and stream the response.
+
+    Returns a Server-Sent Events (SSE) stream with the agent's response.
+    """
+    user_id = user.id if user is not None else None
+
+    # Verify session exists and belongs to user
+    session = get_build_session(session_id, user_id, db_session)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Check if sandbox is running
+    if not session.sandbox or session.sandbox.status != SandboxStatus.RUNNING:
+        raise HTTPException(
+            status_code=400,
+            detail="Sandbox is not running. Please wait for it to start.",
+        )
+
+    # Update last activity timestamp
+    update_session_activity(session_id, db_session)
+
+    # Save user message to database
+    user_message = create_message(
+        session_id=session_id,
+        message_type=MessageType.USER,
+        content=request.content,
+        db_session=db_session,
+    )
+
+    logger.info(f"User message {user_message.id} sent to session {session_id}")
+
+    # Stream the CLI agent's response
+    # The assistant's response will be saved to the database after streaming completes
+    return StreamingResponse(
+        stream_cli_agent_response(session_id, request.content),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
+        },
+    )

--- a/backend/onyx/server/features/build/models.py
+++ b/backend/onyx/server/features/build/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from onyx.configs.constants import MessageType
 from onyx.db.enums import ArtifactType
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import SandboxStatus
@@ -89,6 +90,40 @@ class SessionListResponse(BaseModel):
     """Response containing list of sessions."""
 
     sessions: list[SessionResponse]
+
+
+# ===== Message Models =====
+class MessageRequest(BaseModel):
+    """Request to send a message to the CLI agent."""
+
+    content: str
+
+
+class MessageResponse(BaseModel):
+    """Response containing message details."""
+
+    id: str
+    session_id: str
+    type: MessageType
+    content: str
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, message):
+        """Convert BuildMessage ORM model to response."""
+        return cls(
+            id=str(message.id),
+            session_id=str(message.session_id),
+            type=message.type,
+            content=message.content,
+            created_at=message.created_at,
+        )
+
+
+class MessageListResponse(BaseModel):
+    """Response containing list of messages."""
+
+    messages: list[MessageResponse]
 
 
 # ===== Legacy Models (for compatibility with other code) =====


### PR DESCRIPTION
## Description

messages apis and migrations

## How Has This Been Tested?

yolo

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Build Mode message storage and APIs with SSE streaming for agent responses. Saves user messages immediately and writes assistant responses after streaming completes.

- **New Features**
  - BuildMessage model with session relation and created_at index.
  - Alembic migration reusing existing messagetype enum.
  - DB helpers: create_message and get_session_messages.
  - Endpoints: list messages and send message with SSE stream.
  - Validates session ownership and requires sandbox RUNNING.
  - Persists user messages instantly; accumulates assistant output_delta and saves at end.
  - Added MessageRequest/MessageResponse/MessageListResponse models.
  - Included sessions and messages routers under /build.

- **Migration**
  - Run Alembic upgrade to create build_message table and index.
  - No data backfill needed; enum reused.

<sup>Written for commit 08cbbe2feab597a50e5f9730dab0eee786174ba7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

