### PR TITLE
feat(filesys): hierarchyfetching task impl

### DIFF
--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -245,6 +245,8 @@ CheckpointOutput: TypeAlias = Generator[
     Document | HierarchyNode | ConnectorFailure, None, CT
 ]
 
+HierarchyOutput: TypeAlias = Generator[HierarchyNode, None, None]
+
 
 class CheckpointedConnector(BaseConnector[CT]):
     @abc.abstractmethod
@@ -293,4 +295,14 @@ class CheckpointedConnectorWithPermSync(CheckpointedConnector[CT]):
         end: SecondsSinceUnixEpoch,
         checkpoint: CT,
     ) -> CheckpointOutput[CT]:
+        raise NotImplementedError
+
+
+class HierarchyConnector(BaseConnector):
+    @abc.abstractmethod
+    def load_hierarchy(
+        self,
+        start: SecondsSinceUnixEpoch,  # may be unused if the connector must load the full hierarchy each time
+        end: SecondsSinceUnixEpoch,
+    ) -> HierarchyOutput:
         raise NotImplementedError


### PR DESCRIPTION
## Description

actual code for hierarchyfetching task

## How Has This Been Tested?

not yet

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements hierarchy fetching across connectors and integrates hierarchy into search indexing so users can filter by folders, spaces, channels, and similar structure. Connectors can now emit HierarchyNode objects that are stored in Postgres, cached in Redis, and encoded into OpenSearch for fast filtering.

- **New Features**
  - Added HierarchyNode DB model and migration; tracked per-connector last_time_hierarchy_fetch.
  - Implemented hierarchy fetching task with daily beat schedule; instantiates connectors, streams nodes, batch-upserts to Postgres, caches in Redis, and uses last fetch time.
  - Introduced HierarchyConnector interface and HierarchyOutput; permission sync paths ignore nodes for now.
  - Redis cache resolves ancestor chains; OpenSearch chunks include ancestor_hierarchy_bitmap (RoaringBitmap).
  - Personas can reference hierarchy nodes; minimal snapshot models returned by the API.
  - Added debugging scripts for bitmap encoding/decoding; included pyroaring dependency.

- **Migration**
  - Run Alembic migration to create hierarchy_nodes and update connector pairs.
  - Update OpenSearch mappings to add ancestor_hierarchy_bitmap; reindex to populate the field.
  - Deploy workers with the new dependency (pyroaring).

<sup>Written for commit e3a9b2a0219fea98c82720f564694ad88441a3b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

