### PR TITLE
chore(fe): fix sticky header parent height

### DIFF
--- a/web/src/components/chat/ChatScrollContainer.tsx
+++ b/web/src/components/chat/ChatScrollContainer.tsx
@@ -392,14 +392,14 @@ const ChatScrollContainer = React.memo(
           <div
             key={sessionId}
             ref={scrollContainerRef}
-            className="flex flex-1 justify-center min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
+            className="flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
             onScroll={handleScroll}
             style={{
               scrollbarGutter: "stable both-edges",
             }}
           >
             <div
-              className="w-full flex flex-col items-center"
+              className="w-full flex-1 flex flex-col items-center"
               data-scroll-ready={isScrollReady}
               style={{
                 visibility: isScrollReady ? "visible" : "hidden",


### PR DESCRIPTION
## Description

There was a slight bug in [fix(fe): chat header is sticky and transparent #7487](https://github.com/onyx-dot-app/onyx/pull/7487). 

Sticky elements disappear when their parent elements ends. In this case, the inner scroll container element was `663px`, so scrolling beyond that caused the sticky header to disappear,
<img width="1920" height="1080" alt="20260119_21h52m50s_grim" src="https://github.com/user-attachments/assets/53c68855-328d-4e2e-b2ee-2f7b5bf1feba" />


This updates the scroll container such that the inner and outer elements are `flex: 1` and therefore always expand vertically ensuring the header remains visible atop,
<img width="1920" height="1080" alt="20260119_21h51m54s_grim" src="https://github.com/user-attachments/assets/fa63e911-cd54-4a7f-bce7-f421f284eb19" />


## How Has This Been Tested?

Confirmed the header behaves correctly. Also tested auto-scroll + covered by playwright.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a layout bug that caused the sticky chat header to disappear when scrolling past the inner container. The scroll container and its content now expand to full height, keeping the header visible.

- **Bug Fixes**
  - Set outer container to flex-col + flex-1 and inner content to flex-1 for full-height layout.
  - Confirmed behavior manually; auto-scroll unaffected and covered by Playwright.

<sup>Written for commit 05ae3e956ae4f5aa58f3b20220a98e1b7b172900. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

