### PR TITLE
fix(fe): show scroll-down button when user scrolls up during streaming

### DIFF
--- a/web/src/components/chat/ChatScrollContainer.tsx
+++ b/web/src/components/chat/ChatScrollContainer.tsx
@@ -156,11 +156,8 @@ const ChatScrollContainer = React.memo(
         setHasContentAbove(state.hasContentAbove);
         setHasContentBelow(state.hasContentBelow);
 
-        // Compute button visibility: hide when at bottom, or during streaming with auto-scroll
-        const shouldShowButton =
-          !state.isAtBottom &&
-          !(autoScrollRef.current && isStreamingRef.current);
-        onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
+        // Show button when user is not at bottom (e.g., scrolled up)
+        onScrollButtonVisibilityChangeRef.current?.(!state.isAtBottom);
       }, [getScrollState]);
 
       // Scroll to bottom of content
@@ -200,11 +197,10 @@ const ChatScrollContainer = React.memo(
       // Expose scrollToBottom via ref
       useImperativeHandle(ref, () => ({ scrollToBottom }), [scrollToBottom]);
 
-      // Re-evaluate button visibility when streaming state changes
+      // Re-evaluate button visibility when at-bottom state changes
       useEffect(() => {
-        const shouldShowButton = !isAtBottom && !(autoScroll && isStreaming);
-        onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
-      }, [isAtBottom, autoScroll, isStreaming]);
+        onScrollButtonVisibilityChangeRef.current?.(!isAtBottom);
+      }, [isAtBottom]);
 
       // Handle scroll events (user scrolls)
       const handleScroll = useCallback(() => {
@@ -228,10 +224,7 @@ const ChatScrollContainer = React.memo(
           setHasContentAbove(state.hasContentAbove);
           setHasContentBelow(state.hasContentBelow);
           // Update button visibility based on actual position
-          const shouldShowButton =
-            !state.isAtBottom &&
-            !(autoScrollRef.current && isStreamingRef.current);
-          onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
+          onScrollButtonVisibilityChangeRef.current?.(!state.isAtBottom);
         }
 
         // Recalculate spacer for non-auto-scroll mode during user scroll


### PR DESCRIPTION
## Description

Fixed the scroll-down button not appearing when user scrolls up during streaming. The button visibility logic was incorrectly hiding the button whenever `autoScroll && isStreaming` was true, regardless of whether the user had scrolled up to stop following.

Simplified the visibility logic to show the button whenever the user is not at the bottom of the chat.

## How Has This Been Tested?

- Manual testing: Start a chat with streaming response, scroll up during streaming, verify the scroll-down button appears
![2026-01-19 22 49 09](https://github.com/user-attachments/assets/f85abcba-bf8a-48fc-aa6a-abdfc85cb89a)


## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the scroll-down button not appearing when users scroll up during streaming. The button now shows whenever the chat is not at the bottom, regardless of auto-scroll or streaming state.

<sup>Written for commit 322c6c821fe7d2a9cdce5f60fa2582d445cdd6b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

