### PR TITLE
fix(fe): inline code text wraps

### DIFF
--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -68,7 +68,7 @@ export const CodeBlock = memo(function CodeBlock({
           "bg-background-tint-00",
           "rounded",
           "text-xs",
-          "inline-block",
+          "inline",
           "whitespace-pre-wrap",
           "break-words",
           "py-0.5",


### PR DESCRIPTION
## Description

It's probably not semantically correct to call this a `CodeBlock` if it's `inline`, but probably not worth fussing over.

**Before**
<img width="1176" height="1820" alt="20260120_08h39m26s_grim" src="https://github.com/user-attachments/assets/b12924af-af29-4af8-9901-86305a007b89" />

**After**
<img width="1176" height="1820" alt="20260120_08h39m36s_grim" src="https://github.com/user-attachments/assets/bfd89863-63aa-4d93-93c3-6fd0207b5257" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inline code wrapping in chat messages. Change CodeBlock from inline-block to inline so long inline code wraps and doesn’t overflow.

<sup>Written for commit a09800f76fe4011a4e8fc770c1ec1fa3e1774135. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

