### PR TITLE
chore(pre-commit): disallow large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,13 @@ repos:
       #   pass_filenames: true
       #   files: ^backend/.*\.py$
 
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        name: Check for added large files
+        args: ["--maxkb=1500"]
+
   - repo: https://github.com/rhysd/actionlint
     rev: a443f344ff32813837fa49f7aa6cbc478d770e62 # frozen: v1.7.9
     hooks:


### PR DESCRIPTION
## Description

Large files are easy to accidentally check in and very sticky in git history, so let's be intentional about checking them in.

There are currently 2 files over the limit, and neither are expected to be updated regularly,

```
-rw-r--r-- 1 jamison jamison 1.2M Jan 20 08:22 uv.lock
-rw-r--r-- 1 jamison jamison 4.0M Dec 29 14:11 backend/tests/integration/common_utils/test_files/Sample.pdf
-rw-r--r-- 1 jamison jamison 21M Dec 29 14:11 backend/hello-vmlinux.bin
```

## How Has This Been Tested?

`prek run --all-files`

## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-commit hook to block files larger than 1.5 MB from being committed. This prevents accidental large binaries and keeps git history lean.

- **New Features**
  - Added check-added-large-files (pre-commit-hooks v6.0.0) with --maxkb=1500.

- **Migration**
  - If a large file is required, use Git LFS or raise the limit; to bypass once, use git commit --no-verify.

<sup>Written for commit a7059439f181f1e7cc730e7bf0170fe933614a8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

