### PR TITLE
chore(llm): Removing Claude Haiku 3.5

### DIFF
--- a/backend/onyx/llm/model_metadata_enrichments.json
+++ b/backend/onyx/llm/model_metadata_enrichments.json
@@ -54,11 +54,6 @@
     "model_vendor": "amazon",
     "model_version": "v1:0"
   },
-  "anthropic.claude-3-5-haiku-20241022-v1:0": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022-v1:0"
-  },
   "anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "display_name": "Claude Sonnet 3.5",
     "model_vendor": "anthropic",
@@ -1465,11 +1460,6 @@
     "model_vendor": "mistral",
     "model_version": "v0:1"
   },
-  "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022-v1:0"
-  },
   "chat-bison": {
     "display_name": "Chat Bison",
     "model_vendor": "google",
@@ -1498,16 +1488,6 @@
   "chatgpt-4o-latest": {
     "display_name": "ChatGPT 4o",
     "model_vendor": "openai",
-    "model_version": "latest"
-  },
-  "claude-3-5-haiku-20241022": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022"
-  },
-  "claude-3-5-haiku-latest": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
     "model_version": "latest"
   },
   "claude-3-5-sonnet-20240620": {
@@ -1714,11 +1694,6 @@
     "display_name": "Nova Pro",
     "model_vendor": "amazon",
     "model_version": "v1:0"
-  },
-  "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022-v1:0"
   },
   "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "display_name": "Claude Sonnet 3.5",
@@ -3251,15 +3226,6 @@
     "model_vendor": "anthropic",
     "model_version": "latest"
   },
-  "openrouter/anthropic/claude-3-5-haiku": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic"
-  },
-  "openrouter/anthropic/claude-3-5-haiku-20241022": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022"
-  },
   "openrouter/anthropic/claude-3-haiku": {
     "display_name": "Claude Haiku 3",
     "model_vendor": "anthropic"
@@ -3774,11 +3740,6 @@
     "model_vendor": "amazon",
     "model_version": "1:0"
   },
-  "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022"
-  },
   "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "display_name": "Claude Sonnet 3.5",
     "model_vendor": "anthropic",
@@ -3898,15 +3859,6 @@
     "display_name": "Pegasus 1.2",
     "model_vendor": "twelvelabs",
     "model_version": "v1:0"
-  },
-  "vertex_ai/claude-3-5-haiku": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic"
-  },
-  "vertex_ai/claude-3-5-haiku@20241022": {
-    "display_name": "Claude Haiku 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "20241022"
   },
   "vertex_ai/claude-3-5-sonnet": {
     "display_name": "Claude Sonnet 3.5",

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -282,12 +282,12 @@ def test_anthropic_prompt_caching_reduces_costs(
     Anthropic requires explicit cache_control parameters.
     """
     # Create Anthropic LLM
-    # NOTE: prompt caching support is model-specific; `claude-3-5-haiku-20241022` is known
+    # NOTE: prompt caching support is model-specific; `claude-haiku-4-5-20251001` is known
     # to return cache_creation/cache_read usage metrics, while some newer aliases may not.
     llm = LitellmLLM(
         api_key=os.environ["ANTHROPIC_API_KEY"],
         model_provider="anthropic",
-        model_name="claude-3-5-haiku-20241022",
+        model_name="claude-haiku-4-5-20251001",
         max_input_tokens=200000,
     )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Removing to stay ahead

<img width="604" height="772" alt="Screenshot 2026-01-20 at 10 36 37 AM" src="https://github.com/user-attachments/assets/66c6deb6-2d80-4a2f-a85c-688a55982e6e" />

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran updated tests

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all Claude Haiku 3.5 model aliases from the LLM registry and updated the Anthropic prompt-caching test to a supported Haiku model. This removes a deprecated option and keeps caching metrics coverage.

- **Migration**
  - Update any configs using claude-3-5-haiku* IDs (incl. Bedrock/OpenRouter/Vertex AI variants) to claude-haiku-4-5-20251001 or another supported Anthropic model.

<sup>Written for commit 199b0d7af4d23b5241c7bada4ca5b45e45285e90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

