### PR TITLE
fix(billing): remove grandfathered pricing option when subscription lapses

### DIFF
--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -3,8 +3,6 @@
 import { useState } from "react";
 import Link from "next/link";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
-import { fetchCustomerPortal } from "@/lib/billing/utils";
-import { useRouter } from "next/navigation";
 import Button from "@/refresh-components/buttons/Button";
 import InlineExternalLink from "@/refresh-components/InlineExternalLink";
 import { logout } from "@/lib/user";
@@ -33,37 +31,6 @@ const fetchResubscriptionSession = async () => {
 export default function AccessRestricted() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
-
-  const handleManageSubscription = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await fetchCustomerPortal();
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(
-          `Failed to create customer portal session: ${
-            errorData.message || response.statusText
-          }`
-        );
-      }
-
-      const { url } = await response.json();
-
-      if (!url) {
-        throw new Error("No portal URL returned from the server");
-      }
-
-      router.push(url);
-    } catch (error) {
-      console.error("Error creating customer portal session:", error);
-      setError("Error opening customer portal. Please try again later.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const handleResubscribe = async () => {
     setIsLoading(true);
@@ -118,13 +85,6 @@ export default function AccessRestricted() {
           <div className="flex flex-row gap-2">
             <Button onClick={handleResubscribe} disabled={isLoading}>
               {isLoading ? "Loading..." : "Resubscribe"}
-            </Button>
-            <Button
-              secondary
-              onClick={handleManageSubscription}
-              disabled={isLoading}
-            >
-              Manage Existing Subscription
             </Button>
             <Button
               secondary


### PR DESCRIPTION
## Description

Remove the "Manage Existing Subscription" button from the AccessRestrictedPage when a multi-tenant user's subscription lapses.

Previously, users with lapsed subscriptions saw two confusing options:
- "Resubscribe" → creates new subscription at current pricing ($25)
- "Manage Existing Subscription" → opens Stripe portal where they could potentially renew at grandfathered rates ($8)

Now users only see "Resubscribe", which standardizes the renewal flow to always use current pricing. If a user pays their bill on time as expected, they will still use their grandfathered price. 

## How Has This Been Tested?
![2026-01-20 13 34 12](https://github.com/user-attachments/assets/5141bbfb-aa3a-4165-980e-efda33e4e91e)



## Additional Options

- [x] [Optional] Override Linear Check