### PR TITLE
chore(deployments): fetch secrets from AWS

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,7 +9,8 @@ on:
 # Set restrictive default permissions for all jobs. Jobs that need more permissions
 # should explicitly declare them.
 permissions:
-  id-token: write  # Required for OIDC authentication with AWS
+  # Required for OIDC authentication with AWS
+  id-token: write # zizmor: ignore[excessive-permissions]
 
 env:
   EDGE_TAG: ${{ startsWith(github.ref_name, 'nightly-latest') }}


### PR DESCRIPTION
## Description



## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/21187077932/job/60944472056

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move deployment workflow to fetch secrets from AWS Secrets Manager via OIDC, replacing GitHub Secrets for Docker Hub and Slack. Improves security and consistency across build, merge, and scan jobs.

- **Refactors**
  - Configure AWS credentials using OIDC and set environment to release.
  - Fetch DOCKER_USERNAME, DOCKER_TOKEN, and MONITOR_DEPLOYMENTS_WEBHOOK from AWS Secrets Manager.
  - Replace secrets.* with env.* in Docker login, Trivy scans, and Slack notifications.

- **Migration**
  - Ensure repo secret AWS_OIDC_ROLE_ARN is set to the OIDC role ARN.
  - Create these AWS Secrets Manager entries: deploy/docker-username, deploy/docker-token, deploy/monitor-deployments-webhook.

<sup>Written for commit 270a13a137143415ee205927077a39731b3c4289. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



