### PR TITLE
fix(tests): Anthropic Prompt Caching Test

### DIFF
--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -282,12 +282,12 @@ def test_anthropic_prompt_caching_reduces_costs(
     Anthropic requires explicit cache_control parameters.
     """
     # Create Anthropic LLM
-    # NOTE: prompt caching support is model-specific; `claude-haiku-4-5-20251001` is known
+    # NOTE: prompt caching support is model-specific; `claude-3-haiku-20240307` is known
     # to return cache_creation/cache_read usage metrics, while some newer aliases may not.
     llm = LitellmLLM(
         api_key=os.environ["ANTHROPIC_API_KEY"],
         model_provider="anthropic",
-        model_name="claude-haiku-4-5-20251001",
+        model_name="claude-3-haiku-20240307",
         max_input_tokens=200000,
     )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing prompt caching test

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally to ensure that it's consistently working

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Anthropic prompt caching test to use claude-3-haiku-20240307 so cache_creation/cache_read metrics are returned reliably. This makes the test stable and ensures it correctly validates cost reductions from caching.

<sup>Written for commit 7afd1dd76c011b8c03e0a0fd4cc0bc50a02437c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

