### PR TITLE
chore(tests): Mock LLM

### DIFF
--- a/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
+++ b/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
@@ -9,9 +9,9 @@ from sqlalchemy.orm import Session
 
 from onyx.chat.chat_utils import create_chat_session_from_request
 from onyx.chat.models import AnswerStreamPart
-from onyx.chat.models import CreateChatSessionID
 from onyx.chat.models import MessageResponseIDInfo
 from onyx.chat.process_message import handle_stream_message_objects
+from onyx.db.models import ChatSession
 from onyx.db.models import User
 from onyx.server.query_and_chat.models import ChatSessionCreationRequest
 from onyx.server.query_and_chat.models import SendMessageRequest
@@ -50,7 +50,7 @@ def submit_query(
 def create_chat_session(
     db_session: Session,
     user: User,
-) -> CreateChatSessionID:
+) -> ChatSession:
     return create_chat_session_from_request(
         chat_session_request=ChatSessionCreationRequest(),
         user_id=user.id,

--- a/backend/tests/external_dependency_unit/mock_llm.py
+++ b/backend/tests/external_dependency_unit/mock_llm.py
@@ -35,7 +35,7 @@ class MockLLMController(abc.ABC):
 
 
 class MockLLM(LLM, MockLLMController):
-    def __init__(self):
+    def __init__(self) -> None:
         self.stream_controller: SyncStreamController | None = None
 
     def set_response(self, response_tokens: list[str]) -> None:
@@ -86,6 +86,9 @@ class MockLLM(LLM, MockLLMController):
         reasoning_effort: ReasoningEffort | None = None,
         user_identity: LLMUserIdentity | None = None,
     ) -> Iterator[ModelResponseStream]:
+        if not self.stream_controller:
+            return
+
         for idx, token in enumerate(self.stream_controller):
             yield ModelResponseStream(
                 id="chatcmp-123",
@@ -106,7 +109,7 @@ class StreamTimeoutError(Exception):
 
 
 class SyncStreamController:
-    def __init__(self, tokens: list[str], timeout: float = 5.0):
+    def __init__(self, tokens: list[str], timeout: float = 5.0) -> None:
         self.tokens = tokens
         self.position = 0
         self.pending: list[int] = []  # The indices of the tokens that are pending


### PR DESCRIPTION
## Description
Adds a framework for testing with an LLM that we can control.

Allows us to set what the response should be and forward through tokens during runtime.

## How Has This Been Tested?
This is the test

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a packet-based streaming chat test suite using a controllable mock LLM to validate AnswerStreamPart ordering and placement.

- **New Features**
  - Added tests that verify stream flow: MessageResponseIDInfo → AgentResponseStart → per-token AgentResponseDelta packets → OverallStop.
  - Introduced MockLLM with a SyncStreamController (forward and forward_till_end) and a patch for get_llm_for_persona to control token emission.

<sup>Written for commit 974bea0c06a0ef89175e1f261fb869218dde0b23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





