### PR TITLE
chore(blame): unignore checked in `.vscode/` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # editors
 .vscode
+!/.vscode/env_template.txt
+!/.vscode/launch.json
+!/.vscode/tasks.template.jsonc
 .zed
 .cursor
 


### PR DESCRIPTION
## Description

This files are versioned, so we shouldn't ignore them. Keep the rest of the directory ignored by default.

## How Has This Been Tested?

<img width="2202" height="1036" alt="20260120_14h05m32s_grim" src="https://github.com/user-attachments/assets/8f1cc792-ce18-416a-9f74-d79099ee6e6c" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update .gitignore to track .vscode/env_template.txt, .vscode/launch.json, and .vscode/tasks.template.jsonc while keeping the rest of .vscode ignored. Ensures shared VS Code config stays versioned for consistent local setup and debugging.

<sup>Written for commit 7d537656108d3c0029eef7c0bdead598dac53b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

