### PR TITLE
fix: prompt tunings

### DIFF
--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -48,7 +48,7 @@ Do not use the "site:" operator in your web search queries.
 OPEN_URLS_GUIDANCE = """
 
 ## open_url
-Use the `open_url` tool to read the content of one or more URLs. Use this tool to access the contents of the most promising web pages from your searches.
+Use the `open_url` tool to read the content of one or more URLs. Use this tool to access the contents of the most promising web pages from your web searches or user specified URLs.
 You can open many URLs at once by passing multiple URLs in the array if multiple pages seem promising. Prioritize the most promising pages and reputable sources.
 You should almost always use open_url after a web_search call. Use this tool when a user asks about a specific provided URL.
 """

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -832,7 +832,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 top_sections=merged_sections,
                 citation_start=override_kwargs.starting_citation_num,
                 limit=override_kwargs.max_llm_chunks,
-                include_document_id=True,
+                include_document_id=False,
             )
 
             # End overall timing

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -73,7 +73,7 @@ def convert_inference_sections_to_llm_string(
                 link = next(iter(chunk.source_links.values()), None)
             if link:
                 result["url"] = link
-        if include_document_id and "url" not in result:
+        if include_document_id:
             result["document_identifier"] = chunk.document_id
         if chunk.metadata:
             result["metadata"] = json.dumps(chunk.metadata)


### PR DESCRIPTION
## Description
Minor stuff

## How Has This Been Tested?
N/A

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified open_url usage and fixed document ID handling in citations. We no longer emit document IDs by default in expanded search sections; when requested, document IDs are always included even if a URL is present.

- **Bug Fixes**
  - Prompt: updated guidance to cover web searches and user-provided URLs.
  - Citations: set include_document_id=False in expand_section_safe; utils now always adds document_identifier when include_document_id=True.

<sup>Written for commit b168692b58d915735b4bab1c7d04c386b0d5371c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

