### PR TITLE
chore: bg services launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
         "Slack Bot",
         "Celery primary",
         "Celery light",
+        "Celery heavy",
         "Celery docfetching",
         "Celery docprocessing",
         "Celery beat"


### PR DESCRIPTION
## Description

background encompasses most of the other workers, so don't run it as part of the run all

## How Has This Been Tested?

n/a
## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the VS Code launch configuration from “Celery background” to “Celery heavy” so the Onyx Services compound starts the correct worker with Run All.

<sup>Written for commit 3357a58a0b0973019c6dc52b6c2a6bcf9c3b4f96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

