### PR TITLE
chore(fe): blurred message container fills vertically

### DIFF
--- a/web/src/components/chat/ChatScrollContainer.tsx
+++ b/web/src/components/chat/ChatScrollContainer.tsx
@@ -414,9 +414,7 @@ const ChatScrollContainer = React.memo(
               <div ref={endDivRef} />
 
               {/* Spacer to allow scrolling anchor to top */}
-              {spacerHeight > 0 && (
-                <div style={{ height: spacerHeight }} aria-hidden="true" />
-              )}
+              {spacerHeight > 0 && <div aria-hidden="true" />}
             </div>
           </div>
         </div>

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -113,7 +113,7 @@ const MessageList = React.memo(
     );
 
     return (
-      <div className="w-[min(50rem,100%)] px-6 rounded-2xl backdrop-blur-md">
+      <div className="w-[min(50rem,100%)] h-full px-6 rounded-2xl backdrop-blur-md">
         <Spacer />
         {messages.map((message, i) => {
           const messageReactComponentKey = `message-${message.nodeId}`;


### PR DESCRIPTION
## Description

This has the MessageList container expand vertically so the blur is applied to the entire chat container rather than around the messages only.

**before**
<img width="3840" height="2160" alt="20260120_15h33m32s_grim" src="https://github.com/user-attachments/assets/4e76d1c6-5938-4573-9be5-3ecc44cd7979" />

**after**
<img width="3840" height="2160" alt="20260120_15h33m41s_grim" src="https://github.com/user-attachments/assets/b6567ba9-c884-477f-9726-9c3132369ffd" />

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the blurred message container fill the full chat panel so the blur covers the entire area, not just around messages. Improves visual consistency on tall viewports.

- **Bug Fixes**
  - Added h-full to MessageList wrapper so it stretches vertically.
  - Removed spacer div inline height in ChatScrollContainer to avoid extra gap that clipped the blur.

<sup>Written for commit 067eeeb9e32bd3af5dc7f79cd838ec0aae8a7323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

