### PR TITLE
feat: Allow no system prompt

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -453,12 +453,16 @@ def run_llm_loop(
 
             # The section below calculates the available tokens for history a bit more accurately
             # now that project files are loaded in.
-            if persona and persona.replace_base_system_prompt and persona.system_prompt:
+            if persona and persona.replace_base_system_prompt:
                 # Handles the case where user has checked off the "Replace base system prompt" checkbox
-                system_prompt = ChatMessageSimple(
-                    message=persona.system_prompt,
-                    token_count=token_counter(persona.system_prompt),
-                    message_type=MessageType.SYSTEM,
+                system_prompt = (
+                    ChatMessageSimple(
+                        message=persona.system_prompt,
+                        token_count=token_counter(persona.system_prompt),
+                        message_type=MessageType.SYSTEM,
+                    )
+                    if persona.system_prompt
+                    else None
                 )
                 custom_agent_prompt_msg = None
             else:


### PR DESCRIPTION
## Description
Allows there to not be a system prompt at all

## How Has This Been Tested?
Tested locally

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows chats to run with no system prompt when “Replace base system prompt” is enabled. Handles a missing prompt safely and avoids counting tokens for a prompt that isn’t set.

<sup>Written for commit b51bf74719eb0548aa1fe36fa0bf458ae925d02d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

