### PR TITLE
fix: modal header in index attempt errors

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -135,6 +135,7 @@ export default function IndexAttemptErrorsModal({
               : undefined
           }
           onClose={onClose}
+          height="fit"
         />
         <Modal.Body>
           {!isResolvingErrors && (


### PR DESCRIPTION
## Description

It looked like this
<img width="1378" height="758" alt="Screenshot 2026-01-20 at 4 17 46 PM" src="https://github.com/user-attachments/assets/ce49da34-5ee6-4ce0-b5c3-c4a87d3e2999" />

And now it looks like this
<img width="1373" height="748" alt="Screenshot 2026-01-20 at 4 17 32 PM" src="https://github.com/user-attachments/assets/c0906e1d-b9c1-4703-91fd-75ac133a9d29" />


## How Has This Been Tested?

see above 
## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Index Attempt Errors modal header by setting its height to fit, preventing overflow and clipped text. The title and actions now align correctly and the header spacing is consistent.

<sup>Written for commit 2b6ca43cfa41dc7ae4400f6b834d49f673de3721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

