### PR TITLE
chore: add dialog description to modal

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -355,13 +355,11 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
           <DialogPrimitive.Title asChild>
             <Text headingH3>{title}</Text>
           </DialogPrimitive.Title>
-          {description && (
-            <DialogPrimitive.Description asChild>
-              <Text secondaryBody text03>
-                {description}
-              </Text>
-            </DialogPrimitive.Description>
-          )}
+          <DialogPrimitive.Description asChild>
+            <Text secondaryBody text03>
+              {description || title}
+            </Text>
+          </DialogPrimitive.Description>
         </Section>
         {children}
       </Section>


### PR DESCRIPTION
## Description

We were seeing the following warning in the console:
Modal.tsx:257 Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

now it fixed

## How Has This Been Tested?

tested locally in console

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always render a dialog description in Modal. Uses the provided description or the title as a fallback to fix the “Missing Description or aria-describedby” console warning and improve accessibility.

<sup>Written for commit 15681bbcc7af759cfab25cb3a858cd4ab22e08d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

