### PR TITLE
fix: Fix flashing in `progress-circle` icon

### DIFF
--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -107,6 +107,7 @@ export { default as SvgPlayCircle } from "@opal/icons/play-circle";
 export { default as SvgPlug } from "@opal/icons/plug";
 export { default as SvgPlus } from "@opal/icons/plus";
 export { default as SvgPlusCircle } from "@opal/icons/plus-circle";
+export { default as SvgProgressCircle } from "@opal/icons/progress-circle";
 export { default as SvgQuestionMarkSmall } from "@opal/icons/question-mark-small";
 export { default as SvgQuoteEnd } from "@opal/icons/quote-end";
 export { default as SvgQuoteStart } from "@opal/icons/quote-start";

--- a/web/lib/opal/src/icons/progress-circle.tsx
+++ b/web/lib/opal/src/icons/progress-circle.tsx
@@ -1,16 +1,16 @@
 import { cn } from "@/lib/utils";
-import { SvgCheckCircle } from "@opal/icons";
-import { IconProps } from "@opal/types";
+import SvgCheckCircle from "@opal/icons/check-circle";
+import type { IconProps } from "@opal/types";
 
-export interface ProgressStepsProps extends IconProps {
+export interface SvgProgressCircleProps extends IconProps {
   value?: number;
 }
 
-export default function ProgressSteps({
+const SvgProgressCircle = ({
   value = 100,
   className,
   ...props
-}: ProgressStepsProps) {
+}: SvgProgressCircleProps) => {
   // Clamp value between 0 and 100
   const progress = Math.min(Math.max(value, 0), 100);
   const isComplete = progress >= 100;
@@ -40,7 +40,6 @@ export default function ProgressSteps({
           viewBox="0 0 16 16"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          className="animate-in fade-in duration-200"
         >
           {/* Outer circle - outline only */}
           <circle
@@ -63,8 +62,7 @@ export default function ProgressSteps({
             fill="none"
             strokeDasharray={circumference}
             strokeDashoffset={offset}
-            strokeLinecap="butt"
-            className="text-brand-500 transition-all duration-500 ease-out -rotate-90 origin-center"
+            className="-rotate-90 origin-center"
             style={{
               transformOrigin: "center",
             }}
@@ -73,4 +71,6 @@ export default function ProgressSteps({
       )}
     </div>
   );
-}
+};
+
+export default SvgProgressCircle;

--- a/web/src/refresh-components/onboarding/components/OnboardingHeader.tsx
+++ b/web/src/refresh-components/onboarding/components/OnboardingHeader.tsx
@@ -8,8 +8,7 @@ import {
 import Text from "@/refresh-components/texts/Text";
 import Button from "@/refresh-components/buttons/Button";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import ProgressSteps from "@/refresh-components/inputs/ProgressSteps";
-import { SvgX } from "@opal/icons";
+import { SvgProgressCircle, SvgX } from "@opal/icons";
 import { Card } from "@/refresh-components/cards";
 import { LineItemLayout, Section } from "@/layouts/general-layouts";
 
@@ -42,7 +41,9 @@ const OnboardingHeader = React.memo(
     return (
       <Card padding={0.5}>
         <LineItemLayout
-          icon={(props) => <ProgressSteps value={iconPercentage} {...props} />}
+          icon={(props) => (
+            <SvgProgressCircle value={iconPercentage} {...props} />
+          )}
           title={STEP_CONFIG[onboardingState.currentStep].title}
           rightChildren={
             stepButtonText ? (


### PR DESCRIPTION
## Description

- Move component from `refresh-components/inputs` to `lib/opal/src/icons`
- Rename `ProgressSteps` to `SvgProgressCircle` to follow icon naming convention

## How Has This Been Tested?

No UI changes; screenshots not provided.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed ProgressSteps to SvgProgressCircle and moved it into the @opal/icons package to standardize icon naming and location. Exported it from the icons index and updated OnboardingHeader; no UI changes expected.

- **Migration**
  - Replace <ProgressSteps ... /> with <SvgProgressCircle ... />.
  - Update import: import { SvgProgressCircle } from "@opal/icons".
  - Props are unchanged (value and IconProps).

<sup>Written for commit 950c84475bbb957ecf6147c2b10c966a165adcfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->