### PR TITLE
fix: Prevent description duplication in Modal header

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -337,7 +337,9 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
   ({ icon: Icon, title, description, onClose, children, ...props }, ref) => {
     const { closeButtonRef, setHasDescription } = useModalContext();
 
-    React.useEffect(() => {
+    // useLayoutEffect ensures aria-describedby is set before paint,
+    // so screen readers announce the description when the dialog opens
+    React.useLayoutEffect(() => {
       setHasDescription(!!description);
     }, [description, setHasDescription]);
 


### PR DESCRIPTION
## Description

When no `description` prop is provided to `Modal.Header`, the component was falling back to rendering the title as the description, causing visual and ARIA duplication.

Changes:
- Add `hasDescription` state to `ModalContext` to track if `description` exists
- Only render `DialogPrimitive.Description` when the `description` prop is provided
- Suppress Radix `aria-describedby` warning via conditional prop when no `description` prop is provided

Fixes https://github.com/onyx-dot-app/onyx/pull/7603.

## How Has This Been Tested?

No UI changes; screenshots not required.

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate descriptions in Modal.Header. We now render a description only when the prop is provided and remove aria-describedby when it’s not, preventing visual/ARIA duplication and suppressing the Radix warning.

<sup>Written for commit 9c785883c41fa505f6eeac77eadb55c6a9e34e88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



