### PR TITLE
chore: Delete multilingual docker compose file

### DIFF
--- a/deployment/docker_compose/env.multilingual.template
+++ b/deployment/docker_compose/env.multilingual.template
@@ -1,4 +1,0 @@
-# This env template shows how to configure Onyx for custom multilingual use
-# Note that for most use cases it will be enough to configure Onyx multilingual purely through the UI
-# See "Search Settings" -> "Advanced" for UI options.
-# To use it, copy it to .env in the docker_compose directory (or the equivalent environment settings file for your deployment)


### PR DESCRIPTION
## Description
^
## How Has This Been Tested?
N/A

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated env.multilingual.template from deployment/docker_compose. Multilingual setup is now handled in the UI, so the file was redundant and could cause confusion.

<sup>Written for commit daab01ec09da0eca320e7634ca0b859a57c88f4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

