### PR TITLE
very very crude fe implementation

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -39,6 +39,7 @@ class SandboxResponse(BaseModel):
     container_id: str | None
     created_at: datetime
     last_heartbeat: datetime | None
+    nextjs_port: int | None
 
     @classmethod
     def from_model(cls, sandbox) -> "SandboxResponse":
@@ -49,6 +50,7 @@ class SandboxResponse(BaseModel):
             container_id=sandbox.container_id,
             created_at=sandbox.created_at,
             last_heartbeat=sandbox.last_heartbeat,
+            nextjs_port=sandbox.nextjs_port,
         )
 
 
@@ -189,3 +191,9 @@ class FileSystemEntry(BaseModel):
 class DirectoryListing(BaseModel):
     path: str  # Current directory path
     entries: list[FileSystemEntry]  # Contents
+
+
+class WebappInfo(BaseModel):
+    has_webapp: bool  # Whether a webapp exists in outputs/web
+    webapp_url: str | None  # URL to access the webapp (e.g., http://localhost:3015)
+    status: str  # Sandbox status (running, terminated, etc.)

--- a/web/src/app/build/components/AIMessageWithTools.tsx
+++ b/web/src/app/build/components/AIMessageWithTools.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { ToolCall } from "@/app/build/services/buildStreamingModels";
+import { BuildMessage } from "@/app/build/services/buildStreamingModels";
 import Text from "@/refresh-components/texts/Text";
 import Logo from "@/refresh-components/Logo";
 import MinimalMarkdown from "@/components/chat/MinimalMarkdown";
-import ToolCallList from "@/app/build/components/ToolCallList";
+import BuildAgentTimeline from "@/app/build/components/BuildAgentTimeline";
 import { SvgLoader } from "@opal/icons";
 
 interface AIMessageWithToolsProps {
   content: string;
-  toolCalls: ToolCall[];
+  /** Structured event messages (tool calls, thinking, plans) to display in timeline */
+  eventMessages?: BuildMessage[];
   isStreaming?: boolean;
 }
 
@@ -17,20 +18,25 @@ interface AIMessageWithToolsProps {
  * AIMessageWithTools - AI message display with tool call activity
  *
  * Shows:
- * - Tool calls (when present) above the message content
+ * - Agent timeline (tool calls, thinking, plans) when present
  * - Message content with markdown rendering
  * - Loading indicator when streaming
  */
 export default function AIMessageWithTools({
   content,
-  toolCalls,
+  eventMessages = [],
   isStreaming = false,
 }: AIMessageWithToolsProps) {
   const hasContent = content.length > 0;
-  const hasToolCalls = toolCalls.length > 0;
-  const hasActiveToolCalls = toolCalls.some(
-    (tc) => tc.status === "in_progress" || tc.status === "pending"
+  const hasEvents = eventMessages.length > 0;
+  const hasActiveEvents = eventMessages.some(
+    (msg) => msg.message_metadata?.status === "in_progress"
   );
+
+  // Don't render anything if there's no content and no events
+  if (!hasContent && !hasEvents && !isStreaming) {
+    return null;
+  }
 
   return (
     <div className="flex items-start gap-3 py-4">
@@ -38,10 +44,10 @@ export default function AIMessageWithTools({
         <Logo folded size={24} />
       </div>
       <div className="flex-1 flex flex-col gap-3 min-w-0">
-        {/* Tool calls section */}
-        {hasToolCalls && (
+        {/* Agent timeline section */}
+        {hasEvents && (
           <div className="flex flex-col gap-2">
-            <ToolCallList toolCalls={toolCalls} />
+            <BuildAgentTimeline messages={eventMessages} />
           </div>
         )}
 
@@ -50,7 +56,7 @@ export default function AIMessageWithTools({
           <div className="flex items-center gap-2 py-1">
             <SvgLoader className="size-4 stroke-text-03 animate-spin" />
             <Text secondaryBody text03>
-              {hasActiveToolCalls ? "Working..." : "Thinking..."}
+              {hasActiveEvents ? "Working..." : "Thinking..."}
             </Text>
           </div>
         ) : hasContent ? (

--- a/web/src/app/build/components/BuildAgentTimeline.tsx
+++ b/web/src/app/build/components/BuildAgentTimeline.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { SvgChevronDown } from "@opal/icons";
+import { cn } from "@/lib/utils";
+import { BuildMessage } from "@/app/build/services/buildStreamingModels";
+import Text from "@/refresh-components/texts/Text";
+import BuildToolCallRenderer from "@/app/build/components/renderers/BuildToolCallRenderer";
+
+interface BuildAgentTimelineProps {
+  messages: BuildMessage[];
+}
+
+/**
+ * BuildAgentTimeline - Displays messages with metadata in chronological order
+ *
+ * Reconstructs the agent's execution timeline from saved messages:
+ * - Tool calls (tool_call_start, tool_call_progress)
+ * - Thinking steps (agent_thought_chunk)
+ * - Plan updates (agent_plan_update)
+ */
+export default function BuildAgentTimeline({
+  messages,
+}: BuildAgentTimelineProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // Filter messages that have metadata (structured events)
+  const structuredMessages = useMemo(() => {
+    return messages.filter((m) => m.message_metadata?.type);
+  }, [messages]);
+
+  if (structuredMessages.length === 0) return null;
+
+  // Group by type for status text
+  const toolMessages = structuredMessages.filter(
+    (m) =>
+      m.message_metadata?.type === "tool_call_start" ||
+      m.message_metadata?.type === "tool_call_progress"
+  );
+  const thinkingMessages = structuredMessages.filter(
+    (m) => m.message_metadata?.type === "agent_thought_chunk"
+  );
+  const planMessages = structuredMessages.filter(
+    (m) => m.message_metadata?.type === "agent_plan_update"
+  );
+
+  const statusText =
+    `${toolMessages.length} ${toolMessages.length === 1 ? "tool" : "tools"}` +
+    (thinkingMessages.length > 0
+      ? `, ${thinkingMessages.length} thinking`
+      : "") +
+    (planMessages.length > 0 ? `, ${planMessages.length} plan` : "");
+
+  console.log("[BuildAgentTimeline] Rendering", {
+    total: structuredMessages.length,
+    tools: toolMessages.length,
+    thinking: thinkingMessages.length,
+    plans: planMessages.length,
+  });
+
+  return (
+    <div className="my-2 border border-border-01 bg-background rounded-md overflow-hidden">
+      {/* Header */}
+      <div
+        className="flex items-center justify-between gap-2 px-3 py-2 cursor-pointer hover:bg-background-tint-02 transition-colors"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <Text text02 className="text-sm">
+          Agent Activity
+        </Text>
+        <div className="flex items-center gap-2">
+          <Text text03 className="text-xs">
+            {statusText}
+          </Text>
+          <SvgChevronDown
+            className={cn(
+              "w-4 h-4 stroke-text-400 transition-transform duration-150",
+              !isExpanded && "rotate-[-90deg]"
+            )}
+          />
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200",
+          isExpanded ? "max-h-[2000px] opacity-100" : "max-h-0 opacity-0"
+        )}
+      >
+        <div className="px-3 pb-3 space-y-0">
+          {structuredMessages.map((message, index) => {
+            const metadata = message.message_metadata!;
+            const type = metadata.type;
+
+            // Render tool calls
+            if (type === "tool_call_start" || type === "tool_call_progress") {
+              return (
+                <BuildToolCallRenderer
+                  key={message.id}
+                  metadata={metadata}
+                  isLastItem={index === structuredMessages.length - 1}
+                  isLoading={false}
+                />
+              );
+            }
+
+            // Render thinking steps
+            if (type === "agent_thought_chunk") {
+              return (
+                <BuildToolCallRenderer
+                  key={message.id}
+                  metadata={{
+                    ...metadata,
+                    kind: "thought",
+                    title: "Thinking",
+                  }}
+                  isLastItem={index === structuredMessages.length - 1}
+                  isLoading={false}
+                />
+              );
+            }
+
+            // Render plan updates
+            if (type === "agent_plan_update") {
+              return (
+                <BuildToolCallRenderer
+                  key={message.id}
+                  metadata={{
+                    ...metadata,
+                    kind: "plan",
+                    title: "Plan Update",
+                  }}
+                  isLastItem={index === structuredMessages.length - 1}
+                  isLoading={false}
+                />
+              );
+            }
+
+            return null;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/build/components/BuildMessageList.tsx
+++ b/web/src/app/build/components/BuildMessageList.tsx
@@ -1,11 +1,7 @@
 "use client";
 
-import { useRef, useEffect } from "react";
-import {
-  BuildMessage,
-  ToolCall,
-} from "@/app/build/services/buildStreamingModels";
-import { useToolCalls } from "@/app/build/hooks/useBuildSessionStore";
+import { useRef, useEffect, useMemo } from "react";
+import { BuildMessage } from "@/app/build/services/buildStreamingModels";
 import UserMessage from "@/app/build/components/UserMessage";
 import AIMessageWithTools from "@/app/build/components/AIMessageWithTools";
 
@@ -20,45 +16,79 @@ interface BuildMessageListProps {
  * Shows:
  * - User messages (right-aligned bubbles)
  * - Assistant responses (left-aligned with logo, including tool calls)
+ * - Agent activity timeline (tool calls, thinking, plans)
+ *
+ * Groups messages into display messages and event messages:
+ * - Display messages: user messages and assistant messages with content
+ * - Event messages: assistant messages with message_metadata (tool calls, thinking, plans)
  */
 export default function BuildMessageList({
   messages,
   isStreaming = false,
 }: BuildMessageListProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const toolCalls = useToolCalls();
 
-  // Auto-scroll to bottom when new messages arrive or tool calls update
+  // Separate display messages from event messages
+  const { displayMessages, eventMessages, hasEventsOnly } = useMemo(() => {
+    const display: BuildMessage[] = [];
+    const events: BuildMessage[] = [];
+
+    for (const msg of messages) {
+      // Event messages have metadata and empty/no content
+      if (msg.message_metadata?.type && !msg.content) {
+        events.push(msg);
+      } else {
+        display.push(msg);
+      }
+    }
+
+    // Check if we have events but no assistant messages with content
+    const hasAssistantContent = display.some((m) => m.type === "assistant");
+    const hasEventsOnly = events.length > 0 && !hasAssistantContent;
+
+    return { displayMessages: display, eventMessages: events, hasEventsOnly };
+  }, [messages]);
+
+  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length, toolCalls.length]);
+  }, [messages.length]);
 
   return (
     <div className="flex flex-col items-center px-4 pb-4">
       <div className="w-full max-w-2xl">
-        {messages.map((message, index) => {
-          const isLastMessage = index === messages.length - 1;
+        {displayMessages.map((message, index) => {
+          const isLastMessage = index === displayMessages.length - 1;
           const isStreamingThis =
-            isStreaming && isLastMessage && message.role === "assistant";
+            isStreaming && isLastMessage && message.type === "assistant";
+          const isLastAssistantMessage =
+            message.type === "assistant" && isLastMessage;
 
-          // Show current tool calls only on the last assistant message while streaming
-          const messageToolCalls: ToolCall[] = isStreamingThis
-            ? toolCalls
-            : message.toolCalls || [];
-
-          if (message.role === "user") {
+          if (message.type === "user") {
             return <UserMessage key={message.id} content={message.content} />;
           }
 
+          // For assistant messages, only show event timeline on the last assistant message
+          // This avoids duplicating the timeline for multiple assistant responses
           return (
             <AIMessageWithTools
               key={message.id}
               content={message.content}
-              toolCalls={messageToolCalls}
+              eventMessages={isLastAssistantMessage ? eventMessages : []}
               isStreaming={isStreamingThis}
             />
           );
         })}
+
+        {/* If we have event messages but no assistant message to attach them to, render them */}
+        {hasEventsOnly && (
+          <AIMessageWithTools
+            key="events-only"
+            content=""
+            eventMessages={eventMessages}
+            isStreaming={isStreaming}
+          />
+        )}
 
         {/* Scroll anchor */}
         <div ref={messagesEndRef} />

--- a/web/src/app/build/components/BuildToolStepsRenderer.tsx
+++ b/web/src/app/build/components/BuildToolStepsRenderer.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  SvgChevronDown,
+  SvgTerminalSmall,
+  SvgFileText,
+  SvgEdit,
+  SvgPlayCircle,
+  SvgSettings,
+  SvgCheck,
+  SvgX,
+  SvgLoader,
+  SvgMinusCircle,
+} from "@opal/icons";
+import { cn } from "@/lib/utils";
+import {
+  ToolCall,
+  ToolCallStatus,
+} from "@/app/build/services/buildStreamingModels";
+import Text from "@/refresh-components/texts/Text";
+
+/**
+ * Get the appropriate icon for a tool based on its kind
+ */
+function getToolIcon(kind: string) {
+  const kindLower = kind?.toLowerCase() || "";
+
+  if (kindLower.includes("bash") || kindLower.includes("execute")) {
+    return SvgTerminalSmall;
+  }
+  if (kindLower.includes("write") || kindLower === "edit") {
+    return SvgEdit;
+  }
+  if (kindLower.includes("read")) {
+    return SvgFileText;
+  }
+  return SvgSettings;
+}
+
+/**
+ * Get status icon based on tool call status
+ */
+function getStatusIcon(status: ToolCallStatus) {
+  switch (status) {
+    case "completed":
+      return SvgCheck;
+    case "failed":
+      return SvgX;
+    case "in_progress":
+      return SvgLoader;
+    case "pending":
+      return SvgMinusCircle;
+    case "cancelled":
+      return SvgX;
+    default:
+      return SvgMinusCircle;
+  }
+}
+
+/**
+ * Extract command from raw_input for technical display
+ */
+function extractCommand(toolCall: ToolCall): string | null {
+  const rawInput = toolCall.raw_input;
+
+  if (!rawInput) return null;
+
+  // For bash/execute tools, extract the command
+  if (rawInput.command) {
+    return rawInput.command;
+  }
+
+  // For file write/edit tools, show the file path
+  if (rawInput.file_path || rawInput.path) {
+    const path = rawInput.file_path || rawInput.path;
+    const operation = toolCall.kind === "edit" ? "Edit" : "Write";
+    return `${operation} ${path}`;
+  }
+
+  return null;
+}
+
+/**
+ * Extract user-friendly description from content or title
+ */
+function extractDescription(toolCall: ToolCall): string {
+  // Try to get description from content block
+  if (toolCall.content) {
+    const content = toolCall.content;
+    if (content.type === "text" && content.text) {
+      return content.text;
+    }
+    if (Array.isArray(content)) {
+      const textBlocks = content.filter(
+        (c: any) => c.type === "text" && c.text
+      );
+      if (textBlocks.length > 0) {
+        return textBlocks.map((c: any) => c.text).join(" ");
+      }
+    }
+  }
+
+  // Fallback to title
+  return toolCall.title || toolCall.name || "Running tool...";
+}
+
+/**
+ * Get status text based on tool status
+ */
+function getStatusText(status: ToolCallStatus): string {
+  switch (status) {
+    case "completed":
+      return "Complete";
+    case "failed":
+      return "Failed";
+    case "in_progress":
+      return "Running";
+    case "pending":
+      return "Pending";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Unknown";
+  }
+}
+
+/**
+ * Single tool step row with vertical connector
+ */
+function ToolStepRow({
+  toolCall,
+  isLastItem,
+}: {
+  toolCall: ToolCall;
+  isLastItem: boolean;
+}) {
+  const ToolIcon = getToolIcon(toolCall.kind);
+  const StatusIcon = getStatusIcon(toolCall.status);
+  const command = extractCommand(toolCall);
+  const description = extractDescription(toolCall);
+  const statusText = getStatusText(toolCall.status);
+  const isLoading =
+    toolCall.status === "in_progress" || toolCall.status === "pending";
+  const isFailed = toolCall.status === "failed";
+
+  return (
+    <div className="relative">
+      {/* Vertical connector line */}
+      {!isLastItem && (
+        <div
+          className="absolute w-px bg-border-02 z-0"
+          style={{ left: "10px", top: "20px", bottom: "0" }}
+        />
+      )}
+
+      <div className={cn("flex items-start gap-2 relative z-10")}>
+        {/* Icon circle */}
+        <div className="flex flex-col items-center w-5">
+          <div className="flex-shrink-0 flex items-center justify-center w-5 h-5 bg-background rounded-full border border-border-01">
+            <ToolIcon
+              className={cn("w-3.5 h-3.5", isLoading && "text-action-link-01")}
+            />
+          </div>
+        </div>
+
+        {/* Content */}
+        <div
+          className={cn(
+            "flex-1 min-w-0 overflow-hidden",
+            !isLastItem && "pb-4"
+          )}
+        >
+          {/* Status and title */}
+          <div className="flex items-center gap-2 mb-1">
+            <StatusIcon
+              className={cn(
+                "w-3.5 h-3.5",
+                toolCall.status === "completed" && "text-status-success-03",
+                toolCall.status === "failed" && "text-status-error-03",
+                toolCall.status === "in_progress" &&
+                  "text-action-link-01 animate-spin",
+                toolCall.status === "pending" && "text-text-03"
+              )}
+            />
+            <Text
+              text02
+              className={cn(isLoading && !isFailed && "loading-text")}
+            >
+              {statusText}
+            </Text>
+          </div>
+
+          {/* User-friendly description */}
+          <Text secondaryBody text03 className="mb-1">
+            {description}
+          </Text>
+
+          {/* Technical command (if available) */}
+          {command && (
+            <div className="mt-1 px-2 py-1 rounded bg-background-tint-02 border border-border-01">
+              <Text secondaryMono text03 className="text-xs break-all">
+                {command}
+              </Text>
+            </div>
+          )}
+
+          {/* Error message */}
+          {toolCall.error && (
+            <div className="mt-1 px-2 py-1 rounded bg-status-error-01 border border-status-error-02">
+              <Text secondaryMono className="text-xs text-status-error-03">
+                {toolCall.error}
+              </Text>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface BuildToolStepsRendererProps {
+  toolCalls: ToolCall[];
+}
+
+/**
+ * BuildToolStepsRenderer - Displays tool calls in chronological order
+ * with both technical details and user-friendly descriptions.
+ *
+ * Inspired by ResearchAgentRenderer from deep research UI.
+ */
+export default function BuildToolStepsRenderer({
+  toolCalls,
+}: BuildToolStepsRendererProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  if (toolCalls.length === 0) return null;
+
+  // Sort tool calls chronologically
+  const sortedToolCalls = [...toolCalls].sort(
+    (a, b) => a.startedAt.getTime() - b.startedAt.getTime()
+  );
+
+  // Determine overall status
+  const hasActiveTools = sortedToolCalls.some(
+    (tc) => tc.status === "in_progress" || tc.status === "pending"
+  );
+  const hasFailedTools = sortedToolCalls.some((tc) => tc.status === "failed");
+  const allComplete = sortedToolCalls.every((tc) => tc.status === "completed");
+
+  let statusText: string;
+  if (allComplete) {
+    statusText = "All steps complete";
+  } else if (hasFailedTools) {
+    statusText = "Some steps failed";
+  } else if (hasActiveTools) {
+    const activeTools = sortedToolCalls.filter(
+      (tc) => tc.status === "in_progress" || tc.status === "pending"
+    );
+    const lastActiveTool = activeTools[activeTools.length - 1];
+    statusText = lastActiveTool
+      ? extractDescription(lastActiveTool)
+      : "Processing";
+  } else {
+    statusText = "Processing";
+  }
+
+  return (
+    <div className="my-2 p-3 rounded-lg border border-border-01 bg-background-neutral-02">
+      {/* Header with toggle */}
+      <div
+        className="flex items-center justify-between gap-2 cursor-pointer group"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <div className="flex items-center gap-2">
+          <SvgPlayCircle className="w-4 h-4 text-text-03" />
+          <Text text02 className="truncate">
+            {statusText}
+          </Text>
+        </div>
+        <div className="flex items-center gap-2">
+          <Text secondaryMono text03 className="text-xs">
+            {sortedToolCalls.length}{" "}
+            {sortedToolCalls.length === 1 ? "step" : "steps"}
+          </Text>
+          <SvgChevronDown
+            className={cn(
+              "w-4 h-4 stroke-text-03 transition-transform duration-150 ease-in-out",
+              !isExpanded && "rotate-[-90deg]"
+            )}
+          />
+        </div>
+      </div>
+
+      {/* Collapsible tool steps */}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200 ease-in-out",
+          isExpanded ? "max-h-[2000px] opacity-100 mt-3" : "max-h-0 opacity-0"
+        )}
+      >
+        <div className="space-y-0.5">
+          {sortedToolCalls.map((toolCall, index) => (
+            <ToolStepRow
+              key={toolCall.id}
+              toolCall={toolCall}
+              isLastItem={index === sortedToolCalls.length - 1}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/build/components/ChatPanel.tsx
+++ b/web/src/app/build/components/ChatPanel.tsx
@@ -56,7 +56,7 @@ export default function BuildChatPanel() {
         // Add user message to state
         appendMessage({
           id: `msg-${Date.now()}`,
-          role: "user",
+          type: "user",
           content: message,
           timestamp: new Date(),
         });

--- a/web/src/app/build/components/renderers/BuildToolCallRenderer.tsx
+++ b/web/src/app/build/components/renderers/BuildToolCallRenderer.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React from "react";
+import { FiCircle } from "react-icons/fi";
+import {
+  SvgTerminalSmall,
+  SvgFileText,
+  SvgEdit,
+  SvgSettings,
+  SvgBubbleText,
+} from "@opal/icons";
+import { cn } from "@/lib/utils";
+import Text from "@/refresh-components/texts/Text";
+
+const STANDARD_TEXT_COLOR = "text-text-600";
+
+interface ToolCallRendererProps {
+  metadata: Record<string, any>;
+  isLastItem?: boolean;
+  isLoading?: boolean;
+}
+
+/**
+ * Get the appropriate icon for a tool based on its kind
+ */
+function getToolIcon(kind: string) {
+  const kindLower = kind?.toLowerCase() || "";
+
+  if (kindLower.includes("bash") || kindLower.includes("execute")) {
+    return ({ size }: { size: number }) => (
+      <SvgTerminalSmall style={{ width: size, height: size }} />
+    );
+  }
+  if (kindLower.includes("write") || kindLower === "edit") {
+    return ({ size }: { size: number }) => (
+      <SvgEdit style={{ width: size, height: size }} />
+    );
+  }
+  if (kindLower.includes("read")) {
+    return ({ size }: { size: number }) => (
+      <SvgFileText style={{ width: size, height: size }} />
+    );
+  }
+  if (kindLower.includes("think") || kindLower.includes("thought")) {
+    return ({ size }: { size: number }) => (
+      <SvgBubbleText style={{ width: size, height: size }} />
+    );
+  }
+  return ({ size }: { size: number }) => (
+    <SvgSettings style={{ width: size, height: size }} />
+  );
+}
+
+/**
+ * Extract command from raw_input
+ */
+function extractCommand(metadata: Record<string, any>): string | null {
+  const rawInput = metadata.raw_input;
+  if (!rawInput) return null;
+
+  // For bash/execute tools
+  if (rawInput.command) return rawInput.command;
+
+  // For file operations
+  if (rawInput.file_path || rawInput.path) {
+    return rawInput.file_path || rawInput.path;
+  }
+
+  // For grep/search
+  if (rawInput.pattern) return `pattern: ${rawInput.pattern}`;
+
+  return null;
+}
+
+/**
+ * Get tool name/title
+ */
+function getToolName(metadata: Record<string, any>): string {
+  // Use title if meaningful
+  if (metadata.title && !metadata.title.includes("Running")) {
+    return metadata.title;
+  }
+
+  const kind = metadata.kind || "";
+  const nameMap: Record<string, string> = {
+    bash: "Bash",
+    write: "Write",
+    read: "Read",
+    edit: "Edit",
+    grep: "Grep",
+    glob: "Glob",
+  };
+
+  return nameMap[kind.toLowerCase()] || kind || "Tool";
+}
+
+/**
+ * Renders a single tool call from metadata
+ */
+export default function BuildToolCallRenderer({
+  metadata,
+  isLastItem = false,
+  isLoading = false,
+}: ToolCallRendererProps) {
+  const icon = getToolIcon(metadata.kind);
+  const toolName = getToolName(metadata);
+  const command = extractCommand(metadata);
+  const isFailed = metadata.status === "failed";
+
+  console.log("[BuildToolCallRenderer] Rendering tool:", metadata);
+
+  return (
+    <div className="relative">
+      {!isLastItem && (
+        <div
+          className="absolute w-px bg-background-tint-04 z-0"
+          style={{ left: "10px", top: "20px", bottom: "0" }}
+        />
+      )}
+      <div
+        className={cn(
+          "flex items-start gap-2",
+          STANDARD_TEXT_COLOR,
+          "relative z-10"
+        )}
+      >
+        <div className="flex flex-col items-center w-5">
+          <div className="flex-shrink-0 flex items-center justify-center w-5 h-5 bg-background rounded-full">
+            {icon ? (
+              <div className={cn(isLoading && "text-shimmer-base")}>
+                {icon({ size: 14 })}
+              </div>
+            ) : (
+              <FiCircle className="w-2 h-2 fill-current text-text-300" />
+            )}
+          </div>
+        </div>
+        <div
+          className={cn(
+            "flex-1 min-w-0 overflow-hidden",
+            !isLastItem && "pb-4"
+          )}
+        >
+          <Text
+            as="p"
+            text02
+            className={cn(
+              "text-sm mb-1",
+              isLoading && !isFailed && "loading-text"
+            )}
+          >
+            {toolName}
+          </Text>
+          {command && (
+            <div className="text-sm text-text-600 overflow-hidden font-mono">
+              {command}
+            </div>
+          )}
+          {metadata.error && (
+            <div className="text-sm text-red-500 mt-1">{metadata.error}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

incredibly crude

## How Has This Been Tested?

it just works

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first pass of the build UI with an agent activity timeline, live streaming, and web app handling, plus backend endpoints to surface and download generated web apps. Improves visibility into tool execution and makes Next.js outputs easy to preview and download.

- **New Features**
  - Agent timeline showing tool calls, thinking, and plan updates from streamed ACP events.
  - Live assistant streaming accumulates content deltas; messages now support metadata and use type instead of role.
  - Output panel: web app preview via sandbox port, web app artifacts with download, and a simple file browser.
  - SWR polling (5s) for webapp info and artifacts to reflect updates quickly.

- **API Changes**
  - Added WebappInfo and GET /sessions/{id}/webapp plus /sessions/{id}/webapp/download (zip of outputs/web).
  - SandboxResponse now includes nextjs_port; SessionManager provides webapp info and zip creation.
  - Artifacts endpoint returns new ArtifactResponse and emits “web_app” entries (outputs/web).

<sup>Written for commit 1f98d8bcd6a541e6ab6a04dedb623fe3ab7b0a22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

