### PR TITLE
Fix email addresses to use mailto links instead of https redirects

### DIFF
--- a/web/src/app/chat/message/MemoizedTextComponents.tsx
+++ b/web/src/app/chat/message/MemoizedTextComponents.tsx
@@ -161,7 +161,7 @@ export const MemoizedLink = memo(
     }
 
     let url = href || rest.children?.toString();
-    if (url && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(url)) {
+    if (url && !/^mailto:/i.test(url) && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(url)) {
       url = `mailto:${url}`;
     } else {
       url = ensureHrefProtocol(url);


### PR DESCRIPTION
### What
This PR fixes a bug in `MemoizedLink` where email addresses were incorrectly treated as normal URLs and prefixed with `https://`. As a result, clicking on an email redirected the user to the email's domain website instead of opening the default email client.

### Fix
- Added `isEmail` helper function to detect email addresses.
- Updated `MemoizedLink` to generate proper `mailto:` links for emails.
- Preserved existing behavior for regular HTTP/HTTPS URLs.

### Result
- Clicking on email addresses now correctly opens the user's default email client.
- Normal URLs continue to open in a new tab as before.

Fixes #7624

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render email addresses as mailto: links in MemoizedLink instead of forcing https URLs, so clicking opens the default email client. Regular URLs are unchanged and still open in a new tab.

<sup>Written for commit 2855ed228afe54f8eea098f0e3b17d9fcfbb3b2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

