### PR TITLE
video background

### DIFF
--- a/web/src/app/build/v1/layout.tsx
+++ b/web/src/app/build/v1/layout.tsx
@@ -6,6 +6,8 @@ export interface LayoutProps {
   children: React.ReactNode;
 }
 
+const VIDEO_BACKGROUND_PATH = "https://cdn.onyx.app/build/background.mp4";
+
 /**
  * Build V1 Layout - Skeleton pattern with 3-panel layout
  *
@@ -17,9 +19,23 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <UploadFilesProvider>
       <BuildProvider>
-        <div className="flex flex-row w-full h-full">
-          <BuildSidebar />
-          {children}
+        <div className="relative flex flex-row w-full h-full overflow-hidden">
+          {/* Video Background */}
+          <video
+            autoPlay
+            loop
+            muted
+            playsInline
+            className="absolute inset-0 w-full h-full object-cover z-0 pointer-events-none opacity-50"
+          >
+            <source src={VIDEO_BACKGROUND_PATH} type="video/mp4" />
+          </video>
+
+          {/* Content layer */}
+          <div className="relative z-10 flex flex-row w-full h-full">
+            <BuildSidebar />
+            {children}
+          </div>
         </div>
       </BuildProvider>
     </UploadFilesProvider>


### PR DESCRIPTION
## Description

neccessary

## How Has This Been Tested?

<img width="1906" height="934" alt="Screenshot 2026-01-21 at 10 41 15" src="https://github.com/user-attachments/assets/80edc4c8-2b0b-43cb-a4d0-ae1f852e2cc7" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a muted, looping video background to the Build V1 layout to improve visual polish without affecting interactions.

- **New Features**
  - Video background from https://cdn.onyx.app/build/background.mp4 with autoplay, loop, muted, playsInline, and 50% opacity.
  - Content layered above the video (relative container, z-index) with pointer-events disabled on the video to preserve click/hover behavior.

<sup>Written for commit b87f5b0c8ebda79df3d6d3b645d71d24a15ddf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

