### PR TITLE
fix(image): Image fits generated image bounds

### DIFF
--- a/web/src/app/chat/components/files/images/InMessageImage.tsx
+++ b/web/src/app/chat/components/files/images/InMessageImage.tsx
@@ -73,12 +73,10 @@ export function InMessageImage({
         )}
 
         <img
-          width={1200}
-          height={1200}
           alt="Chat Message Image"
           onLoad={() => setImageLoaded(true)}
           className={cn(
-            "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
+            "object-contain object-left overflow-hidden rounded-lg transition-opacity duration-300 cursor-pointer",
             shapeImageClasses,
             imageLoaded ? "opacity-100" : "opacity-0"
           )}


### PR DESCRIPTION
## Description
There is currently an issue where if the image aspect ratio differs from the parent element, you can end up with left hand corners rounded, but right hand corners not.

This PR solves this by removing the aspect constraints on the img element.

Before:
<img width="265" height="419" alt="Screenshot 2026-01-21 at 11 41 20 AM" src="https://github.com/user-attachments/assets/9fa65330-5fb0-43b3-96d6-d48929d2c155" />

After:
<img width="254" height="420" alt="Screenshot 2026-01-21 at 11 41 30 AM" src="https://github.com/user-attachments/assets/a0465c08-f7ce-4296-b490-b9b362b7d217" />


## How Has This Been Tested?
Played around w/ FE

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uneven rounded corners on chat images by letting the image size naturally to its container. Images now fit the generated bounds and render corners consistently across aspect ratios.

- **Bug Fixes**
  - Removed fixed width/height attributes and w-full h-full classes to avoid forced scaling.
  - Retains object-contain so images align with the container and rounded edges stay uniform.

<sup>Written for commit 9545a7c1d3de8faef60ba6e5c72fbdd205402c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

