### PR TITLE
feat: Add confirmation modal for connector disconnect

### DIFF
--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -1493,7 +1493,7 @@ function FederatedConnectorCard({
       {showDisconnectConfirmation && (
         <ConfirmationModalLayout
           icon={SvgUnplug}
-          title="Disconnect Connector"
+          title={`Disconnect ${sourceMetadata.displayName}`}
           onClose={() => setShowDisconnectConfirmation(false)}
           submit={
             <Button
@@ -1507,10 +1507,14 @@ function FederatedConnectorCard({
         >
           <Section gap={0.5} alignItems="start">
             <Text>
-              Are you sure you want to disconnect{" "}
-              <Text className="!font-bold">{sourceMetadata.displayName}</Text>?
+              Onyx will no longer be able to access or search content from your{" "}
+              <Text className="!font-bold">{sourceMetadata.displayName}</Text>{" "}
+              account.
             </Text>
-            <Text>You can reconnect at any time.</Text>
+            <Text>
+              You can still continue existing sessions referencing{" "}
+              {sourceMetadata.displayName} content.
+            </Text>
           </Section>
         </ConfirmationModalLayout>
       )}


### PR DESCRIPTION
## Description

Clicking the disconnect button on a federated connector now shows a confirmation modal asking the user to confirm before disconnecting. This prevents accidental disconnections.

## Screenshots

<img width="1504" height="1067" alt="image" src="https://github.com/user-attachments/assets/c30e95af-b856-4966-85f7-e6dedae7a65f" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a confirmation modal before disconnecting a federated connector to prevent accidental disconnects. Users must confirm; the modal shows the connector name and a disabled state while disconnecting.

<sup>Written for commit 27fab7c2b07b9412e44c067f939baa18bcf7554a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

