### PR TITLE
.

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -54,6 +54,7 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_session_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.sandbox.manager import get_sandbox_manager
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -141,6 +142,10 @@ class SessionManager:
         Raises:
             RateLimitError: If rate limit is exceeded
         """
+        # Skip rate limiting for self-hosted deployments
+        if not MULTI_TENANT:
+            return
+
         rate_limit_status = get_user_rate_limit_status(user, self._db_session)
         if rate_limit_status.is_limited:
             raise RateLimitError(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make self-hosted deployments unlimited: disable user message rate limits and per-tenant sandbox concurrency caps. Cloud (multi-tenant) behavior is unchanged.

- **New Features**
  - Added MULTI_TENANT switch to separate cloud and self-hosted behavior.
  - Self-hosted: skip rate limit checks and sandbox concurrency limits.
  - Cloud: keep existing weekly/lifetime message limits and per-tenant sandbox cap.

<sup>Written for commit 0e1002a21b5dee9aa83ab6f41fcad8a0530e100c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

