### PR TITLE
fix: color mode and memories

### DIFF
--- a/backend/onyx/db/memory.py
+++ b/backend/onyx/db/memory.py
@@ -9,6 +9,9 @@ def get_memories(user: User | None, db_session: Session) -> list[str]:
     if user is None:
         return []
 
+    if not user.use_memories:
+        return []
+
     user_info = [
         f"User's name: {user.personal_name}" if user.personal_name else "",
         f"User's role: {user.personal_role}" if user.personal_role else "",

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -171,7 +171,7 @@ function PATModal({
 function GeneralSettings() {
   const { user, updateUserPersonalization, updateUserThemePreference } =
     useUser();
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { theme, setTheme, systemTheme } = useTheme();
   const { popup, setPopup } = usePopup();
   const { refreshChatSessions } = useChatSessions();
   const router = useRouter();
@@ -339,14 +339,14 @@ function GeneralSettings() {
                     value={ThemePreference.SYSTEM}
                     icon={() => (
                       <ColorSwatch
-                        light={resolvedTheme === "light"}
-                        dark={resolvedTheme === "dark"}
+                        light={systemTheme === "light"}
+                        dark={systemTheme === "dark"}
                       />
                     )}
                     description={
-                      resolvedTheme
-                        ? resolvedTheme.charAt(0).toUpperCase() +
-                          resolvedTheme.slice(1)
+                      systemTheme
+                        ? systemTheme.charAt(0).toUpperCase() +
+                          systemTheme.slice(1)
                         : undefined
                     }
                   >


### PR DESCRIPTION
## Description
Color mode auto was wrong
Including memories logic was missing

## How Has This Been Tested?
Works now

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “System” color mode preview to match the OS theme and stops fetching memories when the user has memories disabled.

- **Bug Fixes**
  - Frontend: use systemTheme for the System option’s swatch and description in SettingsPage.
  - Backend: get_memories returns an empty list when user.use_memories is False.

<sup>Written for commit 2b30da7c5aebba802da09fdef49779b7f232710f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

