### PR TITLE
fix: deflake chat user journey test

### DIFF
--- a/web/tests/e2e/chat/default_assistant.spec.ts
+++ b/web/tests/e2e/chat/default_assistant.spec.ts
@@ -582,18 +582,10 @@ test.describe("End-to-End Default Assistant Flow", () => {
     await page.waitForLoadState("networkidle");
 
     // Verify greeting message appears
-    const greetingElement = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(greetingElement).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
 
     // Verify Onyx logo is displayed
-    const logoElement = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(logoElement).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
 
     // Send a message using the chat input
     await sendMessage(page, "Hello, can you help me?");
@@ -608,10 +600,6 @@ test.describe("End-to-End Default Assistant Flow", () => {
     await startNewChat(page);
 
     // Verify we're back to default assistant with greeting
-    const newGreeting = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(newGreeting).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
   });
 });

--- a/web/tests/e2e/utils/tools.ts
+++ b/web/tests/e2e/utils/tools.ts
@@ -27,9 +27,9 @@ export async function waitForUnifiedGreeting(page: Page): Promise<string> {
 // Ensure the Action Management popover is open
 export async function openActionManagement(page: Page): Promise<void> {
   const actionToggle = page.locator(TOOL_IDS.actionToggle);
-  await actionToggle.waitFor({ timeout: 5000 });
+  await actionToggle.waitFor();
   await actionToggle.click();
-  await page.locator(TOOL_IDS.options).waitFor({ timeout: 5000 });
+  await page.locator(TOOL_IDS.options).waitFor();
 }
 
 // Check presence of the Action Management toggle


### PR DESCRIPTION
## Description

this test constantly is flaky

targeted changes:
waitForSelector is deprecated and default waitFor is 10 seconds. so updated the action toggle command specifically to use this pattern and switching to some explicit expect.locator().toBeVisible() for some others.

## How Has This Been Tested?

ci

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflaked the Default Assistant E2E by replacing deprecated waits with locator-based waits and explicit visibility checks. Uses Playwright’s default 10s auto-wait to reduce CI flakiness.

- **Bug Fixes**
  - Replaced page.waitForSelector with locator().waitFor() in default_assistant.spec.ts and tools.ts.
  - Switched to expect(locator).toBeVisible() for the Onyx logo check.
  - Removed custom 5s timeouts to rely on Playwright defaults.

<sup>Written for commit dfa0939bd2726cdb3d70d45fc5e3a6c1bda86cf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

