### PR TITLE
chore: Onboarding Image Generation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,11 +15,11 @@
     {
       "name": "Run All Onyx Services",
       "configurations": [
-        //"Web Server",
+        "Web Server",
         "Model Server",
         "API Server",
-        //"MCP Server",
-        //"Slack Bot",
+        "MCP Server",
+        "Slack Bot",
         "Celery primary",
         "Celery light",
         "Celery heavy",


### PR DESCRIPTION
## Description
It shouldn't link to the docs anymore

## How Has This Been Tested?
Works locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the onboarding “Image Generation” button to open the in‑app configuration page (/admin/configuration/image-generation) instead of the docs, so users can set up models directly. Also commented out Web Server, MCP Server, and Slack Bot in the VSCode “Run All Onyx Services” configuration.

<sup>Written for commit 3d373de41bff987f05a0a7bdbc82ef34e6708c7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

