### PR TITLE
fix(ui): First Connector Result

### DIFF
--- a/web/src/components/SourceTile.tsx
+++ b/web/src/components/SourceTile.tsx
@@ -28,13 +28,10 @@ export default function SourceTile({
               w-40
               cursor-pointer
               shadow-md
+              bg-background-tint-00
               hover:bg-background-tint-02
               relative
-              ${
-                preSelect
-                  ? "bg-background-tint-01 subtle-pulse"
-                  : "bg-background-tint-00"
-              }
+              ${preSelect ? "subtle-pulse" : ""}
             `}
       href={navigationUrl as Route}
     >


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
For whatever reason the first searched connector would not have a background and this will fix this issue.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

Before:
<img width="567" height="315" alt="Screenshot 2026-01-21 at 4 54 33 PM" src="https://github.com/user-attachments/assets/a37c9795-0807-4a1b-be51-3f314078d34f" />

After:
<img width="562" height="330" alt="Screenshot 2026-01-21 at 4 54 52 PM" src="https://github.com/user-attachments/assets/19aa8e62-86e2-4af2-a089-40f015b3ea2a" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing background on the first connector search result. SourceTile now always uses the base background, and preSelect only adds the pulse effect.

- **Bug Fixes**
  - Apply bg-background-tint-00 unconditionally and keep hover styling; remove background color from the preSelect branch.

<sup>Written for commit 3a7f31744e098c0daafca5da324a64065b6afb28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

