### PR TITLE
fix(ui): User Groups Connectors Fix

### DIFF
--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -41,7 +41,8 @@ export const ConnectorMultiSelect = ({
     (connector) => !selectedIds.includes(connector.cc_pair_id)
   );
 
-  const allConnectorsSelected = unselectedConnectors.length === 0;
+  const allConnectorsSelected =
+    connectors.length > 0 && unselectedConnectors.length === 0;
 
   const filteredUnselectedConnectors = unselectedConnectors.filter(
     (connector) => {
@@ -51,16 +52,7 @@ export const ConnectorMultiSelect = ({
   );
 
   useEffect(() => {
-    if (allConnectorsSelected && open) {
-      setOpen(false);
-      inputRef.current?.blur();
-      setSearchQuery("");
-    }
-  }, [allConnectorsSelected, open]);
-
-  useEffect(() => {
     if (allConnectorsSelected) {
-      inputRef.current?.blur();
       setSearchQuery("");
     }
   }, [allConnectorsSelected, selectedIds]);
@@ -111,7 +103,7 @@ export const ConnectorMultiSelect = ({
     ? "All connectors selected"
     : placeholder;
 
-  const isInputDisabled = disabled || allConnectorsSelected;
+  const isInputDisabled = disabled;
 
   return (
     <div className="flex flex-col w-full space-y-2 mb-4">
@@ -129,32 +121,39 @@ export const ConnectorMultiSelect = ({
           value={searchQuery}
           variant={isInputDisabled ? "disabled" : undefined}
           onChange={(e) => {
-            setSearchQuery(e.target.value);
-            setOpen(true);
-          }}
-          onFocus={() => {
             if (!allConnectorsSelected) {
+              setSearchQuery(e.target.value);
               setOpen(true);
             }
           }}
+          onFocus={() => {
+            setOpen(true);
+          }}
           onKeyDown={handleKeyDown}
-          className={
-            allConnectorsSelected
-              ? "rounded-12 bg-background-neutral-01"
-              : "rounded-12"
-          }
+          className="rounded-12"
         />
 
-        {open && !allConnectorsSelected && (
+        {open && (
           <div
             ref={dropdownRef}
             className="absolute z-50 w-full mt-1 rounded-12 border border-border-02 bg-background-neutral-00 shadow-md default-scrollbar max-h-[300px] overflow-auto"
           >
-            {filteredUnselectedConnectors.length === 0 ? (
-              <div className="py-4 text-center text-xs text-text-03">
-                {searchQuery
-                  ? "No matching connectors found"
-                  : "No more connectors available"}
+            {allConnectorsSelected ? (
+              <div className="py-4 px-3">
+                <Text as="p" text03 className="text-center text-xs">
+                  All available connectors have been selected. Remove connectors
+                  below to add different ones.
+                </Text>
+              </div>
+            ) : filteredUnselectedConnectors.length === 0 ? (
+              <div className="py-4 px-3">
+                <Text as="p" text03 className="text-center text-xs">
+                  {searchQuery
+                    ? "No matching connectors found"
+                    : connectors.length === 0
+                      ? "No private connectors available. Create a private connector first."
+                      : "No more connectors available"}
+                </Text>
               </div>
             ) : (
               <div>


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently the UI for the User Groups page is messed up and you aren't able to click and select any connectors. 

This prevents the use of user groups since it doesn't do anything right now. Even if you try to edit it, it won't work. 

This PR aims to restore the functionality that was there previously.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally
Before:
<img width="998" height="746" alt="Screenshot 2026-01-21 at 5 09 08 PM" src="https://github.com/user-attachments/assets/09cd28a2-b76e-41e4-b726-8f5bda3de58d" />


After:
<img width="1020" height="712" alt="Screenshot 2026-01-21 at 5 08 26 PM" src="https://github.com/user-attachments/assets/3090f428-df18-484f-8e39-efff2f36b063" />
<img width="994" height="659" alt="Screenshot 2026-01-21 at 5 08 42 PM" src="https://github.com/user-attachments/assets/471cfe5f-96e6-4c94-8e9a-c374510520d0" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored connector selection on the User Groups page by fixing the multi-select dropdown behavior. Users can now add, remove, and edit connectors reliably, with clear messages when all are selected or none are available.

- **Bug Fixes**
  - Corrected allConnectorsSelected logic (requires connectors > 0).
  - Stopped auto-blur/auto-close; input stays usable and dropdown remains open.
  - Improved empty states: all selected, no matches, or no private connectors available.

<sup>Written for commit ad3da281a07eef7c64a6b554886aa0635e303db1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

