### PR TITLE
fix(ui): Fix Token Rate Limits Page

### DIFF
--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -101,7 +101,7 @@ function Main() {
   };
 
   return (
-    <Section alignItems="stretch">
+    <Section alignItems="stretch" justifyContent="start" height="auto">
       {popup}
 
       <Text>


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Making sure the page is aligned to the top

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

Before:
<img width="2996" height="1567" alt="Screenshot 2026-01-21 at 5 15 37 PM" src="https://github.com/user-attachments/assets/ea46e0f6-4b46-4842-816c-67a241c51a1d" />

After: 
<img width="2997" height="719" alt="Screenshot 2026-01-21 at 5 15 52 PM" src="https://github.com/user-attachments/assets/50be4593-1ac7-43a5-821c-13ecf8a4e60d" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Token Rate Limits admin page content to the top to remove extra vertical space. Updated the Section layout to justify content at start and set height to auto.

<sup>Written for commit eced32b836bef6ca03c7f402780830a10687a485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

