### PR TITLE
fix(ui): Make the Admin Setting Clickable

### DIFF
--- a/web/src/refresh-components/buttons/SidebarTab.tsx
+++ b/web/src/refresh-components/buttons/SidebarTab.tsx
@@ -50,23 +50,14 @@ export default function SidebarTab({
       )}
       onClick={onClick}
     >
-      {href && (
-        <Link
-          href={href as Route}
-          scroll={false}
-          className="absolute inset-0 rounded-08"
-          tabIndex={-1}
-        />
-      )}
       <div
         data-state={state}
         className={cn(
-          "relative flex-1 h-[1.5rem] flex flex-row items-center px-1 py-0.5 gap-2 justify-start",
-          !focused && "pointer-events-none"
+          "relative flex-1 h-[1.5rem] flex flex-row items-center px-1 py-0.5 gap-2 justify-start pointer-events-none"
         )}
       >
         {LeftIcon && (
-          <div className="w-[1rem] h-[1rem] flex items-center justify-center pointer-events-auto">
+          <div className="w-[1rem] h-[1rem] flex items-center justify-center">
             <LeftIcon
               data-state={state}
               className={`h-[1rem] w-[1rem] sidebar-tab-icon-${variant}`}
@@ -88,9 +79,17 @@ export default function SidebarTab({
           ))}
       </div>
       {!folded && (
-        <div className="relative h-[1.5rem] flex items-center">
+        <div className="relative h-[1.5rem] flex items-center pointer-events-none">
           {rightChildren}
         </div>
+      )}
+      {href && (
+        <Link
+          href={href as Route}
+          scroll={false}
+          className="absolute inset-0 rounded-08 z-10"
+          tabIndex={-1}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
When the sidebar is collapsed, you are not able to click the Admin Settings gear icon and go to the admin settings page.

This PR aims to fix this properly

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally to ensure the functionality is restored

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Admin Settings gear not clickable when the sidebar is collapsed. Clicking the collapsed tab now reliably opens Admin Settings.

- **Bug Fixes**
  - Added a full-tab Link overlay (absolute, z-10) to capture clicks in SidebarTab.
  - Disabled pointer events on inner content so clicks pass through to the overlay.

<sup>Written for commit f54480c1139789aeb552e66ef410390e0412d1dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

