### PR TITLE
video bg + chat panel beautification

### DIFF
--- a/web/src/app/build/components/ChatPanel.tsx
+++ b/web/src/app/build/components/ChatPanel.tsx
@@ -201,16 +201,22 @@ export default function BuildChatPanel({
       {/* Main content area */}
       <div className="flex-1 overflow-auto">
         {!hasSession && !existingSessionId ? (
-          <BuildWelcome
-            onSubmit={handleSubmit}
-            isRunning={isRunning}
-            sandboxInitializing={isPreProvisioning}
-          />
+          <div className="h-full flex items-center justify-center">
+            <BuildWelcome
+              onSubmit={handleSubmit}
+              isRunning={isRunning}
+              sandboxInitializing={isPreProvisioning}
+            />
+          </div>
         ) : (
-          <BuildMessageList
-            messages={session?.messages ?? []}
-            isStreaming={isRunning}
-          />
+          <div className="flex items-center px-4 py-4">
+            <div className="w-full max-w-3xl mx-auto backdrop-blur-lg rounded-lg">
+              <BuildMessageList
+                messages={session?.messages ?? []}
+                isStreaming={isRunning}
+              />
+            </div>
+          </div>
         )}
       </div>
 

--- a/web/src/app/build/v1/layout.tsx
+++ b/web/src/app/build/v1/layout.tsx
@@ -1,18 +1,14 @@
 "use client";
 
-import {
-  BuildProvider,
-  useBuildContext,
-} from "@/app/build/contexts/BuildContext";
+import { BuildProvider } from "@/app/build/contexts/BuildContext";
 import { UploadFilesProvider } from "@/app/build/contexts/UploadFilesContext";
 import BuildSidebar from "@/app/build/components/SideBar";
-import VideoBackground from "@/app/build/v1/components/VideoBackground";
 
 /**
  * Build V1 Layout - Skeleton pattern with 3-panel layout
  *
  * Wraps with BuildProvider and UploadFilesProvider (for file uploads).
- * Includes BuildSidebar on the left with video background.
+ * Includes BuildSidebar on the left.
  * Pre-provisioning is handled by useBuildSessionController.
  * The page component provides the center (chat) and right (output) panels.
  */
@@ -23,10 +19,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="flex flex-row w-full h-full">
           <BuildSidebar />
           <div className="relative flex-1 h-full overflow-hidden">
-            <VideoBackground />
-            <div className="relative z-10 w-full h-full backdrop-blur-sm">
-              {children}
-            </div>
+            {children}
           </div>
         </div>
       </BuildProvider>

--- a/web/src/app/build/v1/page.tsx
+++ b/web/src/app/build/v1/page.tsx
@@ -10,6 +10,7 @@ import {
 import { getSessionIdFromSearchParams } from "@/app/build/services/searchParams";
 import BuildChatPanel from "@/app/build/components/ChatPanel";
 import BuildOutputPanel from "@/app/build/components/OutputPanel";
+import VideoBackground from "@/app/build/v1/components/VideoBackground";
 
 /**
  * Build V1 Page - Entry point for builds
@@ -17,7 +18,7 @@ import BuildOutputPanel from "@/app/build/components/OutputPanel";
  * URL: /build/v1 (new build)
  * URL: /build/v1?sessionId=xxx (existing session)
  *
- * Renders the 2-panel layout (chat + output) and handles session controller setup.
+ * Renders the 2-panel layout (chat + output) with video background and handles session controller setup.
  */
 export default function BuildV1Page() {
   const searchParams = useSearchParams();
@@ -28,19 +29,27 @@ export default function BuildV1Page() {
   useBuildSessionController({ existingSessionId: sessionId });
 
   return (
-    <div className="flex flex-row flex-1 h-full overflow-hidden">
-      {/* Center panel - Chat */}
-      <div
-        className={cn(
-          "h-full transition-all duration-300 ease-in-out",
-          outputPanelOpen ? "w-1/2" : "w-full"
-        )}
-      >
-        <BuildChatPanel existingSessionId={sessionId} />
-      </div>
+    <div className="relative w-full h-full">
+      <VideoBackground />
+      <div className="relative z-10 w-full h-full">
+        <div className="flex flex-row flex-1 h-full overflow-hidden">
+          {/* Center panel - Chat */}
+          <div
+            className={cn(
+              "h-full transition-all duration-300 ease-in-out",
+              outputPanelOpen ? "w-1/2" : "w-full"
+            )}
+          >
+            <BuildChatPanel existingSessionId={sessionId} />
+          </div>
 
-      {/* Right panel - Output (Preview, Files, Artifacts) */}
-      <BuildOutputPanel onClose={toggleOutputPanel} isOpen={outputPanelOpen} />
+          {/* Right panel - Output (Preview, Files, Artifacts) */}
+          <BuildOutputPanel
+            onClose={toggleOutputPanel}
+            isOpen={outputPanelOpen}
+          />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

FE improvements like contrastive bg in message list, no video bg on connectors page

## How Has This Been Tested?

locally

<img width="1912" height="942" alt="Screenshot 2026-01-21 at 18 49 30" src="https://github.com/user-attachments/assets/c779d500-c5be-4d71-a4ca-b739911b9267" />

<img width="1912" height="937" alt="Screenshot 2026-01-21 at 18 49 40" src="https://github.com/user-attachments/assets/5f2e6320-ddbe-44d5-8351-05eb8e024e4b" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the chat panel UI and moved the video background to the Build V1 page so it doesn’t appear on the connectors page.

- **UI Improvements**
  - Centered the welcome state in the chat panel.
  - Wrapped the message list in a constrained, blurred, rounded container for better contrast.
  - Rendered the video background only in /build/v1 via the page component; removed it from the shared layout.

<sup>Written for commit 399572aed40c67074824816611f2274d40b01e61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

