### PR TITLE
connectors page

### DIFF
--- a/web/src/app/build/v1/configure/components/CredentialStep.tsx
+++ b/web/src/app/build/v1/configure/components/CredentialStep.tsx
@@ -16,7 +16,7 @@ import {
   useOAuthDetails,
   getConnectorOauthRedirectUrl,
 } from "@/lib/connectors/oauth";
-import { deleteCredential, linkCredential } from "@/lib/credential";
+import { deleteCredential } from "@/lib/credential";
 import ModifyCredential from "@/components/credentials/actions/ModifyCredential";
 import CreateCredential from "@/components/credentials/actions/CreateCredential";
 import { CreateStdOAuthCredential } from "@/components/credentials/actions/CreateStdOAuthCredential";
@@ -29,9 +29,8 @@ import {
 } from "@/lib/constants";
 import { BUILD_MODE_OAUTH_COOKIE_NAME } from "@/app/build/v1/constants";
 import Cookies from "js-cookie";
-import { createConnector } from "@/lib/connector";
-import { connectorConfigs, isLoadState } from "@/lib/connectors/connectors";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
+import { createBuildConnector } from "@/app/build/v1/configure/utils/createBuildConnector";
 
 interface CredentialStepProps {
   connectorType: ValidSources;
@@ -43,11 +42,8 @@ interface CredentialStepProps {
   onContinue: () => void;
   onOAuthRedirect: () => void;
   refresh?: () => void;
-  /** When true, this is a single-step flow - connect button creates the connector directly */
   isSingleStep?: boolean;
-  /** Callback when connector is successfully created (for single-step flow) */
   onConnectorSuccess?: () => void;
-  /** Popup setter for error messages */
   setPopup?: (popup: PopupSpec | null) => void;
 }
 
@@ -92,49 +88,19 @@ export default function CredentialStep({
     }
   };
 
-  /**
-   * For single-step connectors, directly create the connector with default values
-   */
   const handleConnect = async () => {
     if (!selectedCredential || !isSingleStep) return;
 
     setIsConnecting(true);
 
     try {
-      const config =
-        connectorConfigs[connectorType as keyof typeof connectorConfigs];
-      const connectorName = `build-mode-${connectorType}`;
-
-      // Create connector with empty/default config (single-step connectors don't need config)
-      const [connectorError, connector] = await createConnector({
-        name: connectorName,
-        source: connectorType,
-        input_type: isLoadState(connectorType) ? "load_state" : "poll",
-        connector_specific_config: {},
-        refresh_freq: config?.overrideDefaultFreq || 1800, // 30 minutes default
-        prune_freq: 2592000, // 30 days default
-        indexing_start: null,
-        access_type: "private",
+      const result = await createBuildConnector({
+        connectorType,
+        credential: selectedCredential,
       });
 
-      if (connectorError || !connector) {
-        throw new Error(connectorError || "Failed to create connector");
-      }
-
-      // Link credential to connector with file_system processing mode
-      const linkResponse = await linkCredential(
-        connector.id,
-        selectedCredential.id,
-        connectorName,
-        "private",
-        [], // No groups for build mode connectors
-        undefined, // No auto sync options
-        "file_system" // Use file system processing mode for build connectors
-      );
-
-      if (!linkResponse.ok) {
-        const linkError = await linkResponse.json();
-        throw new Error(linkError.detail || "Failed to link credential");
+      if (!result.success) {
+        throw new Error(result.error);
       }
 
       onConnectorSuccess?.();
@@ -214,7 +180,6 @@ export default function CredentialStep({
                           }
                         }
                       } else {
-                        // For Google Drive, set build mode flag for OAuth redirect
                         if (connectorType === ValidSources.GoogleDrive) {
                           Cookies.set(BUILD_MODE_OAUTH_COOKIE_NAME, "true", {
                             path: "/",

--- a/web/src/app/build/v1/configure/utils/createBuildConnector.ts
+++ b/web/src/app/build/v1/configure/utils/createBuildConnector.ts
@@ -1,0 +1,87 @@
+import { ValidSources } from "@/lib/types";
+import { Credential } from "@/lib/connectors/credentials";
+import { createConnector } from "@/lib/connector";
+import { linkCredential } from "@/lib/credential";
+import { connectorConfigs, isLoadState } from "@/lib/connectors/connectors";
+
+export interface CreateBuildConnectorParams {
+  connectorType: ValidSources;
+  credential: Credential<any>;
+  connectorSpecificConfig?: Record<string, any>;
+  connectorName?: string;
+}
+
+export interface CreateBuildConnectorResult {
+  success: boolean;
+  error?: string;
+  connectorId?: number;
+}
+
+export async function createBuildConnector({
+  connectorType,
+  credential,
+  connectorSpecificConfig = {},
+  connectorName,
+}: CreateBuildConnectorParams): Promise<CreateBuildConnectorResult> {
+  const config =
+    connectorConfigs[connectorType as keyof typeof connectorConfigs];
+  const name = connectorName || `build-mode-${connectorType}`;
+
+  const filteredConfig: Record<string, any> = {};
+  Object.entries(connectorSpecificConfig).forEach(([key, value]) => {
+    if (value !== "" && value !== null && value !== undefined) {
+      if (Array.isArray(value) && value.length === 0) {
+        return;
+      }
+      filteredConfig[key] = value;
+    }
+  });
+
+  try {
+    const [connectorError, connector] = await createConnector({
+      name,
+      source: connectorType,
+      input_type: isLoadState(connectorType) ? "load_state" : "poll",
+      connector_specific_config: filteredConfig,
+      refresh_freq: config?.overrideDefaultFreq || 1800,
+      prune_freq: 2592000,
+      indexing_start: null,
+      access_type: "private",
+    });
+
+    if (connectorError || !connector) {
+      return {
+        success: false,
+        error: connectorError || "Failed to create connector",
+      };
+    }
+
+    const linkResponse = await linkCredential(
+      connector.id,
+      credential.id,
+      name,
+      "private",
+      [],
+      undefined,
+      "file_system"
+    );
+
+    if (!linkResponse.ok) {
+      const linkError = await linkResponse.json();
+      return {
+        success: false,
+        error: linkError.detail || "Failed to link credential",
+      };
+    }
+
+    return {
+      success: true,
+      connectorId: connector.id,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to create connector",
+    };
+  }
+}


### PR DESCRIPTION
## Description

fix connectors page for build, very closely models the core chat flow now

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Build connectors page by adding single-step connector support. Connectors that don’t need extra configuration can now be created and linked in one click.

- **New Features**
  - Detects if a connector needs a config step by checking visible fields.
  - Adds a single-step flow: creates the connector and links the selected credential automatically.
  - Dynamic modal titles and descriptions based on flow type (single-step vs multi-step).
  - Connect button with loading state (“Connecting...”), plus popup error handling.
  - Uses file_system processing mode and sensible defaults (30m refresh, 30d prune).

<sup>Written for commit f8ca4133d2e343149dc65782188ad70a4673ab75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

