### PR TITLE
chore(fe): remove Text pseudo-element padding

### DIFF
--- a/web/src/refresh-components/texts/Text.tsx
+++ b/web/src/refresh-components/texts/Text.tsx
@@ -197,11 +197,6 @@ export default function Text({
         fonts[font],
         inverted ? colors.inverted[color] : colors[color],
         nowrap && "whitespace-nowrap",
-        // NOTE: We want a small, horizontal padding applied to text components to visually
-        // complement the white-space implicit with line-height. We apply to the before and after
-        // pseudo-elements such that padding applied to the tag directly is additive making the
-        // likelihood of 2px offsets with other text elements much lower.
-        "before:content-[''] before:inline-block before:pl-[2px] after:content-[''] after:inline-block after:pr-[2px]",
         className
       )}
     >


### PR DESCRIPTION
## Description

There are also cases where padding in the pseudo-elements is causing undesired behavior, https://onyx-company.slack.com/archives/C0832RVRVG8/p1769050433567939.

It may be possible to use pseudo-elements in combination with [this](https://github.com/onyx-dot-app/onyx/pull/7451/changes#diff-af89e3bf81aafd5c644c7372d8b95a6c5b71516211f6710d64a6a7fa86027547R208) `box-decoration-clone`, but also, I think [my proposal](https://github.com/onyx-dot-app/onyx/pull/7451#discussion_r2696625458) to require `children` props of the `Text` to be inline-able type (strings, numbers, etc. **not** ReactNodes) is valid.

Either case requires a bit of work, so let's get something temporary in.

I'm also down to re-apply this to the `Tag` directly. I don't think that's the proper long-term solution, but I agree it's better than this current behavior.

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed before/after pseudo-element padding from Text to stop unintended horizontal spacing and 2px offsets when used with other padded elements or Tags. This makes Text spacing consistent and avoids layout glitches in inline contexts.

<sup>Written for commit 56e409573086f0194d9ffa254f14dd34015b2acc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

