### PR TITLE
fix(opensearch): Release Onyx Helm Charts was failing

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
           helm repo add minio https://charts.min.io/


### PR DESCRIPTION
## Description
https://onyx-company.slack.com/archives/C0771QKDBPE/p1769052843318569

## How Has This Been Tested?
It wasn't.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Helm chart release workflow by adding the missing OpenSearch Helm repo, unblocking the Onyx Helm Charts release.

- **Bug Fixes**
  - Add opensearch repo (https://opensearch-project.github.io/helm-charts) to .github/workflows/helm-chart-releases.yml.

<sup>Written for commit 5a47bfb80662468f895be31baeb43290be0f6358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

