### PR TITLE
fix(asana): Workspace Team ID mismatch

### DIFF
--- a/backend/onyx/connectors/asana/connector.py
+++ b/backend/onyx/connectors/asana/connector.py
@@ -36,7 +36,7 @@ class AsanaConnector(LoadConnector, PollConnector):
             self.project_ids_to_index = project_ids or None
         else:
             self.project_ids_to_index = None
-        self.asana_team_id = asana_team_id.strip() if asana_team_id else None
+        self.asana_team_id = (asana_team_id.strip() or None) if asana_team_id else None
         self.batch_size = batch_size
         self.continue_on_failure = continue_on_failure
         logger.info(

--- a/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
+++ b/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
@@ -29,11 +29,22 @@ def test_asana_connector_project_ids_normalization(
     assert connector.asana_team_id == "1210918501948021"
 
 
-def test_asana_connector_team_id_empty_string() -> None:
+@pytest.mark.parametrize(
+    "team_id,expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (" 1210918501948021 ", "1210918501948021"),
+    ],
+)
+def test_asana_connector_team_id_normalization(
+    team_id: str | None, expected: str | None
+) -> None:
     connector = AsanaConnector(
         asana_workspace_id="1153293530468850",
         asana_project_ids=None,
-        asana_team_id="   ",
+        asana_team_id=team_id,
     )
 
-    assert connector.asana_team_id is None
+    assert connector.asana_team_id == expected


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Weird issue with the Asana connector trying to handle new information

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options
- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Asana connector ID parsing to prevent Workspace/Team ID mismatch. Normalizes inputs and ignores empty project IDs so configuration is consistent.

- **Bug Fixes**
  - Trim workspace_id and team_id; treat blank team_id as None to avoid mismatches.
  - Normalize asana_project_ids: trim, remove blanks, set to None when no valid IDs; added unit tests covering these cases.

<sup>Written for commit 474382dc4bab8ef52c2c2c82487306042e27f8d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

