### PR TITLE
feat: RENDER ALL PACKET TYPES :BIG_GRIN: (except thinking)

### DIFF
--- a/cc4a-plans/rendering-todos.md
+++ b/cc4a-plans/rendering-todos.md
@@ -1,0 +1,545 @@
+# Plan: Rendering Todo List Items in Build Chat Panel
+
+## System Analysis
+
+### How SSE Packets Flow (End-to-End)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ OPENCODE AGENT (in Sandbox)                                                 │
+│   - Calls TodoWrite tool with todos array                                   │
+│   - Emits ACP events: ToolCallStart → ToolCallProgress (multiple)           │
+└───────────────────────────────────────┬─────────────────────────────────────┘
+                                        │ JSON-RPC stdout
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ BACKEND: SandboxManager.send_message()                                      │
+│   - Parses ACP events from agent stdout                                     │
+│   - Yields typed objects (ToolCallStart, ToolCallProgress, etc.)            │
+└───────────────────────────────────────┬─────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ BACKEND: SessionManager._stream_cli_agent_response()                        │
+│   File: backend/onyx/server/features/build/session/manager.py               │
+│                                                                             │
+│   - For each ACP event:                                                     │
+│     - ToolCallStart → Yield SSE (NOT saved to DB)                           │
+│     - ToolCallProgress → Yield SSE; Save to DB if status="completed"        │
+│   - Serializes to SSE format: "event: message\ndata: {JSON}\n\n"            │
+└───────────────────────────────────────┬─────────────────────────────────────┘
+                                        │ SSE Stream (text/event-stream)
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ FRONTEND: processSSEStream()                                                │
+│   File: web/src/app/build/services/apiServices.ts                           │
+│                                                                             │
+│   - Parses SSE lines, extracts JSON data                                    │
+│   - Calls onPacket(packet) for each parsed packet                           │
+└───────────────────────────────────────┬─────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ FRONTEND: useBuildStreaming.streamMessage()                                 │
+│   File: web/src/app/build/hooks/useBuildStreaming.ts                        │
+│                                                                             │
+│   - Switch on packet.type:                                                  │
+│     - "agent_message_chunk" → Create/update text StreamItem                 │
+│     - "agent_thought_chunk" → Create/update thinking StreamItem             │
+│     - "tool_call_start" → Create tool_call StreamItem                       │
+│     - "tool_call_progress" → Update tool_call StreamItem                    │
+│   - Appends StreamItems to Zustand store in FIFO order                      │
+└───────────────────────────────────────┬─────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ FRONTEND: BuildMessageList → ToolCallPill                                   │
+│   Files: web/src/app/build/components/BuildMessageList.tsx                  │
+│          web/src/app/build/components/ToolCallPill.tsx                      │
+│                                                                             │
+│   - Renders streamItems in order                                            │
+│   - tool_call items rendered as ToolCallPill (expandable card)              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Current Data Structures
+
+#### StreamItem Types (displayTypes.ts)
+```typescript
+export type StreamItem =
+  | { type: "text"; id: string; content: string; isStreaming: boolean }
+  | { type: "thinking"; id: string; content: string; isStreaming: boolean }
+  | { type: "tool_call"; id: string; toolCall: ToolCallState };
+```
+
+#### ToolCallState (displayTypes.ts)
+```typescript
+export interface ToolCallState {
+  id: string;
+  kind: ToolCallKind;           // "execute" | "read" | "task" | "other"
+  title: string;                 // "Running command", "Writing file", etc.
+  description: string;           // File path or command description
+  command: string;               // Actual command or file path
+  status: ToolCallStatus;        // "pending" | "in_progress" | "completed" | "failed"
+  rawOutput: string;             // Full output for expanded view
+  subagentType?: string;         // For task tool calls
+}
+```
+
+### TodoWrite Packet Structure (Expected from OpenCode)
+
+Based on the ACP protocol and OpenCode tool definitions:
+
+```json
+// tool_call_start
+{
+  "type": "tool_call_start",
+  "tool_call_id": "toolu_xyz123",
+  "kind": "other",
+  "title": "todowrite",
+  "raw_input": {
+    "todos": [
+      { "content": "Create API endpoint", "status": "pending", "activeForm": "Creating API endpoint" },
+      { "content": "Write tests", "status": "pending", "activeForm": "Writing tests" }
+    ]
+  },
+  "status": "pending"
+}
+
+// tool_call_progress (updates as agent works)
+{
+  "type": "tool_call_progress",
+  "tool_call_id": "toolu_xyz123",
+  "kind": "other",
+  "title": "todowrite",
+  "raw_input": {
+    "todos": [
+      { "content": "Create API endpoint", "status": "completed", "activeForm": "Creating API endpoint" },
+      { "content": "Write tests", "status": "in_progress", "activeForm": "Writing tests" }
+    ]
+  },
+  "status": "completed"
+}
+```
+
+---
+
+## Implementation Plan
+
+### Goal
+
+Render todo list items in the chat panel with:
+1. **FIFO rendering**: Multiple todo list cards can appear in sequence in the AI message
+2. **Auto-collapse**: When a new todo list appears, previous ones collapse; final one stays open
+3. **Persistence**: Save todo packets to DB for re-rendering on refresh
+
+---
+
+### Phase 1: Frontend - New StreamItem Type & Component
+
+#### 1.1 Add `todo_list` StreamItem Type
+
+**File**: `web/src/app/build/types/displayTypes.ts`
+
+```typescript
+// Add new types
+export type TodoStatus = "pending" | "in_progress" | "completed";
+
+export interface TodoItem {
+  content: string;          // The task description
+  status: TodoStatus;       // Current status
+  activeForm: string;       // Present tense form (e.g., "Creating API endpoint")
+}
+
+export interface TodoListState {
+  id: string;               // Tool call ID
+  todos: TodoItem[];        // Array of todo items
+  isOpen: boolean;          // Whether the card is expanded (for UI state only)
+}
+
+// Update StreamItem union
+export type StreamItem =
+  | { type: "text"; id: string; content: string; isStreaming: boolean }
+  | { type: "thinking"; id: string; content: string; isStreaming: boolean }
+  | { type: "tool_call"; id: string; toolCall: ToolCallState }
+  | { type: "todo_list"; id: string; todoList: TodoListState };
+```
+
+#### 1.2 Create TodoListCard Component
+
+**File**: `web/src/app/build/components/TodoListCard.tsx`
+
+```typescript
+interface TodoListCardProps {
+  todoList: TodoListState;
+  defaultOpen?: boolean;
+}
+
+export default function TodoListCard({ todoList, defaultOpen = true }: TodoListCardProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  // Calculate progress stats
+  const total = todoList.todos.length;
+  const completed = todoList.todos.filter(t => t.status === "completed").length;
+  const inProgress = todoList.todos.filter(t => t.status === "in_progress").length;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border rounded-lg overflow-hidden bg-background-neutral-01 border-border-02">
+        <CollapsibleTrigger asChild>
+          <button className="w-full flex items-center justify-between px-3 py-2 hover:bg-background-tint-02">
+            <div className="flex items-center gap-2">
+              <SvgChecklist className="size-4 stroke-text-03" />
+              <span className="text-sm font-medium text-text-04">Tasks</span>
+              <span className="text-xs text-text-03">
+                {completed}/{total} completed
+              </span>
+            </div>
+            {inProgress > 0 && (
+              <SvgLoader className="size-4 stroke-status-info-05 animate-spin" />
+            )}
+            <SvgChevronDown className={cn(
+              "size-4 stroke-text-03 transition-transform",
+              !isOpen && "rotate-[-90deg]"
+            )} />
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="px-3 pb-3 space-y-1">
+            {todoList.todos.map((todo, index) => (
+              <TodoItemRow key={index} todo={todo} />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function TodoItemRow({ todo }: { todo: TodoItem }) {
+  return (
+    <div className="flex items-start gap-2 py-1">
+      {/* Status indicator */}
+      {todo.status === "completed" ? (
+        <SvgCheckCircle className="size-4 stroke-status-success-05 mt-0.5 shrink-0" />
+      ) : todo.status === "in_progress" ? (
+        <SvgLoader className="size-4 stroke-status-info-05 animate-spin mt-0.5 shrink-0" />
+      ) : (
+        <div className="size-4 rounded-full border-2 border-text-03 mt-0.5 shrink-0" />
+      )}
+
+      {/* Task text */}
+      <span className={cn(
+        "text-sm",
+        todo.status === "completed" ? "text-text-03 line-through" : "text-text-04"
+      )}>
+        {todo.status === "in_progress" ? todo.activeForm : todo.content}
+      </span>
+    </div>
+  );
+}
+```
+
+---
+
+### Phase 2: Frontend - Streaming Hook Updates
+
+#### 2.1 Handle TodoWrite in useBuildStreaming
+
+**File**: `web/src/app/build/hooks/useBuildStreaming.ts`
+
+```typescript
+// Add helper function to detect TodoWrite tool
+function isTodoWriteTool(packet: Record<string, unknown>): boolean {
+  const toolName = (
+    (packet.tool_name || packet.toolName || packet.title) as string | undefined
+  )?.toLowerCase();
+  return toolName === "todowrite" || toolName === "todo_write";
+}
+
+// Add helper to extract todos from packet
+function extractTodos(packet: Record<string, unknown>): TodoItem[] {
+  const rawInput = (packet.raw_input || packet.rawInput) as Record<string, unknown> | null;
+  if (!rawInput?.todos || !Array.isArray(rawInput.todos)) return [];
+
+  return rawInput.todos.map((t: any) => ({
+    content: t.content || "",
+    status: normalizeTodoStatus(t.status),
+    activeForm: t.activeForm || t.content || "",
+  }));
+}
+
+// In streamMessage callback, update switch statement:
+case "tool_call_start": {
+  // Check if this is a TodoWrite call
+  if (isTodoWriteTool(packetData)) {
+    // Collapse any previous todo lists
+    collapseAllTodoLists(sessionId);
+
+    // Create new todo_list StreamItem (open by default)
+    const toolCallId = (packetData.tool_call_id || packetData.toolCallId || genId("todo")) as string;
+    const todos = extractTodos(packetData);
+
+    const item: StreamItem = {
+      type: "todo_list",
+      id: toolCallId,
+      todoList: {
+        id: toolCallId,
+        todos,
+        isOpen: true,
+      },
+    };
+    appendStreamItem(sessionId, item);
+    lastItemType = "tool"; // Still track as tool for finalization
+    break;
+  }
+
+  // ... existing tool_call_start handling ...
+}
+
+case "tool_call_progress": {
+  // Check if this is a TodoWrite update
+  if (isTodoWriteTool(packetData)) {
+    const toolCallId = (packetData.tool_call_id || packetData.toolCallId) as string;
+    const todos = extractTodos(packetData);
+
+    updateTodoListStreamItem(sessionId, toolCallId, { todos });
+    break;
+  }
+
+  // ... existing tool_call_progress handling ...
+}
+```
+
+#### 2.2 Add Store Actions for Todo Lists
+
+**File**: `web/src/app/build/hooks/useBuildSessionStore.ts`
+
+```typescript
+// Add to interface BuildSessionStore:
+updateTodoListStreamItem: (
+  sessionId: string,
+  todoListId: string,
+  updates: Partial<TodoListState>
+) => void;
+collapseAllTodoLists: (sessionId: string) => void;
+
+// Add implementations:
+updateTodoListStreamItem: (sessionId, todoListId, updates) => {
+  set((state) => {
+    const session = state.sessions.get(sessionId);
+    if (!session) return state;
+
+    const streamItems = session.streamItems.map((item) => {
+      if (item.type === "todo_list" && item.todoList.id === todoListId) {
+        return {
+          ...item,
+          todoList: { ...item.todoList, ...updates },
+        };
+      }
+      return item;
+    }) as StreamItem[];
+
+    const newSessions = new Map(state.sessions);
+    newSessions.set(sessionId, { ...session, streamItems, lastAccessed: new Date() });
+    return { sessions: newSessions };
+  });
+},
+
+collapseAllTodoLists: (sessionId) => {
+  set((state) => {
+    const session = state.sessions.get(sessionId);
+    if (!session) return state;
+
+    const streamItems = session.streamItems.map((item) => {
+      if (item.type === "todo_list") {
+        return {
+          ...item,
+          todoList: { ...item.todoList, isOpen: false },
+        };
+      }
+      return item;
+    }) as StreamItem[];
+
+    const newSessions = new Map(state.sessions);
+    newSessions.set(sessionId, { ...session, streamItems, lastAccessed: new Date() });
+    return { sessions: newSessions };
+  });
+},
+```
+
+---
+
+### Phase 3: Backend - Persist Todo Packets
+
+#### 3.1 Save TodoWrite Progress to DB
+
+**File**: `backend/onyx/server/features/build/session/manager.py`
+
+In `_stream_cli_agent_response()`, update the `ToolCallProgress` handling:
+
+```python
+elif isinstance(acp_event, ToolCallProgress):
+    event_data = acp_event.model_dump(mode="json", by_alias=True, exclude_none=False)
+    event_data["type"] = "tool_call_progress"
+    event_data["timestamp"] = datetime.now(tz=timezone.utc).isoformat()
+
+    # Check if this is a TodoWrite tool call
+    tool_name = (event_data.get("title") or "").lower()
+    is_todo_write = tool_name in ("todowrite", "todo_write")
+
+    # Save to DB:
+    # - For TodoWrite: Save every progress update (todos change frequently)
+    # - For other tools: Only save when status="completed"
+    if is_todo_write or acp_event.status == "completed":
+        create_message(
+            session_id=session_id,
+            message_type=MessageType.ASSISTANT,
+            turn_index=state.turn_index,
+            message_metadata=event_data,
+            db_session=self._db_session,
+        )
+
+    packet_logger.log("tool_call_progress", event_data)
+    yield _serialize_acp_event(acp_event, "tool_call_progress")
+```
+
+**Note**: For TodoWrite, we save every progress update because the todo items change incrementally. This ensures we capture the final state for rendering on refresh.
+
+---
+
+### Phase 4: Frontend - Load Todos from DB
+
+#### 4.1 Update convertMessagesToStreamItems
+
+**File**: `web/src/app/build/hooks/useBuildSessionStore.ts`
+
+```typescript
+function convertMessagesToStreamItems(messages: BuildMessage[]): StreamItem[] {
+  const streamItems: StreamItem[] = [];
+
+  // Track the latest todo list state per tool_call_id (for deduplication)
+  const todoListMap = new Map<string, TodoListState>();
+
+  for (const message of messages) {
+    if (message.type === "user") continue;
+
+    const metadata = message.message_metadata;
+    if (!metadata || typeof metadata !== "object") continue;
+
+    const packetType = metadata.type as string;
+
+    switch (packetType) {
+      // ... existing cases ...
+
+      case "tool_call_progress": {
+        const toolName = ((metadata.title as string) || "").toLowerCase();
+
+        // Handle TodoWrite separately
+        if (toolName === "todowrite" || toolName === "todo_write") {
+          const toolCallId = (metadata.tool_call_id || metadata.toolCallId || message.id) as string;
+          const todos = extractTodosFromMetadata(metadata);
+
+          // Update or create in map (keeps latest state only)
+          todoListMap.set(toolCallId, {
+            id: toolCallId,
+            todos,
+            isOpen: false, // Default to collapsed when loaded from history
+          });
+          break;
+        }
+
+        // ... existing tool_call_progress handling ...
+      }
+    }
+  }
+
+  // Add deduplicated todo lists to stream items
+  // Insert them in the order they first appeared (approximated by message order)
+  for (const [id, todoList] of todoListMap) {
+    streamItems.push({
+      type: "todo_list",
+      id,
+      todoList,
+    });
+  }
+
+  // Note: This simplified approach puts all todo lists at the end.
+  // For proper ordering, we'd need to track insertion positions.
+  // This is acceptable for MVP since todo lists typically appear
+  // interleaved with other content during streaming.
+
+  return streamItems;
+}
+
+function extractTodosFromMetadata(metadata: Record<string, any>): TodoItem[] {
+  const rawInput = (metadata.raw_input || metadata.rawInput);
+  if (!rawInput?.todos || !Array.isArray(rawInput.todos)) return [];
+
+  return rawInput.todos.map((t: any) => ({
+    content: t.content || "",
+    status: (t.status as TodoStatus) || "pending",
+    activeForm: t.activeForm || t.content || "",
+  }));
+}
+```
+
+---
+
+### Phase 5: Frontend - Render in BuildMessageList
+
+#### 5.1 Update BuildMessageList
+
+**File**: `web/src/app/build/components/BuildMessageList.tsx`
+
+```typescript
+import TodoListCard from "@/app/build/components/TodoListCard";
+
+// In the streamItems.map() switch:
+case "todo_list":
+  return (
+    <TodoListCard
+      key={item.id}
+      todoList={item.todoList}
+      defaultOpen={item.todoList.isOpen}
+    />
+  );
+```
+
+---
+
+## File Changes Summary
+
+| File | Changes |
+|------|---------|
+| `web/src/app/build/types/displayTypes.ts` | Add `TodoItem`, `TodoListState`, update `StreamItem` union |
+| `web/src/app/build/components/TodoListCard.tsx` | **NEW** - Collapsible todo list component |
+| `web/src/app/build/hooks/useBuildStreaming.ts` | Handle `todowrite` tool calls specially |
+| `web/src/app/build/hooks/useBuildSessionStore.ts` | Add `updateTodoListStreamItem`, `collapseAllTodoLists`, update `convertMessagesToStreamItems` |
+| `web/src/app/build/components/BuildMessageList.tsx` | Render `todo_list` StreamItem type |
+| `backend/onyx/server/features/build/session/manager.py` | Save TodoWrite progress packets to DB |
+
+---
+
+## Acceptance Criteria
+
+1. **Streaming Rendering**:
+   - When agent calls TodoWrite, a todo list card appears in the chat
+   - Todo items show with status indicators (checkbox, spinner, checkmark)
+   - Items update in real-time as agent marks them complete
+
+2. **FIFO / Multiple Lists**:
+   - Multiple todo list cards can appear in a single response
+   - When a new todo list appears, previous ones auto-collapse
+   - Final todo list remains open
+
+3. **Persistence**:
+   - On page refresh, todo lists are re-rendered from DB
+   - All todo items preserve their final state
+   - Todo lists default to collapsed when loaded from history
+
+4. **UI Polish**:
+   - Shows progress count (e.g., "3/5 completed")
+   - Spinner animates on in-progress items
+   - Completed items have strikethrough styling

--- a/web/src/app/build/components/BuildMessageList.tsx
+++ b/web/src/app/build/components/BuildMessageList.tsx
@@ -5,6 +5,7 @@ import Logo from "@/refresh-components/Logo";
 import TextChunk from "@/app/build/components/TextChunk";
 import ThinkingCard from "@/app/build/components/ThinkingCard";
 import ToolCallPill from "@/app/build/components/ToolCallPill";
+import TodoListCard from "@/app/build/components/TodoListCard";
 import UserMessage from "@/app/build/components/UserMessage";
 import { BuildMessage } from "@/app/build/services/buildStreamingModels";
 import { StreamItem } from "@/app/build/types/displayTypes";
@@ -65,7 +66,7 @@ export default function BuildMessageList({
 
   return (
     <div className="flex flex-col items-center px-4 pb-4">
-      <div className="max-w-2xl w-full backdrop-blur-md rounded-16 p-4">
+      <div className="w-full max-w-2xl backdrop-blur-md rounded-16 p-4">
         {/* Render user messages */}
         {userMessages.map((message) => (
           <UserMessage key={message.id} content={message.content} />
@@ -103,6 +104,14 @@ export default function BuildMessageList({
                           <ToolCallPill
                             key={item.id}
                             toolCall={item.toolCall}
+                          />
+                        );
+                      case "todo_list":
+                        return (
+                          <TodoListCard
+                            key={item.id}
+                            todoList={item.todoList}
+                            defaultOpen={item.todoList.isOpen}
                           />
                         );
                       default:

--- a/web/src/app/build/components/DiffView.tsx
+++ b/web/src/app/build/components/DiffView.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+
+interface DiffViewProps {
+  oldContent: string;
+  newContent: string;
+  maxHeight?: string;
+  /** File path for context (displayed in header) */
+  filePath?: string;
+}
+
+interface DiffLine {
+  type: "added" | "removed" | "unchanged" | "header";
+  content: string;
+  oldLineNum?: number;
+  newLineNum?: number;
+}
+
+/**
+ * Compute a simple line-by-line diff between old and new content.
+ * Uses a basic LCS-like approach for reasonable diff output.
+ */
+function computeDiff(oldText: string, newText: string): DiffLine[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  const result: DiffLine[] = [];
+
+  let oldIdx = 0;
+  let newIdx = 0;
+  let oldLineNum = 1;
+  let newLineNum = 1;
+
+  while (oldIdx < oldLines.length || newIdx < newLines.length) {
+    const oldLine: string | undefined = oldLines[oldIdx];
+    const newLine: string | undefined = newLines[newIdx];
+
+    if (oldIdx >= oldLines.length || oldLine === undefined) {
+      // All remaining new lines are additions
+      result.push({
+        type: "added",
+        content: newLine ?? "",
+        newLineNum: newLineNum++,
+      });
+      newIdx++;
+    } else if (newIdx >= newLines.length || newLine === undefined) {
+      // All remaining old lines are deletions
+      result.push({
+        type: "removed",
+        content: oldLine,
+        oldLineNum: oldLineNum++,
+      });
+      oldIdx++;
+    } else if (oldLine === newLine) {
+      // Lines match - unchanged
+      result.push({
+        type: "unchanged",
+        content: oldLine,
+        oldLineNum: oldLineNum++,
+        newLineNum: newLineNum++,
+      });
+      oldIdx++;
+      newIdx++;
+    } else {
+      // Lines differ - check if old line exists later in new, or vice versa
+      const oldExistsLaterInNew = newLines.slice(newIdx + 1).includes(oldLine);
+      const newExistsLaterInOld = oldLines.slice(oldIdx + 1).includes(newLine);
+
+      if (!oldExistsLaterInNew && newExistsLaterInOld) {
+        // Old line was removed
+        result.push({
+          type: "removed",
+          content: oldLine,
+          oldLineNum: oldLineNum++,
+        });
+        oldIdx++;
+      } else if (oldExistsLaterInNew && !newExistsLaterInOld) {
+        // New line was added
+        result.push({
+          type: "added",
+          content: newLine,
+          newLineNum: newLineNum++,
+        });
+        newIdx++;
+      } else {
+        // Both differ - show as removal then addition (replacement)
+        result.push({
+          type: "removed",
+          content: oldLine,
+          oldLineNum: oldLineNum++,
+        });
+        result.push({
+          type: "added",
+          content: newLine,
+          newLineNum: newLineNum++,
+        });
+        oldIdx++;
+        newIdx++;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Collapse unchanged lines in the middle of the diff.
+ * Shows context lines around changes.
+ */
+function collapseUnchanged(
+  lines: DiffLine[],
+  contextLines: number = 3
+): DiffLine[] {
+  const result: DiffLine[] = [];
+  const changeIndices: number[] = [];
+
+  // Find all indices with changes
+  lines.forEach((line, idx) => {
+    if (line.type === "added" || line.type === "removed") {
+      changeIndices.push(idx);
+    }
+  });
+
+  if (changeIndices.length === 0) {
+    // No changes, show a summary
+    if (lines.length > 10) {
+      return [{ type: "header", content: `(${lines.length} unchanged lines)` }];
+    }
+    return lines;
+  }
+
+  // Create a set of indices to show
+  const showIndices = new Set<number>();
+  changeIndices.forEach((idx) => {
+    for (
+      let i = Math.max(0, idx - contextLines);
+      i <= Math.min(lines.length - 1, idx + contextLines);
+      i++
+    ) {
+      showIndices.add(i);
+    }
+  });
+
+  let lastShownIdx = -1;
+  lines.forEach((line, idx) => {
+    if (showIndices.has(idx)) {
+      if (lastShownIdx !== -1 && idx - lastShownIdx > 1) {
+        // Add collapse marker
+        const skipped = idx - lastShownIdx - 1;
+        result.push({
+          type: "header",
+          content: `... ${skipped} unchanged line${skipped > 1 ? "s" : ""} ...`,
+        });
+      }
+      result.push(line);
+      lastShownIdx = idx;
+    }
+  });
+
+  return result;
+}
+
+/**
+ * DiffView - Displays a diff between old and new content
+ *
+ * Shows added lines in green with + prefix
+ * Shows removed lines in red with - prefix
+ * Collapses long unchanged sections
+ */
+export default function DiffView({
+  oldContent,
+  newContent,
+  maxHeight = "300px",
+  filePath,
+}: DiffViewProps) {
+  const diffLines = useMemo(() => {
+    const rawDiff = computeDiff(oldContent, newContent);
+    return collapseUnchanged(rawDiff);
+  }, [oldContent, newContent]);
+
+  // Count changes for summary
+  const stats = useMemo(() => {
+    const added = diffLines.filter((l) => l.type === "added").length;
+    const removed = diffLines.filter((l) => l.type === "removed").length;
+    return { added, removed };
+  }, [diffLines]);
+
+  return (
+    <div
+      className={cn(
+        "rounded-08 border overflow-hidden",
+        "bg-[#fafafa] border-[#e5e5e5] dark:bg-[#151617] dark:border-[#2a2a2a]"
+      )}
+    >
+      {/* Header with stats */}
+      <div
+        className={cn(
+          "px-3 py-2 border-b text-xs flex items-center gap-3",
+          "bg-[#f5f5f5] border-[#e5e5e5] dark:bg-[#1a1a1a] dark:border-[#2a2a2a]"
+        )}
+        style={{ fontFamily: "var(--font-dm-mono)" }}
+      >
+        {filePath && (
+          <span className="text-text-03 truncate flex-1">{filePath}</span>
+        )}
+        <div className="flex items-center gap-2 shrink-0">
+          {stats.added > 0 && (
+            <span className="text-green-600 dark:text-green-400">
+              +{stats.added}
+            </span>
+          )}
+          {stats.removed > 0 && (
+            <span className="text-red-600 dark:text-red-400">
+              -{stats.removed}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Diff content */}
+      <div
+        className="overflow-auto text-xs"
+        style={{
+          fontFamily: "var(--font-dm-mono)",
+          maxHeight,
+        }}
+      >
+        {diffLines.map((line, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              "px-3 py-0.5 whitespace-pre-wrap break-words",
+              line.type === "added" &&
+                "bg-green-100 dark:bg-green-950/40 text-green-800 dark:text-green-300",
+              line.type === "removed" &&
+                "bg-red-100 dark:bg-red-950/40 text-red-800 dark:text-red-300",
+              line.type === "unchanged" && "text-text-03",
+              line.type === "header" &&
+                "text-text-04 bg-[#f0f0f0] dark:bg-[#1d1d1d] text-center italic py-1"
+            )}
+          >
+            {line.type === "added" && (
+              <span className="select-none text-green-600 dark:text-green-500 mr-2">
+                +
+              </span>
+            )}
+            {line.type === "removed" && (
+              <span className="select-none text-red-600 dark:text-red-500 mr-2">
+                -
+              </span>
+            )}
+            {line.type === "unchanged" && (
+              <span className="select-none text-text-04 mr-2">&nbsp;</span>
+            )}
+            {line.content || (line.type !== "header" ? " " : "")}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/build/components/TodoListCard.tsx
+++ b/web/src/app/build/components/TodoListCard.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/refresh-components/Collapsible";
+import { SvgChevronDown, SvgCheckCircle } from "@opal/icons";
+import {
+  TodoListState,
+  TodoItem,
+  TodoStatus,
+} from "@/app/build/types/displayTypes";
+
+interface TodoListCardProps {
+  todoList: TodoListState;
+  /** Whether this card should be open by default */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Get status icon for a todo item
+ */
+function getStatusIcon(status: TodoStatus) {
+  switch (status) {
+    case "completed":
+      return (
+        <SvgCheckCircle className="size-4 stroke-status-success-05 mt-0.5 shrink-0" />
+      );
+    case "in_progress":
+      // Gray circle with inset filled circle to indicate work in progress
+      return (
+        <div className="size-4 rounded-full border-2 border-text-03 mt-0.5 shrink-0 flex items-center justify-center">
+          <div className="size-2 bg-text-03 rounded-full" />
+        </div>
+      );
+    case "pending":
+    default:
+      return (
+        <div className="size-4 rounded-full border-2 border-text-03 mt-0.5 shrink-0" />
+      );
+  }
+}
+
+/**
+ * Single todo item row
+ */
+function TodoItemRow({ todo }: { todo: TodoItem }) {
+  return (
+    <div className="flex items-start gap-2 py-1">
+      {/* Status indicator */}
+      {getStatusIcon(todo.status)}
+
+      {/* Task text - show activeForm when in_progress, otherwise content */}
+      <span
+        className={cn(
+          "text-sm",
+          todo.status === "completed"
+            ? "text-text-03 line-through"
+            : "text-text-04"
+        )}
+      >
+        {todo.status === "in_progress" ? todo.activeForm : todo.content}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * TodoListCard - Collapsible card showing a list of todo items
+ *
+ * Features:
+ * - Shows progress count (e.g., "3/5 completed")
+ * - Spinner in header when any item is in_progress
+ * - Auto-collapses when new todo list appears (controlled by parent)
+ * - Items show different states: pending (empty circle), in_progress (spinner), completed (checkmark)
+ */
+export default function TodoListCard({
+  todoList,
+  defaultOpen = true,
+}: TodoListCardProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  // Update isOpen when defaultOpen changes (for auto-collapse behavior)
+  useEffect(() => {
+    setIsOpen(defaultOpen);
+  }, [defaultOpen]);
+
+  // Calculate progress stats
+  const total = todoList.todos.length;
+  const completed = todoList.todos.filter(
+    (t) => t.status === "completed"
+  ).length;
+
+  // Determine background color based on state
+  // Only two states: gray (default) and green (completed)
+  const allCompleted = completed === total && total > 0;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div
+        className={cn(
+          "w-full border rounded-lg overflow-hidden",
+          allCompleted
+            ? "bg-status-success-01 border-status-success-02"
+            : "bg-background-neutral-01 border-border-02"
+        )}
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            className={cn(
+              "w-full flex items-center justify-between px-3 py-2",
+              "hover:bg-background-tint-02 transition-colors text-left"
+            )}
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              {/* Status indicator in header - no spinner, only static icons */}
+              {allCompleted ? (
+                <SvgCheckCircle className="size-4 stroke-status-success-05 shrink-0" />
+              ) : (
+                <div className="size-4 rounded border-2 border-text-03 shrink-0 flex items-center justify-center">
+                  <div className="size-2 bg-text-03 rounded-sm" />
+                </div>
+              )}
+
+              {/* Title */}
+              <span className="text-sm font-medium text-text-04">Tasks</span>
+
+              {/* Progress count */}
+              <span className="text-xs text-text-03">
+                {completed}/{total} completed
+              </span>
+            </div>
+
+            {/* Expand arrow */}
+            <SvgChevronDown
+              className={cn(
+                "size-4 stroke-text-03 transition-transform duration-150 shrink-0",
+                !isOpen && "rotate-[-90deg]"
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="px-3 pb-3 pt-0 space-y-0.5">
+            {todoList.todos.map((todo, index) => (
+              <TodoItemRow key={`${todoList.id}-${index}`} todo={todo} />
+            ))}
+            {todoList.todos.length === 0 && (
+              <span className="text-sm text-text-03 italic">No tasks</span>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/web/src/app/build/services/apiServices.ts
+++ b/web/src/app/build/services/apiServices.ts
@@ -173,6 +173,23 @@ export async function deleteSession(sessionId: string): Promise<void> {
 // Messages API
 // =============================================================================
 
+/**
+ * Extract text content from message_metadata.
+ * For user_message: {type: "user_message", content: {type: "text", text: "..."}}
+ */
+function extractContentFromMetadata(
+  metadata: Record<string, any> | null | undefined
+): string {
+  if (!metadata) return "";
+  const content = metadata.content;
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (typeof content === "object" && content.type === "text" && content.text) {
+    return content.text;
+  }
+  return "";
+}
+
 export async function fetchMessages(
   sessionId: string
 ): Promise<BuildMessage[]> {
@@ -186,7 +203,8 @@ export async function fetchMessages(
   return data.messages.map((m: ApiMessageResponse) => ({
     id: m.id,
     type: m.type,
-    content: m.content,
+    // Content is stored in message_metadata, not as a separate field
+    content: m.content || extractContentFromMetadata(m.message_metadata),
     message_metadata: m.message_metadata,
     timestamp: new Date(m.created_at),
   }));

--- a/web/src/app/build/types/displayTypes.ts
+++ b/web/src/app/build/types/displayTypes.ts
@@ -5,7 +5,31 @@
  * Items are stored and rendered in chronological order as they arrive.
  */
 
-export type ToolCallKind = "execute" | "read" | "other";
+export type ToolCallKind = "execute" | "read" | "task" | "other";
+
+// =============================================================================
+// Todo List Types (for TodoWrite tool)
+// =============================================================================
+
+export type TodoStatus = "pending" | "in_progress" | "completed";
+
+export interface TodoItem {
+  /** The task description */
+  content: string;
+  /** Current status */
+  status: TodoStatus;
+  /** Present tense form shown during execution (e.g., "Creating API endpoint") */
+  activeForm: string;
+}
+
+export interface TodoListState {
+  /** Tool call ID */
+  id: string;
+  /** Array of todo items */
+  todos: TodoItem[];
+  /** Whether the card is expanded (UI state only) */
+  isOpen: boolean;
+}
 export type ToolCallStatus =
   | "pending"
   | "in_progress"
@@ -17,10 +41,18 @@ export interface ToolCallState {
   id: string;
   kind: ToolCallKind;
   title: string;
-  description: string; // "Listing output directory"
-  command: string; // "ls outputs/"
+  description: string; // "Listing output directory" or task description
+  command: string; // "ls outputs/" or task prompt for task kind
   status: ToolCallStatus;
   rawOutput: string; // Full output for expanded view
+  /** For task tool calls: the subagent type (e.g., "explore", "plan") */
+  subagentType?: string;
+  /** For edit operations: whether this is a new file (write) or edit of existing */
+  isNewFile?: boolean;
+  /** For edit operations: the old content before the edit (empty for new files) */
+  oldContent?: string;
+  /** For edit operations: the new content after the edit */
+  newContent?: string;
 }
 
 /**
@@ -30,4 +62,5 @@ export interface ToolCallState {
 export type StreamItem =
   | { type: "text"; id: string; content: string; isStreaming: boolean }
   | { type: "thinking"; id: string; content: string; isStreaming: boolean }
-  | { type: "tool_call"; id: string; toolCall: ToolCallState };
+  | { type: "tool_call"; id: string; toolCall: ToolCallState }
+  | { type: "todo_list"; id: string; todoList: TodoListState };

--- a/web/src/app/build/utils/packet-processing-refactor.md
+++ b/web/src/app/build/utils/packet-processing-refactor.md
@@ -1,0 +1,651 @@
+# Packet Processing Refactor Plan
+
+This document outlines a comprehensive refactor of `streamItemHelpers.ts` to cleanly determine packet types and extract relevant information.
+
+---
+
+## Current Problems
+
+### 1. Scattered Type Detection
+The current code has type detection logic spread across multiple functions:
+- `isTodoWriteTool()` checks tool name in multiple places
+- `isTaskTool()` checks tool name separately
+- `normalizeKind()` has mixed tool name and kind logic
+- Each extraction function (`getDescription`, `getCommand`, etc.) re-checks the kind/tool name
+
+### 2. Inconsistent Field Access
+Field names vary between snake_case and camelCase with no central mapping:
+- `tool_call_id` vs `toolCallId`
+- `raw_input` vs `rawInput`
+- `raw_output` vs `rawOutput`
+- `tool_name` vs `toolName` vs `title`
+
+### 3. Mixed Concerns
+Helper functions mix:
+- Packet type identification
+- Field extraction
+- Display formatting
+- Path sanitization
+
+### 4. No Type Safety
+Packets are typed as `Record<string, unknown>` with repeated casting throughout.
+
+---
+
+## Proposed Architecture
+
+### Layer 1: Packet Parsing (Type-Safe)
+
+Create a discriminated union type for all packets:
+
+```typescript
+// packets.ts - New file
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+export type PacketType =
+  | "agent_message_chunk"
+  | "agent_thought_chunk"
+  | "tool_call_start"
+  | "tool_call_progress"
+  | "agent_plan_update"
+  | "prompt_response"
+  | "artifact_created"
+  | "error"
+  | "unknown";
+
+export type ToolName =
+  | "glob"
+  | "grep"
+  | "read"
+  | "write"
+  | "edit"
+  | "bash"
+  | "task"
+  | "todowrite"
+  | "webfetch"
+  | "websearch"
+  | "unknown";
+
+export type ToolKind = "search" | "read" | "execute" | "edit" | "task" | "other";
+
+// ============================================================================
+// Parsed Packet Types (Discriminated Union)
+// ============================================================================
+
+export interface ParsedMessageChunk {
+  type: "agent_message_chunk" | "agent_thought_chunk";
+  text: string;
+}
+
+export interface ParsedToolCallStart {
+  type: "tool_call_start";
+  toolCallId: string;
+  toolName: ToolName;
+  kind: ToolKind;
+}
+
+export interface ParsedToolCallProgress {
+  type: "tool_call_progress";
+  toolCallId: string;
+  toolName: ToolName;
+  kind: ToolKind;
+  status: "pending" | "in_progress" | "completed" | "failed" | "cancelled";
+  input: ToolInput;
+  output: ToolOutput | null;
+  locations: LocationInfo[];
+}
+
+export interface ParsedPlanUpdate {
+  type: "agent_plan_update";
+  entries: PlanEntry[];
+}
+
+export interface ParsedPromptResponse {
+  type: "prompt_response";
+  stopReason: "end_turn" | "max_tokens" | "stop_sequence";
+}
+
+export interface ParsedArtifact {
+  type: "artifact_created";
+  artifact: ArtifactInfo;
+}
+
+export interface ParsedError {
+  type: "error";
+  message: string;
+}
+
+export interface ParsedUnknown {
+  type: "unknown";
+  raw: unknown;
+}
+
+export type ParsedPacket =
+  | ParsedMessageChunk
+  | ParsedToolCallStart
+  | ParsedToolCallProgress
+  | ParsedPlanUpdate
+  | ParsedPromptResponse
+  | ParsedArtifact
+  | ParsedError
+  | ParsedUnknown;
+```
+
+### Layer 2: Tool-Specific Input/Output Types
+
+```typescript
+// ============================================================================
+// Tool Input Types (Discriminated by toolName)
+// ============================================================================
+
+export type ToolInput =
+  | { toolName: "glob"; pattern: string }
+  | { toolName: "grep"; pattern: string; path?: string }
+  | { toolName: "read"; filePath: string }
+  | { toolName: "write"; filePath: string; content: string }
+  | { toolName: "edit"; filePath: string; oldString: string; newString: string }
+  | { toolName: "bash"; command: string; description: string }
+  | { toolName: "task"; prompt: string; description: string; subagentType: string }
+  | { toolName: "todowrite"; todos: TodoItem[] }
+  | { toolName: "webfetch"; url: string; prompt: string }
+  | { toolName: "websearch"; query: string }
+  | { toolName: "unknown"; raw: unknown };
+
+// ============================================================================
+// Tool Output Types
+// ============================================================================
+
+export interface SearchOutput {
+  files: string[];
+  count: number;
+  truncated: boolean;
+}
+
+export interface ReadOutput {
+  content: string;
+  truncated: boolean;
+}
+
+export interface WriteOutput {
+  success: boolean;
+  newText?: string;
+  oldText?: string;        // Empty string for new files, content for edits
+  isNewFile: boolean;      // true = new file (write), false = edit existing
+}
+
+export interface BashOutput {
+  output: string;
+  exitCode: number;
+  truncated: boolean;
+}
+
+export interface TodoOutput {
+  todos: TodoItem[];
+}
+
+export type ToolOutput =
+  | { toolName: "glob" | "grep"; data: SearchOutput }
+  | { toolName: "read"; data: ReadOutput }
+  | { toolName: "write" | "edit"; data: WriteOutput }
+  | { toolName: "bash"; data: BashOutput }
+  | { toolName: "task"; data: { result: string } }
+  | { toolName: "todowrite"; data: TodoOutput }
+  | { toolName: "unknown"; data: unknown };
+```
+
+### Layer 3: Parsing Functions
+
+```typescript
+// packetParser.ts - New file
+
+// ============================================================================
+// Main Parser
+// ============================================================================
+
+export function parsePacket(raw: unknown): ParsedPacket {
+  if (!raw || typeof raw !== "object") {
+    return { type: "unknown", raw };
+  }
+
+  const packet = raw as Record<string, unknown>;
+  const packetType = determinePacketType(packet);
+
+  switch (packetType) {
+    case "agent_message_chunk":
+    case "agent_thought_chunk":
+      return parseMessageChunk(packet, packetType);
+    case "tool_call_start":
+      return parseToolCallStart(packet);
+    case "tool_call_progress":
+      return parseToolCallProgress(packet);
+    case "agent_plan_update":
+      return parsePlanUpdate(packet);
+    case "prompt_response":
+      return parsePromptResponse(packet);
+    case "artifact_created":
+      return parseArtifact(packet);
+    case "error":
+      return parseError(packet);
+    default:
+      return { type: "unknown", raw };
+  }
+}
+
+// ============================================================================
+// Type Determination
+// ============================================================================
+
+function determinePacketType(packet: Record<string, unknown>): PacketType {
+  // Check explicit type field first
+  const type = packet.type as string | undefined;
+  if (type === "agent_message_chunk") return "agent_message_chunk";
+  if (type === "agent_thought_chunk") return "agent_thought_chunk";
+  if (type === "tool_call_progress") return "tool_call_progress";
+  if (type === "agent_plan_update") return "agent_plan_update";
+  if (type === "prompt_response") return "prompt_response";
+  if (type === "artifact_created") return "artifact_created";
+  if (type === "error") return "error";
+
+  // Fall back to sessionUpdate field
+  const sessionUpdate = packet.sessionUpdate as string | undefined;
+  if (sessionUpdate === "agent_message_chunk") return "agent_message_chunk";
+  if (sessionUpdate === "tool_call") return "tool_call_start";
+  if (sessionUpdate === "tool_call_update") return "tool_call_progress";
+  if (sessionUpdate === "plan") return "agent_plan_update";
+
+  return "unknown";
+}
+
+// ============================================================================
+// Tool Name Normalization
+// ============================================================================
+
+function normalizeToolName(packet: Record<string, unknown>): ToolName {
+  const name = (
+    packet.tool_name ??
+    packet.toolName ??
+    packet.title ??
+    ""
+  ) as string;
+
+  const normalized = name.toLowerCase();
+
+  switch (normalized) {
+    case "glob": return "glob";
+    case "grep": return "grep";
+    case "read": return "read";
+    case "write": return "write";
+    case "edit": return "edit";
+    case "bash": return "bash";
+    case "task": return "task";
+    case "todowrite":
+    case "todo_write": return "todowrite";
+    case "webfetch": return "webfetch";
+    case "websearch": return "websearch";
+    default: return "unknown";
+  }
+}
+
+function toolNameToKind(toolName: ToolName, rawKind?: string): ToolKind {
+  // Task is always identified by name, not kind
+  if (toolName === "task") return "task";
+
+  // Tool-specific mappings
+  switch (toolName) {
+    case "glob":
+    case "grep":
+      return "search";
+    case "read":
+      return "read";
+    case "write":
+    case "edit":
+      return "edit";
+    case "bash":
+      return "execute";
+    default:
+      // Fall back to rawKind if provided
+      if (rawKind === "search" || rawKind === "read" || rawKind === "execute" || rawKind === "edit") {
+        return rawKind;
+      }
+      return "other";
+  }
+}
+```
+
+### Layer 4: Display Helpers (Pure)
+
+```typescript
+// displayHelpers.ts - Replaces most of current streamItemHelpers.ts
+
+// ============================================================================
+// Display Formatting (No parsing, just formatting)
+// ============================================================================
+
+/**
+ * Get human-readable title for a tool call
+ * @param isNewFile - For edit/write tools: true = new file, false = editing existing
+ */
+export function getToolDisplayTitle(toolName: ToolName, isNewFile?: boolean): string {
+  // Special handling for edit kind - distinguish between write and edit
+  if (toolName === "write" || toolName === "edit") {
+    return isNewFile === false ? "Editing file" : "Writing file";
+  }
+
+  const titles: Record<ToolName, string> = {
+    glob: "Searching files",
+    grep: "Searching content",
+    read: "Reading file",
+    write: "Writing file",
+    edit: "Editing file",
+    bash: "Running command",
+    task: "Running task",
+    todowrite: "Updating todos",
+    webfetch: "Fetching web content",
+    websearch: "Searching web",
+    unknown: "Running tool",
+  };
+  return titles[toolName];
+}
+
+/**
+ * Get description text for a tool call
+ */
+export function getToolDescription(input: ToolInput): string {
+  switch (input.toolName) {
+    case "glob":
+    case "grep":
+      return input.pattern;
+    case "read":
+    case "write":
+    case "edit":
+      return getRelativePath(input.filePath);
+    case "bash":
+      return input.description || "Running command";
+    case "task":
+      return input.description || "Running subagent";
+    case "todowrite":
+      return `${input.todos.length} todos`;
+    case "webfetch":
+      return input.prompt;
+    case "websearch":
+      return input.query;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Get command/detail text for expanded view
+ */
+export function getToolCommand(input: ToolInput): string {
+  switch (input.toolName) {
+    case "glob":
+    case "grep":
+      return input.pattern;
+    case "read":
+    case "write":
+    case "edit":
+      return getRelativePath(input.filePath);
+    case "bash":
+      return input.command;
+    case "task":
+      return input.prompt;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Format output for display
+ */
+export function formatToolOutput(output: ToolOutput | null): string {
+  if (!output) return "";
+
+  switch (output.toolName) {
+    case "glob":
+    case "grep":
+      return output.data.files.join("\n");
+    case "read":
+      return output.data.content;
+    case "write":
+    case "edit":
+      return output.data.newText ?? "";
+    case "bash":
+      return output.data.output;
+    case "task":
+      return output.data.result;
+    case "todowrite":
+      return JSON.stringify(output.data.todos, null, 2);
+    default:
+      return JSON.stringify(output.data, null, 2);
+  }
+}
+
+/**
+ * Strip sandbox path prefix to get clean relative path
+ */
+export function getRelativePath(fullPath: string): string {
+  if (!fullPath) return "";
+  const outputsMatch = fullPath.match(/\/outputs\/(.+)$/);
+  if (outputsMatch?.[1]) return outputsMatch[1];
+  const sandboxMatch = fullPath.match(/\/sandboxes\/[^/]+\/(.+)$/);
+  if (sandboxMatch?.[1]) return sandboxMatch[1];
+  const lastSlash = fullPath.lastIndexOf("/");
+  return lastSlash >= 0 ? fullPath.slice(lastSlash + 1) : fullPath;
+}
+```
+
+---
+
+## Migration Plan
+
+### Phase 1: Create New Files
+1. Create `packets.ts` with all type definitions
+2. Create `packetParser.ts` with parsing functions
+3. Create `displayHelpers.ts` with formatting functions
+
+### Phase 2: Update Consumers
+Update in order:
+1. `useBuildStreaming.ts` - Use `parsePacket()` in SSE handler
+2. `useBuildSessionStore.ts` - Use `parsePacket()` in `convertMessagesToStreamItems()`
+
+### Phase 3: Clean Up
+1. Delete redundant functions from `streamItemHelpers.ts`
+2. Keep only utilities that are still needed:
+   - `genId()` - ID generation
+   - `normalizeTodoStatus()` - Used by display components
+3. Update imports across codebase
+
+---
+
+## Example: Refactored useBuildStreaming Handler
+
+```typescript
+import { parsePacket, ParsedPacket } from "@/app/build/utils/packetParser";
+import { getToolDisplayTitle, getToolDescription, getToolCommand, formatToolOutput } from "@/app/build/utils/displayHelpers";
+
+// In processSSEStream callback:
+await processSSEStream(response, (rawPacket) => {
+  const packet = parsePacket(rawPacket);
+
+  switch (packet.type) {
+    case "agent_message_chunk":
+      handleTextChunk(sessionId, packet.text);
+      break;
+
+    case "agent_thought_chunk":
+      handleThinkingChunk(sessionId, packet.text);
+      break;
+
+    case "tool_call_start": {
+      // Simple, clean handling
+      if (packet.toolName === "todowrite") {
+        appendTodoList(sessionId, packet.toolCallId);
+      } else {
+        appendToolCall(sessionId, {
+          id: packet.toolCallId,
+          kind: packet.kind,
+          title: getToolDisplayTitle(packet.toolName),
+          status: "pending",
+          description: "",
+          command: "",
+          rawOutput: "",
+          subagentType: packet.toolName === "task" ? undefined : undefined,
+        });
+      }
+      break;
+    }
+
+    case "tool_call_progress": {
+      if (packet.toolName === "todowrite" && packet.input.toolName === "todowrite") {
+        updateTodoList(sessionId, packet.toolCallId, packet.input.todos);
+      } else {
+        updateToolCall(sessionId, packet.toolCallId, {
+          status: packet.status,
+          description: getToolDescription(packet.input),
+          command: getToolCommand(packet.input),
+          rawOutput: formatToolOutput(packet.output),
+          subagentType: packet.input.toolName === "task" ? packet.input.subagentType : undefined,
+        });
+      }
+      break;
+    }
+
+    case "agent_plan_update":
+      // Handle plan updates if needed
+      break;
+
+    case "prompt_response":
+      finalizeStreaming();
+      updateSessionData(sessionId, { status: "completed" });
+      break;
+
+    case "error":
+      updateSessionData(sessionId, {
+        status: "failed",
+        error: packet.message,
+      });
+      break;
+  }
+});
+```
+
+---
+
+## Benefits
+
+1. **Type Safety**: Discriminated unions catch errors at compile time
+2. **Single Source of Truth**: Packet type determined once in `parsePacket()`
+3. **Separation of Concerns**:
+   - Parsing (raw → typed)
+   - Display formatting (typed → strings)
+4. **Testability**: Each layer can be unit tested independently
+5. **Maintainability**: Adding new tool types is straightforward
+6. **Readability**: Switch statements on discriminated unions are self-documenting
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `utils/packets.ts` | CREATE | Type definitions |
+| `utils/packetParser.ts` | CREATE | Parsing functions |
+| `utils/displayHelpers.ts` | CREATE | Formatting functions |
+| `utils/streamItemHelpers.ts` | MODIFY | Keep only `genId()`, `normalizeTodoStatus()` |
+| `hooks/useBuildStreaming.ts` | MODIFY | Use new parser |
+| `hooks/useBuildSessionStore.ts` | MODIFY | Use new parser in `convertMessagesToStreamItems()` |
+
+---
+
+## Discovered Quirks (Session 2026-01-22)
+
+### 1. Title Field Changes on Completion
+
+For certain tools, the `title` field changes between `tool_call_start` and `tool_call_progress`:
+
+| Tool | Start `title` | Completed `title` |
+|------|---------------|-------------------|
+| TodoWrite | `"todowrite"` | `"6 todos"` (count-based) |
+| Edit/Write | `"edit"` or `"write"` | File path (e.g., `"path/to/file.tsx"`) |
+
+**Solution:** Don't rely solely on `title` for tool identification. Check `rawInput` for tool-specific fields:
+- TodoWrite: `rawInput.todos` array exists
+- Task: `rawInput.subagent_type` exists
+- Edit: Check `kind === "edit"` field
+
+### 2. Write vs Edit Detection
+
+The backend sends `kind: "edit"` for both new file creation and editing existing files. The distinction is in the diff content:
+
+| `content[].oldText` | Operation | Display |
+|---------------------|-----------|---------|
+| `""` (empty string) | New file  | "Writing file" |
+| Non-empty string    | Edit      | "Editing file" |
+
+**Extraction Function:**
+```typescript
+function extractDiffData(content: unknown): {
+  oldText: string;
+  newText: string;
+  isNewFile: boolean;
+} {
+  if (!Array.isArray(content)) return { oldText: "", newText: "", isNewFile: true };
+
+  for (const item of content) {
+    if (item?.type === "diff") {
+      const oldText = item.oldText || "";
+      const newText = item.newText || "";
+      return { oldText, newText, isNewFile: oldText === "" };
+    }
+  }
+  return { oldText: "", newText: "", isNewFile: true };
+}
+```
+
+### 3. File Path Extraction for Edit Packets
+
+For `kind: "edit"` packets, the file path can be in multiple locations:
+
+1. `rawInput.file_path` / `rawInput.filePath` / `rawInput.path`
+2. `content[].path` (in diff items)
+3. `title` field (contains full path on completion)
+
+---
+
+## Current Implementation Status
+
+As of 2026-01-22, the following has been implemented in `streamItemHelpers.ts`:
+
+### Implemented Functions
+- `isTodoWriteTool()` - Detects by title OR `rawInput.todos` array
+- `isTaskTool()` - Detects by title OR `rawInput.subagent_type`
+- `isNewFileOperation()` - Checks `kind === "edit"` and `content[].oldText`
+- `extractDiffData()` - Returns `{ oldText, newText, isNewFile }`
+- `extractOldText()` / `extractNewText()` - Extract from diff content
+- `getToolTitle()` - Now accepts optional `isNewFile` parameter
+- `getFilePath()` - Checks rawInput → content[].diff.path → title
+
+### ToolCallState Extended Fields
+```typescript
+interface ToolCallState {
+  // ... existing fields ...
+  isNewFile?: boolean;     // true = new file, false = editing existing
+  oldContent?: string;     // Old content (empty for new files)
+  newContent?: string;     // New content
+}
+```
+
+### DiffView Component
+Created `components/DiffView.tsx` for displaying diffs:
+- Green highlighting for added lines (+)
+- Red highlighting for removed lines (-)
+- Collapsible unchanged sections
+- Stats header showing +N / -M lines
+
+### ToolCallPill Updates
+- Shows `DiffView` for "Editing file" operations
+- Shows `RawOutputBlock` for "Writing file" and other operations

--- a/web/src/app/build/utils/packet-types.md
+++ b/web/src/app/build/utils/packet-types.md
@@ -1,0 +1,611 @@
+# ACP Packet Types Reference
+
+This document defines the JSON structure for every packet type used in the Build streaming protocol.
+
+---
+
+## 1. agent_message_chunk
+
+Streaming text content from the agent. Chunks arrive sequentially and should be concatenated.
+
+```typescript
+interface AgentMessageChunkPacket {
+  _meta: null;
+  type: "agent_message_chunk";
+  sessionUpdate: "agent_message_chunk";
+  content: {
+    _meta: null;
+    type: "text";
+    text: string;           // The text fragment
+    annotations: null;
+  };
+}
+```
+
+**Example:**
+```json
+{
+  "_meta": null,
+  "content": {
+    "_meta": null,
+    "annotations": null,
+    "text": "I'll help you create",
+    "type": "text"
+  },
+  "sessionUpdate": "agent_message_chunk",
+  "type": "agent_message_chunk"
+}
+```
+
+---
+
+## 2. tool_call_start
+
+Signals the beginning of a tool invocation. Contains initial metadata but no results yet.
+
+```typescript
+interface ToolCallStartPacket {
+  _meta: null;
+  type: "tool_call_start";              // NOTE: Not present in actual packets
+  sessionUpdate: "tool_call";           // Discriminator in actual packets
+
+  // Tool identification
+  toolCallId: string;                   // Unique ID for this tool invocation
+  title: string;                        // Tool name: "glob", "read", "bash", "write", "todowrite"
+  kind: ToolCallKind;                   // "search" | "read" | "execute" | "edit" | "other"
+
+  // Initial state
+  status: "pending";
+  content: null;
+  rawInput: {};                         // Empty initially
+  rawOutput: null;
+  locations: [];                        // Empty initially
+}
+
+type ToolCallKind = "search" | "read" | "execute" | "edit" | "other";
+```
+
+**Example (Glob):**
+```json
+{
+  "_meta": null,
+  "content": null,
+  "kind": "search",
+  "locations": [],
+  "rawInput": {},
+  "rawOutput": null,
+  "status": "pending",
+  "title": "glob",
+  "toolCallId": "toolu_01JQPzZLN1GkctYVgpaaxD8X",
+  "sessionUpdate": "tool_call"
+}
+```
+
+**Example (TodoWrite):**
+```json
+{
+  "_meta": null,
+  "content": null,
+  "kind": "other",
+  "locations": [],
+  "rawInput": {},
+  "rawOutput": null,
+  "status": "pending",
+  "title": "todowrite",
+  "toolCallId": "toolu_01RcpWgYMMtMch3XPebkLwcp",
+  "sessionUpdate": "tool_call"
+}
+```
+
+---
+
+## 3. tool_call_progress
+
+Updates for an in-progress or completed tool call. Contains full input/output when complete.
+
+```typescript
+interface ToolCallProgressPacket {
+  _meta: null;
+  type: "tool_call_progress";
+  sessionUpdate: "tool_call_update";
+  timestamp: string;                    // ISO 8601 timestamp
+
+  // Tool identification
+  toolCallId: string;
+  title: string;                        // Updates to description on completion
+  kind: ToolCallKind;
+
+  // State
+  status: "in_progress" | "completed";
+
+  // Input (populated when status changes to in_progress or completed)
+  rawInput: ToolRawInput;
+
+  // Output (populated when status is completed)
+  rawOutput: ToolRawOutput | null;
+  content: ToolContentArray | null;
+
+  // File locations (for read/edit tools)
+  locations: LocationInfo[] | null;
+}
+```
+
+### 3.1 Tool-Specific rawInput Shapes
+
+**Glob/Grep (search):**
+```typescript
+interface GlobInput {
+  pattern: string;           // e.g., "files/linear/**/*.json"
+}
+
+interface GrepInput {
+  pattern: string;           // Search pattern
+  path?: string;             // Directory to search
+}
+```
+
+**Read:**
+```typescript
+interface ReadInput {
+  filePath: string;          // Full path to file
+}
+```
+
+**Write/Edit:**
+```typescript
+interface WriteInput {
+  filePath: string;
+  content: string;           // File content to write
+}
+
+interface EditInput {
+  filePath: string;
+  old_string: string;
+  new_string: string;
+}
+```
+
+**Bash (execute):**
+```typescript
+interface BashInput {
+  command: string;           // Shell command
+  description: string;       // Human-readable description
+}
+```
+
+**Task (subagent):**
+```typescript
+interface TaskInput {
+  prompt: string;            // Task prompt for subagent
+  description: string;       // Short description
+  subagent_type: string;     // "Explore", "Plan", "Bash", etc.
+}
+```
+
+**TodoWrite:**
+```typescript
+interface TodoWriteInput {
+  todos: TodoItem[];
+}
+
+interface TodoItem {
+  content: string;           // Task description
+  status: "pending" | "in_progress" | "completed";
+  activeForm: string;        // Present tense form (e.g., "Creating API endpoint")
+}
+```
+
+### 3.2 Tool-Specific rawOutput Shapes
+
+**Glob/Grep:**
+```typescript
+interface SearchOutput {
+  output: string;            // Newline-separated file paths or "No files found"
+  metadata: {
+    count: number;
+    truncated: boolean;
+  };
+}
+```
+
+**Read:**
+```typescript
+interface ReadOutput {
+  output: string;            // File content wrapped in <file>...</file> tags
+  metadata: {
+    preview: string;         // First N characters
+    truncated: boolean;
+  };
+}
+```
+
+**Bash:**
+```typescript
+interface BashOutput {
+  output: string;            // Command output
+  metadata: {
+    output: string;          // Same as parent output
+    exit: number;            // Exit code
+    description: string;     // From input
+    truncated: boolean;
+  };
+}
+```
+
+**Write:**
+```typescript
+interface WriteOutput {
+  output: string;            // "Wrote file successfully."
+  metadata: {
+    diagnostics: Record<string, unknown[]>;
+    filepath: string;
+    exists: boolean;
+    truncated: boolean;
+  };
+}
+```
+
+**TodoWrite:**
+```typescript
+interface TodoWriteOutput {
+  output: string;            // JSON array of todos
+  metadata: {
+    todos: TodoItem[];       // Same as input todos
+    truncated: boolean;
+  };
+}
+```
+
+### 3.3 Content Array Structure
+
+The `content` field contains structured output for rendering:
+
+```typescript
+type ToolContentArray = ContentItem[];
+
+interface ContentItem {
+  _meta: null;
+  type: "content" | "diff";
+
+  // For type: "content"
+  content?: {
+    _meta: null;
+    type: "text";
+    text: string;
+    annotations: null;
+  };
+
+  // For type: "diff" (write operations)
+  newText?: string;
+  oldText?: string;
+  path?: string;
+}
+```
+
+**Example (Read result):**
+```json
+{
+  "content": [
+    {
+      "_meta": null,
+      "type": "content",
+      "content": {
+        "_meta": null,
+        "type": "text",
+        "text": "<file>\n00001| {content}\n...\n</file>",
+        "annotations": null
+      }
+    }
+  ]
+}
+```
+
+**Example (Write result - NEW file):**
+```json
+{
+  "content": [
+    {
+      "_meta": null,
+      "type": "content",
+      "content": {
+        "_meta": null,
+        "type": "text",
+        "text": "Wrote file successfully.",
+        "annotations": null
+      }
+    },
+    {
+      "_meta": null,
+      "type": "diff",
+      "newText": "// new file content...",
+      "oldText": "",
+      "path": "/path/to/file.ts"
+    }
+  ]
+}
+```
+
+**Example (Edit result - EXISTING file):**
+```json
+{
+  "content": [
+    {
+      "_meta": null,
+      "type": "content",
+      "content": {
+        "_meta": null,
+        "type": "text",
+        "text": "Wrote file successfully.",
+        "annotations": null
+      }
+    },
+    {
+      "_meta": null,
+      "type": "diff",
+      "newText": "const x = 2;\nconst y = 3;",
+      "oldText": "const x = 1;",
+      "path": "/path/to/file.ts"
+    }
+  ]
+}
+```
+
+### 3.4 Write vs Edit Detection
+
+The `oldText` field in diff content items distinguishes between new file creation and editing existing files:
+
+| `oldText` value | Operation | Display Title |
+|-----------------|-----------|---------------|
+| `""` (empty)    | New file  | "Writing file" |
+| Non-empty       | Edit      | "Editing file" |
+
+**Detection Logic:**
+```typescript
+function isNewFileOperation(packet: Record<string, unknown>): boolean | undefined {
+  if (packet.kind !== "edit") return undefined;
+
+  const content = packet.content as unknown[] | undefined;
+  if (!Array.isArray(content)) return undefined;
+
+  for (const item of content) {
+    if (item?.type === "diff") {
+      return item.oldText === "";
+    }
+  }
+  return undefined;
+}
+```
+
+**Important Notes:**
+- For `kind: "edit"` packets, the `title` field contains the **file path**, not the tool name
+- Detection must check both `kind` field AND `oldText` in the diff content
+- The backend persists `kind: "edit"` for both write and edit operations
+
+### 3.5 Locations Array
+
+```typescript
+interface LocationInfo {
+  _meta: null;
+  path: string;              // File path
+  line: number | null;       // Line number (if applicable)
+}
+```
+
+---
+
+## 4. agent_plan_update
+
+Signals updates to the agent's todo/plan list. Separate from tool_call_progress for TodoWrite.
+
+```typescript
+interface AgentPlanUpdatePacket {
+  _meta: null;
+  type: "agent_plan_update";
+  sessionUpdate: "plan";
+  timestamp: string;
+  entries: PlanEntry[];
+}
+
+interface PlanEntry {
+  _meta: null;
+  content: string;           // Task description
+  status: "pending" | "in_progress" | "completed";
+  priority: "medium" | "high" | "low";
+}
+```
+
+**Example:**
+```json
+{
+  "_meta": null,
+  "entries": [
+    {
+      "_meta": null,
+      "content": "Create prepare.sh script",
+      "priority": "medium",
+      "status": "completed"
+    },
+    {
+      "_meta": null,
+      "content": "Build dashboard page",
+      "priority": "medium",
+      "status": "in_progress"
+    }
+  ],
+  "sessionUpdate": "plan",
+  "type": "agent_plan_update",
+  "timestamp": "2026-01-22T19:13:30.917345+00:00"
+}
+```
+
+---
+
+## 5. prompt_response
+
+Signals the end of the agent's response turn.
+
+```typescript
+interface PromptResponsePacket {
+  _meta: {};                 // Note: empty object, not null
+  type: "prompt_response";
+  stopReason: "end_turn" | "max_tokens" | "stop_sequence";
+}
+```
+
+**Example:**
+```json
+{
+  "_meta": {},
+  "stopReason": "end_turn",
+  "type": "prompt_response"
+}
+```
+
+---
+
+## 6. error
+
+Error packet for streaming failures.
+
+```typescript
+interface ErrorPacket {
+  type: "error";
+  message: string;
+  code?: string;
+}
+```
+
+---
+
+## 7. artifact_created
+
+Signals creation of a new artifact (file, webapp, etc.).
+
+```typescript
+interface ArtifactCreatedPacket {
+  type: "artifact_created";
+  artifact: {
+    id: string;
+    type: ArtifactType;
+    name: string;
+    path: string;
+    preview_url?: string | null;
+  };
+}
+
+type ArtifactType = "file" | "image" | "nextjs_app" | "web_app";
+```
+
+---
+
+## Packet Type Determination
+
+To determine packet type, check in this order:
+
+1. Check `type` field if present
+2. Check `sessionUpdate` field:
+   - `"agent_message_chunk"` → agent_message_chunk
+   - `"tool_call"` → tool_call_start
+   - `"tool_call_update"` → tool_call_progress
+   - `"plan"` → agent_plan_update
+
+---
+
+## Tool Name to Kind Mapping
+
+| Tool Name     | kind      | Description                    |
+|---------------|-----------|--------------------------------|
+| `glob`        | search    | File pattern matching          |
+| `grep`        | search    | Content search                 |
+| `read`        | read      | Read file contents             |
+| `write`       | edit      | Write new file                 |
+| `edit`        | edit      | Edit existing file             |
+| `bash`        | execute   | Run shell command              |
+| `task`        | task*     | Spawn subagent                 |
+| `todowrite`   | other     | Update todo list               |
+| `webfetch`    | other     | Fetch web content              |
+| `websearch`   | other     | Search the web                 |
+
+*Note: `task` kind is determined by tool name, not the `kind` field.
+
+---
+
+## Known Quirks & Detection Strategies
+
+### Title Field Changes on Completion
+
+For some tools, the `title` field changes between `tool_call_start` and `tool_call_progress`:
+
+| Tool | Start `title` | Completed `title` |
+|------|---------------|-------------------|
+| TodoWrite | `"todowrite"` | `"6 todos"` (count-based) |
+| Edit/Write | `"edit"` or `"write"` | File path (e.g., `"path/to/file.tsx"`) |
+
+**Detection Strategy:**
+- Don't rely solely on `title` for tool identification
+- Check `rawInput` for tool-specific fields:
+  - TodoWrite: `rawInput.todos` array exists
+  - Task: `rawInput.subagent_type` exists
+  - Edit: Check `kind === "edit"` field
+
+### Tool Detection Functions
+
+```typescript
+// Detect TodoWrite even when title changes
+function isTodoWriteTool(packet: Record<string, unknown>): boolean {
+  const title = packet.title?.toLowerCase();
+  if (title === "todowrite" || title === "todo_write") return true;
+
+  // Fallback: check rawInput for todos array
+  const rawInput = packet.raw_input || packet.rawInput;
+  if (rawInput?.todos && Array.isArray(rawInput.todos)) return true;
+
+  return false;
+}
+
+// Detect Task tool even when title changes
+function isTaskTool(packet: Record<string, unknown>): boolean {
+  const title = packet.title?.toLowerCase();
+  if (title === "task") return true;
+
+  // Fallback: check rawInput for subagent_type
+  const rawInput = packet.raw_input || packet.rawInput;
+  if (rawInput?.subagent_type || rawInput?.subagentType) return true;
+
+  return false;
+}
+```
+
+### Field Path Extraction for Edit Packets
+
+For `kind: "edit"` packets, the file path can be found in multiple locations (checked in order):
+
+1. `rawInput.file_path` or `rawInput.filePath` or `rawInput.path`
+2. `content[].path` (in diff items)
+3. `title` field (contains full path on completion)
+
+```typescript
+function getFilePath(packet: Record<string, unknown>): string {
+  // 1. Check rawInput
+  const rawInput = packet.raw_input || packet.rawInput;
+  if (rawInput?.file_path || rawInput?.filePath || rawInput?.path) {
+    return getRelativePath(rawInput.file_path || rawInput.filePath || rawInput.path);
+  }
+
+  // 2. Check content array for diff items
+  if (Array.isArray(packet.content)) {
+    for (const item of packet.content) {
+      if (item?.type === "diff" && item?.path) {
+        return getRelativePath(item.path);
+      }
+    }
+  }
+
+  // 3. Fall back to title
+  if (packet.title?.includes("/")) {
+    return getRelativePath(packet.title);
+  }
+
+  return "";
+}
+```

--- a/web/src/app/build/utils/streamItemHelpers.ts
+++ b/web/src/app/build/utils/streamItemHelpers.ts
@@ -1,0 +1,640 @@
+/**
+ * Stream Item Helpers
+ *
+ * Shared utility functions for processing ACP packets into StreamItems.
+ * Used by both useBuildStreaming (live streaming) and useBuildSessionStore (loading from DB).
+ */
+
+import {
+  ToolCallKind,
+  ToolCallStatus,
+  TodoItem,
+  TodoStatus,
+} from "@/app/build/types/displayTypes";
+
+// =============================================================================
+// ID Generation
+// =============================================================================
+
+/**
+ * Generate a unique ID for stream items
+ */
+export function genId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// =============================================================================
+// Text Extraction
+// =============================================================================
+
+/**
+ * Extract text from ACP content structure
+ */
+export function extractText(content: unknown): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (typeof content === "object" && content !== null) {
+    const obj = content as Record<string, unknown>;
+    if (obj.type === "text" && typeof obj.text === "string") return obj.text;
+    if (Array.isArray(content)) {
+      return content
+        .filter((c) => c?.type === "text" && typeof c.text === "string")
+        .map((c) => c.text)
+        .join("");
+    }
+    if (typeof obj.text === "string") return obj.text;
+  }
+  return "";
+}
+
+// =============================================================================
+// Path Utilities
+// =============================================================================
+
+/**
+ * Strip sandbox path prefix to get clean relative path
+ */
+export function getRelativePath(fullPath: string): string {
+  if (!fullPath) return "";
+  const outputsMatch = fullPath.match(/\/outputs\/(.+)$/);
+  if (outputsMatch && outputsMatch[1]) return outputsMatch[1];
+  const sandboxMatch = fullPath.match(/\/sandboxes\/[^/]+\/(.+)$/);
+  if (sandboxMatch && sandboxMatch[1]) return sandboxMatch[1];
+  const lastSlash = fullPath.lastIndexOf("/");
+  return lastSlash >= 0 ? fullPath.slice(lastSlash + 1) : fullPath;
+}
+
+/**
+ * Clean sandbox paths embedded in text content.
+ * Replaces paths like /Users/.../sandboxes/<uuid>/files/foo with just foo
+ * Uses getRelativePath for consistent path cleaning logic.
+ */
+export function cleanSandboxPathsInText(text: string): string {
+  if (!text) return "";
+
+  // Match absolute paths that contain /sandboxes/ or /outputs/
+  // Pattern matches: /any/path/sandboxes/... or /any/path/outputs/...
+  return text.replace(
+    /\/[^\s]*(?:\/sandboxes\/[^/\s]+|\/outputs)\/[^\s]+/g,
+    (match) => getRelativePath(match)
+  );
+}
+
+// =============================================================================
+// Tool Detection
+// =============================================================================
+
+/**
+ * Check if a tool is a task/subagent tool
+ * Detects both by tool name ("task") and by presence of subagent_type in rawInput
+ * (needed because backend changes title to description on completion)
+ */
+export function isTaskTool(
+  toolNameOrPacket: string | null | undefined | Record<string, unknown>
+): boolean {
+  if (typeof toolNameOrPacket === "string" || toolNameOrPacket == null) {
+    return toolNameOrPacket?.toLowerCase() === "task";
+  }
+
+  // It's a packet - check tool name first
+  const toolName = (
+    (toolNameOrPacket.tool_name ||
+      toolNameOrPacket.toolName ||
+      toolNameOrPacket.title) as string | undefined
+  )?.toLowerCase();
+
+  if (toolName === "task") return true;
+
+  // Also check for subagent_type in rawInput (present even when title changes)
+  const rawInput = (toolNameOrPacket.raw_input ||
+    toolNameOrPacket.rawInput) as Record<string, unknown> | null;
+  if (rawInput?.subagent_type || rawInput?.subagentType) return true;
+
+  return false;
+}
+
+/**
+ * Check if a tool is a TodoWrite tool.
+ * Detects by tool name ("todowrite", "todo_write") OR by presence of todos array in rawInput.
+ * The second check is needed because the backend may change the title on completion
+ * (e.g., from "todowrite" to "6 todos").
+ */
+export function isTodoWriteTool(
+  toolNameOrPacket: string | null | undefined | Record<string, unknown>
+): boolean {
+  let toolName: string | undefined;
+
+  if (typeof toolNameOrPacket === "object" && toolNameOrPacket !== null) {
+    // It's a packet - extract tool name
+    toolName = (
+      (toolNameOrPacket.tool_name ||
+        toolNameOrPacket.toolName ||
+        toolNameOrPacket.title) as string | undefined
+    )?.toLowerCase();
+
+    // Also check for todos array in rawInput (present even when title changes)
+    const rawInput = (toolNameOrPacket.raw_input ||
+      toolNameOrPacket.rawInput) as Record<string, unknown> | null;
+    if (rawInput?.todos && Array.isArray(rawInput.todos)) {
+      return true;
+    }
+  } else {
+    // It's a string (or null/undefined)
+    toolName = toolNameOrPacket?.toLowerCase();
+  }
+
+  return toolName === "todowrite" || toolName === "todo_write";
+}
+
+// =============================================================================
+// Tool Title & Kind
+// =============================================================================
+
+/**
+ * Get human-readable title based on tool kind and name
+ * @param isNewFile - For "edit" kind: true = new file (Writing), false = existing file (Editing)
+ */
+export function getToolTitle(
+  kind: string | null | undefined,
+  toolName: string | null | undefined,
+  isNewFile?: boolean
+): string {
+  // Handle "edit" kind explicitly - it's a write/edit operation
+  // The title field often contains the file path (not "edit"), so we can't rely on toolName
+  if (kind === "edit") {
+    // isNewFile: true = "Writing file", false = "Editing file", undefined = default to "Writing file"
+    return isNewFile === false ? "Editing file" : "Writing file";
+  }
+
+  const normalizedKind = kind === "edit" ? "other" : kind;
+  const normalizedToolName = toolName?.toLowerCase();
+
+  // First check tool name for specific mappings
+  switch (normalizedToolName) {
+    case "task":
+      return "Running task";
+    case "glob":
+      return "Searching files";
+    case "grep":
+      return "Searching content";
+    case "webfetch":
+      return "Fetching web content";
+    case "websearch":
+      return "Searching web";
+    case "bash":
+      return "Running command";
+    case "read":
+      return "Reading file";
+    case "write":
+    case "edit":
+      return "Writing file";
+  }
+
+  // Fall back to kind-based titles
+  switch (normalizedKind) {
+    case "execute":
+      return "Running command";
+    case "read":
+      return "Reading file";
+    case "task":
+      return "Running task";
+    case "search":
+      return "Searching";
+    case "other":
+    default:
+      // "other" is a fallback for unrecognized kinds
+      // Actual write/edit tools are caught by toolName check above
+      return "Running tool";
+  }
+}
+
+/**
+ * Normalize tool call kind
+ */
+export function normalizeKind(
+  kind: string | null | undefined,
+  toolNameOrPacket?: string | null | Record<string, unknown>
+): ToolCallKind {
+  // Task tool is identified by tool name or subagent_type
+  if (isTaskTool(toolNameOrPacket)) return "task";
+  if (
+    kind === "execute" ||
+    kind === "read" ||
+    kind === "task" ||
+    kind === "other"
+  )
+    return kind;
+  return "other";
+}
+
+/**
+ * Normalize tool call status
+ */
+export function normalizeStatus(
+  status: string | null | undefined
+): ToolCallStatus {
+  if (
+    status === "pending" ||
+    status === "in_progress" ||
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled"
+  ) {
+    return status;
+  }
+  return "pending";
+}
+
+// =============================================================================
+// Tool Call Data Extraction
+// =============================================================================
+
+/**
+ * Extract file path from packet (for read/write tools)
+ */
+export function getFilePath(packet: Record<string, unknown>): string {
+  // 1. Check rawInput for explicit file_path
+  const rawInput = (packet.raw_input || packet.rawInput) as Record<
+    string,
+    unknown
+  > | null;
+  if (rawInput) {
+    const path = (rawInput.file_path || rawInput.filePath || rawInput.path) as
+      | string
+      | undefined;
+    if (path) return getRelativePath(path);
+  }
+
+  // 2. Check content array for diff items (edit packets store path in diff)
+  const content = packet.content as unknown[] | undefined;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "diff"
+      ) {
+        const diffPath = (item as Record<string, unknown>).path as
+          | string
+          | undefined;
+        if (diffPath) return getRelativePath(diffPath);
+      }
+    }
+  }
+
+  // 3. Fall back to title (often contains file path for edit packets)
+  const title = packet.title as string | undefined;
+  if (title && title.includes("/")) return getRelativePath(title);
+  return "";
+}
+
+/**
+ * Extract description from tool call packet
+ */
+export function getDescription(packet: Record<string, unknown>): string {
+  const kind = packet.kind as string | null;
+  const normalizedKind = kind === "edit" ? "other" : kind;
+  const rawInput = (packet.raw_input || packet.rawInput) as Record<
+    string,
+    unknown
+  > | null;
+  const toolName = (
+    (packet.tool_name || packet.toolName || packet.title) as string | undefined
+  )?.toLowerCase();
+
+  // Task tool: use description from rawInput
+  // Pass full packet to detect task tools even when title changes on completion
+  if (isTaskTool(packet)) {
+    if (rawInput?.description && typeof rawInput.description === "string") {
+      return rawInput.description;
+    }
+    return "Running subagent";
+  }
+
+  if (normalizedKind === "read" || normalizedKind === "other") {
+    const filePath = getFilePath(packet);
+    if (filePath) return filePath;
+  }
+
+  if (normalizedKind === "execute") {
+    if (rawInput?.description && typeof rawInput.description === "string") {
+      return cleanSandboxPathsInText(rawInput.description);
+    }
+    return "Running command";
+  }
+
+  if (
+    (toolName === "glob" ||
+      toolName === "grep" ||
+      normalizedKind === "search") &&
+    rawInput?.pattern &&
+    typeof rawInput.pattern === "string"
+  ) {
+    return rawInput.pattern;
+  }
+
+  return getToolTitle(kind, toolName);
+}
+
+/**
+ * Extract command/path from tool call packet
+ */
+export function getCommand(packet: Record<string, unknown>): string {
+  const rawInput = (packet.raw_input || packet.rawInput) as Record<
+    string,
+    unknown
+  > | null;
+  const kind = packet.kind as string | null;
+  const normalizedKind = kind === "edit" ? "other" : kind;
+  const toolName = (
+    (packet.tool_name || packet.toolName || packet.title) as string | undefined
+  )?.toLowerCase();
+
+  // Task tool: use prompt from rawInput
+  // Pass full packet to detect task tools even when title changes on completion
+  if (isTaskTool(packet) && rawInput) {
+    if (typeof rawInput.prompt === "string") return rawInput.prompt;
+    return "";
+  }
+
+  if (normalizedKind === "execute" && rawInput) {
+    if (typeof rawInput.command === "string")
+      return cleanSandboxPathsInText(rawInput.command);
+  }
+
+  if (normalizedKind === "read" || normalizedKind === "other") {
+    return getFilePath(packet);
+  }
+
+  if (
+    (toolName === "glob" ||
+      toolName === "grep" ||
+      normalizedKind === "search") &&
+    rawInput?.pattern &&
+    typeof rawInput.pattern === "string"
+  ) {
+    return rawInput.pattern;
+  }
+
+  return "";
+}
+
+/**
+ * Extract file content from content array (for read operations)
+ */
+export function extractFileContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+
+  for (const item of content) {
+    if (item?.type === "content" && item?.content?.type === "text") {
+      const text = item.content.text as string;
+      const fileMatch = text.match(
+        /<file>\n?([\s\S]*?)\n?\(End of file[^)]*\)\n?<\/file>/
+      );
+      if (fileMatch && fileMatch[1]) {
+        return fileMatch[1].replace(/^\d{5}\| /gm, "");
+      }
+      return text;
+    }
+  }
+  return "";
+}
+
+/**
+ * Extract newText from content array (for write operations)
+ */
+export function extractNewText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+
+  for (const item of content) {
+    if (item?.type === "diff" && typeof item?.newText === "string") {
+      return item.newText;
+    }
+  }
+  return "";
+}
+
+/**
+ * Extract oldText from content array (for edit operations)
+ */
+export function extractOldText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+
+  for (const item of content) {
+    if (item?.type === "diff" && typeof item?.oldText === "string") {
+      return item.oldText;
+    }
+  }
+  return "";
+}
+
+/**
+ * Extract both old and new text from content array for edit operations.
+ * Returns { oldText, newText, isNewFile } where isNewFile is true if oldText is empty.
+ */
+export function extractDiffData(content: unknown): {
+  oldText: string;
+  newText: string;
+  isNewFile: boolean;
+} {
+  const oldText = extractOldText(content);
+  const newText = extractNewText(content);
+  return {
+    oldText,
+    newText,
+    isNewFile: oldText === "",
+  };
+}
+
+/**
+ * Check if an edit packet represents a new file (write) vs editing existing file.
+ * Returns true if it's a new file, false if editing existing, undefined if not applicable.
+ */
+export function isNewFileOperation(
+  packet: Record<string, unknown>
+): boolean | undefined {
+  const kind = packet.kind as string | null;
+  if (kind !== "edit") return undefined;
+
+  const content = packet.content;
+  const oldText = extractOldText(content);
+  return oldText === "";
+}
+
+/**
+ * Extract subagent type from task tool packet
+ */
+export function getSubagentType(
+  packet: Record<string, unknown>
+): string | undefined {
+  const rawInput = (packet.raw_input || packet.rawInput) as Record<
+    string,
+    unknown
+  > | null;
+  if (rawInput?.subagent_type && typeof rawInput.subagent_type === "string") {
+    return rawInput.subagent_type;
+  }
+  if (rawInput?.subagentType && typeof rawInput.subagentType === "string") {
+    return rawInput.subagentType;
+  }
+  return undefined;
+}
+
+/**
+ * Extract task output text from completed task tool packet
+ * Returns the output text if present, null otherwise
+ */
+export function getTaskOutput(packet: Record<string, unknown>): string | null {
+  if (!isTaskTool(packet)) return null;
+
+  const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+    string,
+    unknown
+  > | null;
+
+  if (rawOutput?.output && typeof rawOutput.output === "string") {
+    // Strip task_metadata from the output
+    let output = rawOutput.output;
+    const metadataIndex = output.indexOf("<task_metadata>");
+    if (metadataIndex >= 0) {
+      output = output.slice(0, metadataIndex).trim();
+    }
+    // Clean sandbox paths from the output for cleaner display
+    return cleanSandboxPathsInText(output);
+  }
+
+  return null;
+}
+
+/**
+ * Extract raw output from tool call packet
+ */
+export function getRawOutput(packet: Record<string, unknown>): string {
+  const kind = packet.kind as string | null;
+  const normalizedKind = kind === "edit" ? "other" : kind;
+  const toolName = (
+    (packet.tool_name || packet.toolName || packet.title) as string | undefined
+  )?.toLowerCase();
+
+  // Task tool: show the prompt in expanded view (not the output JSON)
+  // Pass full packet to detect task tools even when title changes on completion
+  if (isTaskTool(packet)) {
+    const rawInput = (packet.raw_input || packet.rawInput) as Record<
+      string,
+      unknown
+    > | null;
+    if (rawInput?.prompt && typeof rawInput.prompt === "string") {
+      // Clean sandbox paths from the prompt for cleaner display
+      return cleanSandboxPathsInText(rawInput.prompt);
+    }
+    // Don't fall back to rawOutput JSON - keep showing the prompt
+    return "";
+  }
+
+  if (normalizedKind === "execute") {
+    const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+      string,
+      unknown
+    > | null;
+    if (!rawOutput) return "";
+    const metadata = rawOutput.metadata as Record<string, unknown> | null;
+    const output = (metadata?.output || rawOutput.output || "") as string;
+    return cleanSandboxPathsInText(output);
+  }
+
+  if (normalizedKind === "read") {
+    const content = packet.content;
+    const fileContent = extractFileContent(content);
+    if (fileContent) return fileContent;
+    const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+      string,
+      unknown
+    > | null;
+    if (!rawOutput) return "";
+    if (typeof rawOutput.content === "string") return rawOutput.content;
+    return JSON.stringify(rawOutput, null, 2);
+  }
+
+  if (normalizedKind === "other") {
+    const content = packet.content;
+    const newText = extractNewText(content);
+    if (newText) return newText;
+    const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+      string,
+      unknown
+    > | null;
+    if (!rawOutput) return "";
+    return JSON.stringify(rawOutput, null, 2);
+  }
+
+  if (
+    toolName === "glob" ||
+    toolName === "grep" ||
+    normalizedKind === "search"
+  ) {
+    const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+      string,
+      unknown
+    > | null;
+    if (!rawOutput) return "";
+    if (typeof rawOutput.output === "string") {
+      // Clean file paths in the output string (one path per line)
+      return rawOutput.output
+        .split("\n")
+        .map((line) => {
+          // If line looks like a file path, clean it
+          if (line.includes("/sandboxes/") || line.includes("/outputs/")) {
+            return getRelativePath(line);
+          }
+          return line;
+        })
+        .join("\n");
+    }
+    if (rawOutput.files && Array.isArray(rawOutput.files)) {
+      return (rawOutput.files as string[]).map(getRelativePath).join("\n");
+    }
+    return JSON.stringify(rawOutput, null, 2);
+  }
+
+  const rawOutput = (packet.raw_output || packet.rawOutput) as Record<
+    string,
+    unknown
+  > | null;
+  if (!rawOutput) return "";
+  return JSON.stringify(rawOutput, null, 2);
+}
+
+// =============================================================================
+// Todo List Helpers
+// =============================================================================
+
+/**
+ * Normalize todo status to valid TodoStatus type
+ */
+export function normalizeTodoStatus(status: unknown): TodoStatus {
+  if (
+    status === "pending" ||
+    status === "in_progress" ||
+    status === "completed"
+  ) {
+    return status;
+  }
+  return "pending";
+}
+
+/**
+ * Extract todos from TodoWrite packet (works with both packet and metadata)
+ */
+export function extractTodos(
+  packetOrMetadata: Record<string, unknown>
+): TodoItem[] {
+  const rawInput = (packetOrMetadata.raw_input ||
+    packetOrMetadata.rawInput) as Record<string, unknown> | null;
+  if (!rawInput?.todos || !Array.isArray(rawInput.todos)) return [];
+
+  return rawInput.todos.map((t: Record<string, unknown>) => ({
+    content: (t.content as string) || "",
+    status: normalizeTodoStatus(t.status),
+    activeForm: (t.activeForm as string) || (t.content as string) || "",
+  }));
+}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all Build streaming packet types (except thinking) with unified parsing for live and historical sessions. Adds Todo list and diff views, and simplifies streaming logic for stability.

- **New Features**
  - Render agent chunks, tool call start/progress/complete, and tool results.
  - TodoWrite support with a TodoListCard showing live statuses.
  - DiffView for file changes inside ToolCallPill; improved command/raw output display.
  - Backend persists TodoWrite progress so history shows todos correctly.
  - Load past messages by parsing message_metadata content.

- **Refactors**
  - Centralized packet parsing in streamItemHelpers shared by useBuildStreaming and useBuildSessionStore.
  - Simplified useBuildStreaming (removed ~350 lines), normalized tool kinds/status, added "task" kind.
  - New display types for todos; small UI tweaks (wider message container).
  - Added docs for packet types and the parsing refactor plan.

<sup>Written for commit 80891c0b74ba947999e371eb6462776060ff00de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

