### PR TITLE
chore(desktop): make artifact filename version-agnostic

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -356,7 +356,7 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
-          releaseAssetNamePattern: "[name]_[arch][ext]"
+          assetNamePattern: "[name]_[arch][ext]"
           args: ${{ matrix.args }}
 
   build-web-amd64:


### PR DESCRIPTION
## Description

I want to link to the releases download url from the documentation. These look like `https://github.com/onyx-dot-app/onyx/releases/latest/download/Onyx_2.9.1_amd64.deb` which currently includes the version in the filename. By explicitly setting the filename, we ensure a stable filename to latest, so we don't need to update the download button on the documentation page.

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/21267955228

<img width="1602" height="2085" alt="20260122_15h15m06s_grim" src="https://github.com/user-attachments/assets/a0861b0d-70f0-46ea-b1ce-d7e77c306532" />


## Additional Options

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a stable, version-agnostic release asset filename by setting assetNamePattern to "[name]_[arch][ext]" in the desktop release workflow. This lets docs link to the latest download URL without updating the button on each release.

<sup>Written for commit 4c6a89b7e0c2ea6c709874889e7b2975a96fbc3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

