### PR TITLE
chore(devtools): `ods db restore --fetch-seeded`

### DIFF
--- a/tools/ods/cmd/db_restore.go
+++ b/tools/ods/cmd/db_restore.go
@@ -109,7 +109,16 @@ func runDBRestoreSeeded(opts *DBRestoreOptions) {
 		log.Fatalf("Failed to download seeded snapshot: %v", err)
 	}
 
-	log.Infof("Downloaded seeded snapshot to: %s", destPath)
+	// Verify download is non-empty
+	info, err := os.Stat(destPath)
+	if err != nil {
+		log.Fatalf("Failed to stat downloaded snapshot: %v", err)
+	}
+	if info.Size() == 0 {
+		log.Fatalf("Downloaded snapshot is empty (0 bytes). The S3 object may be missing or the download was corrupted.")
+	}
+
+	log.Infof("Downloaded seeded snapshot to: %s (%d bytes)", destPath, info.Size())
 
 	// Restore the downloaded snapshot
 	runDBRestore(destPath, opts)

--- a/tools/ods/internal/s3/fetch.go
+++ b/tools/ods/internal/s3/fetch.go
@@ -42,8 +42,8 @@ func (s *S3URL) HTTPEndpoint() string {
 }
 
 // FetchToFile downloads an S3 object to a local file.
-// It first tries an unsigned HTTP request (for IP-whitelisted buckets),
-// and if that fails, tries a signed request using AWS CLI.
+// It first tries an unsigned HTTP request and if that fails,
+// tries a signed request using AWS CLI.
 func FetchToFile(s3url string, destPath string) error {
 	parsed, err := ParseS3URL(s3url)
 	if err != nil {
@@ -56,7 +56,7 @@ func FetchToFile(s3url string, destPath string) error {
 	}
 
 	// Try unsigned HTTP request first
-	log.Info("Attempting unsigned download (IP-whitelisted access)...")
+	log.Info("Attempting unsigned download...")
 	if err := fetchUnsigned(parsed, destPath); err == nil {
 		return nil
 	} else {
@@ -64,9 +64,9 @@ func FetchToFile(s3url string, destPath string) error {
 	}
 
 	// Try signed request using AWS CLI
-	log.Info("Unsigned download failed, attempting signed download with AWS credentials...")
+	log.Info("Unsigned download failed, attempting signed download...")
 	if err := fetchWithAWSCLI(s3url, destPath); err != nil {
-		return fmt.Errorf("failed to download from S3: %w\n\nTo authenticate, run:\n  aws sso login\n\nOr configure AWS credentials with:\n  aws configure", err)
+		return fmt.Errorf("failed to download from S3: %w\n\nTo authenticate, run:\n  aws sso login\n\nOr configure AWS credentials with:\n  aws configure sso", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fetches a pre-seeded database dump from the [onyx-internal-tools](https://github.com/onyx-dot-app/internal-tools/pull/21) s3 bucket and restores it.

## How Has This Been Tested?

```
cd tools/ods
go install .
~/.go/bin/ods db restore --fetch-seeded --clean
```

Confirmed the seeded database was restored cleanly.

## Additional Options

- [x] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ods db restore --fetch-seeded to download and restore a pre-seeded database snapshot from S3, speeding up local setup. The command now accepts an optional input file and shows clear errors when none is provided.

- **New Features**
  - Adds --fetch-seeded to download s3://onyx-internal-tools/seeded.dump to the snapshots dir and restore it.
  - Fetch tries unsigned HTTP first, then falls back to aws s3 cp (works with IP-whitelisted access or AWS credentials).
  - Updates usage to restore [input-file] or run with --fetch-seeded; includes validation and example help text.

<sup>Written for commit 5172615315c6a565a3eb121206ebdc0d353350b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



