### PR TITLE
fix session naming and output panel auto-opening

### DIFF
--- a/web/src/app/build/components/ChatPanel.tsx
+++ b/web/src/app/build/components/ChatPanel.tsx
@@ -85,9 +85,6 @@ export default function BuildChatPanel({
   const appendMessageToSession = useBuildSessionStore(
     (state) => state.appendMessageToSession
   );
-  const refreshSessionHistory = useBuildSessionStore(
-    (state) => state.refreshSessionHistory
-  );
   const nameBuildSession = useBuildSessionStore(
     (state) => state.nameBuildSession
   );
@@ -167,9 +164,10 @@ export default function BuildChatPanel({
             `/build/v1?${BUILD_SEARCH_PARAM_NAMES.SESSION_ID}=${newSessionId}`
           );
 
-          // 4. Name the session and refresh history
-          setTimeout(() => nameBuildSession(newSessionId), 200);
-          await refreshSessionHistory();
+          // 4. Schedule naming after delay (message will be saved by then)
+          // Note: Don't call refreshSessionHistory() here - it would overwrite the
+          // optimistic update from consumePreProvisionedSession() before the message is saved
+          setTimeout(() => nameBuildSession(newSessionId), 500);
 
           // 5. Stream the response (uses session ID directly, not currentSessionId)
           await streamMessage(newSessionId, message);
@@ -187,7 +185,6 @@ export default function BuildChatPanel({
       createNewSession,
       createSession,
       appendMessageToSession,
-      refreshSessionHistory,
       nameBuildSession,
       router,
     ]

--- a/web/src/app/build/components/SideBar.tsx
+++ b/web/src/app/build/components/SideBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, useCallback, useState, useEffect } from "react";
+import { memo, useMemo, useCallback, useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useBuildContext } from "@/app/build/contexts/BuildContext";
 import {
@@ -33,6 +33,7 @@ import {
 } from "@opal/icons";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import Button from "@/refresh-components/buttons/Button";
+import TypewriterText from "@/app/build/components/TypewriterText";
 
 // ============================================================================
 // Build Session Button
@@ -56,6 +57,26 @@ function BuildSessionButton({
   const [renaming, setRenaming] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  // Track title changes for typewriter animation (only for auto-naming, not manual rename)
+  const prevTitleRef = useRef(historyItem.title);
+  const [shouldAnimate, setShouldAnimate] = useState(false);
+
+  // Detect when title changes from "New Build Session" to a real name (auto-naming)
+  useEffect(() => {
+    const prevTitle = prevTitleRef.current;
+    const newTitle = historyItem.title;
+
+    // Animate only when transitioning from default name to LLM-generated name
+    if (
+      prevTitle !== newTitle &&
+      prevTitle === "New Build Session" &&
+      !renaming
+    ) {
+      setShouldAnimate(true);
+    }
+
+    prevTitleRef.current = newTitle;
+  }, [historyItem.title, renaming]);
 
   const handleConfirmDelete = useCallback(
     async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -126,6 +147,12 @@ function BuildSessionButton({
                 initialName={historyItem.title}
                 onRename={onRename}
                 onClose={() => setRenaming(false)}
+              />
+            ) : shouldAnimate ? (
+              <TypewriterText
+                text={historyItem.title}
+                charSpeed={25}
+                onAnimationComplete={() => setShouldAnimate(false)}
               />
             ) : (
               historyItem.title

--- a/web/src/app/build/components/TypewriterText.tsx
+++ b/web/src/app/build/components/TypewriterText.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect, useRef, memo } from "react";
+
+interface TypewriterTextProps {
+  /** The text to display with typewriter animation */
+  text: string;
+  /** Speed of each character animation in ms (default: 30) */
+  charSpeed?: number;
+  /** Whether to animate on initial render (default: false) */
+  animateOnMount?: boolean;
+  /** Class name for the text container */
+  className?: string;
+  /** Callback when animation completes */
+  onAnimationComplete?: () => void;
+}
+
+/**
+ * TypewriterText - Animates text changes with a delete-then-type effect.
+ *
+ * When text changes:
+ * 1. Old text is deleted character by character (from end to start)
+ * 2. New text is typed character by character (from start to end)
+ *
+ * This creates a smooth "rename" animation effect for session titles.
+ */
+function TypewriterText({
+  text,
+  charSpeed = 30,
+  animateOnMount = false,
+  className = "",
+  onAnimationComplete,
+}: TypewriterTextProps) {
+  // Track the currently displayed text
+  const [displayedText, setDisplayedText] = useState(
+    animateOnMount ? "" : text
+  );
+  // Track whether we're in the "deleting" or "typing" phase
+  const [isDeleting, setIsDeleting] = useState(false);
+  // Store the target text we're animating towards
+  const targetTextRef = useRef(text);
+  // Store the previous text for comparison
+  const prevTextRef = useRef(text);
+  // Track if this is the first render
+  const isFirstRender = useRef(true);
+  // Animation frame ID for cleanup
+  const animationRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    // Skip animation on first render unless animateOnMount is true
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (!animateOnMount) {
+        setDisplayedText(text);
+        prevTextRef.current = text;
+        targetTextRef.current = text;
+        return;
+      }
+    }
+
+    // If text hasn't changed, no animation needed
+    if (text === prevTextRef.current) {
+      return;
+    }
+
+    // Clear any existing animation
+    if (animationRef.current) {
+      clearTimeout(animationRef.current);
+    }
+
+    // Update target and start deleting phase
+    targetTextRef.current = text;
+    setIsDeleting(true);
+
+    return () => {
+      if (animationRef.current) {
+        clearTimeout(animationRef.current);
+      }
+    };
+  }, [text, animateOnMount]);
+
+  useEffect(() => {
+    // Handle the animation loop
+    if (isDeleting) {
+      // Deleting phase: remove characters from the end
+      if (displayedText.length > 0) {
+        animationRef.current = setTimeout(() => {
+          setDisplayedText((prev) => prev.slice(0, -1));
+        }, charSpeed);
+      } else {
+        // Done deleting, switch to typing phase
+        setIsDeleting(false);
+        prevTextRef.current = targetTextRef.current;
+      }
+    } else {
+      // Typing phase: add characters from the target
+      const target = targetTextRef.current;
+      if (displayedText.length < target.length) {
+        animationRef.current = setTimeout(() => {
+          setDisplayedText(target.slice(0, displayedText.length + 1));
+        }, charSpeed);
+      } else if (
+        displayedText.length === target.length &&
+        displayedText === target
+      ) {
+        // Animation complete
+        onAnimationComplete?.();
+      }
+    }
+
+    return () => {
+      if (animationRef.current) {
+        clearTimeout(animationRef.current);
+      }
+    };
+  }, [displayedText, isDeleting, charSpeed, onAnimationComplete]);
+
+  return (
+    <span className={className}>
+      {displayedText}
+      {/* Blinking cursor during animation */}
+      {(isDeleting || displayedText !== targetTextRef.current) && (
+        <span className="animate-pulse">|</span>
+      )}
+    </span>
+  );
+}
+
+export default memo(TypewriterText);


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate clean session names from the first user message and animate the auto-rename in the sidebar. Fix output panel auto-opening by refreshing on any web file edits and avoiding overwriting optimistic updates.

- **New Features**
  - Use LLM to create concise session names (50-char cap, safe fallback).
  - Optimistic title update triggers a typewriter animation when auto-naming.

- **Bug Fixes**
  - Output panel now auto-opens after streaming when web files are edited; refresh triggers on any edit/write in web/ paths (absolute and relative).
  - Streaming now handles both raw_input and rawInput packet shapes; removed noisy debug logs.
  - Delayed session naming to avoid overwriting optimistic updates and prevent premature history refresh.

<sup>Written for commit b3315dd5cf3dd8ea927f12cab5b75f624f58c818. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

