### PR TITLE
fix dramatic intro, init suggested prompts, unique connector names

### DIFF
--- a/web/src/app/build/components/BigButton.tsx
+++ b/web/src/app/build/components/BigButton.tsx
@@ -72,6 +72,10 @@ const BigButton = React.forwardRef<HTMLButtonElement, BigButtonProps>(
         : textStyles[subvariant].normal;
     };
 
+    // Check if className contains text color override (for forcing white text)
+    const hasTextWhiteOverride =
+      className?.includes("!text-white") || className?.includes("text-white");
+
     return (
       <button
         ref={ref}
@@ -82,7 +86,10 @@ const BigButton = React.forwardRef<HTMLButtonElement, BigButtonProps>(
       >
         <Text
           mainContentEmphasis
-          className={cn("whitespace-nowrap", getTextStyle())}
+          className={cn(
+            "whitespace-nowrap",
+            hasTextWhiteOverride ? "!text-white" : getTextStyle()
+          )}
           as="span"
         >
           {children}

--- a/web/src/app/build/components/BuildWelcome.tsx
+++ b/web/src/app/build/components/BuildWelcome.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useRef } from "react";
 import { BuildFile } from "@/app/build/contexts/UploadFilesContext";
 import Text from "@/refresh-components/texts/Text";
 import Logo from "@/refresh-components/Logo";
-import InputBar from "@/app/build/components/InputBar";
+import InputBar, { InputBarHandle } from "@/app/build/components/InputBar";
+import SuggestedPrompts from "@/app/build/components/SuggestedPrompts";
 
 interface BuildWelcomeProps {
   onSubmit: (
@@ -26,25 +28,29 @@ export default function BuildWelcome({
   isRunning,
   sandboxInitializing = false,
 }: BuildWelcomeProps) {
+  const inputBarRef = useRef<InputBarHandle>(null);
+
+  const handlePromptClick = (promptText: string) => {
+    inputBarRef.current?.setMessage(promptText);
+  };
+
   return (
     <div className="h-full flex flex-col items-center justify-center px-4">
-      <div className="flex flex-col items-center gap-4 mb-8">
+      <div className="flex flex-col items-center gap-4 mb-6">
         <Logo folded size={48} />
         <Text headingH2 text05>
           What would you like to build?
         </Text>
-        <Text secondaryBody text03 className="text-center max-w-md">
-          Describe your task and I'll execute it in an isolated environment. You
-          can build web apps, run scripts, process data, and more.
-        </Text>
       </div>
       <div className="w-full max-w-2xl">
         <InputBar
+          ref={inputBarRef}
           onSubmit={onSubmit}
           isRunning={isRunning}
           placeholder="Create a React app that shows a dashboard..."
           sandboxInitializing={sandboxInitializing}
         />
+        <SuggestedPrompts onPromptClick={handlePromptClick} />
       </div>
     </div>
   );

--- a/web/src/app/build/components/InputBar.tsx
+++ b/web/src/app/build/components/InputBar.tsx
@@ -27,6 +27,7 @@ const MAX_INPUT_HEIGHT = 200;
 export interface InputBarHandle {
   reset: () => void;
   focus: () => void;
+  setMessage: (message: string) => void;
 }
 
 export interface InputBarProps {
@@ -111,7 +112,7 @@ const InputBar = React.memo(
         hasUploadingFiles,
       } = useUploadFilesContext();
 
-      // Expose reset and focus methods to parent via ref
+      // Expose reset, focus, and setMessage methods to parent via ref
       React.useImperativeHandle(ref, () => ({
         reset: () => {
           setMessage("");
@@ -119,6 +120,17 @@ const InputBar = React.memo(
         },
         focus: () => {
           textAreaRef.current?.focus();
+        },
+        setMessage: (msg: string) => {
+          setMessage(msg);
+          // Move cursor to end after setting message
+          setTimeout(() => {
+            const textarea = textAreaRef.current;
+            if (textarea) {
+              textarea.focus();
+              textarea.setSelectionRange(msg.length, msg.length);
+            }
+          }, 0);
         },
       }));
 
@@ -298,25 +310,27 @@ const InputBar = React.memo(
                 disabled={disabled}
                 onClick={() => fileInputRef.current?.click()}
               />
-              {/* Demo Data indicator pill */}
-              <SimpleTooltip
-                tooltip="Switch to your data in the Configure panel!"
-                side="top"
-              >
-                <span>
-                  <SelectButton
-                    leftIcon={SvgOrganization}
-                    engaged={demoDataEnabled}
-                    action
-                    folded
-                    disabled={disabled}
-                    onClick={() => router.push("/build/v1/configure")}
-                    className="bg-action-link-01"
-                  >
-                    Demo Data
-                  </SelectButton>
-                </span>
-              </SimpleTooltip>
+              {/* Demo Data indicator pill - only show when demo data is enabled */}
+              {demoDataEnabled && (
+                <SimpleTooltip
+                  tooltip="Switch to your data in the Configure panel!"
+                  side="top"
+                >
+                  <span>
+                    <SelectButton
+                      leftIcon={SvgOrganization}
+                      engaged={demoDataEnabled}
+                      action
+                      folded
+                      disabled={disabled}
+                      onClick={() => router.push("/build/v1/configure")}
+                      className="bg-action-link-01"
+                    >
+                      Demo Data
+                    </SelectButton>
+                  </span>
+                </SimpleTooltip>
+              )}
             </div>
 
             {/* Bottom right controls */}

--- a/web/src/app/build/components/IntroContent.tsx
+++ b/web/src/app/build/components/IntroContent.tsx
@@ -29,7 +29,7 @@ export default function BuildModeIntroContent({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.8 }}
         >
-          <Text headingH1 inverted className="!text-8xl">
+          <Text headingH1 className="!text-8xl !text-white">
             Build Mode
           </Text>
         </motion.div>
@@ -41,7 +41,7 @@ export default function BuildModeIntroContent({
         >
           <BigButton
             secondary
-            inverted
+            className="!border-white !text-white hover:!bg-white/10 active:!bg-white/20"
             onClick={(e) => {
               e.stopPropagation();
               onClose();
@@ -51,7 +51,7 @@ export default function BuildModeIntroContent({
           </BigButton>
           <BigButton
             primary
-            inverted
+            className="!bg-white !text-gray-900 hover:!bg-gray-200 active:!bg-gray-300"
             onClick={(e) => {
               e.stopPropagation();
               onTryBuildMode();

--- a/web/src/app/build/components/SuggestedPrompts.tsx
+++ b/web/src/app/build/components/SuggestedPrompts.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Button from "@/refresh-components/buttons/Button";
+import {
+  getPromptsForPersona,
+  UserPersona,
+} from "@/app/build/constants/exampleBuildPrompts";
+
+interface SuggestedPromptsProps {
+  persona?: UserPersona;
+  onPromptClick: (promptText: string) => void;
+}
+
+/**
+ * SuggestedPrompts - Displays clickable prompt suggestions
+ *
+ * Shows a set of example prompts based on user persona.
+ * Clicking a prompt triggers the onPromptClick callback.
+ */
+export default function SuggestedPrompts({
+  persona = "default",
+  onPromptClick,
+}: SuggestedPromptsProps) {
+  const prompts = getPromptsForPersona(persona);
+
+  return (
+    <div className="mt-4 flex flex-wrap justify-start gap-y-2">
+      {prompts.map((prompt) => (
+        <Button
+          key={prompt.id}
+          secondary
+          onClick={() => onPromptClick(prompt.fullText)}
+          className="w-full justify-start"
+        >
+          {prompt.summary}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/build/constants/exampleBuildPrompts.ts
+++ b/web/src/app/build/constants/exampleBuildPrompts.ts
@@ -1,0 +1,160 @@
+/**
+ * Example prompts for the Build Mode welcome screen.
+ * Organized by user persona to allow different prompts for different user types.
+ */
+
+export interface BuildPrompt {
+  id: string;
+  /** Short summary shown on the button */
+  summary: string;
+  /** Full prompt text inserted into the input bar */
+  fullText: string;
+}
+
+export type UserPersona = "default" | "engineering" | "sales" | "product";
+
+/**
+ * Example prompts organized by user persona.
+ * Each persona has a set of prompts tailored to their typical use cases.
+ */
+export const exampleBuildPrompts: Record<UserPersona, BuildPrompt[]> = {
+  default: [
+    {
+      id: "default-1",
+      summary: "Analyze team productivity by month across my company",
+      fullText:
+        "Create a dashboard with the number of closed tickets per month. Split by priority and compare teams.",
+    },
+    {
+      id: "default-2",
+      summary: "Visualize my team's work with interactive drill-downs",
+      fullText:
+        "What did my team work on this month? Create a dashboard that 1) shows the number of actions per activity, 2) shows the individual work items when I select something in the dashboard.",
+    },
+    {
+      id: "default-3",
+      summary: "Connect my backlog to recent customer conversations",
+      fullText:
+        "For each of my open Linear tickets, find at least 2 customers that have discussed related issues. Present the results in a dashboard table.",
+    },
+    {
+      id: "default-4",
+      summary:
+        "Surface the top pain points from this week's customer success calls",
+      fullText:
+        "Based on the customer calls this week, what are the 5 most important challenges? Create a table in a dashboard that shows the challenge and the customers that complained about it.",
+    },
+    {
+      id: "default-5",
+      summary:
+        "Compare and contrast which messaging resonates the most with our prospects",
+      fullText:
+        "If you look at the customer calls over the last 30 days, which part of our messaging seems to resonate the best, and appears to drive the most customer value? Generate a slide that effectively tells the story.",
+    },
+  ],
+  engineering: [
+    {
+      id: "eng-1",
+      summary: "Enrich my open PRs with customer insights and feedback",
+      fullText:
+        "Look at my open PRs and find information from customer discussions regarding these PRs that could help to implement better. Also find for each PR the design doc I wrote and create a new one that is appropriately updated.",
+    },
+    {
+      id: "eng-2",
+      summary: "Track engineering velocity from ticket to merged PR",
+      fullText:
+        "What is the average time it takes the engineers to merge PRs after my team created a Linear ticket? Create a dashboard that shows the average time by engineering team.",
+    },
+    {
+      id: "eng-3",
+      summary: "Build a visual roadmap story from my quarterly contributions",
+      fullText:
+        "Create an image (slide) that groups my PRs by quarter, finds the common thread, and presents a coherent story. This will later go into a historical roadmap.",
+    },
+    {
+      id: "eng-4",
+      summary:
+        "Find churned customers who would have benefited from our releases",
+      fullText:
+        "Look at the PRs that my team merged this month. Then look at the customers we lost over the last 2 months and tell me which of the customers would have likely benefitted from the merged PRs. Rank the customers by importance. Present in a dashboard.",
+    },
+    {
+      id: "eng-5",
+      summary: "Build a Linear dashboard to track my team's progress",
+      fullText: "Create a Linear dashboard for my team.",
+    },
+  ],
+  sales: [
+    {
+      id: "sales-1",
+      summary: "Identify sales blockers and quantify their revenue impact",
+      fullText:
+        "Look at the customer calls that my team had last month and identify the 3 most important sales blockers. Those could be product-related, messaging-related, or persona-chemistry. Create a dashboard showing how much revenue seems to be associated with each blocker.",
+    },
+    {
+      id: "sales-2",
+      summary: "Prepare winning talking points for my upcoming meeting",
+      fullText:
+        "I have a meeting with a prospect next week. Please go through the objections they raised and suggest good talking points based on other customer situations, upcoming product changes, etc.",
+    },
+    {
+      id: "sales-3",
+      summary: "Learn how my teammates overcame similar deal objections",
+      fullText:
+        "I don't want to give up on this opportunity. Find customer discussions from other members of my team where similar issues came up and were overcome. Provide some recommendations.",
+    },
+    {
+      id: "sales-4",
+      summary: "Discover which pitch messaging resonates most with customers",
+      fullText:
+        "If you look at the customer calls over the last 30 days, which part of our messaging seems to resonate the best, and appears to drive the most customer value? Generate a slide that effectively tells the story.",
+    },
+    {
+      id: "sales-5",
+      summary: "Surface the top product challenges from customer calls",
+      fullText:
+        "Based on the customer calls this week, what are the 5 most important challenges with the product? Create a table in a dashboard that shows the challenge and the customers that complained about it.",
+    },
+  ],
+  product: [
+    {
+      id: "product-1",
+      summary: "Summarize my monthly impact for my manager",
+      fullText:
+        "I need to explain to my manager what I did last month, and how it matters for customer impact.",
+    },
+    {
+      id: "product-2",
+      summary: "Connect my backlog to real customer conversations",
+      fullText:
+        "For each of my open Linear tickets, find at least 2 customers that have discussed related issues. Present the results in a dashboard table.",
+    },
+    {
+      id: "product-3",
+      summary: "Visualize my team's work with interactive drill-downs",
+      fullText:
+        "What did my team work on this month? Create a dashboard that 1) shows the number of actions per activity, 2) shows the individual work items when I select something in the dashboard.",
+    },
+    {
+      id: "product-4",
+      summary:
+        "Find churned customers who would have benefited from our releases",
+      fullText:
+        "Look at the PRs that my team merged this month. Then look at the customers we lost over the last 2 months and tell me which of the customers would have likely benefitted from the merged PRs. Rank the customers by importance. Present in a dashboard.",
+    },
+    {
+      id: "product-5",
+      summary: "Analyze team productivity by month across my organization",
+      fullText:
+        "Create a dashboard with the number of closed tickets per month. Split by priority and compare teams.",
+    },
+  ],
+};
+
+/**
+ * Get prompts for a specific user persona.
+ * Falls back to default prompts if persona is not found.
+ */
+export function getPromptsForPersona(persona: UserPersona): BuildPrompt[] {
+  return exampleBuildPrompts[persona] ?? exampleBuildPrompts.default;
+}

--- a/web/src/app/build/v1/configure/components/ConnectorConfigStep.tsx
+++ b/web/src/app/build/v1/configure/components/ConnectorConfigStep.tsx
@@ -15,6 +15,7 @@ import {
 import CardSection from "@/components/admin/CardSection";
 import { RenderField } from "@/app/admin/connectors/[connector]/pages/FieldRendering";
 import { createBuildConnector } from "@/app/build/v1/configure/utils/createBuildConnector";
+import { useUser } from "@/components/user/UserProvider";
 
 interface ConnectorConfigStepProps {
   connectorType: ValidSources;
@@ -33,6 +34,7 @@ function ConnectorConfigForm({
 }: ConnectorConfigStepProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { values } = useFormikContext<Record<string, any>>();
+  const { user } = useUser();
 
   const config =
     connectorConfigs[connectorType as keyof typeof connectorConfigs];
@@ -48,6 +50,7 @@ function ConnectorConfigForm({
         credential,
         connectorSpecificConfig: connectorConfig,
         connectorName: connector_name,
+        userEmail: user?.email,
       });
 
       if (!result.success) {
@@ -111,6 +114,12 @@ function ConnectorConfigForm({
   );
 }
 
+function getUserIdentifier(email?: string): string {
+  if (!email) return "";
+  const prefix = email.split("@")[0] || email;
+  return `-${prefix.replace(/[^a-zA-Z0-9]/g, "-")}`;
+}
+
 export default function ConnectorConfigStep({
   connectorType,
   credential,
@@ -118,10 +127,12 @@ export default function ConnectorConfigStep({
   onBack,
   setPopup,
 }: ConnectorConfigStepProps) {
+  const { user } = useUser();
   const baseInitialValues = createConnectorInitialValues(connectorType as any);
+  const userIdentifier = getUserIdentifier(user?.email);
   const initialValues: Record<string, any> = {
     ...baseInitialValues,
-    connector_name: `build-mode-${connectorType}`,
+    connector_name: `build-mode-${connectorType}${userIdentifier}`,
   };
 
   return (

--- a/web/src/app/build/v1/configure/components/CredentialStep.tsx
+++ b/web/src/app/build/v1/configure/components/CredentialStep.tsx
@@ -31,6 +31,7 @@ import { BUILD_MODE_OAUTH_COOKIE_NAME } from "@/app/build/v1/constants";
 import Cookies from "js-cookie";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
 import { createBuildConnector } from "@/app/build/v1/configure/utils/createBuildConnector";
+import { useUser } from "@/components/user/UserProvider";
 
 interface CredentialStepProps {
   connectorType: ValidSources;
@@ -65,6 +66,7 @@ export default function CredentialStep({
     useState(false);
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
+  const { user } = useUser();
 
   const { data: oauthDetails, isLoading: oauthDetailsLoading } =
     useOAuthDetails(connectorType);
@@ -97,6 +99,7 @@ export default function CredentialStep({
       const result = await createBuildConnector({
         connectorType,
         credential: selectedCredential,
+        userEmail: user?.email,
       });
 
       if (!result.success) {

--- a/web/src/app/build/v1/configure/utils/createBuildConnector.ts
+++ b/web/src/app/build/v1/configure/utils/createBuildConnector.ts
@@ -9,6 +9,7 @@ export interface CreateBuildConnectorParams {
   credential: Credential<any>;
   connectorSpecificConfig?: Record<string, any>;
   connectorName?: string;
+  userEmail?: string;
 }
 
 export interface CreateBuildConnectorResult {
@@ -17,15 +18,25 @@ export interface CreateBuildConnectorResult {
   connectorId?: number;
 }
 
+function getUserIdentifier(email?: string): string {
+  if (!email) return "";
+  // Extract the part before @ and sanitize it
+  const prefix = email.split("@")[0] || email;
+  // Replace any non-alphanumeric characters with dashes
+  return `-${prefix.replace(/[^a-zA-Z0-9]/g, "-")}`;
+}
+
 export async function createBuildConnector({
   connectorType,
   credential,
   connectorSpecificConfig = {},
   connectorName,
+  userEmail,
 }: CreateBuildConnectorParams): Promise<CreateBuildConnectorResult> {
   const config =
     connectorConfigs[connectorType as keyof typeof connectorConfigs];
-  const name = connectorName || `build-mode-${connectorType}`;
+  const userIdentifier = getUserIdentifier(userEmail);
+  const name = connectorName || `build-mode-${connectorType}${userIdentifier}`;
 
   const filteredConfig: Record<string, any> = {};
   Object.entries(connectorSpecificConfig).forEach(([key, value]) => {

--- a/web/src/app/build/v1/constants.ts
+++ b/web/src/app/build/v1/constants.ts
@@ -1,3 +1,4 @@
 export const BUILD_MODE_OAUTH_COOKIE_NAME = "build_mode_oauth";
 export const BUILD_CONFIGURE_PATH = "/build/v1/configure";
 export const OAUTH_STATE_KEY = "build_oauth_state";
+export const BUILD_DEMO_DATA_COOKIE_NAME = "build_demo_data_enabled";


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds suggested prompts to the Build welcome and makes connector names unique per user to avoid collisions. Also persists the demo data toggle and fixes intro/button styling for better readability.

- **New Features**
  - Suggested prompts with persona examples; clicking a prompt sets the input via InputBarHandle.setMessage.
  - Persist demo data toggle with BUILD_DEMO_DATA_COOKIE_NAME; read on init.
  - Connector names append a sanitized email prefix for uniqueness.

- **Bug Fixes**
  - BigButton respects explicit text-white overrides.
  - Build Mode intro uses explicit white styles for text and buttons.
  - Demo Data pill only renders when demo data is enabled.

<sup>Written for commit b10cb1383e1fd4a3ce486ab3d5679fdd52d03d24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

