### PR TITLE
fix reenable demo data on connector deletion

### DIFF
--- a/web/src/app/build/v1/configure/page.tsx
+++ b/web/src/app/build/v1/configure/page.tsx
@@ -111,6 +111,13 @@ export default function BuildConfigPage() {
     ({ config }) => config?.status === "connected"
   );
 
+  // Auto-enable demo data when all connectors are disconnected
+  useEffect(() => {
+    if (!hasActiveConnector && !demoDataEnabled) {
+      setDemoDataEnabled(true);
+    }
+  }, [hasActiveConnector, demoDataEnabled, setDemoDataEnabled]);
+
   const handleDeleteConfirm = async () => {
     if (!connectorToDelete) return;
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically re-enables demo data when all connectors are disconnected, so users aren’t left with an empty state after deleting a connector.

- **Bug Fixes**
  - Detects no active connectors and turns demo data back on via useEffect.
  - Applies immediately after connector deletion on the Build v1 Configure page.

<sup>Written for commit 941c335bb4a4b0a28feaebcda350d95e6d2b75c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

