### PR TITLE
chore(vscode): add useful database operations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -497,28 +497,6 @@
       }
     },
     {
-      "name": "Clean restore seeded database dump (destructive)",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "uv",
-      "runtimeArgs": [
-        "run",
-        "--with",
-        "onyx-devtools",
-        "ods",
-        "db",
-        "restore",
-        "--fetch-seeded",
-        "--clean",
-        "--yes"
-      ],
-      "cwd": "${workspaceFolder}",
-      "console": "integratedTerminal",
-      "presentation": {
-        "group": "3"
-      }
-    },
-    {
       "name": "Clear and Restart External Volumes and Containers",
       "type": "node",
       "request": "launch",
@@ -597,6 +575,99 @@
       "console": "integratedTerminal",
       "presentation": {
         "group": "3"
+      }
+    },
+    {
+      // Dummy entry used to label the group
+      "name": "--- Database ---",
+      "type": "node",
+      "request": "launch",
+      "presentation": {
+        "group": "4",
+        "order": 0
+      }
+    },
+    {
+      "name": "Clean restore seeded database dump (destructive)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": [
+        "run",
+        "--with",
+        "onyx-devtools",
+        "ods",
+        "db",
+        "restore",
+        "--fetch-seeded",
+        "--clean",
+        "--yes"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "presentation": {
+        "group": "4"
+      }
+    },
+    {
+      "name": "Create database snapshot",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": [
+        "run",
+        "--with",
+        "onyx-devtools",
+        "ods",
+        "db",
+        "dump",
+        "backup.dump"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "presentation": {
+        "group": "4"
+      }
+    },
+    {
+      "name": "Clean restore database snapshot (destructive)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": [
+        "run",
+        "--with",
+        "onyx-devtools",
+        "ods",
+        "db",
+        "restore",
+        "--clean",
+        "--yes",
+        "backup.dump"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "presentation": {
+        "group": "4"
+      }
+    },
+    {
+      "name": "Upgrade database to head revision",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": [
+        "run",
+        "--with",
+        "onyx-devtools",
+        "ods",
+        "db",
+        "upgrade"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "presentation": {
+        "group": "4"
       }
     },
     {


### PR DESCRIPTION
## Description

These operations complement restoring the db dump, so let's include so I can explain the full workflow with the seeded db PSA.

## How Has This Been Tested?

<img width="2848" height="1820" alt="20260123_08h22m26s_grim" src="https://github.com/user-attachments/assets/46cde969-06b6-4d7e-a04e-b61f63a67449" />


## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VS Code run configs to manage the local database: snapshot, destructive restore, and upgrade. This streamlines the seeded DB workflow and makes common tasks one click.

- **New Features**
  - New launch group: --- Database ---
  - Create and clean-restore a database snapshot (backup.dump)
  - Clean restore the seeded database dump (destructive)
  - Upgrade the database to the head migration

<sup>Written for commit 5d2156bc7b2b767e4c522f621953c5709b17e279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

