### PR TITLE
fix(fe): inline code text wraps (#7574) to release v2.9

### DIFF
--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -68,7 +68,7 @@ export const CodeBlock = memo(function CodeBlock({
           "bg-background-tint-00",
           "rounded",
           "text-xs",
-          "inline-block",
+          "inline",
           "whitespace-pre-wrap",
           "break-words",
           "py-0.5",


### PR DESCRIPTION
Cherry-pick of commit f2d32b0b3 to release/v2.9 branch.

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrapping for inline code in chat messages to prevent overflow and improve readability.

- **Bug Fixes**
  - In CodeBlock, changed display from inline-block to inline so long inline code wraps correctly.

<sup>Written for commit edc49ac379e0568a83bc75826903e3c465570f08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

