### PR TITLE
feat: google ai studio (gemini api keys)

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -16,6 +16,7 @@ class LlmProviderNames(str, Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     GOOGLE = "google"
+    GOOGLE_AI = "google_ai"  # Google AI Studio (uses gemini/ prefix in litellm)
     BEDROCK = "bedrock"
     BEDROCK_CONVERSE = "bedrock_converse"
     VERTEX_AI = "vertex_ai"
@@ -36,6 +37,7 @@ class LlmProviderNames(str, Enum):
 WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.OPENAI,
     LlmProviderNames.ANTHROPIC,
+    LlmProviderNames.GOOGLE_AI,
     LlmProviderNames.VERTEX_AI,
     LlmProviderNames.BEDROCK,
     LlmProviderNames.OPENROUTER,
@@ -49,6 +51,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.OPENAI: "OpenAI",
     LlmProviderNames.ANTHROPIC: "Anthropic",
     LlmProviderNames.GOOGLE: "Google",
+    LlmProviderNames.GOOGLE_AI: "Google AI Studio",
     LlmProviderNames.BEDROCK: "Bedrock",
     LlmProviderNames.BEDROCK_CONVERSE: "Bedrock",
     LlmProviderNames.VERTEX_AI: "Vertex AI",

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -60,3 +60,13 @@ VERTEXAI_VISIBLE_MODEL_NAMES = {
     "gemini-2.5-flash-lite",
     "gemini-2.5-pro",
 }
+
+# Google AI Studio (uses gemini/ prefix in litellm, requires only API key)
+GOOGLE_AI_PROVIDER_NAME = "google_ai"
+GOOGLE_AI_DEFAULT_MODEL = "gemini-3-pro-preview"
+# Curated list of Google AI Studio models to show by default in the UI
+GOOGLE_AI_VISIBLE_MODEL_NAMES = {
+    "gemini-3-pro-preview",
+    "gemini-3-pro-image-preview",
+    "gemini-3-flash-preview",
+}

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -31,6 +31,18 @@
         }
       ]
     },
+    "google_ai": {
+      "default_model": {
+        "name": "gemini-3-pro-preview",
+        "display_name": "Gemini 3 Pro"
+      },
+      "additional_visible_models": [
+        {
+          "name": "gemini-3-flash-preview",
+          "display_name": "Gemini 3 Flash"
+        }
+      ]
+    },
     "openrouter": {
       "default_model": "z-ai/glm-4.7",
       "additional_visible_models": [

--- a/web/src/app/admin/configuration/llm/LLMConfiguration.tsx
+++ b/web/src/app/admin/configuration/llm/LLMConfiguration.tsx
@@ -10,6 +10,7 @@ import { LLMProviderView } from "./interfaces";
 import { LLM_PROVIDERS_ADMIN_URL } from "./constants";
 import { OpenAIForm } from "./forms/OpenAIForm";
 import { AnthropicForm } from "./forms/AnthropicForm";
+import { GoogleAIForm } from "./forms/GoogleAIForm";
 import { OllamaForm } from "./forms/OllamaForm";
 import { AzureForm } from "./forms/AzureForm";
 import { BedrockForm } from "./forms/BedrockForm";
@@ -71,6 +72,7 @@ export function LLMConfiguration() {
       <div className="flex flex-col gap-y-4">
         <OpenAIForm shouldMarkAsDefault={isFirstProvider} />
         <AnthropicForm shouldMarkAsDefault={isFirstProvider} />
+        <GoogleAIForm shouldMarkAsDefault={isFirstProvider} />
         <OllamaForm shouldMarkAsDefault={isFirstProvider} />
         <AzureForm shouldMarkAsDefault={isFirstProvider} />
         <BedrockForm shouldMarkAsDefault={isFirstProvider} />

--- a/web/src/app/admin/configuration/llm/forms/GoogleAIForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/GoogleAIForm.tsx
@@ -1,0 +1,126 @@
+import { Form, Formik } from "formik";
+import { LLMProviderFormProps } from "../interfaces";
+import * as Yup from "yup";
+import {
+  ProviderFormEntrypointWrapper,
+  ProviderFormContext,
+} from "./components/FormWrapper";
+import { DisplayNameField } from "./components/DisplayNameField";
+import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
+import { FormActionButtons } from "./components/FormActionButtons";
+import {
+  buildDefaultInitialValues,
+  buildDefaultValidationSchema,
+  buildAvailableModelConfigurations,
+  submitLLMProvider,
+  LLM_FORM_CLASS_NAME,
+} from "./formUtils";
+import { AdvancedOptions } from "./components/AdvancedOptions";
+import { DisplayModels } from "./components/DisplayModels";
+
+export const GOOGLE_AI_PROVIDER_NAME = "google_ai";
+const DEFAULT_DEFAULT_MODEL_NAME = "gemini-3-pro-preview";
+
+export function GoogleAIForm({
+  existingLlmProvider,
+  shouldMarkAsDefault,
+}: LLMProviderFormProps) {
+  return (
+    <ProviderFormEntrypointWrapper
+      providerName="Google AI Studio"
+      providerEndpoint={GOOGLE_AI_PROVIDER_NAME}
+      existingLlmProvider={existingLlmProvider}
+    >
+      {({
+        onClose,
+        mutate,
+        popup,
+        setPopup,
+        isTesting,
+        setIsTesting,
+        testError,
+        setTestError,
+        wellKnownLLMProvider,
+      }: ProviderFormContext) => {
+        const modelConfigurations = buildAvailableModelConfigurations(
+          existingLlmProvider,
+          wellKnownLLMProvider
+        );
+        const initialValues = {
+          ...buildDefaultInitialValues(
+            existingLlmProvider,
+            modelConfigurations
+          ),
+          api_key: existingLlmProvider?.api_key ?? "",
+          default_model_name:
+            existingLlmProvider?.default_model_name ??
+            wellKnownLLMProvider?.recommended_default_model?.name ??
+            DEFAULT_DEFAULT_MODEL_NAME,
+          // Default to auto mode for new Google AI providers
+          is_auto_mode: existingLlmProvider?.is_auto_mode ?? true,
+        };
+
+        const validationSchema = buildDefaultValidationSchema().shape({
+          api_key: Yup.string().required("API Key is required"),
+        });
+
+        return (
+          <>
+            {popup}
+            <Formik
+              initialValues={initialValues}
+              validationSchema={validationSchema}
+              validateOnMount={true}
+              onSubmit={async (values, { setSubmitting }) => {
+                await submitLLMProvider({
+                  providerName: GOOGLE_AI_PROVIDER_NAME,
+                  values,
+                  initialValues,
+                  modelConfigurations,
+                  existingLlmProvider,
+                  shouldMarkAsDefault,
+                  setIsTesting,
+                  setTestError,
+                  setPopup,
+                  mutate,
+                  onClose,
+                  setSubmitting,
+                });
+              }}
+            >
+              {(formikProps) => {
+                return (
+                  <Form className={LLM_FORM_CLASS_NAME}>
+                    <DisplayNameField disabled={!!existingLlmProvider} />
+
+                    <PasswordInputTypeInField name="api_key" label="API Key" />
+
+                    <DisplayModels
+                      modelConfigurations={modelConfigurations}
+                      formikProps={formikProps}
+                      recommendedDefaultModel={
+                        wellKnownLLMProvider?.recommended_default_model ?? null
+                      }
+                      shouldShowAutoUpdateToggle={true}
+                    />
+
+                    <AdvancedOptions formikProps={formikProps} />
+
+                    <FormActionButtons
+                      isTesting={isTesting}
+                      testError={testError}
+                      existingLlmProvider={existingLlmProvider}
+                      mutate={mutate}
+                      onClose={onClose}
+                      isFormValid={formikProps.isValid}
+                    />
+                  </Form>
+                );
+              }}
+            </Formik>
+          </>
+        );
+      }}
+    </ProviderFormEntrypointWrapper>
+  );
+}

--- a/web/src/app/admin/configuration/llm/forms/formUtils.ts
+++ b/web/src/app/admin/configuration/llm/forms/formUtils.ts
@@ -9,7 +9,8 @@ import * as Yup from "yup";
 import isEqual from "lodash/isEqual";
 
 // Common class names for the Form component across all LLM provider forms
-export const LLM_FORM_CLASS_NAME = "flex flex-col gap-y-4 items-stretch mt-6";
+export const LLM_FORM_CLASS_NAME =
+  "flex flex-col gap-y-4 items-stretch mt-6 w-full";
 
 export const buildDefaultInitialValues = (
   existingLlmProvider?: LLMProviderView,

--- a/web/src/app/admin/configuration/llm/forms/getForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/getForm.tsx
@@ -1,5 +1,6 @@
 import { LLMProviderName, LLMProviderView } from "../interfaces";
 import { AnthropicForm } from "./AnthropicForm";
+import { GoogleAIForm } from "./GoogleAIForm";
 import { OpenAIForm } from "./OpenAIForm";
 import { OllamaForm } from "./OllamaForm";
 import { AzureForm } from "./AzureForm";
@@ -28,6 +29,8 @@ export const getFormForExistingProvider = (provider: LLMProviderView) => {
       }
     case LLMProviderName.ANTHROPIC:
       return <AnthropicForm existingLlmProvider={provider} />;
+    case LLMProviderName.GOOGLE_AI:
+      return <GoogleAIForm existingLlmProvider={provider} />;
     case LLMProviderName.OLLAMA_CHAT:
       return <OllamaForm existingLlmProvider={provider} />;
     case LLMProviderName.AZURE:

--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -1,6 +1,7 @@
 export enum LLMProviderName {
   OPENAI = "openai",
   ANTHROPIC = "anthropic",
+  GOOGLE_AI = "google_ai",
   OLLAMA_CHAT = "ollama_chat",
   AZURE = "azure",
   OPENROUTER = "openrouter",

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -61,6 +61,7 @@ export const getProviderIcon = (
     microsoft: MicrosoftIconSVG,
     meta: MetaIcon,
     google: GeminiIcon,
+    google_ai: GeminiIcon,
     qwen: QwenIcon,
     qwq: QwenIcon,
     zai: ZAIIcon,

--- a/web/src/refresh-components/onboarding/forms/GoogleAIOnboardingForm.tsx
+++ b/web/src/refresh-components/onboarding/forms/GoogleAIOnboardingForm.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo } from "react";
+import * as Yup from "yup";
+import { FormikField } from "@/refresh-components/form/FormikField";
+import { FormField } from "@/refresh-components/form/FormField";
+import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import Separator from "@/refresh-components/Separator";
+import {
+  ModelConfiguration,
+  WellKnownLLMProviderDescriptor,
+} from "@/app/admin/configuration/llm/interfaces";
+import {
+  OnboardingFormWrapper,
+  OnboardingFormChildProps,
+} from "./OnboardingFormWrapper";
+import { OnboardingActions, OnboardingState } from "../types";
+import { buildInitialValues } from "../components/llmConnectionHelpers";
+import ConnectionProviderIcon from "@/refresh-components/ConnectionProviderIcon";
+import InlineExternalLink from "@/refresh-components/InlineExternalLink";
+import { ProviderIcon } from "@/app/admin/configuration/llm/ProviderIcon";
+
+// Field name constants
+const FIELD_API_KEY = "api_key";
+const FIELD_DEFAULT_MODEL_NAME = "default_model_name";
+
+const DEFAULT_DEFAULT_MODEL_NAME = "gemini-3-pro-preview";
+
+interface GoogleAIOnboardingFormProps {
+  llmDescriptor: WellKnownLLMProviderDescriptor;
+  onboardingState: OnboardingState;
+  onboardingActions: OnboardingActions;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface GoogleAIFormValues {
+  name: string;
+  provider: string;
+  api_key: string;
+  api_key_changed: boolean;
+  default_model_name: string;
+  model_configurations: any[];
+  groups: number[];
+  is_public: boolean;
+}
+
+function GoogleAIFormFields(
+  props: OnboardingFormChildProps<GoogleAIFormValues>
+) {
+  const { apiStatus, showApiMessage, errorMessage, modelOptions, disabled } =
+    props;
+
+  return (
+    <>
+      <FormikField<string>
+        name={FIELD_API_KEY}
+        render={(field, helper, meta, state) => (
+          <FormField name={FIELD_API_KEY} state={state} className="w-full">
+            <FormField.Label>API Key</FormField.Label>
+            <FormField.Control>
+              <PasswordInputTypeIn
+                {...field}
+                placeholder=""
+                error={apiStatus === "error"}
+                showClearButton={false}
+                disabled={disabled}
+              />
+            </FormField.Control>
+            {!showApiMessage && (
+              <FormField.Message
+                messages={{
+                  idle: (
+                    <>
+                      {"Paste your "}
+                      <InlineExternalLink href="https://aistudio.google.com/apikey">
+                        API key
+                      </InlineExternalLink>
+                      {" from Google AI Studio to access Gemini models."}
+                    </>
+                  ),
+                  error: meta.error,
+                }}
+              />
+            )}
+            {showApiMessage && (
+              <FormField.APIMessage
+                state={apiStatus}
+                messages={{
+                  loading: "Checking API key with Google AI Studio...",
+                  success: "API key valid.",
+                  error: errorMessage || "Invalid API key",
+                }}
+              />
+            )}
+          </FormField>
+        )}
+      />
+
+      <Separator className="my-0" />
+
+      <FormikField<string>
+        name={FIELD_DEFAULT_MODEL_NAME}
+        render={(field, helper, meta, state) => (
+          <FormField
+            name={FIELD_DEFAULT_MODEL_NAME}
+            state={state}
+            className="w-full"
+          >
+            <FormField.Label>Default Model</FormField.Label>
+            <FormField.Control>
+              <InputComboBox
+                value={field.value}
+                onValueChange={(value) => helper.setValue(value)}
+                onChange={(e) => helper.setValue(e.target.value)}
+                options={modelOptions}
+                disabled={disabled || modelOptions.length === 0}
+                onBlur={field.onBlur}
+                placeholder="Select a model"
+              />
+            </FormField.Control>
+            <FormField.Message
+              messages={{
+                idle: "This model will be used by Onyx by default.",
+                error: meta.error,
+              }}
+            />
+          </FormField>
+        )}
+      />
+    </>
+  );
+}
+
+export function GoogleAIOnboardingForm({
+  llmDescriptor,
+  onboardingState,
+  onboardingActions,
+  open,
+  onOpenChange,
+}: GoogleAIOnboardingFormProps) {
+  const initialValues = useMemo(
+    (): GoogleAIFormValues => ({
+      ...buildInitialValues(),
+      name: llmDescriptor.name,
+      provider: llmDescriptor.name,
+      default_model_name: DEFAULT_DEFAULT_MODEL_NAME,
+    }),
+    [llmDescriptor.name]
+  );
+
+  const validationSchema = Yup.object().shape({
+    [FIELD_API_KEY]: Yup.string().required("API Key is required"),
+    [FIELD_DEFAULT_MODEL_NAME]: Yup.string().required("Model name is required"),
+  });
+
+  const icon = () => (
+    <ConnectionProviderIcon
+      icon={<ProviderIcon provider={llmDescriptor.name} size={24} />}
+    />
+  );
+
+  // Enable auto mode if user keeps the recommended default model
+  const transformValues = (
+    values: GoogleAIFormValues,
+    modelConfigurations: ModelConfiguration[]
+  ) => ({
+    ...values,
+    model_configurations: modelConfigurations,
+    is_auto_mode: values.default_model_name === DEFAULT_DEFAULT_MODEL_NAME,
+  });
+
+  return (
+    <OnboardingFormWrapper<GoogleAIFormValues>
+      icon={icon}
+      title="Set up Gemini"
+      description="Connect to Google AI Studio and set up your Gemini models."
+      llmDescriptor={llmDescriptor}
+      onboardingState={onboardingState}
+      onboardingActions={onboardingActions}
+      open={open}
+      onOpenChange={onOpenChange}
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      transformValues={transformValues}
+    >
+      {(props) => <GoogleAIFormFields {...props} />}
+    </OnboardingFormWrapper>
+  );
+}

--- a/web/src/refresh-components/onboarding/forms/getOnboardingForm.tsx
+++ b/web/src/refresh-components/onboarding/forms/getOnboardingForm.tsx
@@ -6,10 +6,10 @@ import {
 import { OnboardingActions, OnboardingState } from "../types";
 import { OpenAIOnboardingForm } from "./OpenAIOnboardingForm";
 import { AnthropicOnboardingForm } from "./AnthropicOnboardingForm";
+import { GoogleAIOnboardingForm } from "./GoogleAIOnboardingForm";
 import { OllamaOnboardingForm } from "./OllamaOnboardingForm";
 import { AzureOnboardingForm } from "./AzureOnboardingForm";
 import { BedrockOnboardingForm } from "./BedrockOnboardingForm";
-import { VertexAIOnboardingForm } from "./VertexAIOnboardingForm";
 import { OpenRouterOnboardingForm } from "./OpenRouterOnboardingForm";
 import { CustomOnboardingForm } from "./CustomOnboardingForm";
 
@@ -20,6 +20,10 @@ const PROVIDER_DISPLAY_INFO: Record<
 > = {
   [LLMProviderName.OPENAI]: { title: "GPT", displayName: "OpenAI" },
   [LLMProviderName.ANTHROPIC]: { title: "Claude", displayName: "Anthropic" },
+  [LLMProviderName.GOOGLE_AI]: {
+    title: "Gemini",
+    displayName: "Google AI Studio",
+  },
   [LLMProviderName.OLLAMA_CHAT]: { title: "Ollama", displayName: "Ollama" },
   [LLMProviderName.AZURE]: {
     title: "Azure OpenAI",
@@ -28,10 +32,6 @@ const PROVIDER_DISPLAY_INFO: Record<
   [LLMProviderName.BEDROCK]: {
     title: "Amazon Bedrock",
     displayName: "AWS",
-  },
-  [LLMProviderName.VERTEX_AI]: {
-    title: "Gemini",
-    displayName: "Google Cloud Vertex AI",
   },
   [LLMProviderName.OPENROUTER]: {
     title: "OpenRouter",
@@ -104,6 +104,17 @@ export function getOnboardingForm({
         />
       );
 
+    case LLMProviderName.GOOGLE_AI:
+      return (
+        <GoogleAIOnboardingForm
+          llmDescriptor={llmDescriptor}
+          onboardingState={onboardingState}
+          onboardingActions={onboardingActions}
+          open={open}
+          onOpenChange={onOpenChange}
+        />
+      );
+
     case LLMProviderName.OLLAMA_CHAT:
       return (
         <OllamaOnboardingForm
@@ -129,17 +140,6 @@ export function getOnboardingForm({
     case LLMProviderName.BEDROCK:
       return (
         <BedrockOnboardingForm
-          llmDescriptor={llmDescriptor}
-          onboardingState={onboardingState}
-          onboardingActions={onboardingActions}
-          open={open}
-          onOpenChange={onOpenChange}
-        />
-      );
-
-    case LLMProviderName.VERTEX_AI:
-      return (
-        <VertexAIOnboardingForm
           llmDescriptor={llmDescriptor}
           onboardingState={onboardingState}
           onboardingActions={onboardingActions}

--- a/web/src/refresh-components/onboarding/steps/LLMStep.tsx
+++ b/web/src/refresh-components/onboarding/steps/LLMStep.tsx
@@ -4,7 +4,10 @@ import Button from "@/refresh-components/buttons/Button";
 import Separator from "@/refresh-components/Separator";
 import LLMProviderCard from "../components/LLMProviderCard";
 import { OnboardingActions, OnboardingState, OnboardingStep } from "../types";
-import { WellKnownLLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
+import {
+  WellKnownLLMProviderDescriptor,
+  LLMProviderName,
+} from "@/app/admin/configuration/llm/interfaces";
 import {
   getOnboardingForm,
   getProviderDisplayInfo,
@@ -173,26 +176,35 @@ const LLMStepInner = ({
                 })}
 
               {/* Render provider cards */}
-              {llmDescriptors.map((llmDescriptor) => {
-                const displayInfo = getProviderDisplayInfo(llmDescriptor.name);
-                return (
-                  <div
-                    key={llmDescriptor.name}
-                    className="basis-[calc(50%-theme(spacing.1)/2)] grow"
-                  >
-                    <LLMProviderCard
-                      title={displayInfo.title}
-                      subtitle={displayInfo.displayName}
-                      providerName={llmDescriptor.name}
-                      disabled={disabled}
-                      isConnected={onboardingState.data.llmProviders?.some(
-                        (provider) => provider === llmDescriptor.name
-                      )}
-                      onClick={() => handleProviderClick(llmDescriptor, false)}
-                    />
-                  </div>
-                );
-              })}
+              {llmDescriptors
+                .filter(
+                  (llmDescriptor) =>
+                    llmDescriptor.name !== LLMProviderName.VERTEX_AI
+                )
+                .map((llmDescriptor) => {
+                  const displayInfo = getProviderDisplayInfo(
+                    llmDescriptor.name
+                  );
+                  return (
+                    <div
+                      key={llmDescriptor.name}
+                      className="basis-[calc(50%-theme(spacing.1)/2)] grow"
+                    >
+                      <LLMProviderCard
+                        title={displayInfo.title}
+                        subtitle={displayInfo.displayName}
+                        providerName={llmDescriptor.name}
+                        disabled={disabled}
+                        isConnected={onboardingState.data.llmProviders?.some(
+                          (provider) => provider === llmDescriptor.name
+                        )}
+                        onClick={() =>
+                          handleProviderClick(llmDescriptor, false)
+                        }
+                      />
+                    </div>
+                  );
+                })}
 
               {/* Custom provider card */}
               <div className="basis-[calc(50%-theme(spacing.1)/2)] grow">


### PR DESCRIPTION
- **fix: discord icon and icon creation script**
- **feat: google ai studio**

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google AI Studio as a first-class LLM provider using LiteLLM’s gemini/ API, with admin and onboarding forms, dynamic model discovery, and a curated default model. Also fixes the Discord icon rendering and improves the icon conversion script.

- **New Features**
  - Backend: added provider google_ai, mapped to gemini/ in LiteLLM, sets GEMINI_API_KEY, and exposes curated/default models (Gemini 3 Pro).
  - Admin: new GoogleAIForm with API key input, model selection, auto-update toggle, and provider icon.
  - Onboarding: new GoogleAIOnboardingForm with API key validation and default model selection; Gemini appears under “Google AI Studio.”

- **Bug Fixes**
  - Discord icon now uses currentColor for consistent theming.
  - Icon conversion script removes fill/outline attrs and auto-adds sorted exports to index.ts.

<sup>Written for commit 12af7dc34ff70222199f50e23ae6837b6a8c8f3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

