### PR TITLE
fix(ui): First Connector Result (#7657) to release v2.9

### DIFF
--- a/web/src/components/SourceTile.tsx
+++ b/web/src/components/SourceTile.tsx
@@ -30,13 +30,10 @@ export default function SourceTile({
               w-40
               cursor-pointer
               shadow-md
+              bg-background-tint-00
               hover:bg-background-tint-02
               relative
-              ${
-                preSelect
-                  ? "bg-background-tint-01 subtle-pulse"
-                  : "bg-background-tint-00"
-              }
+              ${preSelect ? "subtle-pulse" : ""}
             `}
       href={navigationUrl as Route}
     >


### PR DESCRIPTION
Cherry-pick of commit 11b7e0d571d4086feebeeca5d585ddf67eb3e616 to release/v2.9 branch.

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SourceTile styling so the first connector result no longer looks selected by default; pre-selected items now only show a subtle pulse. Improves clarity while keeping the hover tint behavior.

- **Bug Fixes**
  - Always use bg-background-tint-00; apply subtle-pulse only when preSelect; keep hover:bg-background-tint-02.

<sup>Written for commit aa4c04375daf09937606ec82679c9922b777dc8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

