### PR TITLE
fix: modal header in index attempt errors (#7601) to release v2.9

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -135,6 +135,7 @@ export default function IndexAttemptErrorsModal({
               : undefined
           }
           onClose={onClose}
+          height="fit"
         />
         <Modal.Body>
           {!isResolvingErrors && (


### PR DESCRIPTION
Cherry-pick of commit 67081efe0875bae1dd4363602b29a4c17c8c43ef to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Index Attempt Errors modal header by setting its height to “fit,” so the header matches its content and avoids clipping or extra vertical space.

<sup>Written for commit a3dccfbb5ee0df16a196080097cd227faaad2c6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

