### PR TITLE
chore(hotfix): cherry-pick 3 commits to release v2.9

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-      - "release/**"
+      - 'release/**'
   push:
     tags:
       - "v*.*.*"
@@ -21,13 +21,7 @@ jobs:
     # See https://runs-on.com/runners/linux/
     # Note: Mypy seems quite optimized for x64 compared to arm64.
     # Similarly, mypy is single-threaded and incremental, so 2cpu is sufficient.
-    runs-on:
-      [
-        runs-on,
-        runner=2cpu-linux-x64,
-        "run-id=${{ github.run_id }}-mypy-check",
-        "extras=s3-cache",
-      ]
+    runs-on: [runs-on, runner=2cpu-linux-x64, "run-id=${{ github.run_id }}-mypy-check", "extras=s3-cache"]
     timeout-minutes: 45
 
     steps:
@@ -59,6 +53,7 @@ jobs:
           key: mypy-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/*.py', '**/*.pyi', 'backend/pyproject.toml') }}
           restore-keys: |
             mypy-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
+            mypy-${{ runner.os }}-
 
       - name: Run MyPy
         working-directory: ./backend


### PR DESCRIPTION
Cherry-pick of 3 commits to release/v2.9 branch:

- a3603c498
- 8be261405
- 20a73bdd2

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MyPy cache to avoid stale results when switching between branches on v2.9. The cache key and restore keys now include the base or ref name so each branch uses its own cache.

<sup>Written for commit bc19e1c140f6559bc2b134e553b8b5555bb862c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



