### PR TITLE
fix: bedrock non-anthropic prompt caching (#7435) to release v2.9

### DIFF
--- a/backend/onyx/llm/prompt_cache/processor.py
+++ b/backend/onyx/llm/prompt_cache/processor.py
@@ -63,7 +63,7 @@ def process_with_prompt_cache(
         return suffix, None
 
     # Get provider adapter
-    provider_adapter = get_provider_adapter(llm_config.model_provider)
+    provider_adapter = get_provider_adapter(llm_config)
 
     # If provider doesn't support caching, combine and return unchanged
     if not provider_adapter.supports_caching():

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -1,14 +1,17 @@
 """Factory for creating provider-specific prompt cache adapters."""
 
 from onyx.llm.constants import LlmProviderNames
+from onyx.llm.interfaces import LLMConfig
 from onyx.llm.prompt_cache.providers.anthropic import AnthropicPromptCacheProvider
 from onyx.llm.prompt_cache.providers.base import PromptCacheProvider
 from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
 from onyx.llm.prompt_cache.providers.openai import OpenAIPromptCacheProvider
 from onyx.llm.prompt_cache.providers.vertex import VertexAIPromptCacheProvider
 
+ANTHROPIC_BEDROCK_TAG = "anthropic."
 
-def get_provider_adapter(provider: str) -> PromptCacheProvider:
+
+def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
     """Get the appropriate prompt cache provider adapter for a given provider.
 
     Args:
@@ -17,11 +20,14 @@ def get_provider_adapter(provider: str) -> PromptCacheProvider:
     Returns:
         PromptCacheProvider instance for the given provider
     """
-    if provider == LlmProviderNames.OPENAI:
+    if llm_config.model_provider == LlmProviderNames.OPENAI:
         return OpenAIPromptCacheProvider()
-    elif provider in [LlmProviderNames.ANTHROPIC, LlmProviderNames.BEDROCK]:
+    elif llm_config.model_provider == LlmProviderNames.ANTHROPIC or (
+        llm_config.model_provider == LlmProviderNames.BEDROCK
+        and ANTHROPIC_BEDROCK_TAG in llm_config.model_name
+    ):
         return AnthropicPromptCacheProvider()
-    elif provider == LlmProviderNames.VERTEX_AI:
+    elif llm_config.model_provider == LlmProviderNames.VERTEX_AI:
         return VertexAIPromptCacheProvider()
     else:
         # Default to no-op for providers without caching support


### PR DESCRIPTION
Cherry-pick of commit 79302f19be2bc1808f887608e780126474c608ec to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix prompt cache adapter selection so Bedrock non-Anthropic models no longer use Anthropic caching. This restores correct caching behavior and avoids errors for Bedrock models.

- **Bug Fixes**
  - Use LLMConfig in the provider factory and select Anthropic cache only for Anthropic or Bedrock models tagged "anthropic."; others route to their provider or no-op.
  - Update processor to pass LLMConfig to the factory for accurate provider detection.

<sup>Written for commit 4dbe78ad2645ae91ce856b533e725e6a6b3b08c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

