### PR TITLE
fix(mcp): per-user auth (#7400) to release v2.9

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -697,7 +697,7 @@ def save_user_credentials(
             # TODO: fix and/or type correctly w/base model
             config_data = MCPConnectionData(
                 headers=auth_template.config.get("headers", {}),
-                header_substitutions=auth_template.config.get(HEADER_SUBSTITUTIONS, {}),
+                header_substitutions=request.credentials,
             )
             for oauth_field_key in MCPOAuthKeys:
                 field_key: Literal["client_info", "tokens", "metadata"] = (

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -41,6 +41,12 @@ API_KEY_RECORDS: Dict[str, Dict[str, Any]] = {
     },
 }
 
+# These are inferrable from the file anyways, no need to obfuscate.
+# use them to test your auth with this server
+#
+# mcp_live-kid_alice_001-S3cr3tAlice
+# mcp_live-kid_bob_001-S3cr3tBob
+
 
 # ---- verifier ---------------------------------------------------------------
 class ApiKeyVerifier(TokenVerifier):

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -438,7 +438,17 @@ export default function ActionsPopover({
         serverId: server.id,
         serverName: server.name,
         authTemplate: server.auth_template,
-        onSuccess: undefined,
+        onSuccess: () => {
+          // Update the authentication state after successful credential submission
+          setMcpServerData((prev) => ({
+            ...prev,
+            [server.id]: {
+              ...prev[server.id],
+              isAuthenticated: true,
+              isLoading: false,
+            },
+          }));
+        },
         isAuthenticated: server.user_authenticated,
         existingCredentials: server.user_credentials,
       });


### PR DESCRIPTION
Cherry-pick of commit a63b906789f45d9fde64be8e32c4ea817cdec4b8 to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user MCP authentication by using the user’s submitted credentials for header substitutions and updating the UI auth state after submission. Users now authenticate with their own keys instead of a shared template.

- **Bug Fixes**
  - Backend: Use request.credentials for header_substitutions in save_user_credentials.
  - Frontend: ActionsPopover sets isAuthenticated=true and isLoading=false on successful credential submission.
  - Tests: Added sample per-user keys (alice/bob) in mock MCP server for easier verification.

<sup>Written for commit 9b72ba0675d122fadc67cc3679307284fffceb00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

