### PR TITLE
fix: prevent updates from overwriting perm syncing (#7384) to release v2.9

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -566,30 +566,33 @@ export default function AgentEditorPage({
     replace_base_system_prompt:
       existingAgent?.replace_base_system_prompt ?? false,
     reminders: existingAgent?.task_prompt ?? "",
+    // For new assistants, default to false for optional tools to avoid
+    // "Tool not available" errors when the tool isn't configured.
+    // For existing assistants, preserve the current tool configuration.
     image_generation:
-      (!!imageGenTool &&
-        existingAgent?.tools?.some(
-          (tool) => tool.in_code_tool_id === IMAGE_GENERATION_TOOL_ID
-        )) ??
-      true,
+      !!imageGenTool &&
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === IMAGE_GENERATION_TOOL_ID
+      ) ??
+        false),
     web_search:
-      (!!webSearchTool &&
-        existingAgent?.tools?.some(
-          (tool) => tool.in_code_tool_id === WEB_SEARCH_TOOL_ID
-        )) ??
-      true,
+      !!webSearchTool &&
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === WEB_SEARCH_TOOL_ID
+      ) ??
+        false),
     open_url:
-      (!!openURLTool &&
-        existingAgent?.tools?.some(
-          (tool) => tool.in_code_tool_id === OPEN_URL_TOOL_ID
-        )) ??
-      true,
+      !!openURLTool &&
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === OPEN_URL_TOOL_ID
+      ) ??
+        false),
     code_interpreter:
-      (!!codeInterpreterTool &&
-        existingAgent?.tools?.some(
-          (tool) => tool.in_code_tool_id === PYTHON_TOOL_ID
-        )) ??
-      true,
+      !!codeInterpreterTool &&
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === PYTHON_TOOL_ID
+      ) ??
+        false),
 
     // MCP servers - dynamically add fields for each server with nested tool fields
     ...Object.fromEntries(


### PR DESCRIPTION
Cherry-pick of commit 651a54470da93883724969b7e44b3b12180d93f6 to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents document upserts from overwriting synced permissions and fixes agent editor defaults to avoid tool availability errors.

- **Bug Fixes**
  - Backend: Only update permission fields when incoming data includes permissions; use COALESCE to preserve existing values on NULL (external_user_emails, external_user_group_ids, is_public).
  - Frontend: For new assistants, default optional tools (image generation, web search, open URL, code interpreter) to off unless configured; existing agents keep their current tool settings.

<sup>Written for commit f2ce5e16d542f8539177ec9eadd27182b95d6cad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

