### PR TITLE
Revert "fix: modal header in index attempt errors (#7601) to release v2.9"

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -135,7 +135,6 @@ export default function IndexAttemptErrorsModal({
               : undefined
           }
           onClose={onClose}
-          height="fit"
         />
         <Modal.Body>
           {!isResolvingErrors && (


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#7714

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the modal header height change in IndexAttemptErrorsModal by removing height="fit". Restores the default modal layout in the admin connector “Index Attempt Errors” view for v2.9.

<sup>Written for commit 89f54bcf9f524489be73a6c74c9d2536249e7bb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

