### PR TITLE
consolidate cookies and send to BE

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -18,6 +18,8 @@ class SessionCreateRequest(BaseModel):
     demo_data_enabled: bool = (
         True  # Whether to mount demo data files in sandbox (not yet implemented)
     )
+    user_work_area: str | None = None  # User's work area (e.g., "engineering")
+    user_level: str | None = None  # User's level (e.g., "ic", "manager")
 
 
 class SessionUpdateRequest(BaseModel):

--- a/web/src/app/build/hooks/useBuildSessionStore.ts
+++ b/web/src/app/build/hooks/useBuildSessionStore.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import Cookies from "js-cookie";
 import { BUILD_DEMO_DATA_COOKIE_NAME } from "@/app/build/v1/constants";
+import { getBuildUserPersona } from "@/app/build/onboarding/constants";
 
 import {
   ApiSandboxResponse,
@@ -1306,7 +1307,14 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
     // Start new provisioning with current demoDataEnabled value
     const promise = (async (): Promise<string | null> => {
       try {
-        const sessionData = await apiCreateSession({ demoDataEnabled });
+        // Parse user persona from cookie
+        const persona = getBuildUserPersona();
+
+        const sessionData = await apiCreateSession({
+          demoDataEnabled,
+          userWorkArea: persona?.workArea || null,
+          userLevel: persona?.level || null,
+        });
         set({
           preProvisioning: {
             status: "ready",

--- a/web/src/app/build/onboarding/README.md
+++ b/web/src/app/build/onboarding/README.md
@@ -1,0 +1,140 @@
+# Build User Persona Cookie
+
+This document explains how the build user persona data is stored and used.
+
+## Cookie Structure
+
+User persona information (work area and level) is stored in a single consolidated cookie named `build_user_persona`.
+
+**Cookie Name:** `build_user_persona`
+
+**Cookie Value:** JSON-encoded object with the following structure:
+
+```typescript
+{
+  workArea: string,    // e.g., "engineering", "product", "sales"
+  level?: string       // e.g., "ic", "manager" (optional)
+}
+```
+
+**Example Cookie Value:**
+
+```
+build_user_persona={"workArea":"engineering","level":"ic"}
+```
+
+## Reading the Cookie
+
+### Frontend (TypeScript/React)
+
+Use the helper function `getBuildUserPersona()`:
+
+```typescript
+import { getBuildUserPersona } from "@/app/build/onboarding/constants";
+
+// Get the persona data
+const persona = getBuildUserPersona();
+
+if (persona) {
+  console.log("Work Area:", persona.workArea); // "engineering"
+  console.log("Level:", persona.level); // "ic"
+}
+```
+
+### Backend (Python)
+
+Parse the cookie from the request:
+
+```python
+import json
+from urllib.parse import unquote
+from fastapi import Request
+
+def get_build_user_persona(request: Request) -> dict | None:
+    """Parse build user persona from cookie."""
+    cookie_value = request.cookies.get("build_user_persona")
+    if not cookie_value:
+        return None
+
+    try:
+        # URL decode and parse JSON
+        decoded = unquote(cookie_value)
+        persona = json.loads(decoded)
+        return {
+            "work_area": persona.get("workArea"),
+            "level": persona.get("level")
+        }
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+# Usage in an endpoint
+@router.post("/sessions")
+def create_session(request: Request):
+    persona = get_build_user_persona(request)
+    if persona:
+        work_area = persona["work_area"]  # "engineering"
+        level = persona["level"]           # "ic"
+```
+
+## Writing the Cookie
+
+### Frontend (TypeScript/React)
+
+Use the helper function `setBuildUserPersona()`:
+
+```typescript
+import { setBuildUserPersona } from "@/app/build/onboarding/constants";
+
+// Set the persona data
+setBuildUserPersona({
+  workArea: "engineering",
+  level: "ic",
+});
+```
+
+## API Integration
+
+The persona data is automatically included when creating new build sessions:
+
+```typescript
+import { createSession } from "@/app/build/services/apiServices";
+import { getBuildUserPersona } from "@/app/build/onboarding/constants";
+
+// Parse persona from cookie
+const persona = getBuildUserPersona();
+
+// Create session with persona data
+const session = await createSession({
+  demoDataEnabled: true,
+  userWorkArea: persona?.workArea || null,
+  userLevel: persona?.level || null,
+});
+```
+
+The backend receives this in the `SessionCreateRequest`:
+
+```python
+class SessionCreateRequest(BaseModel):
+    name: str | None = None
+    demo_data_enabled: bool = True
+    user_work_area: str | None = None  # From cookie
+    user_level: str | None = None      # From cookie
+```
+
+## Available Options
+
+### Work Areas
+
+- `engineering` - Engineering
+- `product` - Product
+- `executive` - Executive
+- `sales` - Sales
+- `marketing` - Marketing
+- `other` - Other
+
+### Levels
+
+- `ic` - IC (Individual Contributor)
+- `manager` - Manager
+
+Note: Level is only required for certain work areas (engineering, product, sales).

--- a/web/src/app/build/onboarding/constants.ts
+++ b/web/src/app/build/onboarding/constants.ts
@@ -14,5 +14,35 @@ export const LEVEL_OPTIONS = [
 
 export const WORK_AREAS_WITH_LEVEL = ["engineering", "product", "sales"];
 
-export const BUILD_USER_LEVEL_COOKIE_NAME = "build_user_level";
-export const BUILD_USER_WORK_AREA_COOKIE_NAME = "build_user_work_area";
+export const BUILD_USER_PERSONA_COOKIE_NAME = "build_user_persona";
+
+// Helper type for the consolidated cookie
+export interface BuildUserPersona {
+  workArea: string;
+  level?: string;
+}
+
+// Helper functions for getting/setting the consolidated cookie
+export function getBuildUserPersona(): BuildUserPersona | null {
+  if (typeof window === "undefined") return null;
+
+  const cookieValue = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${BUILD_USER_PERSONA_COOKIE_NAME}=`))
+    ?.split("=")[1];
+
+  if (!cookieValue) return null;
+
+  try {
+    return JSON.parse(decodeURIComponent(cookieValue));
+  } catch {
+    return null;
+  }
+}
+
+export function setBuildUserPersona(persona: BuildUserPersona): void {
+  const cookieValue = encodeURIComponent(JSON.stringify(persona));
+  const expires = new Date();
+  expires.setFullYear(expires.getFullYear() + 1);
+  document.cookie = `${BUILD_USER_PERSONA_COOKIE_NAME}=${cookieValue}; path=/; expires=${expires.toUTCString()}`;
+}

--- a/web/src/app/build/services/apiServices.ts
+++ b/web/src/app/build/services/apiServices.ts
@@ -81,6 +81,8 @@ export async function processSSEStream(
 export interface CreateSessionOptions {
   name?: string | null;
   demoDataEnabled?: boolean;
+  userWorkArea?: string | null;
+  userLevel?: string | null;
 }
 
 export async function createSession(
@@ -92,6 +94,8 @@ export async function createSession(
     body: JSON.stringify({
       name: options?.name || null,
       demo_data_enabled: options?.demoDataEnabled ?? true,
+      user_work_area: options?.userWorkArea || null,
+      user_level: options?.userLevel || null,
     }),
   });
 

--- a/web/src/app/build/v1/configure/page.tsx
+++ b/web/src/app/build/v1/configure/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
-import Cookies from "js-cookie";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
@@ -34,8 +33,8 @@ import { updateUserPersonalization } from "@/lib/userSettings";
 import {
   WORK_AREA_OPTIONS,
   LEVEL_OPTIONS,
-  BUILD_USER_WORK_AREA_COOKIE_NAME,
-  BUILD_USER_LEVEL_COOKIE_NAME,
+  getBuildUserPersona,
+  setBuildUserPersona,
 } from "@/app/build/onboarding/constants";
 import { BuildUserInfo } from "@/app/build/onboarding/types";
 
@@ -86,8 +85,9 @@ export default function BuildConfigPage() {
   );
 
   // Read persona from cookies
-  const workAreaValue = Cookies.get(BUILD_USER_WORK_AREA_COOKIE_NAME) || "";
-  const levelValue = Cookies.get(BUILD_USER_LEVEL_COOKIE_NAME) || "";
+  const existingPersona = getBuildUserPersona();
+  const workAreaValue = existingPersona?.workArea || "";
+  const levelValue = existingPersona?.level || "";
 
   // Get display labels
   const workAreaLabel =
@@ -112,17 +112,10 @@ export default function BuildConfigPage() {
       const fullName = `${info.firstName} ${info.lastName}`.trim();
       await updateUserPersonalization({ name: fullName });
 
-      Cookies.set(BUILD_USER_WORK_AREA_COOKIE_NAME, info.workArea, {
-        path: "/",
-        expires: 365,
+      setBuildUserPersona({
+        workArea: info.workArea,
+        level: info.level,
       });
-
-      if (info.level) {
-        Cookies.set(BUILD_USER_LEVEL_COOKIE_NAME, info.level, {
-          path: "/",
-          expires: 365,
-        });
-      }
 
       await refreshUser();
       setShowPersonaModal(false);


### PR DESCRIPTION
## Description

consolidate build onboarding cookies to one `build_user_persona` that stores both values as a json

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated build onboarding into a single build_user_persona cookie (JSON: workArea, level) and send persona data to the backend when creating sessions. This simplifies cookie management and enables persona-aware provisioning.

- **New Features**
  - Added getBuildUserPersona/setBuildUserPersona helpers for the consolidated cookie.
  - Frontend now includes userWorkArea and userLevel in createSession/apiCreateSession.
  - Backend SessionCreateRequest supports user_work_area and user_level.
  - Added README documenting cookie structure and usage.

<sup>Written for commit d68910fa41cf1e13e214d09267b076e39444f416. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

