### PR TITLE
fix build connectors

### DIFF
--- a/web/src/app/build/v1/configure/components/ConfigureConnectorModal.tsx
+++ b/web/src/app/build/v1/configure/components/ConfigureConnectorModal.tsx
@@ -25,14 +25,13 @@ function connectorNeedsConfigStep(connectorType: ValidSources): boolean {
   const config = connectorConfigs[connectorType as ConfigurableSources];
   if (!config) return false;
 
+  // Only check main values, not advanced_values
+  // Advanced values are optional configuration and shouldn't force a 2-step flow
   const hasVisibleValues = config.values.some(
     (field) => !("hidden" in field && field.hidden)
   );
-  const hasVisibleAdvancedValues = config.advanced_values.some(
-    (field) => !("hidden" in field && field.hidden)
-  );
 
-  return hasVisibleValues || hasVisibleAdvancedValues;
+  return hasVisibleValues;
 }
 
 interface ConfigureConnectorModalProps {

--- a/web/src/app/build/v1/configure/components/ConnectorConfigStep.tsx
+++ b/web/src/app/build/v1/configure/components/ConnectorConfigStep.tsx
@@ -43,7 +43,9 @@ function ConnectorConfigForm({
     setIsSubmitting(true);
 
     try {
-      const { connector_name, ...connectorConfig } = values;
+      // Extract connector_name and exclude access_type/groups (these are top-level fields)
+      const { connector_name, access_type, groups, ...connectorConfig } =
+        values;
 
       const result = await createBuildConnector({
         connectorType,

--- a/web/src/app/build/v1/configure/utils/createBuildConnector.ts
+++ b/web/src/app/build/v1/configure/utils/createBuildConnector.ts
@@ -58,6 +58,7 @@ export async function createBuildConnector({
       prune_freq: 2592000,
       indexing_start: null,
       access_type: "private",
+      groups: [],
     });
 
     if (connectorError || !connector) {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build connector flow so single-step connectors (e.g., Gmail) create immediately after OAuth, and the config step only shows when main fields are required. Also cleans up payloads to prevent misconfigured builds.

- **Bug Fixes**
  - Only check main config values to decide if a config step is needed; advanced values no longer trigger a second step.
  - Create connector right after credential creation for single-step connectors, with loading and error feedback.
  - Exclude access_type and groups from connector config payload; set groups: [] by default in createBuildConnector.

<sup>Written for commit e06648a0f6199d41652016501d2398a6dc01f88e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

