### PR TITLE
fix: Azure OpenAI Tool Calls

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -496,6 +496,9 @@ def _patch_openai_responses_chunk_parser() -> None:
         elif event_type == "response.completed":
             # Final event signaling all output items (including parallel tool calls) are done
             # Check if we already received tool calls via streaming events
+            # There is an issue where OpenAI (not via Azure) will give back the tool calls streamed out as tokens
+            # But on Azure, it's only given out all at once. OpenAI also happens to give back the tool calls in the
+            # response.completed event so we need to throw it out here or there are duplicate tool calls.
             has_streamed_tool_calls = getattr(self, "_has_streamed_tool_calls", False)
 
             response_data = parsed_chunk.get("response", {})


### PR DESCRIPTION
## Description
Tool Calls in Azure OpenAI are not given back as streamed objects but rather just a final response.completed object. This now correctly extracts them. 

## How Has This Been Tested?
Works locally where previously it didnt.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Azure OpenAI tool calls in streaming by extracting function_call items from response.completed and emitting delta.tool_calls with a tool_calls finish reason. Tracks streamed tool calls to avoid duplicates and correctly signal completion, so tools execute reliably with the Azure Responses API.

<sup>Written for commit f3a82add5dc5fec7bb26d96ae83ba850512bbac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

