### PR TITLE
fix: CP improve scroll behavior (#7364)

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -66,7 +66,8 @@ import OnboardingFlow from "@/refresh-components/onboarding/OnboardingFlow";
 import { OnboardingStep } from "@/refresh-components/onboarding/types";
 import { useShowOnboarding } from "@/hooks/useShowOnboarding";
 import * as AppLayouts from "@/layouts/app-layouts";
-import { SvgFileText } from "@opal/icons";
+import { SvgChevronDown, SvgFileText } from "@opal/icons";
+import IconButton from "@/refresh-components/buttons/IconButton";
 import Spacer from "@/refresh-components/Spacer";
 import { DEFAULT_CONTEXT_TOKENS } from "@/lib/constants";
 
@@ -268,17 +269,16 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
   });
 
   const chatUiRef = useRef<ChatUIHandle>(null);
-  const autoScrollEnabled = user?.preferences?.auto_scroll ?? false;
+  const [showScrollButton, setShowScrollButton] = useState(false);
 
-  // Handle input bar height changes for scroll adjustment
-  const handleInputHeightChange = useCallback(
-    (delta: number) => {
-      if (autoScrollEnabled && delta > 0) {
-        chatUiRef.current?.scrollBy(delta);
-      }
-    },
-    [autoScrollEnabled]
-  );
+  // Reset scroll button when session changes
+  useEffect(() => {
+    setShowScrollButton(false);
+  }, [currentChatSessionId]);
+
+  const handleScrollToBottom = useCallback(() => {
+    chatUiRef.current?.scrollToBottom();
+  }, []);
 
   const resetInputBar = useCallback(() => {
     chatInputBarRef.current?.reset();
@@ -627,7 +627,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
         >
           {({ getRootProps }) => (
             <div
-              className="h-full w-full flex flex-col items-center outline-none"
+              className="h-full w-full flex flex-col items-center outline-none relative"
               {...getRootProps({ tabIndex: -1 })}
             >
               {/* ProjectUI */}
@@ -652,6 +652,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
                   onMessageSelection={onMessageSelection}
                   stopGenerating={stopGenerating}
                   handleResubmitLastMessage={handleResubmitLastMessage}
+                  onScrollButtonVisibilityChange={setShowScrollButton}
                 />
               )}
 
@@ -665,58 +666,82 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
                 </div>
               )}
 
-              {/* ChatInputBar container */}
-              <div className="w-[min(50rem,100%)] pointer-events-auto z-sticky flex flex-col px-4 justify-center items-center">
-                {(showOnboarding ||
-                  (user?.role !== UserRole.ADMIN &&
-                    !user?.personalization?.name)) &&
-                  currentProjectId === null && (
-                    <OnboardingFlow
-                      handleHideOnboarding={hideOnboarding}
-                      handleFinishOnboarding={finishOnboarding}
-                      state={onboardingState}
-                      actions={onboardingActions}
-                      llmDescriptors={llmDescriptors}
-                    />
+              {/* ChatInputBar container - absolutely positioned when in chat, centered when no session */}
+              <div
+                className={cn(
+                  "flex justify-center",
+                  currentChatSessionId
+                    ? "absolute bottom-0 left-0 right-0 pointer-events-none"
+                    : "w-full"
+                )}
+              >
+                <div
+                  className={cn(
+                    "w-[min(50rem,100%)] z-sticky flex flex-col px-4",
+                    currentChatSessionId && "pointer-events-auto"
+                  )}
+                >
+                  {/* Scroll to bottom button - positioned above ChatInputBar */}
+                  {showScrollButton && (
+                    <div className="mb-2 self-center">
+                      <IconButton
+                        icon={SvgChevronDown}
+                        onClick={handleScrollToBottom}
+                        aria-label="Scroll to bottom"
+                      />
+                    </div>
                   )}
 
-                <ChatInputBar
-                  ref={chatInputBarRef}
-                  deepResearchEnabled={deepResearchEnabled}
-                  toggleDeepResearch={toggleDeepResearch}
-                  toggleDocumentSidebar={toggleDocumentSidebar}
-                  filterManager={filterManager}
-                  llmManager={llmManager}
-                  removeDocs={() => setSelectedDocuments([])}
-                  retrievalEnabled={retrievalEnabled}
-                  selectedDocuments={selectedDocuments}
-                  initialMessage={
-                    searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) || ""
-                  }
-                  stopGenerating={stopGenerating}
-                  onSubmit={handleChatInputSubmit}
-                  onHeightChange={handleInputHeightChange}
-                  chatState={currentChatState}
-                  currentSessionFileTokenCount={
-                    currentChatSessionId
-                      ? currentSessionFileTokenCount
-                      : projectContextTokenCount
-                  }
-                  availableContextTokens={availableContextTokens}
-                  selectedAssistant={selectedAssistant || liveAssistant}
-                  handleFileUpload={handleMessageSpecificFileUpload}
-                  setPresentingDocument={setPresentingDocument}
-                  disabled={
-                    (!llmManager.isLoadingProviders &&
-                      llmManager.hasAnyProvider === false) ||
-                    (!isLoadingOnboarding &&
-                      onboardingState.currentStep !== OnboardingStep.Complete)
-                  }
-                />
+                  {(showOnboarding ||
+                    (user?.role !== UserRole.ADMIN &&
+                      !user?.personalization?.name)) &&
+                    currentProjectId === null && (
+                      <OnboardingFlow
+                        handleHideOnboarding={hideOnboarding}
+                        handleFinishOnboarding={finishOnboarding}
+                        state={onboardingState}
+                        actions={onboardingActions}
+                        llmDescriptors={llmDescriptors}
+                      />
+                    )}
 
-                <Spacer rem={0.5} />
+                  <ChatInputBar
+                    ref={chatInputBarRef}
+                    deepResearchEnabled={deepResearchEnabled}
+                    toggleDeepResearch={toggleDeepResearch}
+                    toggleDocumentSidebar={toggleDocumentSidebar}
+                    filterManager={filterManager}
+                    llmManager={llmManager}
+                    removeDocs={() => setSelectedDocuments([])}
+                    retrievalEnabled={retrievalEnabled}
+                    selectedDocuments={selectedDocuments}
+                    initialMessage={
+                      searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) || ""
+                    }
+                    stopGenerating={stopGenerating}
+                    onSubmit={handleChatInputSubmit}
+                    chatState={currentChatState}
+                    currentSessionFileTokenCount={
+                      currentChatSessionId
+                        ? currentSessionFileTokenCount
+                        : projectContextTokenCount
+                    }
+                    availableContextTokens={availableContextTokens}
+                    selectedAssistant={selectedAssistant || liveAssistant}
+                    handleFileUpload={handleMessageSpecificFileUpload}
+                    setPresentingDocument={setPresentingDocument}
+                    disabled={
+                      (!llmManager.isLoadingProviders &&
+                        llmManager.hasAnyProvider === false) ||
+                      (!isLoadingOnboarding &&
+                        onboardingState.currentStep !== OnboardingStep.Complete)
+                    }
+                  />
 
-                {!!currentProjectId && <ProjectChatSessionList />}
+                  <Spacer rem={0.5} />
+
+                  {!!currentProjectId && <ProjectChatSessionList />}
+                </div>
               </div>
 
               {/* SearchUI */}

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/app/chat/services/actionUtils";
 import { SvgArrowUp, SvgHourglass, SvgPlusCircle, SvgStop } from "@opal/icons";
 
+const LINE_HEIGHT = 24;
+const MIN_INPUT_HEIGHT = 44;
 const MAX_INPUT_HEIGHT = 200;
 
 export interface SourceChipProps {
@@ -90,7 +92,6 @@ export interface ChatInputBarProps {
   initialMessage?: string;
   stopGenerating: () => void;
   onSubmit: (message: string) => void;
-  onHeightChange?: (delta: number) => void;
   llmManager: LlmManager;
   chatState: ChatState;
   currentSessionFileTokenCount: number;
@@ -121,7 +122,6 @@ const ChatInputBar = React.memo(
         initialMessage = "",
         stopGenerating,
         onSubmit,
-        onHeightChange,
         chatState,
         currentSessionFileTokenCount,
         availableContextTokens,
@@ -141,9 +141,6 @@ const ChatInputBar = React.memo(
       const [message, setMessage] = useState(initialMessage);
       const textAreaRef = useRef<HTMLTextAreaElement>(null);
       const containerRef = useRef<HTMLDivElement>(null);
-      const previousHeightRef = useRef<number | null>(null);
-      const onHeightChangeRef = useRef(onHeightChange);
-      onHeightChangeRef.current = onHeightChange;
 
       // Expose reset and focus methods to parent via ref
       React.useImperativeHandle(ref, () => ({
@@ -198,15 +195,37 @@ const ChatInputBar = React.memo(
 
       const combinedSettings = useContext(SettingsContext);
 
+      // Track previous message to detect when lines might decrease
+      const prevMessageRef = useRef("");
+
       // Auto-resize textarea based on content
       useEffect(() => {
         const textarea = textAreaRef.current;
         if (textarea) {
-          textarea.style.height = "0px"; // this is necessary in order to "reset" the scrollHeight
-          textarea.style.height = `${Math.min(
-            textarea.scrollHeight,
-            MAX_INPUT_HEIGHT
-          )}px`;
+          const prevLineCount = (prevMessageRef.current.match(/\n/g) || [])
+            .length;
+          const currLineCount = (message.match(/\n/g) || []).length;
+          const lineRemoved = currLineCount < prevLineCount;
+          prevMessageRef.current = message;
+
+          if (message.length === 0) {
+            textarea.style.height = `${MIN_INPUT_HEIGHT}px`;
+            return;
+          } else if (lineRemoved) {
+            const linesRemoved = prevLineCount - currLineCount;
+            textarea.style.height = `${Math.max(
+              MIN_INPUT_HEIGHT,
+              Math.min(
+                textarea.scrollHeight - LINE_HEIGHT * linesRemoved,
+                MAX_INPUT_HEIGHT
+              )
+            )}px`;
+          } else {
+            textarea.style.height = `${Math.min(
+              textarea.scrollHeight,
+              MAX_INPUT_HEIGHT
+            )}px`;
+          }
         }
       }, [message]);
 
@@ -215,27 +234,6 @@ const ChatInputBar = React.memo(
           setMessage(initialMessage);
         }
       }, [initialMessage]);
-
-      // Detect height changes and notify parent for scroll adjustment
-      useEffect(() => {
-        if (!containerRef.current) return;
-
-        const observer = new ResizeObserver((entries) => {
-          for (const entry of entries) {
-            const newHeight = entry.contentRect.height;
-            if (previousHeightRef.current !== null) {
-              const delta = newHeight - previousHeightRef.current;
-              if (delta !== 0) {
-                onHeightChangeRef.current?.(delta);
-              }
-            }
-            previousHeightRef.current = newHeight;
-          }
-        });
-
-        observer.observe(containerRef.current);
-        return () => observer.disconnect();
-      }, []);
 
       const handlePaste = (event: React.ClipboardEvent) => {
         const items = event.clipboardData?.items;

--- a/web/src/components/chat/ChatScrollContainer.tsx
+++ b/web/src/components/chat/ChatScrollContainer.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import React, {
+  ForwardedRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+// Size constants
+const DEFAULT_ANCHOR_OFFSET_PX = 16; // 1rem
+const DEFAULT_FADE_THRESHOLD_PX = 80; // 5rem
+const DEFAULT_BUTTON_THRESHOLD_PX = 32; // 2rem
+const SCROLL_DEBOUNCE_MS = 100;
+const FADE_OVERLAY_HEIGHT = "h-8"; // 2rem
+
+export interface ScrollState {
+  isAtBottom: boolean;
+  hasContentAbove: boolean;
+  hasContentBelow: boolean;
+}
+
+export interface ChatScrollContainerHandle {
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+}
+
+export interface ChatScrollContainerProps {
+  children: React.ReactNode;
+
+  /**
+   * CSS selector for the element to anchor at top (e.g., "#message-123")
+   * When set, positions this element at top with spacer below content
+   */
+  anchorSelector?: string;
+
+  /** Enable auto-scroll behavior (follow new content) */
+  autoScroll?: boolean;
+
+  /** Whether content is currently streaming (affects scroll button visibility) */
+  isStreaming?: boolean;
+
+  /** Callback when scroll button visibility should change */
+  onScrollButtonVisibilityChange?: (visible: boolean) => void;
+
+  /** Session ID - resets scroll state when changed */
+  sessionId?: string;
+}
+
+const FadeOverlay = React.memo(
+  ({ show, position }: { show: boolean; position: "top" | "bottom" }) => {
+    if (!show) return null;
+    const isTop = position === "top";
+    return (
+      <div
+        aria-hidden="true"
+        className={`absolute left-0 right-0 ${FADE_OVERLAY_HEIGHT} z-sticky pointer-events-none ${
+          isTop ? "top-0" : "bottom-0"
+        }`}
+        style={{
+          background: `linear-gradient(${
+            isTop ? "to bottom" : "to top"
+          }, var(--background-tint-01) 0%, transparent 100%)`,
+        }}
+      />
+    );
+  }
+);
+FadeOverlay.displayName = "FadeOverlay";
+
+const ChatScrollContainer = React.memo(
+  React.forwardRef(
+    (
+      {
+        children,
+        anchorSelector,
+        autoScroll = true,
+        isStreaming = false,
+        onScrollButtonVisibilityChange,
+        sessionId,
+      }: ChatScrollContainerProps,
+      ref: ForwardedRef<ChatScrollContainerHandle>
+    ) => {
+      const anchorOffsetPx = DEFAULT_ANCHOR_OFFSET_PX;
+      const fadeThresholdPx = DEFAULT_FADE_THRESHOLD_PX;
+      const buttonThresholdPx = DEFAULT_BUTTON_THRESHOLD_PX;
+      const scrollContainerRef = useRef<HTMLDivElement>(null);
+      const endDivRef = useRef<HTMLDivElement>(null);
+      const scrolledForSessionRef = useRef<string | null>(null);
+      const prevAnchorSelectorRef = useRef<string | null>(null);
+
+      const [spacerHeight, setSpacerHeight] = useState(0);
+      const [hasContentAbove, setHasContentAbove] = useState(false);
+      const [hasContentBelow, setHasContentBelow] = useState(false);
+      const [isAtBottom, setIsAtBottom] = useState(true);
+      const isAtBottomRef = useRef(true); // Ref for use in callbacks
+      const isAutoScrollingRef = useRef(false); // Prevent handleScroll from interfering during auto-scroll
+      const prevScrollTopRef = useRef(0); // Track scroll position to detect scroll direction
+      const [isScrollReady, setIsScrollReady] = useState(false);
+
+      // Use refs for values that change during streaming to prevent effect re-runs
+      const onScrollButtonVisibilityChangeRef = useRef(
+        onScrollButtonVisibilityChange
+      );
+      onScrollButtonVisibilityChangeRef.current =
+        onScrollButtonVisibilityChange;
+      const autoScrollRef = useRef(autoScroll);
+      autoScrollRef.current = autoScroll;
+      const isStreamingRef = useRef(isStreaming);
+      isStreamingRef.current = isStreaming;
+
+      // Calculate spacer height to position anchor at top
+      const calcSpacerHeight = useCallback(
+        (anchorElement: HTMLElement): number => {
+          if (!endDivRef.current || !scrollContainerRef.current) return 0;
+          const contentEnd = endDivRef.current.offsetTop;
+          const contentFromAnchor = contentEnd - anchorElement.offsetTop;
+          return Math.max(
+            0,
+            scrollContainerRef.current.clientHeight -
+              contentFromAnchor -
+              anchorOffsetPx
+          );
+        },
+        [anchorOffsetPx]
+      );
+
+      // Get current scroll state
+      const getScrollState = useCallback((): ScrollState => {
+        const container = scrollContainerRef.current;
+        if (!container || !endDivRef.current) {
+          return {
+            isAtBottom: true,
+            hasContentAbove: false,
+            hasContentBelow: false,
+          };
+        }
+
+        const contentEnd = endDivRef.current.offsetTop;
+        const viewportBottom = container.scrollTop + container.clientHeight;
+        const contentBelowViewport = contentEnd - viewportBottom;
+
+        return {
+          isAtBottom: contentBelowViewport <= buttonThresholdPx,
+          hasContentAbove: container.scrollTop > fadeThresholdPx,
+          hasContentBelow: contentBelowViewport > fadeThresholdPx,
+        };
+      }, [buttonThresholdPx, fadeThresholdPx]);
+
+      // Update scroll state and notify parent about button visibility
+      const updateScrollState = useCallback(() => {
+        const state = getScrollState();
+        setIsAtBottom(state.isAtBottom);
+        isAtBottomRef.current = state.isAtBottom; // Keep ref in sync
+        setHasContentAbove(state.hasContentAbove);
+        setHasContentBelow(state.hasContentBelow);
+
+        // Compute button visibility: hide when at bottom, or during streaming with auto-scroll
+        const shouldShowButton =
+          !state.isAtBottom &&
+          !(autoScrollRef.current && isStreamingRef.current);
+        onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
+      }, [getScrollState]);
+
+      // Scroll to bottom of content
+      const scrollToBottom = useCallback(
+        (behavior: ScrollBehavior = "smooth") => {
+          const container = scrollContainerRef.current;
+          if (!container || !endDivRef.current) return;
+
+          // Mark as auto-scrolling to prevent handleScroll interference
+          isAutoScrollingRef.current = true;
+
+          // Use scrollTo instead of scrollIntoView for better cross-browser support
+          const targetScrollTop =
+            container.scrollHeight - container.clientHeight;
+          container.scrollTo({ top: targetScrollTop, behavior });
+
+          // Update tracking refs
+          prevScrollTopRef.current = targetScrollTop;
+          isAtBottomRef.current = true;
+
+          // For smooth scrolling, keep isAutoScrollingRef true longer
+          if (behavior === "smooth") {
+            // Clear after animation likely completes (Safari smooth scroll is ~500ms)
+            setTimeout(() => {
+              isAutoScrollingRef.current = false;
+              if (container) {
+                prevScrollTopRef.current = container.scrollTop;
+              }
+            }, 600);
+          } else {
+            isAutoScrollingRef.current = false;
+          }
+        },
+        []
+      );
+
+      // Expose scrollToBottom via ref
+      useImperativeHandle(ref, () => ({ scrollToBottom }), [scrollToBottom]);
+
+      // Re-evaluate button visibility when streaming state changes
+      useEffect(() => {
+        const shouldShowButton = !isAtBottom && !(autoScroll && isStreaming);
+        onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
+      }, [isAtBottom, autoScroll, isStreaming]);
+
+      // Handle scroll events (user scrolls)
+      const handleScroll = useCallback(() => {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+
+        // Skip if this scroll was triggered by auto-scroll
+        if (isAutoScrollingRef.current) return;
+
+        const currentScrollTop = container.scrollTop;
+        const scrolledUp = currentScrollTop < prevScrollTopRef.current - 5; // 5px threshold to ignore micro-movements
+        prevScrollTopRef.current = currentScrollTop;
+
+        // Only update isAtBottomRef when user explicitly scrolls UP
+        // This prevents content growth or programmatic scrolls from disabling auto-scroll
+        if (scrolledUp) {
+          updateScrollState();
+        } else {
+          // Still update fade overlays, but preserve isAtBottomRef
+          const state = getScrollState();
+          setHasContentAbove(state.hasContentAbove);
+          setHasContentBelow(state.hasContentBelow);
+          // Update button visibility based on actual position
+          const shouldShowButton =
+            !state.isAtBottom &&
+            !(autoScrollRef.current && isStreamingRef.current);
+          onScrollButtonVisibilityChangeRef.current?.(shouldShowButton);
+        }
+
+        // Recalculate spacer for non-auto-scroll mode during user scroll
+        if (!autoScrollRef.current && anchorSelector && endDivRef.current) {
+          const anchorElement = container.querySelector(
+            anchorSelector
+          ) as HTMLElement;
+          if (anchorElement) {
+            setSpacerHeight(calcSpacerHeight(anchorElement));
+          }
+        }
+      }, [anchorSelector, calcSpacerHeight, updateScrollState, getScrollState]);
+
+      // Watch for content changes (MutationObserver + ResizeObserver)
+      useEffect(() => {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+
+        let rafId: number | null = null;
+
+        const onContentChange = () => {
+          if (rafId) return;
+          rafId = requestAnimationFrame(() => {
+            rafId = null;
+
+            // Capture whether we were at bottom BEFORE content changed
+            const wasAtBottom = isAtBottomRef.current;
+
+            // Update spacer for non-auto-scroll mode
+            if (!autoScrollRef.current && anchorSelector) {
+              const anchorElement = container.querySelector(
+                anchorSelector
+              ) as HTMLElement;
+              if (anchorElement) {
+                setSpacerHeight(calcSpacerHeight(anchorElement));
+              }
+            }
+
+            // Auto-scroll: follow content if we were at bottom
+            if (autoScrollRef.current && wasAtBottom) {
+              // scrollToBottom handles isAutoScrollingRef and ref updates
+              scrollToBottom("instant");
+            }
+
+            updateScrollState();
+          });
+        };
+
+        // MutationObserver for content changes
+        const mutationObserver = new MutationObserver(onContentChange);
+        mutationObserver.observe(container, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+
+        // ResizeObserver for container size changes
+        const resizeObserver = new ResizeObserver(onContentChange);
+        resizeObserver.observe(container);
+
+        return () => {
+          mutationObserver.disconnect();
+          resizeObserver.disconnect();
+          if (rafId) cancelAnimationFrame(rafId);
+        };
+      }, [anchorSelector, calcSpacerHeight, updateScrollState, scrollToBottom]);
+
+      // Handle session changes and anchor changes
+      useEffect(() => {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+
+        const isNewSession =
+          scrolledForSessionRef.current !== null &&
+          scrolledForSessionRef.current !== sessionId;
+        const isNewAnchor = prevAnchorSelectorRef.current !== anchorSelector;
+
+        // Reset on session change
+        if (isNewSession) {
+          scrolledForSessionRef.current = null;
+          setIsScrollReady(false);
+          prevScrollTopRef.current = 0;
+          isAtBottomRef.current = true;
+        }
+
+        const shouldScroll =
+          (scrolledForSessionRef.current !== sessionId || isNewAnchor) &&
+          anchorSelector;
+
+        if (!shouldScroll) {
+          prevAnchorSelectorRef.current = anchorSelector ?? null;
+          return;
+        }
+
+        const anchorElement = container.querySelector(
+          anchorSelector!
+        ) as HTMLElement;
+        if (!anchorElement || !endDivRef.current) {
+          setIsScrollReady(true);
+          scrolledForSessionRef.current = sessionId ?? null;
+          prevAnchorSelectorRef.current = anchorSelector ?? null;
+          return;
+        }
+
+        // Calculate spacer
+        if (!autoScrollRef.current) {
+          setSpacerHeight(calcSpacerHeight(anchorElement));
+        } else {
+          setSpacerHeight(0);
+        }
+
+        // Determine scroll behavior
+        // New session with existing content = instant, new anchor = smooth
+        const isLoadingExistingContent =
+          isNewSession || scrolledForSessionRef.current === null;
+        const behavior: ScrollBehavior = isLoadingExistingContent
+          ? "instant"
+          : "smooth";
+
+        // Defer scroll to next tick so spacer height takes effect
+        const timeoutId = setTimeout(() => {
+          const targetScrollTop = Math.max(
+            0,
+            anchorElement.offsetTop - anchorOffsetPx
+          );
+          container.scrollTo({ top: targetScrollTop, behavior });
+
+          // Update prevScrollTopRef so scroll direction is measured from new position
+          prevScrollTopRef.current = targetScrollTop;
+
+          updateScrollState();
+
+          // When autoScroll is on, assume we're "at bottom" after positioning
+          // so that MutationObserver will continue auto-scrolling
+          if (autoScrollRef.current) {
+            isAtBottomRef.current = true;
+          }
+
+          setIsScrollReady(true);
+          scrolledForSessionRef.current = sessionId ?? null;
+          prevAnchorSelectorRef.current = anchorSelector ?? null;
+        }, 0);
+
+        return () => clearTimeout(timeoutId);
+      }, [
+        sessionId,
+        anchorSelector,
+        anchorOffsetPx,
+        calcSpacerHeight,
+        updateScrollState,
+      ]);
+
+      return (
+        <div className="flex flex-col flex-1 min-h-0 w-full relative overflow-hidden mb-[7.5rem]">
+          <FadeOverlay show={hasContentAbove} position="top" />
+          <FadeOverlay show={hasContentBelow} position="bottom" />
+
+          <div
+            key={sessionId}
+            ref={scrollContainerRef}
+            className="flex flex-1 justify-center min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
+            onScroll={handleScroll}
+            style={{
+              scrollbarGutter: "stable both-edges",
+            }}
+          >
+            <div
+              className="w-[min(50rem,100%)] px-4 pb-8"
+              data-scroll-ready={isScrollReady}
+              style={{
+                visibility: isScrollReady ? "visible" : "hidden",
+              }}
+            >
+              {children}
+
+              {/* End marker - before spacer so we can measure content end */}
+              <div ref={endDivRef} />
+
+              {/* Spacer to allow scrolling anchor to top */}
+              {spacerHeight > 0 && (
+                <div style={{ height: spacerHeight }} aria-hidden="true" />
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
+  )
+);
+
+ChatScrollContainer.displayName = "ChatScrollContainer";
+
+export default ChatScrollContainer;

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import React, { useCallback, useMemo, useRef } from "react";
+import { Message } from "@/app/chat/interfaces";
+import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
+import HumanMessage from "@/app/chat/message/HumanMessage";
+import { ErrorBanner } from "@/app/chat/message/Resubmit";
+import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
+import { LlmDescriptor, LlmManager } from "@/lib/hooks";
+import AIMessage from "@/app/chat/message/messageComponents/AIMessage";
+import Spacer from "@/refresh-components/Spacer";
+
+export interface MessageListProps {
+  messages: Message[];
+  messageTree: Map<number, Message> | undefined;
+  liveAssistant: MinimalPersonaSnapshot;
+  llmManager: LlmManager;
+  setPresentingDocument: (doc: MinimalOnyxDocument | null) => void;
+  onMessageSelection: (nodeId: number) => void;
+  stopGenerating: () => void;
+
+  // Submit handlers
+  onSubmit: (args: {
+    message: string;
+    messageIdToResend?: number;
+    currentMessageFiles: any[];
+    deepResearch: boolean;
+    modelOverride?: LlmDescriptor;
+    regenerationRequest?: {
+      messageId: number;
+      parentMessage: Message;
+      forceSearch?: boolean;
+    };
+    forceSearch?: boolean;
+  }) => Promise<void>;
+  deepResearchEnabled: boolean;
+  currentMessageFiles: any[];
+
+  // Error state
+  error: string | null;
+  loadError: string | null;
+  onResubmit: () => void;
+
+  /**
+   * Node ID of the message to use as scroll anchor.
+   * This message will get a data-anchor attribute for ChatScrollContainer.
+   */
+  anchorNodeId?: number;
+}
+
+const MessageList = React.memo(
+  ({
+    messages,
+    messageTree,
+    liveAssistant,
+    llmManager,
+    setPresentingDocument,
+    onMessageSelection,
+    stopGenerating,
+    onSubmit,
+    deepResearchEnabled,
+    currentMessageFiles,
+    error,
+    loadError,
+    onResubmit,
+    anchorNodeId,
+  }: MessageListProps) => {
+    // Stable fallbacks to avoid changing prop identities on each render
+    const emptyDocs = useMemo<OnyxDocument[]>(() => [], []);
+    const emptyChildrenIds = useMemo<number[]>(() => [], []);
+
+    // Use refs to keep callbacks stable while always using latest values
+    const onSubmitRef = useRef(onSubmit);
+    const deepResearchEnabledRef = useRef(deepResearchEnabled);
+    const currentMessageFilesRef = useRef(currentMessageFiles);
+    onSubmitRef.current = onSubmit;
+    deepResearchEnabledRef.current = deepResearchEnabled;
+    currentMessageFilesRef.current = currentMessageFiles;
+
+    const createRegenerator = useCallback(
+      (regenerationRequest: {
+        messageId: number;
+        parentMessage: Message;
+        forceSearch?: boolean;
+      }) => {
+        return async function (modelOverride: LlmDescriptor) {
+          return await onSubmitRef.current({
+            message: regenerationRequest.parentMessage.message,
+            currentMessageFiles: currentMessageFilesRef.current,
+            deepResearch: deepResearchEnabledRef.current,
+            modelOverride,
+            messageIdToResend: regenerationRequest.parentMessage.messageId,
+            regenerationRequest,
+            forceSearch: regenerationRequest.forceSearch,
+          });
+        };
+      },
+      []
+    );
+
+    const handleEditWithMessageId = useCallback(
+      (editedContent: string, msgId: number) => {
+        onSubmitRef.current({
+          message: editedContent,
+          messageIdToResend: msgId,
+          currentMessageFiles: [],
+          deepResearch: deepResearchEnabledRef.current,
+        });
+      },
+      []
+    );
+
+    return (
+      <>
+        <Spacer />
+        {messages.map((message, i) => {
+          const messageReactComponentKey = `message-${message.nodeId}`;
+          const parentMessage = message.parentNodeId
+            ? messageTree?.get(message.parentNodeId)
+            : null;
+          const isAnchor = message.nodeId === anchorNodeId;
+
+          if (message.type === "user") {
+            const nextMessage =
+              messages.length > i + 1 ? messages[i + 1] : null;
+
+            return (
+              <div
+                id={messageReactComponentKey}
+                key={messageReactComponentKey}
+                data-anchor={isAnchor ? "true" : undefined}
+              >
+                <HumanMessage
+                  disableSwitchingForStreaming={
+                    (nextMessage && nextMessage.is_generating) || false
+                  }
+                  stopGenerating={stopGenerating}
+                  content={message.message}
+                  files={message.files}
+                  messageId={message.messageId}
+                  nodeId={message.nodeId}
+                  onEdit={handleEditWithMessageId}
+                  otherMessagesCanSwitchTo={
+                    parentMessage?.childrenNodeIds ?? emptyChildrenIds
+                  }
+                  onMessageSelection={onMessageSelection}
+                />
+              </div>
+            );
+          } else if (message.type === "assistant") {
+            if ((error || loadError) && i === messages.length - 1) {
+              return (
+                <div key={`error-${message.nodeId}`} className="p-4">
+                  <ErrorBanner
+                    resubmit={onResubmit}
+                    error={error || loadError || ""}
+                    errorCode={message.errorCode || undefined}
+                    isRetryable={message.isRetryable ?? true}
+                    details={message.errorDetails || undefined}
+                    stackTrace={message.stackTrace || undefined}
+                  />
+                </div>
+              );
+            }
+
+            const previousMessage = i !== 0 ? messages[i - 1] : null;
+            const chatStateData = {
+              assistant: liveAssistant,
+              docs: message.documents ?? emptyDocs,
+              citations: message.citations,
+              setPresentingDocument,
+              overriddenModel: llmManager.currentLlm?.modelName,
+              researchType: message.researchType,
+            };
+
+            return (
+              <div
+                id={`message-${message.nodeId}`}
+                key={messageReactComponentKey}
+                data-anchor={isAnchor ? "true" : undefined}
+              >
+                <AIMessage
+                  rawPackets={message.packets}
+                  chatState={chatStateData}
+                  nodeId={message.nodeId}
+                  messageId={message.messageId}
+                  currentFeedback={message.currentFeedback}
+                  llmManager={llmManager}
+                  otherMessagesCanSwitchTo={
+                    parentMessage?.childrenNodeIds ?? emptyChildrenIds
+                  }
+                  onMessageSelection={onMessageSelection}
+                  onRegenerate={createRegenerator}
+                  parentMessage={previousMessage}
+                />
+              </div>
+            );
+          }
+          return null;
+        })}
+
+        {/* Error banner when last message is user message or error type */}
+        {(((error !== null || loadError !== null) &&
+          messages[messages.length - 1]?.type === "user") ||
+          messages[messages.length - 1]?.type === "error") && (
+          <div className="p-4">
+            <ErrorBanner
+              resubmit={onResubmit}
+              error={error || loadError || ""}
+              errorCode={messages[messages.length - 1]?.errorCode || undefined}
+              isRetryable={messages[messages.length - 1]?.isRetryable ?? true}
+              details={messages[messages.length - 1]?.errorDetails || undefined}
+              stackTrace={
+                messages[messages.length - 1]?.stackTrace || undefined
+              }
+            />
+          </div>
+        )}
+      </>
+    );
+  }
+);
+
+MessageList.displayName = "MessageList";
+
+export default MessageList;

--- a/web/src/refresh-components/Spacer.tsx
+++ b/web/src/refresh-components/Spacer.tsx
@@ -1,12 +1,19 @@
-export interface SpacerProps {
+type DirectionProps = {
   vertical?: boolean;
   horizontal?: boolean;
-  rem?: number;
-}
+};
 
-export default function Spacer({ vertical, horizontal, rem = 1 }: SpacerProps) {
+export type SpacerProps = DirectionProps &
+  ({ rem?: number; pixels?: never } | { pixels: number; rem?: never });
+
+export default function Spacer({
+  vertical,
+  horizontal,
+  rem = 1,
+  pixels,
+}: SpacerProps) {
   const isVertical = vertical ? true : horizontal ? false : true;
-  const size = `${rem}rem`;
+  const size = pixels !== undefined ? `${pixels}px` : `${rem}rem`;
 
   return (
     <div

--- a/web/src/sections/ChatUI.tsx
+++ b/web/src/sections/ChatUI.tsx
@@ -1,25 +1,11 @@
 "use client";
 
-import React, {
-  ForwardedRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import IconButton from "@/refresh-components/buttons/IconButton";
+import React, { ForwardedRef, useImperativeHandle, useRef } from "react";
 import { Message } from "@/app/chat/interfaces";
-import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
-import HumanMessage from "@/app/chat/message/HumanMessage";
-import { ErrorBanner } from "@/app/chat/message/Resubmit";
+import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import { LlmDescriptor, LlmManager } from "@/lib/hooks";
-import AIMessage from "@/app/chat/message/messageComponents/AIMessage";
 import { ProjectFile } from "@/app/chat/projects/projectsService";
-import { useScrollonStream } from "@/app/chat/services/lib";
-import useScreenSize from "@/hooks/useScreenSize";
 import {
   useCurrentChatState,
   useCurrentMessageHistory,
@@ -28,15 +14,14 @@ import {
   useUncaughtError,
 } from "@/app/chat/stores/useChatSessionStore";
 import useChatSessions from "@/hooks/useChatSessions";
-import { useDeepResearchToggle } from "../app/chat/hooks/useDeepResearchToggle";
 import { useUser } from "@/components/user/UserProvider";
-import { HORIZON_DISTANCE_PX } from "@/lib/constants";
-import Spacer from "@/refresh-components/Spacer";
-import { SvgChevronDown } from "@opal/icons";
+import ChatScrollContainer, {
+  ChatScrollContainerHandle,
+} from "@/components/chat/ChatScrollContainer";
+import MessageList from "@/components/chat/MessageList";
 
 export interface ChatUIHandle {
   scrollToBottom: () => boolean;
-  scrollBy: (delta: number) => void;
 }
 
 export interface ChatUIProps {
@@ -63,6 +48,7 @@ export interface ChatUIProps {
   onMessageSelection: (nodeId: number) => void;
   stopGenerating: () => void;
   handleResubmitLastMessage: () => void;
+  onScrollButtonVisibilityChange?: (visible: boolean) => void;
 }
 
 const ChatUI = React.memo(
@@ -78,293 +64,75 @@ const ChatUI = React.memo(
         onMessageSelection,
         stopGenerating,
         handleResubmitLastMessage,
+        onScrollButtonVisibilityChange,
       }: ChatUIProps,
       ref: ForwardedRef<ChatUIHandle>
     ) => {
       const { user } = useUser();
       const { currentChatSessionId } = useChatSessions();
-      const { isMobile } = useScreenSize();
       const loadError = useLoadingError();
       const messages = useCurrentMessageHistory();
       const error = useUncaughtError();
       const messageTree = useCurrentMessageTree();
       const currentChatState = useCurrentChatState();
 
-      // Stable fallbacks to avoid changing prop identities on each render
-      const emptyDocs = useMemo<OnyxDocument[]>(() => [], []);
-      const emptyChildrenIds = useMemo<number[]>(() => [], []);
+      const scrollContainerRef = useRef<ChatScrollContainerHandle>(null);
 
-      const scrollContainerRef = useRef<HTMLDivElement>(null);
-      const endDivRef = useRef<HTMLDivElement>(null);
-      const scrollDist = useRef<number>(0);
-      const scrolledForSession = useRef<string | null>(null);
-      const prevMessageCount = useRef<number>(0);
-      const [aboveHorizon, setAboveHorizon] = useState(false);
-      const debounceNumber = 100;
+      const autoScrollEnabled = user?.preferences.auto_scroll !== false;
+      const isStreaming = currentChatState === "streaming";
 
-      // Use refs to keep callbacks stable while always using latest values
-      const onSubmitRef = useRef(onSubmit);
-      const deepResearchEnabledRef = useRef(deepResearchEnabled);
-      const currentMessageFilesRef = useRef(currentMessageFiles);
-      onSubmitRef.current = onSubmit;
-      deepResearchEnabledRef.current = deepResearchEnabled;
-      currentMessageFilesRef.current = currentMessageFiles;
+      // Determine anchor: second-to-last message (last user message before current response)
+      const anchorMessage = messages.at(-2) ?? messages[0];
+      const anchorNodeId = anchorMessage?.nodeId;
+      const anchorSelector = anchorNodeId
+        ? `#message-${anchorNodeId}`
+        : undefined;
 
-      const createRegenerator = useCallback(
-        (regenerationRequest: {
-          messageId: number;
-          parentMessage: Message;
-          forceSearch?: boolean;
-        }) => {
-          return async function (modelOverride: LlmDescriptor) {
-            return await onSubmitRef.current({
-              message: regenerationRequest.parentMessage.message,
-              currentMessageFiles: currentMessageFilesRef.current,
-              deepResearch: deepResearchEnabledRef.current,
-              modelOverride,
-              messageIdToResend: regenerationRequest.parentMessage.messageId,
-              regenerationRequest,
-              forceSearch: regenerationRequest.forceSearch,
-            });
-          };
-        },
-        [] // Stable - uses refs for latest values
-      );
-
-      const handleEditWithMessageId = useCallback(
-        (editedContent: string, msgId: number) => {
-          onSubmitRef.current({
-            message: editedContent,
-            messageIdToResend: msgId,
-            currentMessageFiles: [],
-            deepResearch: deepResearchEnabledRef.current,
-          });
-        },
-        [] // Stable - uses refs for latest values
-      );
-
-      const handleScroll = useCallback(() => {
-        const container = scrollContainerRef.current;
-        if (!container) return;
-
-        const distanceFromBottom =
-          container.scrollHeight -
-          (container.scrollTop + container.clientHeight);
-
-        scrollDist.current = distanceFromBottom;
-        setAboveHorizon(distanceFromBottom > HORIZON_DISTANCE_PX);
-      }, []);
-
-      const scrollToBottom = useCallback(() => {
-        if (!endDivRef.current) return false;
-        endDivRef.current.scrollIntoView({ behavior: "smooth" });
-        return true;
-      }, []);
-
-      const scrollBy = useCallback((delta: number) => {
-        if (!scrollContainerRef.current) return;
-        scrollContainerRef.current.scrollBy({
-          behavior: "smooth",
-          top: delta,
-        });
-      }, []);
-
+      // Expose scrollToBottom via ref
       useImperativeHandle(
         ref,
         () => ({
-          scrollToBottom,
-          scrollBy,
+          scrollToBottom: () => {
+            scrollContainerRef.current?.scrollToBottom();
+            return true;
+          },
         }),
-        [scrollToBottom, scrollBy]
+        []
       );
-
-      useScrollonStream({
-        chatState: currentChatState,
-        scrollableDivRef: scrollContainerRef,
-        scrollDist,
-        endDivRef,
-        debounceNumber,
-        mobile: isMobile,
-        enableAutoScroll: user?.preferences.auto_scroll,
-      });
-
-      // Scroll to bottom on session load and when new messages are added
-      useEffect(() => {
-        const messageCount = messages.length;
-        const isNewSession =
-          scrolledForSession.current !== null &&
-          scrolledForSession.current !== currentChatSessionId;
-        const isNewMessage = messageCount > prevMessageCount.current;
-
-        // Reset tracking when session changes
-        if (isNewSession) {
-          scrolledForSession.current = null;
-          prevMessageCount.current = 0;
-        }
-
-        // Determine if we should scroll
-        const shouldScrollForSession =
-          scrolledForSession.current !== currentChatSessionId &&
-          messageCount > 0;
-        const shouldScrollForNewMessage = isNewMessage && messageCount > 0;
-
-        if (!shouldScrollForSession && !shouldScrollForNewMessage) {
-          prevMessageCount.current = messageCount;
-          return;
-        }
-
-        if (!scrollContainerRef.current) {
-          prevMessageCount.current = messageCount;
-          return;
-        }
-
-        // Use requestAnimationFrame to ensure DOM is ready
-        const rafId = requestAnimationFrame(() => {
-          if (scrollContainerRef.current) {
-            scrollContainerRef.current.scrollTop =
-              scrollContainerRef.current.scrollHeight;
-            scrolledForSession.current = currentChatSessionId;
-          }
-        });
-
-        prevMessageCount.current = messageCount;
-        return () => cancelAnimationFrame(rafId);
-      }, [messages.length, currentChatSessionId]);
 
       if (!liveAssistant) return <div className="flex-1" />;
 
       return (
-        <div className="flex flex-col flex-1 w-full relative overflow-hidden">
-          {aboveHorizon && (
-            <div className="absolute bottom-0 left-1/2 -translate-x-1/2 z-sticky">
-              <IconButton icon={SvgChevronDown} onClick={scrollToBottom} />
-
-              <Spacer />
-            </div>
-          )}
-
-          <div
-            key={currentChatSessionId}
-            ref={scrollContainerRef}
-            className="flex flex-1 justify-center min-h-0 overflow-y-auto overflow-x-hidden default-scrollbar"
-            onScroll={handleScroll}
-          >
-            <div className="w-[min(50rem,100%)] px-4">
-              {messages.map((message, i) => {
-                const messageReactComponentKey = `message-${message.nodeId}`;
-                const parentMessage = message.parentNodeId
-                  ? messageTree?.get(message.parentNodeId)
-                  : null;
-
-                if (message.type === "user") {
-                  const nextMessage =
-                    messages.length > i + 1 ? messages[i + 1] : null;
-
-                  return (
-                    <div
-                      id={messageReactComponentKey}
-                      key={messageReactComponentKey}
-                    >
-                      <HumanMessage
-                        disableSwitchingForStreaming={
-                          (nextMessage && nextMessage.is_generating) || false
-                        }
-                        stopGenerating={stopGenerating}
-                        content={message.message}
-                        files={message.files}
-                        messageId={message.messageId}
-                        nodeId={message.nodeId}
-                        onEdit={handleEditWithMessageId}
-                        otherMessagesCanSwitchTo={
-                          parentMessage?.childrenNodeIds ?? emptyChildrenIds
-                        }
-                        onMessageSelection={onMessageSelection}
-                      />
-                    </div>
-                  );
-                } else if (message.type === "assistant") {
-                  if ((error || loadError) && i === messages.length - 1) {
-                    return (
-                      <div key={`error-${message.nodeId}`} className="p-4">
-                        <ErrorBanner
-                          resubmit={handleResubmitLastMessage}
-                          error={error || loadError || ""}
-                          errorCode={message.errorCode || undefined}
-                          isRetryable={message.isRetryable ?? true}
-                          details={message.errorDetails || undefined}
-                          stackTrace={message.stackTrace || undefined}
-                        />
-                      </div>
-                    );
-                  }
-
-                  // NOTE: it's fine to use the previous entry in messageHistory
-                  // since this is a "parsed" version of the message tree
-                  // so the previous message is guaranteed to be the parent of the current message
-                  const previousMessage = i !== 0 ? messages[i - 1] : null;
-                  const chatStateData = {
-                    assistant: liveAssistant,
-                    docs: message.documents ?? emptyDocs,
-                    citations: message.citations,
-                    setPresentingDocument,
-                    overriddenModel: llmManager.currentLlm?.modelName,
-                    researchType: message.researchType,
-                  };
-                  return (
-                    <div
-                      id={`message-${message.nodeId}`}
-                      key={messageReactComponentKey}
-                    >
-                      <AIMessage
-                        rawPackets={message.packets}
-                        chatState={chatStateData}
-                        nodeId={message.nodeId}
-                        messageId={message.messageId}
-                        currentFeedback={message.currentFeedback}
-                        llmManager={llmManager}
-                        otherMessagesCanSwitchTo={
-                          parentMessage?.childrenNodeIds ?? emptyChildrenIds
-                        }
-                        onMessageSelection={onMessageSelection}
-                        onRegenerate={createRegenerator}
-                        parentMessage={previousMessage}
-                      />
-                    </div>
-                  );
-                }
-              })}
-
-              {(((error !== null || loadError !== null) &&
-                messages[messages.length - 1]?.type === "user") ||
-                messages[messages.length - 1]?.type === "error") && (
-                <div className="p-4">
-                  <ErrorBanner
-                    resubmit={handleResubmitLastMessage}
-                    error={error || loadError || ""}
-                    errorCode={
-                      messages[messages.length - 1]?.errorCode || undefined
-                    }
-                    isRetryable={
-                      messages[messages.length - 1]?.isRetryable ?? true
-                    }
-                    details={
-                      messages[messages.length - 1]?.errorDetails || undefined
-                    }
-                    stackTrace={
-                      messages[messages.length - 1]?.stackTrace || undefined
-                    }
-                  />
-                </div>
-              )}
-
-              <div ref={endDivRef} />
-            </div>
-          </div>
-        </div>
+        <ChatScrollContainer
+          ref={scrollContainerRef}
+          sessionId={currentChatSessionId ?? undefined}
+          anchorSelector={anchorSelector}
+          autoScroll={autoScrollEnabled}
+          isStreaming={isStreaming}
+          onScrollButtonVisibilityChange={onScrollButtonVisibilityChange}
+        >
+          <MessageList
+            messages={messages}
+            messageTree={messageTree}
+            liveAssistant={liveAssistant}
+            llmManager={llmManager}
+            setPresentingDocument={setPresentingDocument}
+            onMessageSelection={onMessageSelection}
+            stopGenerating={stopGenerating}
+            onSubmit={onSubmit}
+            deepResearchEnabled={deepResearchEnabled}
+            currentMessageFiles={currentMessageFiles}
+            error={error}
+            loadError={loadError}
+            onResubmit={handleResubmitLastMessage}
+            anchorNodeId={anchorNodeId}
+          />
+        </ChatScrollContainer>
       );
     }
   )
 );
+
 ChatUI.displayName = "ChatUI";
 
 export default ChatUI;

--- a/web/src/sections/sidebar/Settings/UserSettings.tsx
+++ b/web/src/sections/sidebar/Settings/UserSettings.tsx
@@ -437,6 +437,7 @@ export default function UserSettings() {
                       onCheckedChange={(checked) => {
                         updateUserAutoScroll(checked);
                       }}
+                      aria-label="Auto-scroll"
                     />
                   </div>
                   <div className="flex items-center justify-between">

--- a/web/tests/e2e/chat/scroll_behavior.spec.ts
+++ b/web/tests/e2e/chat/scroll_behavior.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@chromatic-com/playwright";
+import type { Page } from "@playwright/test";
+import { loginAsRandomUser } from "../utils/auth";
+import { sendMessage, startNewChat } from "../utils/chatActions";
+
+/**
+ * Helper to toggle auto-scroll setting via the settings panel
+ */
+async function setAutoScroll(page: Page, enabled: boolean) {
+  // Open user dropdown menu (same pattern as other tests)
+  await page.locator("#onyx-user-dropdown").click();
+  await page.getByText("User Settings").first().click();
+  // Wait for dialog to appear
+  await page.waitForSelector('[role="dialog"]', { state: "visible" });
+
+  // Find the auto-scroll switch by aria-label
+  const autoScrollSwitch = page.getByLabel("Auto-scroll");
+  const isCurrentlyChecked =
+    (await autoScrollSwitch.getAttribute("data-state")) === "checked";
+
+  if (isCurrentlyChecked !== enabled) {
+    await autoScrollSwitch.click();
+    // Wait for the switch state to update
+    const expectedState = enabled ? "checked" : "unchecked";
+    await expect(autoScrollSwitch).toHaveAttribute("data-state", expectedState);
+  }
+
+  // Close settings panel
+  await page.keyboard.press("Escape");
+  await page.waitForSelector('[role="dialog"]', { state: "hidden" });
+}
+
+/**
+ * Helper to get the scroll container element
+ */
+function getScrollContainer(page: Page) {
+  // The scroll container is the div with overflow-y-auto inside ChatUI
+  return page.locator(".overflow-y-auto").first();
+}
+
+test.describe("Chat Scroll Behavior", () => {
+  // Configure this suite to run serially to resepect auto-scroll settings
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAsRandomUser(page);
+    await page.goto("/chat");
+    const nameInput = page.getByPlaceholder("Your name");
+    await nameInput.waitFor();
+    await nameInput.fill("Playwright Tester");
+    await page.getByText("Save").click();
+    await Promise.all([
+      // Wait for sidebar navigation to be visible to indicate page is loaded
+      page.getByText("Agents").first().waitFor(),
+      page.getByText("Projects").first().waitFor(),
+    ]);
+  });
+
+  // TODO(Nik): https://linear.app/onyx-app/issue/ENG-3422/playwright-tests-for-scroll-behavior
+  test.skip("Opening existing conversation positions correctly", async ({
+    page,
+  }) => {
+    // Turn off auto-scroll
+    await setAutoScroll(page, false);
+
+    // Create a conversation with multiple messages
+    await sendMessage(
+      page,
+      "Message 1: Creating some content to enable scrolling"
+    );
+    await sendMessage(page, "Message 2: More content for the scroll test");
+
+    // Reload page to simulate opening an existing conversation
+    await page.reload();
+    await Promise.all([
+      // Wait for sidebar navigation to be visible to indicate page is loaded
+      page.getByText("Agents").first().waitFor(),
+      page.getByText("Projects").first().waitFor(),
+    ]);
+
+    // Wait for scroll positioning to complete (content becomes visible)
+    await page
+      .locator('[data-scroll-ready="true"]')
+      .waitFor({ timeout: 30000 });
+
+    // Wait for the user messages to be visible
+    const lastUserMessage = page.locator("#onyx-human-message").last();
+    await lastUserMessage.waitFor({ state: "visible", timeout: 30000 });
+
+    // Verify the last user message is positioned near the top of the viewport
+    const isPositionedCorrectly = await lastUserMessage.evaluate(
+      (el: HTMLElement) => {
+        const scrollContainer = el.closest(".overflow-y-auto");
+        if (!scrollContainer) return false;
+
+        const containerRect = scrollContainer.getBoundingClientRect();
+        const elementRect = el.getBoundingClientRect();
+
+        // Check if element is near the top of the container (within 100px)
+        return elementRect.top - containerRect.top < 100;
+      }
+    );
+
+    expect(isPositionedCorrectly).toBe(true);
+  });
+
+  test("Auto-scroll ON: scrolls to bottom on new message", async ({ page }) => {
+    // Ensure auto-scroll is ON (default)
+    await setAutoScroll(page, true);
+
+    // Send a message
+    await sendMessage(page, "Hello, this is a test message");
+
+    // Send another message to create some content
+    await sendMessage(page, "Another message to test scrolling behavior");
+
+    // The scroll container should be scrolled to bottom
+    const scrollContainer = getScrollContainer(page);
+    const isAtBottom = await scrollContainer.evaluate((el: HTMLElement) => {
+      return Math.abs(el.scrollHeight - el.scrollTop - el.clientHeight) < 10;
+    });
+
+    expect(isAtBottom).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

see original 

## How Has This Been Tested?

see original

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved chat scrolling with a dedicated container that keeps the view stable, auto-scrolls only when appropriate, and anchors the last user message near the top when reopening sessions. Adds a scroll-to-bottom button, fade overlays, and simpler message rendering.

- **New Features**
  - Added ChatScrollContainer with auto-scroll, anchor positioning, fade overlays, and an exposed scrollToBottom API.
  - Introduced MessageList to render messages and mark the anchor message for positioning.
  - Shows a scroll-to-bottom button above the input when not at bottom (hidden while auto-scrolling during streaming).
  - ChatInputBar is now absolutely positioned at the bottom during sessions; textarea auto-resizes with min height and per-line handling.
  - Added e2e test for scroll behavior; updated test utils to wait for new AI messages.
  - Spacer supports pixel sizing; Auto-scroll switch gets an aria-label for testability.

- **Refactors**
  - Removed useScrollonStream; moved scroll logic out of services/lib and into ChatScrollContainer.
  - ChatUI delegates scrolling to ChatScrollContainer and handles session changes and streaming state cleanly.
  - Eliminated input height delta-based scrolling; prevents unintended jumps and keeps position stable as content grows.

<sup>Written for commit dae059d7fbb219f828d7e4cd7e490bf6cbd274e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

