### PR TITLE
fix not allwoed modal, allow managing all build connectors, render assistant messages correctly

### DIFF
--- a/web/src/app/build/onboarding/BuildOnboardingProvider.tsx
+++ b/web/src/app/build/onboarding/BuildOnboardingProvider.tsx
@@ -28,7 +28,10 @@ export function BuildOnboardingProvider({
   return (
     <>
       {/* Blocking modal - takes precedence */}
-      <NotAllowedModal open={flow.showNotAllowedModal} />
+      <NotAllowedModal
+        open={flow.showNotAllowedModal}
+        onClose={actions.closeNotAllowedModal}
+      />
 
       {/* Combined onboarding modal */}
       <BuildOnboardingModal

--- a/web/src/app/build/onboarding/components/NotAllowedModal.tsx
+++ b/web/src/app/build/onboarding/components/NotAllowedModal.tsx
@@ -3,21 +3,21 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Text from "@/refresh-components/texts/Text";
-import { SvgLock, SvgArrowRight, SvgBubbleText } from "@opal/icons";
+import { SvgLock, SvgArrowRight } from "@opal/icons";
 import { logout } from "@/lib/user";
 import { cn } from "@/lib/utils";
 
 interface NotAllowedModalProps {
   open: boolean;
+  onClose: () => void;
 }
 
-export default function NotAllowedModal({ open }: NotAllowedModalProps) {
+export default function NotAllowedModal({
+  open,
+  onClose,
+}: NotAllowedModalProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-
-  const handleReturnToChat = () => {
-    router.push("/chat");
-  };
 
   const handleCreateNewAccount = async () => {
     setIsLoading(true);
@@ -52,9 +52,9 @@ export default function NotAllowedModal({ open }: NotAllowedModalProps) {
                 Build Mode Access Restricted
               </Text>
               <Text mainUiBody text03 className="max-w-sm">
-                Unfortunately, Build Mode is only available to admins and
-                curators. You can create a new Onyx account and try Build Mode
-                with our demo data!
+                Unfortunately, connecting your own data to Build Mode requires
+                admin permissions. You can create a new Onyx account and try
+                Build Mode with your own data!
               </Text>
             </div>
           </div>
@@ -63,11 +63,10 @@ export default function NotAllowedModal({ open }: NotAllowedModalProps) {
           <div className="flex justify-center gap-3 pt-2">
             <button
               type="button"
-              onClick={handleReturnToChat}
+              onClick={onClose}
               className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
             >
-              <SvgBubbleText className="w-4 h-4" />
-              <Text mainUiAction>Return to Chat</Text>
+              <Text mainUiAction>Go Back</Text>
             </button>
             <button
               type="button"

--- a/web/src/app/build/onboarding/hooks/useBuildOnboarding.ts
+++ b/web/src/app/build/onboarding/hooks/useBuildOnboarding.ts
@@ -27,6 +27,8 @@ export function useBuildOnboarding() {
   const { user, isAdmin, isCurator, refreshUser } = useUser();
   const { llmProviders, isLoading: isLoadingLlm, refetch } = useLLMProviders();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [notAllowedModalDismissed, setNotAllowedModalDismissed] =
+    useState(false);
 
   const existingPersona = getBuildUserPersona();
   const hasUserInfo = !!(
@@ -35,7 +37,7 @@ export function useBuildOnboarding() {
   const hasRecommendedLlms = checkHasRecommendedLlms(llmProviders);
 
   const flow: BuildOnboardingFlow = {
-    showNotAllowedModal: false,
+    showNotAllowedModal: false && !notAllowedModalDismissed,
     showUserInfoModal: !hasUserInfo,
     showLlmModal: isAdmin && !hasRecommendedLlms,
   };
@@ -70,6 +72,10 @@ export function useBuildOnboarding() {
     await refetch();
   }, [refetch]);
 
+  const closeNotAllowedModal = useCallback(() => {
+    setNotAllowedModalDismissed(true);
+  }, []);
+
   const isLoading = isLoadingLlm || !user;
 
   // Get existing personalization data for pre-filling the form
@@ -87,6 +93,7 @@ export function useBuildOnboarding() {
     actions: {
       completeUserInfo,
       completeLlmSetup,
+      closeNotAllowedModal,
     },
     isLoading,
     isSubmitting,

--- a/web/src/app/build/v1/configure/components/ConnectorCard.tsx
+++ b/web/src/app/build/v1/configure/components/ConnectorCard.tsx
@@ -128,19 +128,17 @@ export default function ConnectorCard({
       </Popover.Trigger>
       <Popover.Content side="right" align="start" sideOffset={4}>
         <Popover.Menu>
-          {status === "error" && (
-            <LineItem
-              key="manage"
-              icon={SvgSettings}
-              onClick={(e) => {
-                e.stopPropagation();
-                setPopoverOpen(false);
-                router.push(`/admin/connector/${config?.cc_pair_id}`);
-              }}
-            >
-              Manage connector
-            </LineItem>
-          )}
+          <LineItem
+            key="manage"
+            icon={SvgSettings}
+            onClick={(e) => {
+              e.stopPropagation();
+              setPopoverOpen(false);
+              router.push(`/admin/connector/${config?.cc_pair_id}`);
+            }}
+          >
+            Manage connector
+          </LineItem>
           <LineItem
             key="delete"
             danger

--- a/web/src/app/build/v1/configure/page.tsx
+++ b/web/src/app/build/v1/configure/page.tsx
@@ -356,7 +356,10 @@ export default function BuildConfigPage() {
         }}
       />
 
-      <NotAllowedModal open={showNotAllowedModal} />
+      <NotAllowedModal
+        open={showNotAllowedModal}
+        onClose={() => setShowNotAllowedModal(false)}
+      />
     </SettingsLayouts.Root>
   );
 }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Build Mode access modal behavior, correctly renders assistant messages with full stream items, and lets users manage all build connectors from the card menu.

- **Bug Fixes**
  - Assistant messages are consolidated into single turns with saved streamItems; the in-progress response is saved to history on completion.
  - Streaming UI shows only when replying to the latest user message, avoiding empty assistant areas after navigation.
  - NotAllowedModal is now dismissible via onClose and hooked into provider/config page; copy updated for clearer access guidance.

- **New Features**
  - “Manage connector” action is available for all connectors, regardless of status.

<sup>Written for commit d5344ba113685fd600d20ecb920c7eb8fea341c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

