### PR TITLE
fix chat rendering and tab curve

### DIFF
--- a/web/src/app/build/components/OutputPanel.tsx
+++ b/web/src/app/build/components/OutputPanel.tsx
@@ -280,7 +280,7 @@ const BuildOutputPanel = memo(({ onClose, isOpen }: BuildOutputPanelProps) => {
             />
           </div>
           {/* Scrollable tabs container */}
-          <div className="flex items-end gap-1.5 flex-1 pr-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+          <div className="flex items-end gap-1.5 flex-1 pl-3 pr-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             {/* Pinned tabs */}
             {tabs.map((tab) => {
               const Icon = tab.icon;

--- a/web/src/app/build/hooks/useBuildStreaming.ts
+++ b/web/src/app/build/hooks/useBuildStreaming.ts
@@ -417,6 +417,7 @@ export function useBuildStreaming() {
               const shouldOpenPanel = session?.webappNeedsRefresh === true;
               updateSessionData(sessionId, {
                 status: "completed",
+                streamItems: [], // Clear stream items since they're now saved in the message
                 ...(shouldOpenPanel && { outputPanelOpen: true }),
               });
               break;


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed chat message rendering by preserving streaming state and clearing stream items on completion, preventing duplicate/stale content. Also adjusted tab padding so curved tabs align correctly.

- **Bug Fixes**
  - Preserve streaming status when refetching sessions to avoid premature “completed/idle”.
  - Clear streamItems on completion since content is saved in the message, preventing duplication.

- **UI**
  - Add left padding to the tabs container to align the tab curve and spacing.

<sup>Written for commit 8d6f9f6aca0ed805250bb6e2dca564ede0e8a413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

