### PR TITLE
fix: CP - Extract person names and filter garbage in query expansion

### DIFF
--- a/backend/onyx/context/search/federated/slack_search_utils.py
+++ b/backend/onyx/context/search/federated/slack_search_utils.py
@@ -566,6 +566,23 @@ def extract_content_words_from_recency_query(
     return content_words_filtered[:MAX_CONTENT_WORDS]
 
 
+def _is_valid_keyword_query(line: str) -> bool:
+    """Check if a line looks like a valid keyword query vs explanatory text.
+
+    Returns False for lines that appear to be LLM explanations rather than keywords.
+    """
+    # Reject lines that start with parentheses (explanatory notes)
+    if line.startswith("("):
+        return False
+
+    # Reject lines that are too long (likely sentences, not keywords)
+    # Keywords should be short - reject if > 50 chars or > 6 words
+    if len(line) > 50 or len(line.split()) > 6:
+        return False
+
+    return True
+
+
 def expand_query_with_llm(query_text: str, llm: LLM) -> list[str]:
     """Use LLM to expand query into multiple search variations.
 
@@ -586,9 +603,17 @@ def expand_query_with_llm(query_text: str, llm: LLM) -> list[str]:
         response_clean = _parse_llm_code_block_response(response)
 
         # Split into lines and filter out empty lines
-        rephrased_queries = [
+        raw_queries = [
             line.strip() for line in response_clean.split("\n") if line.strip()
         ]
+
+        # Filter out lines that look like explanatory text rather than keywords
+        rephrased_queries = [q for q in raw_queries if _is_valid_keyword_query(q)]
+
+        # Log if we filtered out garbage
+        if len(raw_queries) != len(rephrased_queries):
+            filtered_out = set(raw_queries) - set(rephrased_queries)
+            logger.warning(f"Filtered out non-keyword LLM responses: {filtered_out}")
 
         # If no queries generated, use empty query
         if not rephrased_queries:

--- a/backend/onyx/prompts/federated_search.py
+++ b/backend/onyx/prompts/federated_search.py
@@ -1,29 +1,38 @@
 from onyx.configs.app_configs import MAX_SLACK_QUERY_EXPANSIONS
 
 SLACK_QUERY_EXPANSION_PROMPT = f"""
-Rewrite the user's query and, if helpful, split it into at most {MAX_SLACK_QUERY_EXPANSIONS} \
-keyword-only queries, so that Slack's keyword search yields the best matches.
+Rewrite the user's query into at most {MAX_SLACK_QUERY_EXPANSIONS} keyword-only queries for Slack's keyword search.
 
-Keep in mind the Slack's search behavior:
-- Pure keyword AND search (no semantics).
-- Word order matters.
-- More words = fewer matches, so keep each query concise.
-- IMPORTANT: Prefer simple 1-2 word queries over longer multi-word queries.
+Slack search behavior:
+- Pure keyword AND search (no semantics)
+- More words = fewer matches, so keep queries concise (1-3 words)
 
-Critical: Extract ONLY keywords that would actually appear in Slack message content.
+ALWAYS include:
+- Person names (e.g., "Sarah Chen", "Mike Johnson") - people search for messages from/about specific people
+- Project/product names, technical terms, proper nouns
+- Actual content words: "performance", "bug", "deployment", "API", "error"
 
 DO NOT include:
-- Meta-words: "topics", "conversations", "discussed", "summary", "messages", "big", "main", "talking"
-- Temporal: "today", "yesterday", "week", "month", "recent", "past", "last"
-- Channels/Users: "general", "eng-general", "engineering", "@username"
-
-DO include:
-- Actual content: "performance", "bug", "deployment", "API", "database", "error", "feature"
+- Meta-words: "topics", "conversations", "discussed", "summary", "messages"
+- Temporal: "today", "yesterday", "week", "month", "recent", "last"
+- Channel names: "general", "eng-general", "random"
 
 Examples:
 
 Query: "what are the big topics in eng-general this week?"
 Output:
+
+Query: "messages with Sarah about the deployment"
+Output:
+Sarah deployment
+Sarah
+deployment
+
+Query: "what did Mike say about the budget?"
+Output:
+Mike budget
+Mike
+budget
 
 Query: "performance issues in eng-general"
 Output:
@@ -41,7 +50,7 @@ Now process this query:
 
 {{query}}
 
-Output:
+Output (keywords only, one per line, NO explanations or commentary):
 """
 
 SLACK_DATE_EXTRACTION_PROMPT = """


### PR DESCRIPTION
## Description

The Slack federated search query expansion was failing to extract person names from queries like "what did Nick say about the budget?" because the prompt explicitly excluded "Channels/Users". Additionally, when no keywords could be extracted, the LLM would output explanatory text like `(No content keywords to extract - this query is user/temporal-based only)` which was passed through as an actual Slack search query, returning irrelevant results.

**Changes:**
- Updated `SLACK_QUERY_EXPANSION_PROMPT` to explicitly include person names as keywords with examples
- Added `_is_valid_keyword_query()` validation function to filter out LLM explanatory text
- Rejects lines starting with parentheses, containing explanation patterns, or too long (>50 chars / >6 words)

## How Has This Been Tested?

locally:

we see two queries sent because include_dm is true
```
DEBUG:    01/21/2026 11:22:47 AM                chat_backend.py  555: [API:tF_qI9jl] Received new chat message: show me the last 5 messages sent by Nik Garza
.....
DEBUG:    01/21/2026 11:22:57 AM          slack_search_utils.py  639: [API:tF_qI9jl] Expanded query into 1 queries: ['Nik Garza']
INFO:     01/21/2026 11:22:57 AM                slack_search.py  454: [API:tF_qI9jl] Final query to slack: Nik Garza after:2025-12-22 in:#eng in:#eng-general in:#general in:#golf in:#random in:#office in:#hawaii-trip
INFO:     01/21/2026 11:22:57 AM                slack_search.py  454: [API:tF_qI9jl] Final query to slack: Nik Garza after:2025-12-22
INFO:     01/21/2026 11:22:58 AM                slack_search.py  478: [API:tF_qI9jl] Slack search found 25 messages
INFO:     01/21/2026 11:22:58 AM                slack_search.py  478: [API:tF_qI9jl] Slack search found 25 messages
INFO:     01/21/2026 11:22:58 AM                slack_search.py 1102: [API:tF_qI9jl] [req:no-ctx] Slack federated search: 2 queries, 50 raw msgs -> 45 after dedup -> 45 final
INFO:     01/21/2026 11:22:58 AM                slack_search.py  822: [API:tF_qI9jl] Fetching thread context for 5 of 45 messages (batch_size=5, max=5)
NOTICE:   01/21/2026 11:22:59 AM                      timing.py   41: [API:tF_qI9jl] slack_retrieval took 3.142 seconds
INFO:     01/21/2026 11:22:59 AM                 search_tool.py  403: [API:tF_qI9jl] Slack federated search returned 5 chunks
INFO:onyx.utils.logger:[API:tF_qI9jl] Slack federated search returned 5 chunks
```

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make migrations atomic and delete legacy notifications before creating the notification dedup index. Improve Slack federated search by extracting person names and filtering LLM explanatory text; add annual billing, update persona sharing, and clean up modal sizing.

- **Bug Fixes**
  - Alembic: commit per schema and delete legacy "New Notification" rows before creating the unique index.
  - Slack search: prompt now includes person names; added keyword validation to drop explanatory lines.
  - Prompt cache: correctly detect non-Anthropic Bedrock providers and pass full LLMConfig.
  - Documents: preserve existing permissions on upsert when new values are null.
  - MCP auth: use request credentials for per-user header substitutions.
  - UI: inline code wraps properly; removed triple-click selection behavior.

- **New Features**
  - Billing: support “monthly” and “annual” subscription checkout.
  - Persona sharing: unified API to set public status and share with users or groups.
  - Frontend: Modal.Content now uses width/height props for consistent sizing and scrolling.
  - Hooks: added useUsers and useGroups for sharing and admin UIs.

<sup>Written for commit cefb9087b85d3f3c987e22c0c527256e29fd57be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

