### PR TITLE
fix(chat): prevent streaming text from appearing in bursts after citations

### DIFF
--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -643,6 +643,7 @@ export function useChatController({
       let toolCall: ToolCallMetadata | null = null;
       let files = projectFilesToFileDescriptors(currentMessageFiles);
       let packets: Packet[] = [];
+      let packetsVersion = 0;
 
       let newUserMessageId: number | null = null;
       let newAssistantMessageId: number | null = null;
@@ -729,7 +730,6 @@ export function useChatController({
             if (!packet) {
               continue;
             }
-            console.debug("Packet:", JSON.stringify(packet));
 
             // We've processed initial packets and are starting to stream content.
             // Transition from 'loading' to 'streaming'.
@@ -800,8 +800,8 @@ export function useChatController({
                 updateCanContinue(true, frozenSessionId);
               }
             } else if (Object.hasOwn(packet, "obj")) {
-              console.debug("Object packet:", JSON.stringify(packet));
               packets.push(packet as Packet);
+              packetsVersion++;
 
               // Check if the packet contains document information
               const packetObj = (packet as Packet).obj;
@@ -859,6 +859,7 @@ export function useChatController({
                   overridden_model: finalMessage?.overridden_model,
                   stopReason: stopReason,
                   packets: packets,
+                  packetsVersion: packetsVersion,
                 },
               ],
               // Pass the latest map state

--- a/web/src/app/chat/interfaces.ts
+++ b/web/src/app/chat/interfaces.ts
@@ -139,6 +139,8 @@ export interface Message {
 
   // new gen
   packets: Packet[];
+  // Version counter for efficient memo comparison (increments with each packet)
+  packetsVersion?: number;
 
   // cached values for easy access
   documents?: OnyxDocument[] | null;

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -74,6 +74,8 @@ export type RegenerationFactory = (regenerationRequest: {
 
 export interface AIMessageProps {
   rawPackets: Packet[];
+  // Version counter for efficient memo comparison (avoids array copying)
+  packetsVersion?: number;
   chatState: FullChatState;
   nodeId: number;
   messageId?: number;
@@ -88,8 +90,6 @@ export interface AIMessageProps {
 }
 
 // TODO: Consider more robust comparisons:
-// - `rawPackets.length` assumes packets are append-only. Could compare the last
-//   packet or use a shallow comparison if packets can be modified in place.
 // - `chatState.docs`, `chatState.citations`, and `otherMessagesCanSwitchTo` use
 //   reference equality. Shallow array/object comparison would be more robust if
 //   these are recreated with the same values.
@@ -98,7 +98,7 @@ function arePropsEqual(prev: AIMessageProps, next: AIMessageProps): boolean {
     prev.nodeId === next.nodeId &&
     prev.messageId === next.messageId &&
     prev.currentFeedback === next.currentFeedback &&
-    prev.rawPackets.length === next.rawPackets.length &&
+    prev.packetsVersion === next.packetsVersion &&
     prev.chatState.assistant?.id === next.chatState.assistant?.id &&
     prev.chatState.docs === next.chatState.docs &&
     prev.chatState.citations === next.chatState.citations &&

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -195,6 +195,7 @@ const MessageList = React.memo(
               >
                 <AIMessage
                   rawPackets={message.packets}
+                  packetsVersion={message.packetsVersion}
                   chatState={chatStateData}
                   nodeId={message.nodeId}
                   messageId={message.messageId}


### PR DESCRIPTION
## Description

Fixes a regression where AI response text appeared in large bursts instead of streaming smoothly.

### Root Cause

The `AIMessage` component uses `React.memo` with a custom `arePropsEqual` function that compared `prev.rawPackets.length === next.rawPackets.length`. However, the packets array was being **mutated in place** with `.push()` and the same array reference was passed to the store on each update.

This violated React's immutability expectation: `prev.rawPackets` and `next.rawPackets` pointed to the **same object**, so the length comparison always returned `true` (comparing identical objects), preventing re-renders during streaming.

### Solution

Added a `packetsVersion` counter that increments with each new packet. The memo comparison now checks `prev.packetsVersion === next.packetsVersion` instead of comparing array lengths.

### Why Version Counter Over Array Copying?

An alternative fix would be to create a new array on each update: `packets: [...packets]`. However:

| Approach | Complexity per packet | Memory |
|----------|----------------------|--------|
| `[...packets]` | O(n) - copies entire array | Creates n arrays of sizes 1, 2, 3, ..., n |
| `packetsVersion++` | O(1) - increment integer | Single integer |

For a response with 500 packets, array copying would perform ~125,000 copy operations total, while the version counter approach performs 500 increments. This matters for long AI responses.

## How Has This Been Tested?

![2026-01-24 10 28 05](https://github.com/user-attachments/assets/a7ba22fc-c2d0-405b-aeb4-bb6f79f1cf74)


## Additional Options

- [x] [Optional] Override Linear Check