### PR TITLE
fix(tests): use crawler-friendly search query in Exa integration test

### DIFF
--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -270,7 +270,7 @@ def test_web_search_endpoints_with_exa(
     provider_id = _activate_exa_provider(admin_user)
     assert isinstance(provider_id, int)
 
-    search_request = {"queries": ["latest ai research news"], "max_results": 3}
+    search_request = {"queries": ["wikipedia python programming"], "max_results": 3}
 
     lite_response = requests.post(
         f"{API_SERVER_URL}/web-search/search-lite",


### PR DESCRIPTION
## Description

Fixes flaky `test_web_search_endpoints_with_exa` integration test. The previous search query "latest ai research news" returned URLs from news sites (e.g., chemistryworld.com) that block web crawlers with bot protection, causing consistent test failures.

Changed to "wikipedia python programming" which returns Wikipedia URLs that are reliably crawlable without bot protection.

## How Has This Been Tested?

The test was failing consistently on PR #7745 due to chemistryworld.com blocking the crawler. Wikipedia URLs should be reliably fetchable.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky Exa integration test by using a crawler-friendly query that returns Wikipedia pages. Replaced "latest ai research news" with "wikipedia python programming" to avoid bot-protected news sites.

<sup>Written for commit fa233cbb9fb1d99bd8ad00b3a353ad62414cd98a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

