### PR TITLE
fix: Spacing issue on Feedback

### DIFF
--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -169,14 +169,14 @@ function LabelLayout({
       <Section
         flexDirection="row"
         justifyContent={center ? "center" : "start"}
-        gap={0}
+        gap={0.25}
       >
         <Text mainContentEmphasis text04>
           {title}
         </Text>
         {optional && (
           <Text text03 mainContentMuted>
-            {" (Optional)"}
+            (Optional)
           </Text>
         )}
       </Section>


### PR DESCRIPTION
## Description
The Optional text use to have no gap at all on the left. now it does

## How Has This Been Tested?
<img width="723" height="472" alt="image" src="https://github.com/user-attachments/assets/422bb431-bb7e-444b-8064-7eced7094c54" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix spacing between the field label and the (Optional) text in the Feedback form so they no longer run together. Adds a small gap (0.25) for clearer, consistent layout.

<sup>Written for commit 5a7c845460edb9c1bcf2f105d8bcd74d9dbfcd0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

