### PR TITLE
fix(chat): prevent streaming text from appearing in bursts after citations (#7745) to release v2.9

### DIFF
--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -643,6 +643,7 @@ export function useChatController({
       let toolCall: ToolCallMetadata | null = null;
       let files = projectFilesToFileDescriptors(currentMessageFiles);
       let packets: Packet[] = [];
+      let packetsVersion = 0;
 
       let newUserMessageId: number | null = null;
       let newAssistantMessageId: number | null = null;
@@ -729,7 +730,6 @@ export function useChatController({
             if (!packet) {
               continue;
             }
-            console.debug("Packet:", JSON.stringify(packet));
 
             // We've processed initial packets and are starting to stream content.
             // Transition from 'loading' to 'streaming'.
@@ -800,8 +800,8 @@ export function useChatController({
                 updateCanContinue(true, frozenSessionId);
               }
             } else if (Object.hasOwn(packet, "obj")) {
-              console.debug("Object packet:", JSON.stringify(packet));
               packets.push(packet as Packet);
+              packetsVersion++;
 
               // Check if the packet contains document information
               const packetObj = (packet as Packet).obj;
@@ -859,6 +859,7 @@ export function useChatController({
                   overridden_model: finalMessage?.overridden_model,
                   stopReason: stopReason,
                   packets: packets,
+                  packetsVersion: packetsVersion,
                 },
               ],
               // Pass the latest map state

--- a/web/src/app/chat/interfaces.ts
+++ b/web/src/app/chat/interfaces.ts
@@ -139,6 +139,8 @@ export interface Message {
 
   // new gen
   packets: Packet[];
+  // Version counter for efficient memo comparison (increments with each packet)
+  packetsVersion?: number;
 
   // cached values for easy access
   documents?: OnyxDocument[] | null;

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -72,6 +72,8 @@ export type RegenerationFactory = (regenerationRequest: {
 
 export interface AIMessageProps {
   rawPackets: Packet[];
+  // Version counter for efficient memo comparison (avoids array copying)
+  packetsVersion?: number;
   chatState: FullChatState;
   nodeId: number;
   messageId?: number;
@@ -86,8 +88,6 @@ export interface AIMessageProps {
 }
 
 // TODO: Consider more robust comparisons:
-// - `rawPackets.length` assumes packets are append-only. Could compare the last
-//   packet or use a shallow comparison if packets can be modified in place.
 // - `chatState.docs`, `chatState.citations`, and `otherMessagesCanSwitchTo` use
 //   reference equality. Shallow array/object comparison would be more robust if
 //   these are recreated with the same values.
@@ -96,7 +96,7 @@ function arePropsEqual(prev: AIMessageProps, next: AIMessageProps): boolean {
     prev.nodeId === next.nodeId &&
     prev.messageId === next.messageId &&
     prev.currentFeedback === next.currentFeedback &&
-    prev.rawPackets.length === next.rawPackets.length &&
+    prev.packetsVersion === next.packetsVersion &&
     prev.chatState.assistant?.id === next.chatState.assistant?.id &&
     prev.chatState.docs === next.chatState.docs &&
     prev.chatState.citations === next.chatState.citations &&

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -183,6 +183,7 @@ const MessageList = React.memo(
               >
                 <AIMessage
                   rawPackets={message.packets}
+                  packetsVersion={message.packetsVersion}
                   chatState={chatStateData}
                   nodeId={message.nodeId}
                   messageId={message.messageId}


### PR DESCRIPTION
Cherry-pick of commit d9db849e9450d954e448c1a8813ff537281ae21e to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat streaming so text renders smoothly instead of bursting after citations. Adds a packet version counter to trigger timely re-renders as packets arrive.

- **Bug Fixes**
  - Introduced packetsVersion on messages and AIMessage; incremented on each packet and included in state.
  - Updated AIMessage memo comparison to use packetsVersion instead of rawPackets.length for accurate streaming updates.
  - Passed packetsVersion through MessageList and removed noisy debug logs.

<sup>Written for commit c03ac68bc6b0f1f336c6b5e8815d04ae91d19949. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

- [x] Override Linear Check
