### PR TITLE
fix(tests): use crawler-friendly search query in Exa integration test (#7746) to release v2.9

### DIFF
--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -270,7 +270,7 @@ def test_web_search_endpoints_with_exa(
     provider_id = _activate_exa_provider(admin_user)
     assert isinstance(provider_id, int)
 
-    search_request = {"queries": ["latest ai research news"], "max_results": 3}
+    search_request = {"queries": ["wikipedia python programming"], "max_results": 3}
 
     lite_response = requests.post(
         f"{API_SERVER_URL}/web-search/search-lite",


### PR DESCRIPTION
Cherry-pick of commit eb7b91e08e95277c1f46bb197e266b9a79a1417d to release/v2.9 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Exa web search integration test to use a crawler-friendly query (“wikipedia python programming”) for more consistent results. This reduces test flakiness in the v2.9 release pipeline.

<sup>Written for commit c2e69db995ea81faba92944e768f11aef2dc5fec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

