### PR TITLE
fix: Stop header from collapsing repeatedly

### DIFF
--- a/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/MultiToolRenderer.tsx
@@ -750,7 +750,11 @@ export default function MultiToolRenderer({
   };
 
   // If still processing, show tools progressively with timing
-  if (!isComplete) {
+  // Use stopPacketSeen instead of isComplete to prevent flickering.
+  // isComplete (finalAnswerComing) toggles back and forth when message and tool
+  // packets interleave, causing the UI to flip between streaming and complete views.
+  // stopPacketSeen only transitions from false to true, providing a stable condition.
+  if (!stopPacketSeen) {
     // Filter display items to only show those whose (turn_index, tab_index) is visible
     const itemsToDisplay = displayItems.filter((item) =>
       visibleTools.has(`${item.turn_index}-${item.tab_index}`)


### PR DESCRIPTION
## Description

- Fixes flickering in the "Thinking block" / steps UI during message streaming.
  - The issue was caused by `isComplete` (mapped to `finalAnswerComing`) toggling between true and false as message and tool packets interleaved, causing the UI to flip between the streaming view (expanded timeline) and complete view (collapsed "N steps" header).
  - Changed the condition from `isComplete` to `stopPacketSeen`, which only transitions from false to true once, providing a stable UI state during streaming.

## Video

https://github.com/user-attachments/assets/32d71842-77cb-4c6f-8da6-fd9a85803a2f

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the “N steps” header from collapsing repeatedly during streaming by using stopPacketSeen instead of isComplete. This removes flicker in the Thinking/steps UI.

- **Bug Fixes**
  - Replace isComplete (finalAnswerComing) with stopPacketSeen in MultiToolRenderer to prevent toggling between streaming and complete states when packets interleave.
  - Keeps the timeline expanded until a stop packet is received for a stable view.

<sup>Written for commit 372bc1de16a92fcce41a66b156f94ac0e67df757. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

