### PR TITLE
fix(layout): adjust footer margin and prevent page refresh on chatsession drop

### DIFF
--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -119,7 +119,7 @@ function Footer() {
     }](https://www.onyx.app/) - Open Source AI Platform`;
 
   return (
-    <footer className="w-full flex flex-row justify-center items-center gap-2 pb-2">
+    <footer className="w-full flex flex-row justify-center items-center gap-2 pb-2 mt-auto">
       <MinimalMarkdown
         content={customFooterContent}
         className={cn("max-w-full text-center")}

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -435,7 +435,7 @@ const ChatButton = memo(
       >
         <Popover.Anchor>
           <SidebarTab
-            href={`/chat?chatId=${chatSession.id}`}
+            href={isDragging ? undefined : `/chat?chatId=${chatSession.id}`}
             onClick={handleClick}
             transient={active}
             rightChildren={rightMenu}


### PR DESCRIPTION
## Description
This PR fixes the footer position for project page and prevent page refresh on chatsession drag and drop

## How Has This Been Tested?
Tested from UI

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the footer so it stays at the bottom of the project page and prevents page refresh when dragging a chat session.

- **Bug Fixes**
  - Footer: added mt-auto to keep it anchored at the bottom in the flex layout.
  - Chat sessions: disable href while dragging to avoid accidental navigation on drop.

<sup>Written for commit e6ea753a73602bf96f56290d32853cb245d13c59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

