### PR TITLE
local sandbox demo data hookup

### DIFF
--- a/backend/onyx/server/features/build/.gitignore
+++ b/backend/onyx/server/features/build/.gitignore
@@ -1,1 +1,1 @@
-templates/venv
+sandbox/kubernetes/docker/templates/outputs/venv

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -74,7 +74,11 @@ def create_session(
     session_manager = SessionManager(db_session)
 
     try:
-        build_session = session_manager.get_or_create_empty_session(user.id)
+        build_session = session_manager.get_or_create_empty_session(
+            user.id,
+            user_work_area=request.user_work_area,
+            user_level=request.user_level,
+        )
         db_session.commit()
     except ValueError as e:
         # Max concurrent sandboxes reached or other validation error

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -122,6 +122,8 @@ class SandboxManager(ABC):
         snapshot_path: str | None = None,
         user_name: str | None = None,
         user_role: str | None = None,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
     ) -> None:
         """Set up a session workspace within an existing sandbox.
 
@@ -142,6 +144,8 @@ class SandboxManager(ABC):
             snapshot_path: Optional storage path to restore outputs from
             user_name: User's name for personalization in AGENTS.md
             user_role: User's role/title for personalization in AGENTS.md
+            user_work_area: User's work area for demo persona (e.g., "engineering")
+            user_level: User's level for demo persona (e.g., "ic", "manager")
 
         Raises:
             RuntimeError: If workspace setup fails

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -707,6 +707,8 @@ echo "Sandbox init complete (user-level only, no sessions yet)"
         snapshot_path: str | None = None,
         user_name: str | None = None,
         user_role: str | None = None,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
     ) -> None:
         """Set up a session workspace within an existing sandbox pod.
 
@@ -726,6 +728,8 @@ echo "Sandbox init complete (user-level only, no sessions yet)"
             llm_config: LLM provider configuration for opencode.json
             file_system_path: Not used in k8s (files synced from S3 during init)
             snapshot_path: Optional S3 path - logged but ignored (no S3 access)
+            user_work_area: User's work area for demo persona (PR2 - not yet used)
+            user_level: User's level for demo persona (PR2 - not yet used)
 
         Raises:
             RuntimeError: If workspace setup fails

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -243,6 +243,8 @@ class LocalSandboxManager(SandboxManager):
         snapshot_path: str | None = None,
         user_name: str | None = None,
         user_role: str | None = None,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
     ) -> None:
         """Set up a session workspace within an existing sandbox.
 
@@ -265,6 +267,8 @@ class LocalSandboxManager(SandboxManager):
             snapshot_path: Optional storage path to restore outputs from
             user_name: User's name for personalization in AGENTS.md
             user_role: User's role/title for personalization in AGENTS.md
+            user_work_area: User's work area for demo persona (e.g., "engineering")
+            user_level: User's level for demo persona (e.g., "ic", "manager")
 
         Raises:
             RuntimeError: If workspace setup fails
@@ -295,6 +299,15 @@ class LocalSandboxManager(SandboxManager):
                     session_path, Path(file_system_path)
                 )
                 logger.debug("Files symlink ready")
+
+                # Setup user identity file with persona info (after files symlink)
+                if user_work_area:
+                    logger.debug(
+                        f"Setting up user identity for {user_work_area}/{user_level}"
+                    )
+                    self._directory_manager.setup_user_identity_file(
+                        session_path, user_work_area, user_level
+                    )
 
             logger.debug("Setting up outputs directory from template")
             self._directory_manager.setup_outputs_directory(session_path)

--- a/backend/onyx/server/features/build/sandbox/manager/directory_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/directory_manager.py
@@ -15,6 +15,7 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_opencode_config,
 )
+from onyx.server.features.build.sandbox.util.persona_mapping import get_persona_info
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -162,6 +163,56 @@ class DirectoryManager:
         files_link = sandbox_path / "files"
         if not files_link.exists():
             files_link.symlink_to(file_system_path, target_is_directory=True)
+
+    def setup_user_identity_file(
+        self,
+        sandbox_path: Path,
+        user_work_area: str | None,
+        user_level: str | None,
+    ) -> None:
+        """Replace placeholders in user identity file with persona info.
+
+        Reads the identity file template and replaces {{USER_FULL_NAME}} and
+        {{USER_EMAIL}} placeholders with the appropriate persona information
+        based on the user's work area and level.
+
+        Args:
+            sandbox_path: Path to the sandbox/session directory
+            user_work_area: User's work area (e.g., "engineering", "product")
+            user_level: User's level (e.g., "ic", "manager")
+        """
+        # Get persona info from mapping
+        persona = get_persona_info(user_work_area, user_level)
+        if not persona:
+            logger.debug(
+                f"No persona found for work_area={user_work_area}, "
+                f"level={user_level}, skipping identity file setup"
+            )
+            return
+
+        # Path to identity file
+        identity_file = (
+            sandbox_path / "files" / "org_info" / "user_identity_profile.txt"
+        )
+
+        if not identity_file.exists():
+            logger.debug(f"Identity file not found at {identity_file}, skipping setup")
+            return
+
+        try:
+            # Read current content
+            content = identity_file.read_text()
+
+            # Replace placeholders
+            content = content.replace("{{USER_FULL_NAME}}", persona["name"])
+            content = content.replace("{{USER_EMAIL}}", persona["email"])
+
+            # Write back
+            identity_file.write_text(content)
+            logger.info(f"Set user identity: {persona['name']} <{persona['email']}>")
+        except Exception as e:
+            # Don't fail provisioning if identity file setup fails
+            logger.warning(f"Failed to set user identity file: {e}")
 
     def setup_outputs_directory(self, sandbox_path: Path) -> None:
         """Copy outputs template and create additional directories.

--- a/backend/onyx/server/features/build/sandbox/util/persona_mapping.py
+++ b/backend/onyx/server/features/build/sandbox/util/persona_mapping.py
@@ -1,0 +1,99 @@
+"""Persona mapping utility for demo user identities.
+
+Maps frontend persona selections (work_area + level) to demo user profiles
+with name and email for sandbox provisioning.
+"""
+
+from typing import TypedDict
+
+
+class PersonaInfo(TypedDict):
+    """Type for persona information."""
+
+    name: str
+    email: str
+
+
+# Mapping from work_area -> level -> persona info
+# Note: Frontend uses "product" and "executive", which we map here
+PERSONA_MAPPING: dict[str, dict[str, PersonaInfo]] = {
+    "engineering": {
+        "ic": {
+            "name": "Tyler Jenkins",
+            "email": "tyler_jenkins@netherite-extraction.onyx.app",
+        },
+        "manager": {
+            "name": "Javier Morales",
+            "email": "javier_morales@netherite-extraction.onyx.app",
+        },
+    },
+    "sales": {
+        "ic": {
+            "name": "Megan Foster",
+            "email": "megan_foster@netherite-extraction.onyx.app",
+        },
+        "manager": {
+            "name": "Valeria Cruz",
+            "email": "valeria_cruz@netherite-extraction.onyx.app",
+        },
+    },
+    "product": {
+        "ic": {
+            "name": "Michael Anderson",
+            "email": "michael_anderson@netherite-extraction.onyx.app",
+        },
+        "manager": {
+            "name": "David Liu",
+            "email": "david_liu@netherite-extraction.onyx.app",
+        },
+    },
+    "marketing": {
+        "ic": {
+            "name": "Rahul Patel",
+            "email": "rahul_patel@netherite-extraction.onyx.app",
+        },
+        "manager": {
+            "name": "Olivia Reed",
+            "email": "olivia_reed@netherite-extraction.onyx.app",
+        },
+    },
+    "executive": {
+        "manager": {
+            "name": "Sarah Mitchell",
+            "email": "sarah_mitchell@netherite-extraction.onyx.app",
+        },
+    },
+    "other": {
+        "ic": {
+            "name": "John Carpenter",
+            "email": "john_carpenter@netherite-extraction.onyx.app",
+        },
+        "manager": {
+            "name": "Ralf Schroeder",
+            "email": "ralf_schroeder@netherite-extraction.onyx.app",
+        },
+    },
+}
+
+
+def get_persona_info(work_area: str | None, level: str | None) -> PersonaInfo | None:
+    """Get persona info from work area and level.
+
+    Args:
+        work_area: User's work area (e.g., "engineering", "product", "sales")
+        level: User's level (e.g., "ic", "manager")
+
+    Returns:
+        PersonaInfo with name and email, or None if no matching persona
+    """
+    if not work_area:
+        return None
+
+    work_area_lower = work_area.lower().strip()
+    level_lower = (level or "manager").lower().strip()
+
+    work_area_mapping = PERSONA_MAPPING.get(work_area_lower)
+    if not work_area_mapping:
+        return None
+
+    return work_area_mapping.get(level_lower)

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -313,6 +313,8 @@ class SessionManager:
         self,
         user_id: UUID,
         name: str | None = None,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
     ) -> BuildSession:
         """
         Create a new build session with a sandbox.
@@ -324,6 +326,8 @@ class SessionManager:
         Args:
             user_id: The user ID
             name: Optional session name
+            user_work_area: User's work area for demo persona (e.g., "engineering")
+            user_level: User's level for demo persona (e.g., "ic", "manager")
 
         Returns:
             The created BuildSession model
@@ -454,6 +458,8 @@ class SessionManager:
             snapshot_path=None,  # TODO: Support restoring from snapshot
             user_name=user_name,
             user_role=user_role,
+            user_work_area=user_work_area,
+            user_level=user_level,
         )
         sandbox_id = sandbox.id
         logger.info(
@@ -462,7 +468,12 @@ class SessionManager:
 
         return build_session
 
-    def get_or_create_empty_session(self, user_id: UUID) -> BuildSession:
+    def get_or_create_empty_session(
+        self,
+        user_id: UUID,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
+    ) -> BuildSession:
         """Get existing empty session or create a new one with provisioned sandbox.
 
         Used for pre-provisioning sandboxes when user lands on /build/v1.
@@ -470,6 +481,8 @@ class SessionManager:
 
         Args:
             user_id: The user ID
+            user_work_area: User's work area for demo persona (e.g., "engineering")
+            user_level: User's level for demo persona (e.g., "ic", "manager")
 
         Returns:
             BuildSession (existing empty or newly created)
@@ -484,7 +497,11 @@ class SessionManager:
                 f"Returning existing empty session {existing.id} for user {user_id}"
             )
             return existing
-        return self.create_session__no_commit(user_id=user_id)
+        return self.create_session__no_commit(
+            user_id=user_id,
+            user_work_area=user_work_area,
+            user_level=user_level,
+        )
 
     def get_session(
         self,


### PR DESCRIPTION
## Description

hook up local sandbox to the FE cookies for user department and function and use that to map to the demo data email/name

## How Has This Been Tested?

locally
<img width="1911" height="943" alt="Screenshot 2026-01-25 at 10 44 44" src="https://github.com/user-attachments/assets/da880a5d-1884-43d4-be92-abf456a34f2c" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Personalized local sandbox provisioning using frontend cookies to set demo user identity. Maps department (work_area) and level to a demo persona, and injects name/email into the user identity profile.

- **New Features**
  - API and session manager now pass user_work_area and user_level into sandbox setup.
  - Added persona_mapping utility to convert work area + level to demo name/email.
  - Local sandbox fills user_identity_profile.txt placeholders with persona info after files are symlinked.
  - Kubernetes sandbox accepts the new fields but doesn’t use them yet.

<sup>Written for commit 61beae5f4b47434de02724cd9bb7701c366b9825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

