### PR TITLE
fix(bookstack): use ISO-8601 datetime format for incremental polling

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -61,7 +61,7 @@ class BookstackConnector(LoadConnector, PollConnector):
 
         if end:
             params["filter[updated_at:lte]"] = datetime.utcfromtimestamp(end).strftime(
-                "%Y-%m-%d"
+                "%Y-%m-%dT%H:%M:%SZ"
             )
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])


### PR DESCRIPTION
## Description

The BookStack connector's incremental polling only works once per day. Subsequent polls within the same day re-fetch all documents updated that day instead of only those updated since the last poll.

### Root Cause

The date filter in `_get_doc_batch` uses `strftime("%Y-%m-%d")`, which truncates timestamps to date-only format. This means:
- Poll at 08:00 → filters by `updated_at >= "2025-01-25"` → returns all docs from that day
- Poll at 14:00 → filters by `updated_at >= "2025-01-25"` → same query, same results

### Solution

Use ISO-8601 format with full timestamp precision: `%Y-%m-%dT%H:%M:%SZ`

BookStack API supports this format since v21.11.

## How Has This Been Tested?

Tested against production BookStack instance:
```bash
# Date-only filter (current behavior)
filter[updated_at:gte]=2025-01-25 → 18 pages

# ISO-8601 filter (fixed behavior)  
filter[updated_at:gte]=2025-01-25T22:00:00Z → 1 page
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incremental polling in the BookStack connector by using ISO-8601 UTC timestamps for updated_at filters. This stops same-day re-fetches and only pulls documents updated since the last poll.

<sup>Written for commit e4e9fefd1dd5d822b2e0c7dd07411010f167a45b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

