### PR TITLE
more kube stuff

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -341,11 +341,11 @@ echo "Sandbox init complete (user-level only, no sessions yet)"
             client.V1Volume(
                 name="workspace",
                 # Increased size: holds sessions/ directory with per-session outputs
-                empty_dir=client.V1EmptyDirVolumeSource(size_limit="10Gi"),
+                empty_dir=client.V1EmptyDirVolumeSource(size_limit="50Gi"),
             ),
             client.V1Volume(
                 name="files",
-                empty_dir=client.V1EmptyDirVolumeSource(size_limit="1Gi"),
+                empty_dir=client.V1EmptyDirVolumeSource(size_limit="5Gi"),
             ),
         ]
 
@@ -356,7 +356,7 @@ echo "Sandbox init complete (user-level only, no sessions yet)"
             containers=[sandbox_container],
             volumes=volumes,
             restart_policy="Never",
-            termination_grace_period_seconds=300,
+            termination_grace_period_seconds=600,
             # Node selection for sandbox nodes
             node_selector={"onyx.app/workload": "sandbox"},
             tolerations=[
@@ -375,9 +375,9 @@ echo "Sandbox init complete (user-level only, no sessions yet)"
                 seccomp_profile=client.V1SeccompProfile(type="RuntimeDefault"),
             ),
             # Disable host access
-            # host_network=False,
-            # host_pid=False,
-            # host_ipc=False,
+            host_network=False,
+            host_pid=False,
+            host_ipc=False,
         )
 
         return client.V1Pod(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase sandbox pod storage and shutdown grace period, and explicitly disable host access to improve reliability and security.

- **Refactors**
  - workspace emptyDir size_limit: 10Gi → 50Gi
  - files emptyDir size_limit: 1Gi → 5Gi
  - termination_grace_period_seconds: 300 → 600
  - Set host_network, host_pid, host_ipc to false

<sup>Written for commit 3d60275e299e686fe4e501745154631214bb9817. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

