### PR TITLE
completely overhaul pre-provisioning with llm selection and demo data toggle

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -20,6 +20,9 @@ class SessionCreateRequest(BaseModel):
     )
     user_work_area: str | None = None  # User's work area (e.g., "engineering")
     user_level: str | None = None  # User's level (e.g., "ic", "manager")
+    # LLM selection from user's cookie
+    llm_provider_type: str | None = None  # Provider type (e.g., "anthropic", "openai")
+    llm_model_name: str | None = None  # Model name (e.g., "claude-opus-4-5")
 
 
 class SessionUpdateRequest(BaseModel):

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -78,6 +78,8 @@ def create_session(
             user.id,
             user_work_area=request.user_work_area,
             user_level=request.user_level,
+            llm_provider_type=request.llm_provider_type,
+            llm_model_name=request.llm_model_name,
         )
         db_session.commit()
     except ValueError as e:

--- a/web/src/app/build/components/BuildLLMPopover.tsx
+++ b/web/src/app/build/components/BuildLLMPopover.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import {
+  SvgCheck,
+  SvgChevronDown,
+  SvgChevronRight,
+  SvgPlug,
+} from "@opal/icons";
+import Text from "@/refresh-components/texts/Text";
+import Popover, { PopoverMenu } from "@/refresh-components/Popover";
+import Switch from "@/refresh-components/inputs/Switch";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import { LLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
+import {
+  BuildLlmSelection,
+  BUILD_MODE_PROVIDERS,
+  isRecommendedModel,
+} from "@/app/build/onboarding/constants";
+import { ToggleWarningModal } from "./ToggleWarningModal";
+import { getProviderIcon } from "@/app/admin/configuration/llm/utils";
+import { Section } from "@/layouts/general-layouts";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+interface BuildLLMPopoverProps {
+  currentSelection: BuildLlmSelection | null;
+  onSelectionChange: (selection: BuildLlmSelection) => void;
+  llmProviders: LLMProviderDescriptor[] | undefined;
+  onOpenOnboarding: (providerKey: string) => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+interface ModelOption {
+  providerKey: string;
+  providerName: string;
+  providerDisplayName: string;
+  modelName: string;
+  displayName: string;
+  isRecommended: boolean;
+  isConfigured: boolean;
+}
+
+export function BuildLLMPopover({
+  currentSelection,
+  onSelectionChange,
+  llmProviders,
+  onOpenOnboarding,
+  children,
+  disabled = false,
+}: BuildLLMPopoverProps) {
+  const [showRecommendedOnly, setShowRecommendedOnly] = useState(true);
+  const [showToggleWarning, setShowToggleWarning] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const isClosingModalRef = useRef(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
+
+  // Check which providers are configured (exact match on provider field)
+  const isProviderConfigured = useCallback(
+    (providerKey: string) => {
+      return llmProviders?.some((p) => p.provider === providerKey);
+    },
+    [llmProviders]
+  );
+
+  // Get the actual provider descriptor for a configured provider
+  const getProviderDescriptor = useCallback(
+    (providerKey: string) => {
+      return llmProviders?.find((p) => p.provider === providerKey);
+    },
+    [llmProviders]
+  );
+
+  // Build model options based on mode
+  const modelOptions = useMemo((): ModelOption[] => {
+    const options: ModelOption[] = [];
+
+    if (showRecommendedOnly) {
+      // Show curated list from BUILD_MODE_PROVIDERS
+      BUILD_MODE_PROVIDERS.forEach((provider) => {
+        const isConfigured = isProviderConfigured(provider.providerName);
+        const descriptor = getProviderDescriptor(provider.providerName);
+        const modelsToShow = provider.models.filter((m) => m.recommended);
+
+        modelsToShow.forEach((model) => {
+          // Get display name from backend if available
+          const backendConfig = descriptor?.model_configurations.find(
+            (mc) => mc.name === model.name
+          );
+          options.push({
+            providerKey: provider.providerName,
+            providerName: descriptor?.name || provider.label,
+            providerDisplayName: provider.label,
+            modelName: model.name,
+            displayName: backendConfig?.display_name || model.label,
+            isRecommended: true,
+            isConfigured: isConfigured ?? false,
+          });
+        });
+      });
+    } else {
+      // Show ALL configured providers and their visible models
+      llmProviders?.forEach((provider) => {
+        const visibleModels = provider.model_configurations.filter(
+          (m) => m.is_visible
+        );
+
+        visibleModels.forEach((model) => {
+          options.push({
+            providerKey: provider.provider,
+            providerName: provider.name,
+            providerDisplayName:
+              provider.provider_display_name || provider.provider,
+            modelName: model.name,
+            displayName: model.display_name || model.name,
+            isRecommended: isRecommendedModel(provider.provider, model.name),
+            isConfigured: true,
+          });
+        });
+      });
+    }
+
+    return options;
+  }, [
+    showRecommendedOnly,
+    llmProviders,
+    isProviderConfigured,
+    getProviderDescriptor,
+  ]);
+
+  // Group options by provider
+  const groupedOptions = useMemo(() => {
+    const groups = new Map<
+      string,
+      {
+        providerKey: string;
+        displayName: string;
+        options: ModelOption[];
+        isConfigured: boolean;
+      }
+    >();
+
+    modelOptions.forEach((option) => {
+      const groupKey = option.providerKey;
+
+      if (!groups.has(groupKey)) {
+        groups.set(groupKey, {
+          providerKey: option.providerKey,
+          displayName: option.providerDisplayName,
+          options: [],
+          isConfigured: option.isConfigured,
+        });
+      }
+
+      groups.get(groupKey)!.options.push(option);
+    });
+
+    // Sort groups alphabetically
+    const sortedKeys = Array.from(groups.keys()).sort((a, b) =>
+      groups.get(a)!.displayName.localeCompare(groups.get(b)!.displayName)
+    );
+
+    return sortedKeys.map((key) => groups.get(key)!);
+  }, [modelOptions]);
+
+  // Determine current group for auto-expand
+  const currentGroupKey = useMemo(() => {
+    if (!currentSelection) return "";
+    return currentSelection.provider;
+  }, [currentSelection]);
+
+  // Track expanded groups
+  const [expandedGroups, setExpandedGroups] = useState<string[]>([
+    currentGroupKey,
+  ]);
+
+  // Reset expanded groups when popover opens
+  useEffect(() => {
+    if (isOpen) {
+      setExpandedGroups([currentGroupKey]);
+    }
+  }, [isOpen, currentGroupKey]);
+
+  // Auto-scroll to selected model
+  useEffect(() => {
+    if (isOpen) {
+      const timer = setTimeout(() => {
+        selectedItemRef.current?.scrollIntoView({
+          behavior: "instant",
+          block: "center",
+        });
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const handleAccordionChange = (value: string[]) => {
+    setExpandedGroups(value);
+  };
+
+  const applySelection = useCallback(
+    (option: ModelOption) => {
+      if (!option.isConfigured) return;
+
+      onSelectionChange({
+        providerName: option.providerName,
+        provider: option.providerKey,
+        modelName: option.modelName,
+      });
+      setIsOpen(false);
+    },
+    [onSelectionChange]
+  );
+
+  // Handle toggle change - show warning when turning OFF
+  const handleToggleChange = (checked: boolean) => {
+    if (!checked && showRecommendedOnly) {
+      setShowToggleWarning(true);
+    } else {
+      setShowRecommendedOnly(checked);
+    }
+  };
+
+  // Reset closing flag after modal close transition
+  useEffect(() => {
+    if (!showToggleWarning && isClosingModalRef.current) {
+      const timeoutId = setTimeout(() => {
+        isClosingModalRef.current = false;
+      }, 100);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [showToggleWarning]);
+
+  const handleConnectClick = (providerKey: string) => {
+    setIsOpen(false);
+    onOpenOnboarding(providerKey);
+  };
+
+  const handlePopoverOpenChange = (open: boolean) => {
+    if (disabled && open) {
+      return;
+    }
+    if (!open && (showToggleWarning || isClosingModalRef.current)) {
+      return;
+    }
+    setIsOpen(open);
+  };
+
+  const renderModelItem = (option: ModelOption) => {
+    const isSelected =
+      currentSelection?.modelName === option.modelName &&
+      currentSelection?.provider === option.providerKey;
+
+    // Build description with recommendation badge
+    const description = option.isRecommended ? "Recommended" : undefined;
+
+    return (
+      <div
+        key={`${option.providerKey}-${option.modelName}`}
+        ref={isSelected ? selectedItemRef : undefined}
+      >
+        <LineItem
+          selected={isSelected}
+          description={description}
+          onClick={() => applySelection(option)}
+          rightChildren={
+            isSelected ? (
+              <SvgCheck className="h-4 w-4 stroke-action-link-05 shrink-0" />
+            ) : null
+          }
+        >
+          {option.displayName}
+        </LineItem>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <Popover open={isOpen} onOpenChange={handlePopoverOpenChange}>
+        <Popover.Trigger asChild>{children}</Popover.Trigger>
+        <Popover.Content
+          side="bottom"
+          align="start"
+          width="lg"
+          onInteractOutside={(e) => {
+            if (showToggleWarning || isClosingModalRef.current) {
+              e.preventDefault();
+            }
+          }}
+          onPointerDownOutside={(e) => {
+            if (showToggleWarning || isClosingModalRef.current) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <div className="px-3">
+            <Section gap={0.5}>
+              {/* Toggle for recommended only */}
+              <div className="flex items-center justify-between py-3 gap-3 border-b border-border-01 px-1">
+                <Text secondaryBody text03>
+                  Recommended Models Only
+                </Text>
+                <Switch
+                  checked={showRecommendedOnly}
+                  onCheckedChange={handleToggleChange}
+                />
+              </div>
+
+              {/* Model List */}
+              <PopoverMenu scrollContainerRef={scrollContainerRef}>
+                {groupedOptions.length === 0
+                  ? [
+                      <div key="empty" className="py-3 px-2">
+                        <Text secondaryBody text03>
+                          No models found
+                        </Text>
+                      </div>,
+                    ]
+                  : groupedOptions.length === 1
+                    ? // Single provider - show models directly
+                      [
+                        <div
+                          key="single-provider"
+                          className="flex flex-col gap-1"
+                        >
+                          {groupedOptions[0]!.isConfigured ? (
+                            groupedOptions[0]!.options.map(renderModelItem)
+                          ) : (
+                            <div className="flex items-center justify-between px-2 py-2">
+                              <Text secondaryBody text03>
+                                Not configured
+                              </Text>
+                              <button
+                                onClick={() =>
+                                  handleConnectClick(
+                                    groupedOptions[0]!.providerKey
+                                  )
+                                }
+                                className="flex items-center gap-1 px-2 py-1 text-xs rounded-08 bg-background-02 hover:bg-background-03 transition-colors"
+                              >
+                                <SvgPlug className="w-3 h-3" />
+                                <span>Connect</span>
+                              </button>
+                            </div>
+                          )}
+                        </div>,
+                      ]
+                    : // Multiple providers - show accordion
+                      [
+                        <Accordion
+                          key="accordion"
+                          type="multiple"
+                          value={expandedGroups}
+                          onValueChange={handleAccordionChange}
+                          className="w-full flex flex-col"
+                        >
+                          {groupedOptions.map((group) => {
+                            const isExpanded = expandedGroups.includes(
+                              group.providerKey
+                            );
+                            const ProviderIcon = getProviderIcon(
+                              group.providerKey
+                            );
+
+                            return (
+                              <AccordionItem
+                                key={group.providerKey}
+                                value={group.providerKey}
+                                className="border-none pt-1"
+                              >
+                                {/* Group Header */}
+                                <AccordionTrigger className="flex items-center rounded-08 hover:no-underline hover:bg-background-tint-02 group [&>svg]:hidden w-full py-1">
+                                  <div className="flex items-center gap-1 shrink-0">
+                                    <div className="flex items-center justify-center size-5 shrink-0">
+                                      <ProviderIcon size={16} />
+                                    </div>
+                                    <Text
+                                      secondaryBody
+                                      text03
+                                      nowrap
+                                      className="px-0.5"
+                                    >
+                                      {group.displayName}
+                                    </Text>
+                                  </div>
+                                  <div className="flex-1" />
+                                  {!group.isConfigured && (
+                                    <button
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleConnectClick(group.providerKey);
+                                      }}
+                                      className="flex items-center gap-1 px-2 py-0.5 mr-1 text-xs rounded-08 bg-background-02 hover:bg-background-03 transition-colors"
+                                    >
+                                      <SvgPlug className="w-3 h-3" />
+                                      <span>Connect</span>
+                                    </button>
+                                  )}
+                                  <div className="flex items-center justify-center size-6 shrink-0">
+                                    {isExpanded ? (
+                                      <SvgChevronDown className="h-4 w-4 stroke-text-04 shrink-0" />
+                                    ) : (
+                                      <SvgChevronRight className="h-4 w-4 stroke-text-04 shrink-0" />
+                                    )}
+                                  </div>
+                                </AccordionTrigger>
+
+                                {/* Model Items */}
+                                <AccordionContent className="pb-0 pt-0">
+                                  <div className="flex flex-col gap-1">
+                                    {group.isConfigured ? (
+                                      group.options.map(renderModelItem)
+                                    ) : (
+                                      <div className="py-1.5 px-3">
+                                        <Text secondaryBody text03>
+                                          Not configured
+                                        </Text>
+                                      </div>
+                                    )}
+                                  </div>
+                                </AccordionContent>
+                              </AccordionItem>
+                            );
+                          })}
+                        </Accordion>,
+                      ]}
+              </PopoverMenu>
+            </Section>
+          </div>
+        </Popover.Content>
+      </Popover>
+
+      {/* Warning modal when turning OFF "Recommended Models Only" */}
+      <ToggleWarningModal
+        open={showToggleWarning}
+        onConfirm={() => {
+          setShowRecommendedOnly(false);
+          isClosingModalRef.current = true;
+          setShowToggleWarning(false);
+        }}
+        onCancel={() => {
+          isClosingModalRef.current = true;
+          setShowToggleWarning(false);
+        }}
+      />
+    </>
+  );
+}

--- a/web/src/app/build/components/ToggleWarningModal.tsx
+++ b/web/src/app/build/components/ToggleWarningModal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Text from "@/refresh-components/texts/Text";
+
+interface ToggleWarningModalProps {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ToggleWarningModal({
+  open,
+  onConfirm,
+  onCancel,
+}: ToggleWarningModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[1400] flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancel();
+        }}
+      />
+
+      {/* Modal */}
+      <div className="relative z-10 w-full max-w-xl mx-4 bg-background-tint-01 rounded-16 shadow-lg border border-border-01">
+        <div className="p-6 flex flex-col gap-6">
+          {/* Header */}
+          <div className="flex items-center justify-center">
+            <Text headingH2 text05>
+              Show all models?
+            </Text>
+          </div>
+
+          {/* Message */}
+          <div className="flex justify-center">
+            <Text mainUiBody text04 className="text-center">
+              We recommend using <strong>Claude Opus 4.5</strong> for Crafting.
+              <br />
+              Other models may have reduced capabilities for code creation,
+              <br />
+              data analysis, and artifact creation.
+            </Text>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirm();
+              }}
+              className="px-4 py-2 rounded-12 bg-background-neutral-01 border border-border-02 hover:opacity-90 transition-colors"
+            >
+              <Text mainUiBody text05>
+                Show All Models
+              </Text>
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCancel();
+              }}
+              className="px-4 py-2 rounded-12 bg-black dark:bg-white hover:opacity-90 transition-colors"
+            >
+              <Text
+                mainUiAction
+                className="text-text-light-05 dark:text-text-dark-05"
+              >
+                Keep Recommended
+              </Text>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/build/hooks/useBuildLlmSelection.ts
+++ b/web/src/app/build/hooks/useBuildLlmSelection.ts
@@ -1,0 +1,110 @@
+import { useMemo, useState, useCallback } from "react";
+import { LLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
+import {
+  BuildLlmSelection,
+  getBuildLlmSelection,
+  setBuildLlmSelection,
+  clearBuildLlmSelection,
+  RECOMMENDED_BUILD_MODELS,
+} from "@/app/build/onboarding/constants";
+
+/**
+ * Hook for managing Build mode LLM selection.
+ *
+ * Resolution priority:
+ * 1. Cookie - User's explicit selection (via onboarding or configure page)
+ * 2. Smart default - Anthropic Opus 4.5 if available and no cookie exists
+ * 3. System default - System default provider if no Anthropic and no cookie
+ */
+export function useBuildLlmSelection(
+  llmProviders: LLMProviderDescriptor[] | undefined
+) {
+  const [selection, setSelectionState] = useState<BuildLlmSelection | null>(
+    () => getBuildLlmSelection()
+  );
+
+  // Validate that a selection is still valid against current providers
+  const isSelectionValid = useCallback(
+    (sel: BuildLlmSelection | null): boolean => {
+      if (!sel || !llmProviders) return false;
+      const provider = llmProviders.find((p) => p.name === sel.providerName);
+      if (!provider) return false;
+      return provider.model_configurations.some(
+        (m) => m.name === sel.modelName
+      );
+    },
+    [llmProviders]
+  );
+
+  // Compute effective selection: cookie > smart default > system default
+  const effectiveSelection = useMemo((): BuildLlmSelection | null => {
+    if (!llmProviders || llmProviders.length === 0) return null;
+
+    // 1. Use cookie if valid
+    if (selection && isSelectionValid(selection)) {
+      return selection;
+    }
+
+    // 2. Smart default: Anthropic Opus 4.5 if available
+    const anthropicProvider = llmProviders.find(
+      (p) =>
+        p.provider === "anthropic" || p.name.toLowerCase().includes("anthropic")
+    );
+    if (anthropicProvider) {
+      const opusModel = anthropicProvider.model_configurations.find(
+        (m) =>
+          m.name === RECOMMENDED_BUILD_MODELS.preferred.modelName ||
+          m.name.includes("opus-4-5") ||
+          m.name.includes("opus-4.5")
+      );
+      if (opusModel) {
+        return {
+          providerName: anthropicProvider.name,
+          provider: anthropicProvider.provider,
+          modelName: opusModel.name,
+        };
+      }
+    }
+
+    // 3. Fall back to system default provider
+    const defaultProvider = llmProviders.find((p) => p.is_default_provider);
+    if (defaultProvider) {
+      return {
+        providerName: defaultProvider.name,
+        provider: defaultProvider.provider,
+        modelName: defaultProvider.default_model_name,
+      };
+    }
+
+    // 4. First available provider
+    const firstProvider = llmProviders[0];
+    if (firstProvider) {
+      return {
+        providerName: firstProvider.name,
+        provider: firstProvider.provider,
+        modelName: firstProvider.default_model_name,
+      };
+    }
+
+    return null;
+  }, [selection, llmProviders, isSelectionValid]);
+
+  // Update selection and persist to cookie
+  const updateSelection = useCallback((newSelection: BuildLlmSelection) => {
+    setBuildLlmSelection(newSelection);
+    setSelectionState(newSelection);
+  }, []);
+
+  // Clear selection (removes cookie)
+  const clearSelection = useCallback(() => {
+    clearBuildLlmSelection();
+    setSelectionState(null);
+  }, []);
+
+  return {
+    selection: effectiveSelection,
+    updateSelection,
+    clearSelection,
+    isFromCookie: selection !== null && isSelectionValid(selection),
+  };
+}

--- a/web/src/app/build/onboarding/constants.ts
+++ b/web/src/app/build/onboarding/constants.ts
@@ -1,3 +1,126 @@
+// =============================================================================
+// LLM Selection Types and Utilities
+// =============================================================================
+
+export interface BuildLlmSelection {
+  providerName: string; // e.g., "build-mode-anthropic" (LLMProviderDescriptor.name)
+  provider: string; // e.g., "anthropic"
+  modelName: string; // e.g., "claude-opus-4-5"
+}
+
+// Recommended models config
+export const RECOMMENDED_BUILD_MODELS = {
+  preferred: {
+    provider: "anthropic",
+    modelName: "claude-opus-4-5",
+    displayName: "Claude Opus 4.5",
+  },
+  alternatives: [{ provider: "anthropic", modelName: "claude-sonnet-4-5" }],
+} as const;
+
+// Cookie utilities
+const BUILD_LLM_COOKIE_KEY = "build_llm_selection";
+
+export function getBuildLlmSelection(): BuildLlmSelection | null {
+  if (typeof document === "undefined") return null;
+  const cookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${BUILD_LLM_COOKIE_KEY}=`));
+  if (!cookie) return null;
+  try {
+    const value = cookie.split("=")[1];
+    if (!value) return null;
+    return JSON.parse(decodeURIComponent(value));
+  } catch {
+    return null;
+  }
+}
+
+export function setBuildLlmSelection(selection: BuildLlmSelection): void {
+  if (typeof document === "undefined") return;
+  const value = encodeURIComponent(JSON.stringify(selection));
+  // Cookie expires in 1 year
+  const expires = new Date(
+    Date.now() + 365 * 24 * 60 * 60 * 1000
+  ).toUTCString();
+  document.cookie = `${BUILD_LLM_COOKIE_KEY}=${value}; path=/; expires=${expires}; SameSite=Lax`;
+}
+
+export function clearBuildLlmSelection(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${BUILD_LLM_COOKIE_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
+
+export function isRecommendedModel(
+  provider: string,
+  modelName: string
+): boolean {
+  const { preferred, alternatives } = RECOMMENDED_BUILD_MODELS;
+  // Exact match for preferred model
+  if (preferred.provider === provider && modelName === preferred.modelName) {
+    return true;
+  }
+  // Exact match for alternatives
+  return alternatives.some(
+    (alt) => alt.provider === provider && modelName === alt.modelName
+  );
+}
+
+// Curated providers for Build mode (shared between BuildOnboardingModal and BuildLLMPopover)
+export interface BuildModeModel {
+  name: string;
+  label: string;
+  recommended?: boolean;
+}
+
+export interface BuildModeProvider {
+  key: string;
+  label: string;
+  providerName: string;
+  recommended?: boolean;
+  models: BuildModeModel[];
+}
+
+export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
+  {
+    key: "anthropic",
+    label: "Anthropic",
+    providerName: "anthropic",
+    recommended: true,
+    models: [
+      { name: "claude-opus-4-5", label: "Claude Opus 4.5", recommended: true },
+      { name: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+    ],
+  },
+  {
+    key: "openai",
+    label: "OpenAI",
+    providerName: "openai",
+    models: [
+      { name: "gpt-5.2", label: "GPT-5.2", recommended: true },
+      { name: "gpt-5.1", label: "GPT-5.1" },
+    ],
+  },
+  {
+    key: "openrouter",
+    label: "OpenRouter",
+    providerName: "openrouter",
+    models: [
+      {
+        name: "moonshotai/kimi-k2-thinking",
+        label: "Kimi K2 Thinking",
+        recommended: true,
+      },
+      { name: "google/gemini-3-pro-preview", label: "Gemini 3 Pro" },
+      { name: "qwen/qwen3-235b-a22b-thinking-2507", label: "Qwen3 235B" },
+    ],
+  },
+];
+
+// =============================================================================
+// User Info/Persona Constants
+// =============================================================================
+
 export const WORK_AREA_OPTIONS = [
   { value: "engineering", label: "Engineering" },
   { value: "product", label: "Product" },

--- a/web/src/app/build/services/apiServices.ts
+++ b/web/src/app/build/services/apiServices.ts
@@ -83,6 +83,9 @@ export interface CreateSessionOptions {
   demoDataEnabled?: boolean;
   userWorkArea?: string | null;
   userLevel?: string | null;
+  // LLM selection from user's cookie
+  llmProviderType?: string | null; // Provider type (e.g., "anthropic", "openai")
+  llmModelName?: string | null;
 }
 
 export async function createSession(
@@ -96,6 +99,8 @@ export async function createSession(
       demo_data_enabled: options?.demoDataEnabled ?? true,
       user_work_area: options?.userWorkArea || null,
       user_level: options?.userLevel || null,
+      llm_provider_type: options?.llmProviderType || null,
+      llm_model_name: options?.llmModelName || null,
     }),
   });
 

--- a/web/src/app/build/v1/configure/components/ConfigureOverlays.tsx
+++ b/web/src/app/build/v1/configure/components/ConfigureOverlays.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import Message from "@/refresh-components/messages/Message";
+
+interface ConnectorInfoOverlayProps {
+  visible: boolean;
+}
+
+export function ConnectorInfoOverlay({ visible }: ConnectorInfoOverlayProps) {
+  return (
+    <div
+      className={cn(
+        "fixed bottom-16 left-1/2 -translate-x-1/2 z-toast transition-all duration-300 ease-in-out",
+        visible
+          ? "opacity-100 translate-y-0"
+          : "opacity-0 translate-y-4 pointer-events-none"
+      )}
+    >
+      <Message
+        info
+        text="Existing sessions won't have access to this data"
+        description="Once synced, documents from this connector will be available in your new sessions!"
+        close={false}
+      />
+    </div>
+  );
+}
+
+interface ReprovisionWarningOverlayProps {
+  visible: boolean;
+}
+
+export function ReprovisionWarningOverlay({
+  visible,
+}: ReprovisionWarningOverlayProps) {
+  return (
+    <div
+      className={cn(
+        "transition-all duration-300 ease-in-out",
+        visible
+          ? "opacity-100 translate-y-0"
+          : "opacity-0 translate-y-4 pointer-events-none"
+      )}
+    >
+      <Message
+        warning
+        text="Click Update to apply your changes"
+        description="Your sandbox will be recreated with your new settings. Previously running sessions will not be affected by your changes."
+        close={false}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overhauled Build mode pre-provisioning to respect the user’s chosen LLM and demo data settings. Adds a simple model picker, stores the choice in a cookie, and safely reprovisions the empty session when settings change.

- **New Features**
  - Model picker (BuildLLMPopover) with a “Recommended Models Only” toggle and a warning modal.
  - “Connect” flow opens LLM onboarding to configure missing providers.
  - LLM selection saved in a cookie; resolves as cookie > Anthropic Opus 4.5 (if available) > system default.
  - Backend provisions sandboxes with the requested provider/model, falling back to default if invalid; supports “build-mode-{type}” or any provider by type.
  - Configure page shows pending LLM/demo-data changes, adds “Update” to apply and reprovision, and disables controls while provisioning.
  - Store/API send llm_provider_type/model_name on session creation and pre-provision; new clearPreProvisionedSession to delete the empty session when settings change.

- **Migration**
  - In Build > Configure, choose your LLM and click Update to reprovision your empty session with the new settings.
  - Changing LLM or demo data deletes only the pre-provisioned empty session and creates a new one; active sessions are unaffected.

<sup>Written for commit 16aa3654f9abeb4a89d9ed24f0a18353d6028661. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

