### PR TITLE
Fix web again

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -26,6 +26,7 @@ from acp.schema import ToolCallProgress
 from acp.schema import ToolCallStart
 from sqlalchemy.orm import Session as DBSession
 
+from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
 from onyx.db.llm import fetch_default_provider
@@ -1340,7 +1341,7 @@ class SessionManager:
         # Build webapp URL if we have a port and webapp exists
         webapp_url = None
         if session.nextjs_port:
-            webapp_url = f"http://localhost:{session.nextjs_port}"
+            webapp_url = f"{WEB_DOMAIN}:{session.nextjs_port}"
 
         return {
             "has_webapp": session.nextjs_port is not None,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Build Mode backend with user-shared sandboxes (local/Kubernetes), session and messaging APIs, and optional filesystem output. Includes connector hierarchy metadata, cleanup tasks, and database tables to support the new experience.

- **New Features**
  - Build endpoints: sessions, messages, and Next.js asset router with streaming packets.
  - Sandboxes: one per user, session workspaces, local/Kubernetes backends, and Docker templates.
  - Rate limits: weekly message caps with subscription detection; enforced on send message.
  - Storage: optional persistent document writing with hierarchical paths; new processing_mode on connector pairs (REGULAR, FILE_SYSTEM).
  - Connectors: added hierarchy doc_metadata (Fireflies, GitHub, Slack, Linear, HubSpot), Google Drive parents/caching, Gmail 403 fallback.
  - Scheduling: new “sandbox” Celery queue and periodic cleanup of idle sandboxes and old snapshots.
  - Database: build_session, sandbox, build_message, artifact, snapshot tables; shared sandbox per user; nextjs_port moved to build_session; new enums.

- **Migration**
  - Run Alembic migrations.
  - Set SANDBOX_BACKEND and PERSISTENT_DOCUMENT_STORAGE_* env vars; configure the “sandbox” Celery queue.
  - For Kubernetes, build and deploy the sandbox image and grant required permissions.
  - Use processing_mode=FILE_SYSTEM for Build Mode-only connector pairs as needed.
  - Restart API and workers to load new routers and beat tasks.

<sup>Written for commit 4c190a409acb74f50e2ce0bd8888a3d4d01a9d78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

