### PR TITLE
chore(deployment): remove no auth option from setup script

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -582,30 +582,33 @@ else
     fi
 
     # Ask for authentication schema
-    echo ""
-    print_info "Which authentication schema would you like to set up?"
-    echo ""
-    echo "1) Basic - Username/password authentication"
-    # TODO (jessica): Uncomment this once no auth users still have an account
+    # echo ""
+    # print_info "Which authentication schema would you like to set up?"
+    # echo ""
+    # echo "1) Basic - Username/password authentication"
     # echo "2) No Auth - Open access (development/testing)"
-    echo ""
-    read -p "Choose an option (1-2) [default 1]: " -r AUTH_CHOICE
-    echo ""
+    # echo ""
+    # read -p "Choose an option (1) [default 1]: " -r AUTH_CHOICE
+    # echo ""
 
-    case "${AUTH_CHOICE:-1}" in
-        1)
-            AUTH_SCHEMA="basic"
-            print_info "Selected: Basic authentication"
-            ;;
-        2)
-            AUTH_SCHEMA="disabled"
-            print_info "Selected: No authentication"
-            ;;
-        *)
-            AUTH_SCHEMA="basic"
-            print_info "Invalid choice, using basic authentication"
-            ;;
-    esac
+    # case "${AUTH_CHOICE:-1}" in
+    #     1)
+    #         AUTH_SCHEMA="basic"
+    #         print_info "Selected: Basic authentication"
+    #         ;;
+    #     # 2)
+    #     #     AUTH_SCHEMA="disabled"
+    #     #     print_info "Selected: No authentication"
+    #     #     ;;
+    #     *)
+    #         AUTH_SCHEMA="basic"
+    #         print_info "Invalid choice, using basic authentication"
+    #         ;;
+    # esac
+
+    # TODO (jessica): Uncomment this once no auth users still have an account
+    # Use basic auth by default
+    AUTH_SCHEMA="basic"
 
     # Create .env file from template
     print_info "Creating .env file with your selections..."


### PR DESCRIPTION
## Description

as part of onyx craft launch, we want to show all users the intro animation to push them to try craft. currently, anonymous users aren't in db, and this is a requirement to be shown the intro animation. therefore, we disable no auth option from setup script

## How Has This Been Tested?

locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “No Auth” option from the deployment setup script so every user gets a DB account and sees the Craft intro animation. This aligns with the Craft launch requirement and limits setups to Basic auth only.

<sup>Written for commit be275b3586913561cbb300df65544005d63e19c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

