### PR TITLE
feat suggested followup prompts, connect data input bar banner, get help with connectors banner

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -270,3 +270,31 @@ class BuildConnectorListResponse(BaseModel):
     """List of build connectors."""
 
     connectors: list[BuildConnectorInfo]
+
+
+# ===== Suggestion Bubble Models =====
+class SuggestionTheme(str, Enum):
+    """Theme/category of a follow-up suggestion."""
+
+    ADD = "add"
+    QUESTION = "question"
+
+
+class SuggestionBubble(BaseModel):
+    """A single follow-up suggestion bubble."""
+
+    theme: SuggestionTheme
+    text: str
+
+
+class GenerateSuggestionsRequest(BaseModel):
+    """Request to generate follow-up suggestions."""
+
+    user_message: str  # First user message
+    assistant_message: str  # First assistant text response (accumulated)
+
+
+class GenerateSuggestionsResponse(BaseModel):
+    """Response containing generated suggestions."""
+
+    suggestions: list[SuggestionBubble]

--- a/backend/onyx/server/features/build/session/prompts.py
+++ b/backend/onyx/server/features/build/session/prompts.py
@@ -1,0 +1,47 @@
+"""Prompts used for build session operations."""
+
+# Build session naming prompts (similar to chat naming)
+BUILD_NAMING_SYSTEM_PROMPT = """
+Given the user's build request, provide a SHORT name for the build session. \
+Focus on the main task or goal the user wants to accomplish.
+
+IMPORTANT: DO NOT OUTPUT ANYTHING ASIDE FROM THE NAME. MAKE IT AS CONCISE AS POSSIBLE. \
+NEVER USE MORE THAN 5 WORDS, LESS IS FINE.
+""".strip()
+
+BUILD_NAMING_USER_PROMPT = """
+User's request: {user_message}
+
+Provide a short name for this build session.
+""".strip()
+
+
+# Follow-up suggestion prompts
+FOLLOWUP_SUGGESTIONS_SYSTEM_PROMPT = """You generate follow-up suggestions for an AI workplace assistant conversation.
+
+Given the user's initial request and the assistant's response, generate exactly 2 suggestions:
+
+1. ADD: A suggestion to extend or enhance what was built.
+Start with "Great! Now add..." or similar positive acknowledgment + extension.
+
+2. QUESTION: A follow-up question the user might want to ask about the implementation or to explore further.
+Start with something like "Can you explain..." or "How does...".
+
+IMPORTANT:
+- Keep each suggestion SHORT (under 100 characters preferred, max 150)
+- Make them specific to the actual request and response
+- They should feel natural, like what a user might actually type
+- Output ONLY a JSON array with objects containing "theme" and "text" fields
+- Do NOT wrap in code fences or add any other text
+
+Example output:
+[{"theme": "add", "text": "Great! Now add form validation for the email field"},
+{"theme": "question", "text": "Can you explain how the authentication flow works?"}]""".strip()
+
+FOLLOWUP_SUGGESTIONS_USER_PROMPT = """User's request:
+{user_message}
+
+Assistant's response:
+{assistant_message}
+
+Generate 2 follow-up suggestions (add, question) as a JSON array:""".strip()

--- a/web/lib/opal/src/icons/chevron-down.tsx
+++ b/web/lib/opal/src/icons/chevron-down.tsx
@@ -1,6 +1,6 @@
 import type { IconProps } from "@opal/types";
 
-const SvgChevronDown = ({ size, ...props }: IconProps) => (
+const SvgChevronDown = ({ size, strokeWidth = 1.5, ...props }: IconProps) => (
   <svg
     width={size}
     height={size}
@@ -12,7 +12,7 @@ const SvgChevronDown = ({ size, ...props }: IconProps) => (
   >
     <path
       d="M4 6L8 10L12 6"
-      strokeWidth={1.5}
+      strokeWidth={strokeWidth}
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/web/src/app/build/components/BuildWelcome.tsx
+++ b/web/src/app/build/components/BuildWelcome.tsx
@@ -6,6 +6,7 @@ import Text from "@/refresh-components/texts/Text";
 import Logo from "@/refresh-components/Logo";
 import InputBar, { InputBarHandle } from "@/app/build/components/InputBar";
 import SuggestedPrompts from "@/app/build/components/SuggestedPrompts";
+import ConnectDataBanner from "@/app/build/components/ConnectDataBanner";
 
 interface BuildWelcomeProps {
   onSubmit: (
@@ -42,7 +43,7 @@ export default function BuildWelcome({
       <div className="flex flex-col items-center gap-4 mb-6">
         <Logo folded size={48} />
         <Text headingH2 text05>
-          What would you like to build?
+          What are we crafting today?
         </Text>
       </div>
       <div className="w-full max-w-2xl">
@@ -54,6 +55,7 @@ export default function BuildWelcome({
           sandboxInitializing={sandboxInitializing}
           preProvisionedSessionId={preProvisionedSessionId}
         />
+        <ConnectDataBanner />
         <SuggestedPrompts onPromptClick={handlePromptClick} />
       </div>
     </div>

--- a/web/src/app/build/components/ConnectDataBanner.tsx
+++ b/web/src/app/build/components/ConnectDataBanner.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import Text from "@/refresh-components/texts/Text";
+import {
+  ConfluenceIcon,
+  GoogleDriveIcon,
+  GithubIcon,
+  NotionIcon,
+  ColorSlackIcon,
+  HubSpotIcon,
+} from "@/components/icons/icons";
+import { SvgChevronRight } from "@opal/icons";
+import { useBuildConnectors } from "@/app/build/hooks/useBuildConnectors";
+
+interface ConnectDataBannerProps {
+  className?: string;
+}
+
+function IconWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-6 h-6 rounded-full bg-background-neutral-00 border border-border-01 flex items-center justify-center overflow-hidden">
+      {children}
+    </div>
+  );
+}
+
+export default function ConnectDataBanner({
+  className,
+}: ConnectDataBannerProps) {
+  const router = useRouter();
+  const { hasAnyConnector } = useBuildConnectors();
+
+  const handleClick = () => {
+    router.push("/build/v1/configure");
+  };
+
+  // Hide banner if user has any connectors configured
+  if (hasAnyConnector) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={handleClick}
+        className={cn(
+          // Layout
+          "flex items-center justify-between gap-2",
+          "mx-auto px-4 py-2",
+          // Sizing - thin and full width to match InputBar
+          "h-9 w-[50%]",
+          // Appearance - slightly different color, rounded bottom
+          "bg-background-neutral-01 hover:bg-background-neutral-02",
+          "rounded-b-12 rounded-t-none",
+          // Border for definition
+          "border border-t-0 border-border-01",
+          // Transition
+          "transition-colors duration-200",
+          // Cursor
+          "cursor-pointer",
+          // Group for hover effects
+          "group",
+          className
+        )}
+      >
+        {/* Left side: 3 icons */}
+        <div className="flex items-center -space-x-2">
+          {/* Outermost - no movement */}
+          <div>
+            <IconWrapper>
+              <ColorSlackIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Middle - slight movement */}
+          <div className="transition-transform duration-200 group-hover:translate-x-2">
+            <IconWrapper>
+              <GoogleDriveIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Innermost - moves towards center */}
+          <div className="transition-transform duration-200 group-hover:translate-x-4">
+            <IconWrapper>
+              <ConfluenceIcon size={16} />
+            </IconWrapper>
+          </div>
+        </div>
+
+        {/* Center: Text and Arrow */}
+        <div className="flex items-center justify-center gap-1">
+          <Text secondaryBody text03>
+            Connect your data
+          </Text>
+          <SvgChevronRight className="h-4 w-4 text-text-03" />
+        </div>
+
+        {/* Right side: 3 icons */}
+        <div className="flex items-center -space-x-2">
+          {/* Innermost - moves towards center */}
+          <div className="transition-transform duration-200 group-hover:-translate-x-4">
+            <IconWrapper>
+              <GithubIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Middle - slight movement */}
+          <div className="transition-transform duration-200 group-hover:-translate-x-2">
+            <IconWrapper>
+              <NotionIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Outermost - no movement */}
+          <div>
+            <IconWrapper>
+              <HubSpotIcon size={16} />
+            </IconWrapper>
+          </div>
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/build/components/ConnectorBannersRow.tsx
+++ b/web/src/app/build/components/ConnectorBannersRow.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import Text from "@/refresh-components/texts/Text";
+import {
+  ConfluenceIcon,
+  GoogleDriveIcon,
+  GithubIcon,
+  NotionIcon,
+  ColorSlackIcon,
+  HubSpotIcon,
+} from "@/components/icons/icons";
+import { SvgChevronRight, SvgCalendar } from "@opal/icons";
+import { useBuildConnectors } from "@/app/build/hooks/useBuildConnectors";
+import { ONYX_CRAFT_CALENDAR_URL } from "@/app/build/v1/constants";
+
+interface ConnectorBannersRowProps {
+  className?: string;
+}
+
+function IconWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-6 h-6 rounded-full bg-background-neutral-00 border border-border-01 flex items-center justify-center overflow-hidden">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Row of two banners that appear above the InputBar after first assistant response.
+ * - Left: "Connect your data" - exact same look as welcome page banner, but flipped
+ * - Right: "Get help setting up connectors" - links to cal.com booking
+ *
+ * Only shows if user has no connectors configured.
+ * Slides up from the input bar with animation.
+ */
+export default function ConnectorBannersRow({
+  className,
+}: ConnectorBannersRowProps) {
+  const { hasAnyConnector } = useBuildConnectors();
+
+  // Hide if user has any connectors configured
+  if (hasAnyConnector) {
+    return null;
+  }
+
+  const handleConnectClick = () => {
+    window.location.href = "/build/v1/configure";
+  };
+
+  const handleHelpClick = () => {
+    window.open(ONYX_CRAFT_CALENDAR_URL, "_blank");
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex justify-center animate-in slide-in-from-bottom-2 fade-in duration-300",
+        className
+      )}
+    >
+      {/* Left banner: Connect your data - exact same as welcome page but flipped */}
+      <button
+        onClick={handleConnectClick}
+        className={cn(
+          // Layout
+          "flex items-center justify-between gap-2",
+          "px-4 py-2",
+          // Sizing - thin and slightly narrower than 50% width
+          "h-9 w-[calc(48%-4px)]",
+          // Appearance - rounded top left only
+          "bg-background-neutral-01 hover:bg-background-neutral-02",
+          "rounded-tl-12 rounded-tr-none rounded-bl-none rounded-br-none",
+          // Border - flipped: no bottom border instead of no top
+          "border border-b-0 border-border-01",
+          // Transition
+          "transition-colors duration-200",
+          // Cursor
+          "cursor-pointer",
+          // Group for hover effects
+          "group"
+        )}
+      >
+        {/* Left side: 3 icons */}
+        <div className="flex items-center -space-x-2">
+          {/* Outermost - no movement */}
+          <div>
+            <IconWrapper>
+              <ColorSlackIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Middle - slight movement */}
+          <div className="transition-transform duration-200 group-hover:translate-x-2">
+            <IconWrapper>
+              <GoogleDriveIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Innermost - moves towards center */}
+          <div className="transition-transform duration-200 group-hover:translate-x-4">
+            <IconWrapper>
+              <ConfluenceIcon size={16} />
+            </IconWrapper>
+          </div>
+        </div>
+
+        {/* Center: Text and Arrow */}
+        <div className="flex items-center justify-center gap-1">
+          <Text secondaryBody text03>
+            Connect your data
+          </Text>
+          <SvgChevronRight className="h-4 w-4 text-text-03" />
+        </div>
+
+        {/* Right side: 3 icons */}
+        <div className="flex items-center -space-x-2">
+          {/* Innermost - moves towards center */}
+          <div className="transition-transform duration-200 group-hover:-translate-x-4">
+            <IconWrapper>
+              <GithubIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Middle - slight movement */}
+          <div className="transition-transform duration-200 group-hover:-translate-x-2">
+            <IconWrapper>
+              <NotionIcon size={16} />
+            </IconWrapper>
+          </div>
+          {/* Outermost - no movement */}
+          <div>
+            <IconWrapper>
+              <HubSpotIcon size={16} />
+            </IconWrapper>
+          </div>
+        </div>
+      </button>
+
+      {/* Right banner: Get help setting up connectors */}
+      <button
+        onClick={handleHelpClick}
+        className={cn(
+          // Layout
+          "flex items-center justify-center gap-2",
+          "px-4 py-2",
+          // Sizing - same as left banner
+          "h-9 w-[calc(49%)]",
+          // Appearance - rounded top right only
+          "bg-background-neutral-01 hover:bg-background-neutral-02",
+          "rounded-tr-12 rounded-tl-none rounded-bl-none rounded-br-none",
+          // Border - flipped: no bottom border
+          "border border-b-0 border-border-01",
+          // Transition
+          "transition-colors duration-200",
+          // Cursor
+          "cursor-pointer"
+        )}
+      >
+        {/* Calendar icon */}
+        <SvgCalendar className="h-4 w-4 text-text-03" />
+
+        {/* Text */}
+        <Text secondaryBody text03>
+          Get help setting up connectors
+        </Text>
+
+        {/* Arrow indicator */}
+        <SvgChevronRight className="h-4 w-4 text-text-03" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/build/components/InputBar.tsx
+++ b/web/src/app/build/components/InputBar.tsx
@@ -46,6 +46,8 @@ export interface InputBarProps {
   preProvisionedSessionId?: string | null;
   /** When true, shows spinner on send button with "Initializing sandbox..." tooltip */
   sandboxInitializing?: boolean;
+  /** When true, removes bottom rounding to allow seamless connection with components below */
+  noBottomRounding?: boolean;
 }
 
 /**
@@ -120,6 +122,7 @@ const InputBar = React.memo(
         sessionId,
         preProvisionedSessionId,
         sandboxInitializing = false,
+        noBottomRounding = false,
       },
       ref
     ) => {
@@ -270,7 +273,8 @@ const InputBar = React.memo(
         <div
           ref={containerRef}
           className={cn(
-            "w-full flex flex-col shadow-01 bg-background-neutral-00 rounded-16",
+            "w-full flex flex-col shadow-01 bg-background-neutral-00",
+            noBottomRounding ? "rounded-t-16 rounded-b-none" : "rounded-16",
             disabled && "opacity-50 cursor-not-allowed pointer-events-none"
           )}
           aria-disabled={disabled}

--- a/web/src/app/build/components/SideBar.tsx
+++ b/web/src/app/build/components/SideBar.tsx
@@ -149,11 +149,21 @@ function BuildSessionButton({
                 onClose={() => setRenaming(false)}
               />
             ) : shouldAnimate ? (
-              <TypewriterText
-                text={historyItem.title}
-                charSpeed={25}
-                onAnimationComplete={() => setShouldAnimate(false)}
-              />
+              <Text
+                as="p"
+                data-state={isActive ? "active" : "inactive"}
+                className={cn(
+                  "sidebar-tab-text-defaulted line-clamp-1 break-all text-left"
+                )}
+                mainUiBody
+              >
+                <TypewriterText
+                  text={historyItem.title}
+                  charSpeed={25}
+                  animateOnMount={true}
+                  onAnimationComplete={() => setShouldAnimate(false)}
+                />
+              </Text>
             ) : (
               historyItem.title
             )}

--- a/web/src/app/build/components/SuggestedPrompts.tsx
+++ b/web/src/app/build/components/SuggestedPrompts.tsx
@@ -48,7 +48,7 @@ export default function SuggestedPrompts({
           </span>
           {/* Square image - cropped to half height for demonstration */}
           {prompt.image && (
-            <div className="w-full aspect-[2/1] rounded-08 overflow-hidden bg-background-neutral-01">
+            <div className="w-full aspect-[4/1] rounded-08 overflow-hidden bg-background-neutral-01">
               <img
                 src={prompt.image}
                 alt={prompt.summary}

--- a/web/src/app/build/components/SuggestionBubbles.tsx
+++ b/web/src/app/build/components/SuggestionBubbles.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { SuggestionBubble } from "@/app/build/hooks/useBuildSessionStore";
+
+interface SuggestionBubblesProps {
+  suggestions: SuggestionBubble[];
+  loading?: boolean;
+  onSelect: (text: string) => void;
+}
+
+/**
+ * Get theme-specific styles for suggestion bubbles
+ */
+function getThemeStyles(theme: string): string {
+  // Match user message styling - same gray background
+  switch (theme) {
+    case "add":
+    case "question":
+    default:
+      // Same gray as user messages
+      return "bg-background-tint-02 hover:bg-background-tint-03";
+  }
+}
+
+/**
+ * Displays follow-up suggestion bubbles after the first assistant message.
+ * Styled like user chat messages - stacked vertically and right-aligned.
+ * Each bubble is clickable and populates the input bar with the suggestion text.
+ */
+export default function SuggestionBubbles({
+  suggestions,
+  loading,
+  onSelect,
+}: SuggestionBubblesProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-col items-end gap-2">
+        {/* Loading skeleton bubbles - right aligned */}
+        {[1, 2].map((i) => (
+          <div
+            key={i}
+            className="h-10 w-48 bg-background-neutral-01 rounded-16 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!suggestions || suggestions.length === 0) return null;
+
+  return (
+    <div className="flex flex-col items-end gap-3">
+      {suggestions.map((suggestion, idx) => (
+        <button
+          key={idx}
+          onClick={() => onSelect(suggestion.text)}
+          className={cn(
+            "px-4 py-3 rounded-t-16 rounded-bl-16 text-sm text-left",
+            "text-text-03 transition-colors cursor-pointer",
+            "max-w-[95%] shadow-01",
+            "animate-in fade-in duration-500",
+            getThemeStyles(suggestion.theme)
+          )}
+          style={{
+            animationDelay: `${idx * 100}ms`,
+            animationFillMode: "both",
+          }}
+        >
+          {suggestion.text}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/build/hooks/useBuildConnectors.ts
+++ b/web/src/app/build/hooks/useBuildConnectors.ts
@@ -1,0 +1,44 @@
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import {
+  BuildConnectorConfig,
+  ConnectorStatus,
+} from "@/app/build/v1/configure/components/ConnectorCard";
+
+interface BuildConnectorListResponse {
+  connectors: BuildConnectorConfig[];
+}
+
+/**
+ * Hook to fetch and manage build mode connectors.
+ *
+ * @returns Object containing:
+ * - `connectors`: Array of connector configurations
+ * - `hasActiveConnector`: True if at least one connector has status "connected"
+ * - `hasAnyConnector`: True if any connectors exist (regardless of status)
+ * - `isLoading`: True while fetching
+ * - `mutate`: Function to refetch connectors
+ */
+export function useBuildConnectors() {
+  const { data, isLoading, mutate } = useSWR<BuildConnectorListResponse>(
+    "/api/build/connectors",
+    errorHandlingFetcher,
+    { refreshInterval: 30000 } // 30 seconds - matches configure page
+  );
+
+  const connectors = data?.connectors ?? [];
+
+  // At least one connector with status "connected" (actively synced)
+  const hasActiveConnector = connectors.some((c) => c.status === "connected");
+
+  // Any connector exists (regardless of status)
+  const hasAnyConnector = connectors.length > 0;
+
+  return {
+    connectors,
+    hasActiveConnector,
+    hasAnyConnector,
+    isLoading,
+    mutate,
+  };
+}

--- a/web/src/app/build/hooks/useBuildSessionStore.ts
+++ b/web/src/app/build/hooks/useBuildSessionStore.ts
@@ -339,6 +339,12 @@ export interface TabNavigationHistory {
   currentIndex: number;
 }
 
+/** Follow-up suggestion bubble */
+export interface SuggestionBubble {
+  theme: "add" | "question";
+  text: string;
+}
+
 /** Output panel tab types */
 export type OutputTabType = "preview" | "files" | "artifacts";
 
@@ -375,6 +381,10 @@ export interface BuildSessionData {
   filesTabState: FilesTabState;
   /** Browser-style tab navigation history for back/forward */
   tabHistory: TabNavigationHistory;
+  /** Follow-up suggestions after first assistant message */
+  followupSuggestions: SuggestionBubble[] | null;
+  /** Whether suggestions are currently being generated */
+  suggestionsLoading: boolean;
 }
 
 interface BuildSessionStore {
@@ -508,6 +518,14 @@ interface BuildSessionStore {
   // Tab Navigation History Actions
   navigateTabBack: (sessionId: string) => void;
   navigateTabForward: (sessionId: string) => void;
+
+  // Follow-up Suggestion Actions
+  setFollowupSuggestions: (
+    sessionId: string,
+    suggestions: SuggestionBubble[] | null
+  ) => void;
+  setSuggestionsLoading: (sessionId: string, loading: boolean) => void;
+  clearFollowupSuggestions: (sessionId: string) => void;
 }
 
 // =============================================================================
@@ -555,6 +573,8 @@ const createInitialSessionData = (
     entries: [{ type: "pinned", tab: "preview" }],
     currentIndex: 0,
   },
+  followupSuggestions: null,
+  suggestionsLoading: false,
   ...initialData,
 });
 
@@ -1871,6 +1891,63 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       return { sessions: newSessions };
     });
   },
+
+  // ===========================================================================
+  // Follow-up Suggestion Actions
+  // ===========================================================================
+
+  setFollowupSuggestions: (
+    sessionId: string,
+    suggestions: SuggestionBubble[] | null
+  ) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        followupSuggestions: suggestions,
+        suggestionsLoading: false,
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  setSuggestionsLoading: (sessionId: string, loading: boolean) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        suggestionsLoading: loading,
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  clearFollowupSuggestions: (sessionId: string) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        followupSuggestions: null,
+        suggestionsLoading: false,
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
 }));
 
 // =============================================================================
@@ -2040,4 +2117,19 @@ export const useTabHistory = () =>
     const { currentSessionId, sessions } = state;
     if (!currentSessionId) return EMPTY_TAB_HISTORY;
     return sessions.get(currentSessionId)?.tabHistory ?? EMPTY_TAB_HISTORY;
+  });
+
+// Follow-up suggestion selectors
+export const useFollowupSuggestions = () =>
+  useBuildSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    if (!currentSessionId) return null;
+    return sessions.get(currentSessionId)?.followupSuggestions ?? null;
+  });
+
+export const useSuggestionsLoading = () =>
+  useBuildSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    if (!currentSessionId) return false;
+    return sessions.get(currentSessionId)?.suggestionsLoading ?? false;
   });

--- a/web/src/app/build/services/apiServices.ts
+++ b/web/src/app/build/services/apiServices.ts
@@ -152,6 +152,36 @@ export async function generateSessionName(sessionId: string): Promise<string> {
   return data.name;
 }
 
+export interface SuggestionBubble {
+  theme: "add" | "question";
+  text: string;
+}
+
+export async function generateFollowupSuggestions(
+  sessionId: string,
+  userMessage: string,
+  assistantMessage: string
+): Promise<SuggestionBubble[]> {
+  const res = await fetch(
+    `${API_BASE}/sessions/${sessionId}/generate-suggestions`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_message: userMessage,
+        assistant_message: assistantMessage,
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to generate suggestions: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data.suggestions;
+}
+
 export async function updateSessionName(
   sessionId: string,
   name: string | null

--- a/web/src/app/build/v1/constants.ts
+++ b/web/src/app/build/v1/constants.ts
@@ -2,3 +2,4 @@ export const BUILD_MODE_OAUTH_COOKIE_NAME = "build_mode_oauth";
 export const BUILD_CONFIGURE_PATH = "/build/v1/configure";
 export const OAUTH_STATE_KEY = "build_oauth_state";
 export const BUILD_DEMO_DATA_COOKIE_NAME = "build_demo_data_enabled";
+export const ONYX_CRAFT_CALENDAR_URL = "https://cal.com/team/onyx/onyx-craft";


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds follow-up suggestion bubbles after the first assistant reply and connector setup banners, helping users take next steps and connect data faster in Build mode.

- New Features
  - Backend endpoint to generate two follow-up suggestions (“add”, “question”) using LLM prompts, with resilient output parsing.
  - Suggestions generate asynchronously after the first assistant message, show as right-aligned bubbles, fill the input on click, and clear on the next user message.
  - Connector banners above the input: “Connect your data” (to configure) and “Get help setting up connectors” (cal.com). Hidden when any connector exists. Adds the same slim banner to the welcome view.
  - New useBuildConnectors hook for connector status; reused on the configure page and in banners.
  - UI polish: InputBar supports noBottomRounding, soft gradient borders in chat, updated chevron icon stroke width, improved TypewriterText animate-on-mount, and small layout tweaks.

<sup>Written for commit 71cf0fc839c9f8fa08cc3c8de51d2aa28c3ab64e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

