### PR TITLE
Zero out nextjs ports on snapshot

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -478,6 +478,31 @@ def allocate_nextjs_port(db_session: Session) -> int:
     )
 
 
+def clear_nextjs_ports_for_user(db_session: Session, user_id: UUID) -> int:
+    """Clear nextjs_port for all sessions belonging to a user.
+
+    Called when sandbox goes to sleep to release port allocations.
+
+    Args:
+        db_session: Database session
+        user_id: The user whose sessions should have ports cleared
+
+    Returns:
+        Number of sessions updated
+    """
+    result = (
+        db_session.query(BuildSession)
+        .filter(
+            BuildSession.user_id == user_id,
+            BuildSession.nextjs_port.isnot(None),
+        )
+        .update({BuildSession.nextjs_port: None})
+    )
+    db_session.flush()
+    logger.info(f"Cleared {result} nextjs_port allocations for user {user_id}")
+    return result
+
+
 def fetch_llm_provider_by_type_for_build_mode(
     db_session: Session, provider_type: str
 ) -> LLMProviderView | None:

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -228,11 +228,12 @@ class SandboxManager(ABC):
         session_id: UUID,
         snapshot_storage_path: str,
         tenant_id: str,
+        nextjs_port: int,
     ) -> None:
         """Restore a snapshot into a session's workspace directory.
 
-        Downloads the snapshot from storage and extracts it into
-        sessions/$session_id/outputs/.
+        Downloads the snapshot from storage, extracts it into
+        sessions/$session_id/outputs/, and starts the NextJS server.
 
         For Kubernetes backend, this downloads from S3 and streams
         into the pod via kubectl exec (since the pod has no S3 access).
@@ -242,6 +243,7 @@ class SandboxManager(ABC):
             session_id: The session ID to restore
             snapshot_storage_path: Path to the snapshot in storage
             tenant_id: Tenant identifier for storage access
+            nextjs_port: Port number for the NextJS dev server
 
         Raises:
             RuntimeError: If snapshot restoration fails


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restoring a session from snapshot now assigns a fresh Next.js port and starts the dev server for both Kubernetes and local sandboxes. Idle sandbox cleanup clears port allocations so ports are reusable and no stale collisions occur.

- **New Features**
  - Allocate a new nextjs_port on restore and start Next.js after snapshot extraction (K8s checks node_modules, logs PID).
  - Unified Next.js start script generation; workspace setup now uses it.

- **Bug Fixes**
  - Clear nextjs_port for all user sessions when a sandbox goes to SLEEPING.
  - Local backend: restrict read_file to outputs/, update directory listing (size_bytes, modified_at), remove unused dev-mode and webapp URL.

<sup>Written for commit b44237b497e1f5f52a72d4f77ee54150ef41f8e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

