### PR TITLE
add feature flag for craft

### DIFF
--- a/backend/onyx/feature_flags/feature_flags_keys.py
+++ b/backend/onyx/feature_flags/feature_flags_keys.py
@@ -2,3 +2,7 @@
 Feature flag keys used throughout the application.
 Centralizes feature flag key definitions to avoid magic strings.
 """
+
+# Build Mode feature flag - controls access to /build routes and features
+# When disabled via PostHog, all build routes return 404
+BUILD_MODE_ENABLED = "build-mode-enabled"

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -63,6 +63,7 @@ from onyx.server.documents.connector import router as connector_router
 from onyx.server.documents.credential import router as credential_router
 from onyx.server.documents.document import router as document_router
 from onyx.server.documents.standard_oauth import router as standard_oauth_router
+from onyx.server.features.build.api.api import build_status_router
 from onyx.server.features.build.api.api import nextjs_assets_router
 from onyx.server.features.build.api.api import router as build_router
 from onyx.server.features.default_assistant.api import (
@@ -379,6 +380,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, cc_pair_router)
     include_router_with_global_prefix_prepended(application, projects_router)
     include_router_with_global_prefix_prepended(application, build_router)
+    include_router_with_global_prefix_prepended(application, build_status_router)
     include_router_with_global_prefix_prepended(application, nextjs_assets_router)
     include_router_with_global_prefix_prepended(application, document_set_router)
     include_router_with_global_prefix_prepended(application, search_settings_router)

--- a/web/src/app/build/layout.tsx
+++ b/web/src/app/build/layout.tsx
@@ -1,14 +1,34 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import type { Route } from "next";
 import { unstable_noStore as noStore } from "next/cache";
 import { requireAuth } from "@/lib/auth/requireAuth";
+import { fetchSS } from "@/lib/utilsSS";
 
 export interface LayoutProps {
   children: React.ReactNode;
 }
 
 /**
- * Build Layout - Minimal wrapper that handles authentication
+ * Check if Build Mode is enabled via PostHog feature flag.
+ * Returns true if enabled, false otherwise.
+ */
+async function isBuildModeEnabled(): Promise<boolean> {
+  try {
+    const response = await fetchSS("/api/build-status/enabled");
+    if (!response.ok) {
+      // If the endpoint fails, default to disabled for safety
+      return false;
+    }
+    const data = await response.json();
+    return data.enabled === true;
+  } catch {
+    // If the fetch fails, default to disabled for safety
+    return false;
+  }
+}
+
+/**
+ * Build Layout - Minimal wrapper that handles authentication and feature flag check
  *
  * Child routes (/build and /build/v1) handle their own UI structure.
  */
@@ -20,6 +40,12 @@ export default async function Layout({ children }: LayoutProps) {
 
   if (authResult.redirect) {
     redirect(authResult.redirect as Route);
+  }
+
+  // Check if Build Mode is enabled via PostHog feature flag
+  const buildModeEnabled = await isBuildModeEnabled();
+  if (!buildModeEnabled) {
+    notFound();
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Build Mode behind a PostHog feature flag and add a status endpoint the frontend uses to hide routes when disabled. Users without the flag now get 404s for /build and related endpoints.

- **New Features**
  - Added BUILD_MODE_ENABLED flag and is_build_mode_enabled helper.
  - Applied a router-wide dependency to all /build routes; disabled flag returns 404.
  - Introduced GET /api/build-status/enabled for frontend checks; web build layout calls notFound when disabled.
  - Local dev (NoOp provider) defaults to enabled.

- **Migration**
  - Create and enable the build-mode-enabled flag in PostHog for users who should access Build Mode.

<sup>Written for commit 1c992229dc0f565b10d962b780ac6ed0f4e9ba41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

