### PR TITLE
chore(vscode): add non-clean seeded db restore

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -606,6 +606,27 @@
       }
     },
     {
+      "name": "Restore seeded database dump",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": [
+        "run",
+        "--with",
+        "onyx-devtools",
+        "ods",
+        "db",
+        "restore",
+        "--fetch-seeded",
+        "--yes"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "presentation": {
+        "group": "4"
+      }
+    },
+    {
       "name": "Clean restore seeded database dump (destructive)",
       "type": "node",
       "request": "launch",


### PR DESCRIPTION
## Description

## How Has This Been Tested?

## Additional Options

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VS Code launch option to restore a seeded database dump without cleaning, making local setup faster and non-destructive.

- **New Features**
  - Added “Restore seeded database dump” launch config that runs `uv` with `onyx-devtools ods db restore --fetch-seeded --yes`, preserving existing data and complementing the destructive “Clean restore” option.

<sup>Written for commit 6365ef0bcf411061131dc6e2eac00d17ef68619d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

