### PR TITLE
fix: conditional api key settiing based on web search provider

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -57,7 +57,7 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
             if provider_model is None:
                 raise RuntimeError("No web search provider configured.")
             provider_type = WebSearchProviderType(provider_model.provider_type)
-            api_key = provider_model.api_key
+            api_key = "" if provider_type == WebSearchProviderType.SEARXNG else provider_model.api_key
             config = provider_model.config
 
         # TODO - This should just be enforced at the DB level


### PR DESCRIPTION
closes #7117

## Description

Fixes issue where model crashes when searxng is set as web search tool. This is because the code checks for an api key, if there is none, it throws an error. Since searxng doesn't require an API key, it crashes when it tries to look for it since it's not set. This PR adds a check if the search provider is searxng, if it is then it will leave the api key as an empty string instead of `None` to avoid the error from being thrown. 

## How Has This Been Tested?

Tested locally myself, original fix was by redhell in https://github.com/onyx-dot-app/onyx/issues/7117#issuecomment-3719707503 . 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash in the web search tool when SearXNG is selected by treating its API key as an empty string instead of None. SearXNG doesn’t need an API key, so this prevents the “API key unavailable” error.

- **Bug Fixes**
  - Conditionally set api_key to '' when provider is SearXNG to allow searches to run without errors.

<sup>Written for commit 05fff0b44476939259f0dbae509885786fdda488. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

