### PR TITLE
simple mypy fix

### DIFF
--- a/backend/onyx/server/features/build/indexing/persistent_document_writer.py
+++ b/backend/onyx/server/features/build/indexing/persistent_document_writer.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+from mypy_boto3_s3.client import S3Client
 
 from onyx.connectors.models import Document
 from onyx.server.features.build.configs import PERSISTENT_DOCUMENT_STORAGE_PATH
@@ -281,9 +282,9 @@ class S3PersistentDocumentWriter:
         self.tenant_id = tenant_id
         self.user_id = user_id
         self.bucket = SANDBOX_S3_BUCKET
-        self._s3_client = None
+        self._s3_client: S3Client | None = None
 
-    def _get_s3_client(self):
+    def _get_s3_client(self) -> S3Client:
         """Lazily initialize S3 client.
 
         Uses the default boto3 credential chain which supports:
@@ -349,7 +350,7 @@ class S3PersistentDocumentWriter:
 
         return "/".join(parts)
 
-    def _write_document(self, s3_client, doc: Document, s3_key: str) -> None:
+    def _write_document(self, s3_client: S3Client, doc: Document, s3_key: str) -> None:
         """Serialize and write document to S3."""
         content = serialize_document(doc)
         json_content = json.dumps(content, indent=2, default=str)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mypy errors in PersistentDocumentWriter by adding explicit S3Client typing from mypy_boto3_s3. Improves type safety and IDE hints with no runtime changes.

- **Refactors**
  - Import S3Client from mypy_boto3_s3 and annotate _s3_client, _get_s3_client, and _write_document.
  - No functional changes; only type annotations.

<sup>Written for commit 530371e9cb7ef0bbf3155b4c8c8a7f6e690239cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

