### PR TITLE
Wait for resource deletion

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -330,7 +330,12 @@ class KubernetesSandboxManager(SandboxManager):
         file_sync_container = client.V1Container(
             name="file-sync",
             image="amazon/aws-cli:latest",
-            env=_get_local_aws_credential_env_vars(),
+            env=_get_local_aws_credential_env_vars()
+            + [
+                # Set HOME to a writable directory so AWS CLI can create .aws config dir
+                # Without this, AWS CLI tries to access /.aws which fails with permission denied
+                client.V1EnvVar(name="HOME", value="/tmp"),
+            ],
             command=["/bin/sh", "-c"],
             args=[
                 f"""


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for Kubernetes pods and services to be fully deleted before re-provisioning to prevent 409 conflicts caused by resources stuck in a Terminating state.

- **Bug Fixes**
  - Added a polling-based deletion wait with a 30s timeout and 0.5s interval.
  - Implemented a helper to confirm deletion by checking for 404 on pods/services.
  - Updated cleanup to optionally wait (default true) and handle 404s; set HOME=/tmp for AWS CLI file-sync to avoid .aws permission errors.

<sup>Written for commit 4ec7cabc6e6f63b8a0f0747228790bc38c339f21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

