### PR TITLE
allow connected but now error state

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -242,6 +242,7 @@ class BuildConnectorStatus(str, Enum):
 
     NOT_CONNECTED = "not_connected"
     CONNECTED = "connected"
+    CONNECTED_WITH_ERRORS = "connected_with_errors"
     INDEXING = "indexing"
     ERROR = "error"
     DELETING = "deleting"

--- a/web/src/app/build/components/ConnectDataBanner.tsx
+++ b/web/src/app/build/components/ConnectDataBanner.tsx
@@ -30,14 +30,14 @@ export default function ConnectDataBanner({
   className,
 }: ConnectDataBannerProps) {
   const router = useRouter();
-  const { hasAnyConnector, isLoading } = useBuildConnectors();
+  const { hasConnectorEverSucceeded, isLoading } = useBuildConnectors();
 
   const handleClick = () => {
     router.push("/build/v1/configure");
   };
 
-  // Only show banner if user has no connectors configured (and not loading)
-  if (isLoading || hasAnyConnector) {
+  // Only show banner if user hasn't successfully synced any connectors (and not loading)
+  if (isLoading || hasConnectorEverSucceeded) {
     return null;
   }
 

--- a/web/src/app/build/components/ConnectorBannersRow.tsx
+++ b/web/src/app/build/components/ConnectorBannersRow.tsx
@@ -37,10 +37,10 @@ function IconWrapper({ children }: { children: React.ReactNode }) {
 export default function ConnectorBannersRow({
   className,
 }: ConnectorBannersRowProps) {
-  const { hasAnyConnector } = useBuildConnectors();
+  const { hasConnectorEverSucceeded } = useBuildConnectors();
 
-  // Hide if user has any connectors configured
-  if (hasAnyConnector) {
+  // Hide if user has successfully synced at least one connector
+  if (hasConnectorEverSucceeded) {
     return null;
   }
 

--- a/web/src/app/build/constants/exampleBuildPrompts.ts
+++ b/web/src/app/build/constants/exampleBuildPrompts.ts
@@ -155,7 +155,7 @@ export const exampleBuildPrompts: Record<UserPersona, BuildPrompt[]> = {
         "Visualize what my team did this month with interactive drill-downs",
       fullText:
         "What did my team work on this month? Create a dashboard that 1) shows the number of actions per activity, 2) shows the individual work items when I select something in the dashboard.",
-      image: "/craft_suggested_image_3.png",
+      image: "/craft_suggested_image_4.png",
     },
     {
       id: "product-4",
@@ -163,7 +163,7 @@ export const exampleBuildPrompts: Record<UserPersona, BuildPrompt[]> = {
         "Find churned customers who would have benefited from the releases this month",
       fullText:
         "Look at the PRs that my team merged this month. Then look at the customers we lost over the last 2 months and tell me which of the customers would have likely benefitted from the merged PRs. Rank the customers by importance. Present in a dashboard.",
-      image: "/craft_suggested_image_4.png",
+      image: "/craft_suggested_image_3.png",
     },
     {
       id: "product-5",

--- a/web/src/app/build/hooks/useBuildConnectors.ts
+++ b/web/src/app/build/hooks/useBuildConnectors.ts
@@ -14,8 +14,10 @@ interface BuildConnectorListResponse {
  *
  * @returns Object containing:
  * - `connectors`: Array of connector configurations
- * - `hasActiveConnector`: True if at least one connector has status "connected"
- * - `hasAnyConnector`: True if any connectors exist (regardless of status)
+ * - `hasActiveConnector`: True if at least one connector has status "connected" (currently synced)
+ * - `hasConnectorEverSucceeded`: True if any connector has ever succeeded (has last_indexed timestamp).
+ *   Use this to determine if demo data can be disabled or if banners should be hidden.
+ * - `hasAnyConnector`: True if any connectors exist (regardless of status). Useful for general checks.
  * - `isLoading`: True while fetching
  * - `mutate`: Function to refetch connectors
  */
@@ -31,12 +33,19 @@ export function useBuildConnectors() {
   // At least one connector with status "connected" (actively synced)
   const hasActiveConnector = connectors.some((c) => c.status === "connected");
 
+  // Check if any connector has ever succeeded (has last_indexed timestamp)
+  // This allows demo data to be turned off even if connectors currently have errors
+  const hasConnectorEverSucceeded = connectors.some(
+    (c) => c.last_indexed !== null
+  );
+
   // Any connector exists (regardless of status)
   const hasAnyConnector = connectors.length > 0;
 
   return {
     connectors,
     hasActiveConnector,
+    hasConnectorEverSucceeded,
     hasAnyConnector,
     isLoading,
     mutate,

--- a/web/src/app/build/v1/configure/components/ConnectorCard.tsx
+++ b/web/src/app/build/v1/configure/components/ConnectorCard.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 export type ConnectorStatus =
   | "not_connected"
   | "connected"
+  | "connected_with_errors"
   | "indexing"
   | "error"
   | "deleting";
@@ -41,6 +42,7 @@ interface ConnectorCardProps {
 
 const STATUS_COLORS: Record<ConnectorStatus, string> = {
   connected: "bg-status-success-05",
+  connected_with_errors: "bg-status-warning-05",
   indexing: "bg-status-warning-05 animate-pulse",
   error: "bg-status-error-05",
   deleting: "bg-status-error-05 animate-pulse",
@@ -53,6 +55,10 @@ function getStatusText(status: ConnectorStatus, docsIndexed: number): string {
       return docsIndexed > 0
         ? `${docsIndexed.toLocaleString()} docs`
         : "Connected";
+    case "connected_with_errors":
+      return docsIndexed > 0
+        ? `${docsIndexed.toLocaleString()} docs`
+        : "Connected, has errors";
     case "indexing":
       return "Syncing...";
     case "error":
@@ -98,7 +104,8 @@ export default function ConnectorCard({
   const router = useRouter();
   const sourceMetadata = getSourceMetadata(connectorType);
   const status: ConnectorStatus = config?.status || "not_connected";
-  const isConnected = status !== "not_connected";
+  const isConnected =
+    status !== "not_connected" && status !== "error" && status !== "deleting";
 
   const isDeleting = status === "deleting";
 

--- a/web/src/app/build/v1/configure/page.tsx
+++ b/web/src/app/build/v1/configure/page.tsx
@@ -257,7 +257,7 @@ export default function BuildConfigPage() {
 
   const hasLlmProvider = (llmProviders?.length ?? 0) > 0;
 
-  const { connectors, hasActiveConnector, isLoading, mutate } =
+  const { connectors, hasConnectorEverSucceeded, isLoading, mutate } =
     useBuildConnectors();
 
   // Check for OAuth return state on mount
@@ -286,15 +286,15 @@ export default function BuildConfigPage() {
     config: connectors.find((c) => c.source === type) || null,
   }));
 
-  // Auto-enable demo data when all connectors are disconnected
+  // Auto-enable demo data when no connectors have ever succeeded
   useEffect(() => {
-    if (!hasActiveConnector && !demoDataEnabled) {
+    if (!hasConnectorEverSucceeded && !demoDataEnabled) {
       setDemoDataEnabled(true);
       // Also sync pending state so UI stays consistent
       setPendingDemoData(true);
       setOriginalDemoData(true);
     }
-  }, [hasActiveConnector, demoDataEnabled, setDemoDataEnabled]);
+  }, [hasConnectorEverSucceeded, demoDataEnabled, setDemoDataEnabled]);
 
   const handleDeleteConfirm = async () => {
     if (!connectorToDelete) return;
@@ -440,25 +440,31 @@ export default function BuildConfigPage() {
                     tooltip={
                       isUpdating || isPreProvisioning
                         ? "Please wait while your session is being provisioned"
-                        : !hasActiveConnector
+                        : !hasConnectorEverSucceeded
                           ? "Connect and sync a data source to disable demo data"
                           : undefined
                     }
                     disabled={
-                      hasActiveConnector && !isUpdating && !isPreProvisioning
+                      hasConnectorEverSucceeded &&
+                      !isUpdating &&
+                      !isPreProvisioning
                     }
                   >
                     <Card
                       padding={0.75}
                       className={
-                        !hasActiveConnector || isUpdating || isPreProvisioning
+                        !hasConnectorEverSucceeded ||
+                        isUpdating ||
+                        isPreProvisioning
                           ? "opacity-50"
                           : ""
                       }
                     >
                       <div
                         className={`flex items-center gap-3 ${
-                          !hasActiveConnector || isUpdating || isPreProvisioning
+                          !hasConnectorEverSucceeded ||
+                          isUpdating ||
+                          isPreProvisioning
                             ? "pointer-events-none"
                             : ""
                         }`}
@@ -476,7 +482,7 @@ export default function BuildConfigPage() {
                           disabled={
                             isUpdating ||
                             isPreProvisioning ||
-                            !hasActiveConnector
+                            !hasConnectorEverSucceeded
                           }
                           onCheckedChange={(newValue) => {
                             setPendingDemoDataEnabled(newValue);


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new “connected_with_errors” state for connectors that previously synced but now have issues. This keeps the connector usable (e.g., disable demo data) while clearly showing the error.

- **New Features**
  - Backend: Added BuildConnectorStatus.connected_with_errors. If a connector has a past successful sync, map INVALID credentials or FAILED/COMPLETED_WITH_ERRORS attempts to connected_with_errors and return the error message.
  - Frontend: useBuildConnectors now exposes hasConnectorEverSucceeded. Banners hide after any successful sync, demo data auto-enables only when no connector has ever succeeded, and the toggle is enabled only after a successful sync.
  - UI: ConnectorCard displays a warning style and “Connected, has errors” label for connected_with_errors, and treats error/deleting as not connected.
  - Misc: Updated two example prompt image paths.

<sup>Written for commit 469955989e51b31963415b5d7fe22bb4ae6fb76e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

