### PR TITLE
better restore

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -16,6 +16,7 @@ from onyx.db.enums import SandboxStatus
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.models import ArtifactResponse
+from onyx.server.features.build.api.models import DetailedSessionResponse
 from onyx.server.features.build.api.models import DirectoryListing
 from onyx.server.features.build.api.models import GenerateSuggestionsRequest
 from onyx.server.features.build.api.models import GenerateSuggestionsResponse
@@ -69,12 +70,12 @@ def list_sessions(
     )
 
 
-@router.post("", response_model=SessionResponse)
+@router.post("", response_model=DetailedSessionResponse)
 def create_session(
     request: SessionCreateRequest,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
-) -> SessionResponse:
+) -> DetailedSessionResponse:
     """
     Create or get an existing empty build session.
 
@@ -115,19 +116,24 @@ def create_session(
 
     # Get the user's sandbox to include in response
     sandbox = get_sandbox_by_user_id(db_session, user.id)
-    return SessionResponse.from_model(build_session, sandbox)
+    base_response = SessionResponse.from_model(build_session, sandbox)
+    # Session was just created, so it's loaded in the sandbox
+    return DetailedSessionResponse.from_session_response(
+        base_response, session_loaded_in_sandbox=True
+    )
 
 
-@router.get("/{session_id}", response_model=SessionResponse)
+@router.get("/{session_id}", response_model=DetailedSessionResponse)
 def get_session_details(
     session_id: UUID,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
-) -> SessionResponse:
+) -> DetailedSessionResponse:
     """
     Get details of a specific build session.
 
-    If the sandbox is terminated, this will restore it synchronously.
+    Returns session_loaded_in_sandbox to indicate if the session workspace
+    exists in the running sandbox.
     """
     session_manager = SessionManager(db_session)
 
@@ -138,7 +144,19 @@ def get_session_details(
 
     # Get the user's sandbox to include in response
     sandbox = get_sandbox_by_user_id(db_session, user.id)
-    return SessionResponse.from_model(session, sandbox)
+
+    # Check if session workspace exists in the sandbox
+    session_loaded = False
+    if sandbox and sandbox.status == SandboxStatus.RUNNING:
+        sandbox_manager = get_sandbox_manager()
+        session_loaded = sandbox_manager.session_workspace_exists(
+            sandbox.id, session_id
+        )
+
+    base_response = SessionResponse.from_model(session, sandbox)
+    return DetailedSessionResponse.from_session_response(
+        base_response, session_loaded_in_sandbox=session_loaded
+    )
 
 
 @router.post("/{session_id}/generate-name", response_model=SessionNameGenerateResponse)
@@ -250,12 +268,12 @@ def delete_session(
 RESTORE_LOCK_TIMEOUT_SECONDS = 300
 
 
-@router.post("/{session_id}/restore", response_model=SessionResponse)
+@router.post("/{session_id}/restore", response_model=DetailedSessionResponse)
 def restore_session(
     session_id: UUID,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
-) -> SessionResponse:
+) -> DetailedSessionResponse:
     """Restore sandbox and load session snapshot. Blocks until complete.
 
     Uses Redis lock to ensure only one restore runs per sandbox at a time.
@@ -266,6 +284,7 @@ def restore_session(
     2. Sandbox is RUNNING but session not loaded: Just load session snapshot
 
     Returns immediately if session workspace already exists in pod.
+    Always returns session_loaded_in_sandbox=True on success.
     """
     session = get_build_session(session_id, user.id, db_session)
     if not session:
@@ -311,7 +330,10 @@ def restore_session(
                 logger.info(
                     f"Session {session_id} workspace was restored by another request"
                 )
-                return SessionResponse.from_model(session, sandbox)
+                base_response = SessionResponse.from_model(session, sandbox)
+                return DetailedSessionResponse.from_session_response(
+                    base_response, session_loaded_in_sandbox=True
+                )
 
             if not is_healthy:
                 logger.warning(
@@ -403,7 +425,10 @@ def restore_session(
         if lock.owned():
             lock.release()
 
-    return SessionResponse.from_model(session, sandbox)
+    base_response = SessionResponse.from_model(session, sandbox)
+    return DetailedSessionResponse.from_session_response(
+        base_response, session_loaded_in_sandbox=True
+    )
 
 
 # =============================================================================

--- a/web/src/app/build/services/apiServices.ts
+++ b/web/src/app/build/services/apiServices.ts
@@ -1,5 +1,6 @@
 import {
   ApiSessionResponse,
+  ApiDetailedSessionResponse,
   ApiMessageResponse,
   ApiArtifactResponse,
   ApiUsageLimitsResponse,
@@ -90,7 +91,7 @@ export interface CreateSessionOptions {
 
 export async function createSession(
   options?: CreateSessionOptions
-): Promise<ApiSessionResponse> {
+): Promise<ApiDetailedSessionResponse> {
   const res = await fetch(`${API_BASE}/sessions`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -113,7 +114,7 @@ export async function createSession(
 
 export async function fetchSession(
   sessionId: string
-): Promise<ApiSessionResponse> {
+): Promise<ApiDetailedSessionResponse> {
   const res = await fetch(`${API_BASE}/sessions/${sessionId}`);
 
   if (!res.ok) {
@@ -219,7 +220,7 @@ export async function deleteSession(sessionId: string): Promise<void> {
  */
 export async function restoreSession(
   sessionId: string
-): Promise<ApiSessionResponse> {
+): Promise<ApiDetailedSessionResponse> {
   const res = await fetch(`${API_BASE}/sessions/${sessionId}/restore`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/web/src/app/build/types/streamingTypes.ts
+++ b/web/src/app/build/types/streamingTypes.ts
@@ -155,6 +155,10 @@ export interface ApiSessionResponse {
   artifacts: ApiArtifactResponse[];
 }
 
+export interface ApiDetailedSessionResponse extends ApiSessionResponse {
+  session_loaded_in_sandbox: boolean;
+}
+
 export interface ApiMessageResponse {
   id: string;
   session_id: string;


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smarter session restore by adding session_loaded_in_sandbox to session APIs and updating the UI to restore only when needed. This reduces redundant restores and fixes cases where a running sandbox didn’t have the session workspace.

- **New Features**
  - Added DetailedSessionResponse with session_loaded_in_sandbox.
  - create_session, get_session_details, and restore_session now return DetailedSessionResponse; create/restore always return session_loaded_in_sandbox=true, get computes it based on sandbox state.
  - Frontend types and services updated to consume the new response.
  - UI now restores when sandbox is sleeping, terminated, or running without the session workspace.

- **Migration**
  - API responses now include session_loaded_in_sandbox; use it to decide when to call restore.
  - No breaking changes in JSON shape; typed clients should update to ApiDetailedSessionResponse.

<sup>Written for commit 1cb1d059521b42224bed484e413d013cf77c80eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

