### PR TITLE
fix(ui): User Groups Connectors Fix (#7658) to release v2.10

### DIFF
--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -41,7 +41,8 @@ export const ConnectorMultiSelect = ({
     (connector) => !selectedIds.includes(connector.cc_pair_id)
   );
 
-  const allConnectorsSelected = unselectedConnectors.length === 0;
+  const allConnectorsSelected =
+    connectors.length > 0 && unselectedConnectors.length === 0;
 
   const filteredUnselectedConnectors = unselectedConnectors.filter(
     (connector) => {
@@ -51,16 +52,7 @@ export const ConnectorMultiSelect = ({
   );
 
   useEffect(() => {
-    if (allConnectorsSelected && open) {
-      setOpen(false);
-      inputRef.current?.blur();
-      setSearchQuery("");
-    }
-  }, [allConnectorsSelected, open]);
-
-  useEffect(() => {
     if (allConnectorsSelected) {
-      inputRef.current?.blur();
       setSearchQuery("");
     }
   }, [allConnectorsSelected, selectedIds]);
@@ -111,7 +103,7 @@ export const ConnectorMultiSelect = ({
     ? "All connectors selected"
     : placeholder;
 
-  const isInputDisabled = disabled || allConnectorsSelected;
+  const isInputDisabled = disabled;
 
   return (
     <div className="flex flex-col w-full space-y-2 mb-4">
@@ -129,32 +121,39 @@ export const ConnectorMultiSelect = ({
           value={searchQuery}
           disabled={isInputDisabled}
           onChange={(e) => {
-            setSearchQuery(e.target.value);
-            setOpen(true);
-          }}
-          onFocus={() => {
             if (!allConnectorsSelected) {
+              setSearchQuery(e.target.value);
               setOpen(true);
             }
           }}
+          onFocus={() => {
+            setOpen(true);
+          }}
           onKeyDown={handleKeyDown}
-          className={
-            allConnectorsSelected
-              ? "rounded-12 bg-background-neutral-01"
-              : "rounded-12"
-          }
+          className="rounded-12"
         />
 
-        {open && !allConnectorsSelected && (
+        {open && (
           <div
             ref={dropdownRef}
             className="absolute z-50 w-full mt-1 rounded-12 border border-border-02 bg-background-neutral-00 shadow-md default-scrollbar max-h-[300px] overflow-auto"
           >
-            {filteredUnselectedConnectors.length === 0 ? (
-              <div className="py-4 text-center text-xs text-text-03">
-                {searchQuery
-                  ? "No matching connectors found"
-                  : "No more connectors available"}
+            {allConnectorsSelected ? (
+              <div className="py-4 px-3">
+                <Text as="p" text03 className="text-center text-xs">
+                  All available connectors have been selected. Remove connectors
+                  below to add different ones.
+                </Text>
+              </div>
+            ) : filteredUnselectedConnectors.length === 0 ? (
+              <div className="py-4 px-3">
+                <Text as="p" text03 className="text-center text-xs">
+                  {searchQuery
+                    ? "No matching connectors found"
+                    : connectors.length === 0
+                      ? "No private connectors available. Create a private connector first."
+                      : "No more connectors available"}
+                </Text>
               </div>
             ) : (
               <div>


### PR DESCRIPTION
Cherry-pick of commit 0ee58333b478768e48cca1b8c122ab1002d83ddc to release/v2.10 branch.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the User Groups connectors multi-select to handle “all selected” and “no connectors” states correctly. Improves messages and keeps the dropdown behavior consistent.

- **Bug Fixes**
  - Corrected “all selected” detection to require at least one connector.
  - Removed auto-close/blur when all connectors are selected; show a clear message instead.
  - Kept the input enabled; on focus, the dropdown opens, and search clears when all are selected.
  - Improved empty states: added messages for no private connectors and no search matches.

<sup>Written for commit b0b3df21e6dc1ed0a56f988272a0fed524274833. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

