### PR TITLE
fix(ui): First Connector Result (#7657) to release v2.10

### DIFF
--- a/web/src/components/SourceTile.tsx
+++ b/web/src/components/SourceTile.tsx
@@ -28,13 +28,10 @@ export default function SourceTile({
               w-40
               cursor-pointer
               shadow-md
+              bg-background-tint-00
               hover:bg-background-tint-02
               relative
-              ${
-                preSelect
-                  ? "bg-background-tint-01 subtle-pulse"
-                  : "bg-background-tint-00"
-              }
+              ${preSelect ? "subtle-pulse" : ""}
             `}
       href={navigationUrl as Route}
     >


### PR DESCRIPTION
Cherry-pick of commit 11b7e0d571d4086feebeeca5d585ddf67eb3e616 to release/v2.10 branch.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SourceTile preSelect state so it no longer changes the background tint. The tile always uses bg-background-tint-00, and preSelect only adds the subtle-pulse animation, preventing the first connector result from appearing selected.

<sup>Written for commit eb19ba0d3063df3de8ed85317e7316accb5661a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

