### PR TITLE
improve meaning of health check

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -321,9 +321,7 @@ def restore_session(
         # restored it while we were waiting)
         if sandbox.status == SandboxStatus.RUNNING:
             # Verify pod is healthy before proceeding
-            is_healthy = sandbox_manager.health_check(
-                sandbox.id, nextjs_port=session.nextjs_port, timeout=5.0
-            )
+            is_healthy = sandbox_manager.health_check(sandbox.id, timeout=10.0)
             if is_healthy and sandbox_manager.session_workspace_exists(
                 sandbox.id, session_id
             ):

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -252,14 +252,11 @@ class SandboxManager(ABC):
         ...
 
     @abstractmethod
-    def health_check(
-        self, sandbox_id: UUID, nextjs_port: int | None, timeout: float = 60.0
-    ) -> bool:
+    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
         """Check if the sandbox is healthy.
 
         Args:
             sandbox_id: The sandbox ID to check
-            nextjs_port: The Next.js port (for local backend health checks)
 
         Returns:
             True if sandbox is healthy, False otherwise

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1394,14 +1394,11 @@ echo '{tar_b64}' | base64 -d | tar -xzf -
                         f"Failed to cleanup temp file {tmp_path}: {cleanup_error}"
                     )
 
-    def health_check(
-        self, sandbox_id: UUID, nextjs_port: int | None, timeout: float = 60.0
-    ) -> bool:
+    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
         """Check if the sandbox pod is healthy (can exec into it).
 
         Args:
             sandbox_id: The sandbox ID to check
-            nextjs_port: Not used in kubernetes
             timeout: Health check timeout in seconds
 
         Returns:

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -529,28 +529,21 @@ class LocalSandboxManager(SandboxManager):
                 f"Web directory not found at {web_dir}, skipping NextJS startup"
             )
 
-    def health_check(
-        self, sandbox_id: UUID, nextjs_port: int | None, timeout: float = 60.0
-    ) -> bool:
-        """Check if the sandbox is healthy (Next.js server running).
+    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
+        """Check if the sandbox is healthy (folder exists).
 
         Args:
             sandbox_id: The sandbox ID to check
-            nextjs_port: The Next.js port to check
             timeout: Health check timeout in seconds
 
         Returns:
             True if sandbox is healthy, False otherwise
         """
         # assume healthy if no port is specified
-        if not nextjs_port:
-            return True
-
-        # Check Next.js server is responsive on the sandbox's allocated port
-        return self._process_manager._wait_for_server(
-            f"http://localhost:{nextjs_port}",
-            timeout=timeout,
-        )
+        sandbox_path = self._get_sandbox_path(sandbox_id)
+        if not sandbox_path.exists():
+            return False
+        return True
 
     def send_message(
         self,

--- a/backend/onyx/server/features/build/sandbox/local/test_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/test_manager.py
@@ -295,7 +295,7 @@ class TestHealthCheck:
 
         Note: nextjs_port is now passed by the caller instead of being fetched from DB.
         """
-        result = sandbox_manager.health_check(sandbox_record.id, nextjs_port=1)
+        result = sandbox_manager.health_check(sandbox_record.id)
 
         assert result is False
 

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -479,9 +479,7 @@ class SessionManager:
                 self._db_session.flush()
             elif sandbox.status.is_active():
                 # Verify pod is healthy before reusing (use short timeout for quick check)
-                if not self._sandbox_manager.health_check(
-                    sandbox_id, nextjs_port=nextjs_port, timeout=5.0
-                ):
+                if not self._sandbox_manager.health_check(sandbox_id, timeout=5.0):
                     logger.warning(
                         f"Sandbox {sandbox_id} marked as {sandbox.status} but pod is "
                         f"unhealthy/missing. Entering recovery mode."
@@ -602,9 +600,7 @@ class SessionManager:
 
             if sandbox and sandbox.status.is_active():
                 # Quick health check to verify sandbox is actually responsive
-                if self._sandbox_manager.health_check(
-                    sandbox.id, nextjs_port=existing.nextjs_port, timeout=5.0
-                ):
+                if self._sandbox_manager.health_check(sandbox.id, timeout=5.0):
                     logger.info(
                         f"Returning existing empty session {existing.id} for user {user_id}"
                     )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redefines sandbox health checks to verify sandbox readiness (existence/exec) instead of Next.js availability, and removes the nextjs_port parameter. This reduces flakiness and makes checks consistent across local and Kubernetes environments.

- **Refactors**
  - Changed BaseSandboxManager.health_check to health_check(sandbox_id, timeout).
  - Local: health check now checks sandbox folder existence; no Next.js port probing.
  - Kubernetes: kept exec-based pod check; removed unused nextjs_port.
  - Updated session create/restore paths to use new signature; restore_session timeout increased to 10s.
  - Updated tests to match the new health check behavior.

<sup>Written for commit 9fa68abeb3f4b8ac15defe48596f7d43a7b4ce28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

