### PR TITLE
chore(hotfix): cherry-pick 3 commits to release v2.10

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -311,6 +311,7 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
+          assetNamePattern: "[name]_[arch][ext]"
           args: ${{ matrix.args }}
 
   build-web-amd64:


### PR DESCRIPTION
Cherry-pick of 3 commits to release/v2.10 branch:

- a3603c498cf4ff8f8898918f9b4b94bd39120ef1
- 8be261405a25cf5d32703732d1fd0f6ffd944d03
- 20a73bdd2e11a699525e47c9b9c425777c83f140

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the deployment workflow to use AWS OIDC and Secrets Manager for credentials, and fixes the AWS region to keep v2.10 deployments working. Improves security and reduces reliance on GitHub secrets.

- **Refactors**
  - Use OIDC to assume an AWS role and fetch Docker and Slack secrets from AWS Secrets Manager; set desktop release assetNamePattern to [name]_[arch][ext] for version-agnostic filenames.
  - Switch Docker login, Trivy scans, and Slack notifications to use env secrets.
  - Add environment: release to deployment jobs.

- **Bug Fixes**
  - Set AWS region to us-east-2.

<sup>Written for commit 4913aae682ceb5caf0f8c1ed41d5a1e41e192d80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

