### PR TITLE
chore(hotfix): cherry-pick 3 commits to release v2.9

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -311,6 +311,7 @@ jobs:
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
           prerelease: false
+          assetNamePattern: "[name]_[arch][ext]"
           args: ${{ matrix.args }}
 
   build-web-amd64:


### PR DESCRIPTION
Cherry-pick of 3 commits to release/v2.9 branch:

- a3603c498cf4ff8f8898918f9b4b94bd39120ef1
- 8be261405a25cf5d32703732d1fd0f6ffd944d03
- 20a73bdd2e11a699525e47c9b9c425777c83f140

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release/v2.9 deployment workflow to AWS OIDC + Secrets Manager and fix the AWS region to stabilize releases and tighten secret handling. Secrets for Docker and Slack now come from AWS, and jobs use env vars instead of GitHub secrets.

- **Refactors**
  - Enable OIDC (permissions.id-token: write) and assume role via aws-actions/configure-aws-credentials.
  - Fetch Docker Hub and Slack webhook secrets from AWS Secrets Manager; use env vars in Docker login, Trivy, and Slack steps.
  - Add environment: release to relevant jobs.
  - Make desktop artifact filenames version-agnostic via assetNamePattern [name]_[arch][ext].

- **Bug Fixes**
  - Set AWS region to us-east-2 in all credential steps.

<sup>Written for commit 8d52234116a944434df3542c3b65632e82abb6d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

