### PR TITLE
fix: type ignore unrelated mypy for onyx craft head

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1468,7 +1468,7 @@ class OAuth2AuthorizeResponse(BaseModel):
 
 def generate_state_token(
     data: Dict[str, str],
-    secret: SecretType,
+    secret: SecretType,  # type: ignore[valid-type]
     lifetime_seconds: int = STATE_TOKEN_LIFETIME_SECONDS,
 ) -> str:
     data["aud"] = STATE_TOKEN_AUDIENCE
@@ -1484,7 +1484,7 @@ def generate_csrf_token() -> str:
 def create_onyx_oauth_router(
     oauth_client: BaseOAuth2,
     backend: AuthenticationBackend,
-    state_secret: SecretType,
+    state_secret: SecretType,  # type: ignore[valid-type]
     redirect_url: Optional[str] = None,
     associate_by_email: bool = False,
     is_verified_by_default: bool = False,
@@ -1504,7 +1504,7 @@ def get_oauth_router(
     oauth_client: BaseOAuth2,
     backend: AuthenticationBackend,
     get_user_manager: UserManagerDependency[models.UP, models.ID],
-    state_secret: SecretType,
+    state_secret: SecretType,  # type: ignore[valid-type]
     redirect_url: Optional[str] = None,
     associate_by_email: bool = False,
     is_verified_by_default: bool = False,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silenced mypy valid-type errors by adding type: ignore[valid-type] to SecretType parameters in OAuth auth helpers to unblock CI on Onyx Craft head. No runtime behavior changes.

<sup>Written for commit 2c5ce805d288e6d48fef26df9eb41576f7260e53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

