### PR TITLE
feat(filesys): filter on assistant info

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -75,7 +75,22 @@ class UserFileFilters(BaseModel):
     project_id: int | None = None
 
 
-class IndexFilters(BaseFilters, UserFileFilters):
+class AssistantKnowledgeFilters(BaseModel):
+    """Filters for knowledge attached to an assistant (persona).
+
+    These filters scope search to documents/folders explicitly attached
+    to the assistant. When present, only documents matching these criteria
+    are searched (in addition to ACL filtering).
+    """
+
+    # Document IDs explicitly attached to the assistant
+    attached_document_ids: list[str] | None = None
+    # Hierarchy node IDs (folders/spaces) attached to the assistant.
+    # Matches chunks where ancestor_hierarchy_node_ids contains any of these.
+    hierarchy_node_ids: list[int] | None = None
+
+
+class IndexFilters(BaseFilters, UserFileFilters, AssistantKnowledgeFilters):
     # NOTE: These strings must be formatted in the same way as the output of
     # DocumentAccess::to_acl.
     access_control_list: list[str] | None


### PR DESCRIPTION
## Description

add hierarchynode and document info from the assistant to the opensearch query

## How Has This Been Tested?

not yet

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes search results to knowledge attached to an assistant, and updates auth to use an anonymous user for unauthenticated access. ACLs are still enforced; anonymous sessions only see public content.

- **New Features**
  - Added AssistantKnowledgeFilters (attached_document_ids, hierarchy_node_ids) to IndexFilters; pipeline reads persona attachments and OpenSearch applies a document-ID OR ancestor-folder filter in both ID-based and hybrid queries.
  - Introduced an anonymous user; all endpoints now operate with a non-null User, with anonymous users limited to public/global objects and global-only rate limits.
  - Added migrations to create a permanent anonymous user and migrate legacy no-auth data; AUTH_TYPE='disabled' now defaults to 'basic'.

<sup>Written for commit 62eeb9721a36dd8a424efc54202183474dd1cd03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

