### PR TITLE
fix: pass in correct region to allow IRSA usage

### DIFF
--- a/backend/onyx/server/features/build/indexing/persistent_document_writer.py
+++ b/backend/onyx/server/features/build/indexing/persistent_document_writer.py
@@ -18,16 +18,15 @@ import json
 from pathlib import Path
 from typing import Any
 
-import boto3
 from botocore.exceptions import ClientError
 from mypy_boto3_s3.client import S3Client
 
-from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.connectors.models import Document
 from onyx.server.features.build.configs import PERSISTENT_DOCUMENT_STORAGE_PATH
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_S3_BUCKET
 from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.s3.s3_client import build_s3_client
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -288,21 +287,10 @@ class S3PersistentDocumentWriter:
     def _get_s3_client(self) -> S3Client:
         """Lazily initialize S3 client.
 
-        Uses the default boto3 credential chain which supports:
-        - Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-        - AWS config files
-        - IAM roles (EC2/ECS/EKS instance profiles, IRSA)
-
-        Region is explicitly set via AWS_REGION_NAME config to ensure
-        IAM role credential resolution works properly.
+        Uses the craft-specific boto3 client which only supports IAM roles (IRSA).
         """
         if self._s3_client is None:
-            # Use IAM role credential resolution rather than keys
-            client_kwargs: dict[str, Any] = {
-                "service_name": "s3",
-                "region_name": AWS_REGION_NAME,
-            }
-            self._s3_client = boto3.client(**client_kwargs)
+            self._s3_client = build_s3_client()
         return self._s3_client
 
     def write_documents(self, documents: list[Document]) -> list[str]:

--- a/backend/onyx/server/features/build/s3/s3_client.py
+++ b/backend/onyx/server/features/build/s3/s3_client.py
@@ -1,0 +1,9 @@
+import boto3
+from mypy_boto3_s3.client import S3Client
+
+from onyx.configs.app_configs import AWS_REGION_NAME
+
+
+def build_s3_client() -> S3Client:
+    """Build an S3 client using IAM roles (IRSA)"""
+    return boto3.client("s3", region_name=AWS_REGION_NAME)


### PR DESCRIPTION
## Description

Currently seeing `botocore.exceptions.NoCredentialsError: Unable to locate credentials` in logs when trying to write to S3 during indexing.

## How Has This Been Tested?

👀 

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set the AWS region for S3 via a new helper to ensure IRSA works. Fixes NoCredentialsError during S3 writes/reads in indexing and snapshot restore.

- **Bug Fixes**
  - Build S3 clients with region_name=AWS_REGION_NAME.
  - Replace direct boto3.client calls in persistent_document_writer and Kubernetes restore_snapshot.

<sup>Written for commit 476eec56b22adfa563a1eed97d5596217dda4c08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

