### PR TITLE
fix: connector details back button should nav back

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -455,9 +455,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
         />
       )}
 
-      <BackButton
-        behaviorOverride={() => router.push("/admin/indexing/status")}
-      />
+      <BackButton />
       <div
         className="flex
         items-center


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Back button on the connector details page to use history navigation, returning to the previous page instead of redirecting to /admin/indexing/status. This preserves the user's navigation context.

<sup>Written for commit 17bc683627f05807bb34dc8842cdf0ddd0f32b9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

