### PR TITLE
fix(fe): inline code text wraps (#7574) to release v2.10

### DIFF
--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -68,7 +68,7 @@ export const CodeBlock = memo(function CodeBlock({
           "bg-background-tint-00",
           "rounded",
           "text-xs",
-          "inline-block",
+          "inline",
           "whitespace-pre-wrap",
           "break-words",
           "py-0.5",


### PR DESCRIPTION
Cherry-pick of commit f2d32b0b3b8eb5099cfb7bc4232ed4b58c52e980 to release/v2.10 branch.

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inline code wrapping in chat messages by changing the CodeBlock element from inline-block to inline. Prevents overflow and keeps long snippets wrapping naturally within paragraphs.

<sup>Written for commit 4d2ee88c51e4860245a494db62b8883f622e2023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



