### PR TITLE
fix(tests): use crawler-friendly search query in Exa integration test (#7746) to release v2.10

### DIFF
--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -270,7 +270,7 @@ def test_web_search_endpoints_with_exa(
     provider_id = _activate_exa_provider(admin_user)
     assert isinstance(provider_id, int)
 
-    search_request = {"queries": ["latest ai research news"], "max_results": 3}
+    search_request = {"queries": ["wikipedia python programming"], "max_results": 3}
 
     lite_response = requests.post(
         f"{API_SERVER_URL}/web-search/search-lite",


### PR DESCRIPTION
Cherry-pick of commit eb7b91e08 to release/v2.10 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Exa web search integration test query with a crawler-friendly one to reduce flakiness in v2.10. Changed "latest ai research news" to "wikipedia python programming".

<sup>Written for commit 67998649dcc62d27af7bbc2b8d12e7863290ed78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

