### PR TITLE
fix: deflake chat user journey test (#7646) to release v2.10

### DIFF
--- a/web/tests/e2e/chat/default_assistant.spec.ts
+++ b/web/tests/e2e/chat/default_assistant.spec.ts
@@ -582,18 +582,10 @@ test.describe("End-to-End Default Assistant Flow", () => {
     await page.waitForLoadState("networkidle");
 
     // Verify greeting message appears
-    const greetingElement = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(greetingElement).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
 
     // Verify Onyx logo is displayed
-    const logoElement = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(logoElement).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
 
     // Send a message using the chat input
     await sendMessage(page, "Hello, can you help me?");
@@ -608,10 +600,6 @@ test.describe("End-to-End Default Assistant Flow", () => {
     await startNewChat(page);
 
     // Verify we're back to default assistant with greeting
-    const newGreeting = await page.waitForSelector(
-      '[data-testid="onyx-logo"]',
-      { timeout: 5000 }
-    );
-    expect(newGreeting).toBeTruthy();
+    await expect(page.locator('[data-testid="onyx-logo"]')).toBeVisible();
   });
 });

--- a/web/tests/e2e/utils/tools.ts
+++ b/web/tests/e2e/utils/tools.ts
@@ -27,9 +27,9 @@ export async function waitForUnifiedGreeting(page: Page): Promise<string> {
 // Ensure the Action Management popover is open
 export async function openActionManagement(page: Page): Promise<void> {
   const actionToggle = page.locator(TOOL_IDS.actionToggle);
-  await actionToggle.waitFor({ timeout: 5000 });
+  await actionToggle.waitFor();
   await actionToggle.click();
-  await page.locator(TOOL_IDS.options).waitFor({ timeout: 5000 });
+  await page.locator(TOOL_IDS.options).waitFor();
 }
 
 // Check presence of the Action Management toggle


### PR DESCRIPTION
Cherry-pick of commit 8ca06ef3e to release/v2.10 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the chat user journey E2E test by switching to locator visibility checks and removing brittle timeouts. Improves test reliability in release v2.10.

- **Bug Fixes**
  - Replaced waitForSelector + truthy checks with expect(page.locator).toBeVisible for the Onyx logo/greeting.
  - Removed fixed 5s timeouts in action management helpers; rely on Playwright’s auto-wait.
  - Keeps test behavior the same while reducing flakiness.

<sup>Written for commit 93ef4da8176f08d5e625f6ffc0489fd1b5132e44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

