### PR TITLE
fix(layout): adjust footer margin and prevent page refresh on chatsession drop (#7759) to release v2.10

### DIFF
--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -119,7 +119,7 @@ function AppFooter() {
     }](https://www.onyx.app/) - Open Source AI Platform`;
 
   return (
-    <footer className="w-full flex flex-row justify-center items-center gap-2 pb-2">
+    <footer className="w-full flex flex-row justify-center items-center gap-2 pb-2 mt-auto">
       <MinimalMarkdown
         content={customFooterContent}
         className={cn("max-w-full text-center")}

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -442,7 +442,7 @@ const ChatButton = memo(
       >
         <Popover.Anchor>
           <SidebarTab
-            href={`/chat?chatId=${chatSession.id}`}
+            href={isDragging ? undefined : `/chat?chatId=${chatSession.id}`}
             onClick={handleClick}
             transient={active}
             rightChildren={rightMenu}


### PR DESCRIPTION
Cherry-pick of commit 605e80815853934b1baaba643eb6bcd37926ae47 to release/v2.10 branch.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the app footer to stick to the bottom of the page. Prevented page refresh when dropping a chat session by disabling the link while dragging.

<sup>Written for commit bb461dd6218c7370639ae85718264df2ecff8479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

