### PR TITLE
fix(redis): Adding more TTLs

### DIFF
--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -32,6 +32,7 @@ class RedisConnectorDelete:
     FENCE_PREFIX = f"{PREFIX}_fence"  # "connectordeletion_fence"
     FENCE_TTL = 7 * 24 * 60 * 60  # 7 days - defensive TTL to prevent memory leaks
     TASKSET_PREFIX = f"{PREFIX}_taskset"  # "connectordeletion_taskset"
+    TASKSET_TTL = FENCE_TTL
 
     # used to signal the overall workflow is still active
     # it's impossible to get the exact state of the system at a single point in time
@@ -136,6 +137,7 @@ class RedisConnectorDelete:
             # add to the tracking taskset in redis BEFORE creating the celery task.
             # note that for the moment we are using a single taskset key, not differentiated by cc_pair id
             self.redis.sadd(self.taskset_key, custom_task_id)
+            self.redis.expire(self.taskset_key, self.TASKSET_TTL)
 
             # Priority on sync's triggered by new indexing should be medium
             celery_app.send_task(

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -45,6 +45,7 @@ class RedisConnectorPrune:
     )  # connectorpruning_generator_complete
 
     TASKSET_PREFIX = f"{PREFIX}_taskset"  # connectorpruning_taskset
+    TASKSET_TTL = FENCE_TTL
     SUBTASK_PREFIX = f"{PREFIX}+sub"  # connectorpruning+sub
 
     # used to signal the overall workflow is still active
@@ -184,6 +185,7 @@ class RedisConnectorPrune:
 
             # add to the tracking taskset in redis BEFORE creating the celery task.
             self.redis.sadd(self.taskset_key, custom_task_id)
+            self.redis.expire(self.taskset_key, self.TASKSET_TTL)
 
             # Priority on sync's triggered by new indexing should be medium
             result = celery_app.send_task(

--- a/backend/onyx/redis/redis_document_set.py
+++ b/backend/onyx/redis/redis_document_set.py
@@ -23,6 +23,7 @@ class RedisDocumentSet(RedisObjectHelper):
     FENCE_PREFIX = PREFIX + "_fence"
     FENCE_TTL = 7 * 24 * 60 * 60  # 7 days - defensive TTL to prevent memory leaks
     TASKSET_PREFIX = PREFIX + "_taskset"
+    TASKSET_TTL = FENCE_TTL
 
     def __init__(self, tenant_id: str, id: int) -> None:
         super().__init__(tenant_id, str(id))
@@ -83,6 +84,7 @@ class RedisDocumentSet(RedisObjectHelper):
 
             # add to the set BEFORE creating the task.
             redis_client.sadd(self.taskset_key, custom_task_id)
+            redis_client.expire(self.taskset_key, self.TASKSET_TTL)
 
             celery_app.send_task(
                 OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,

--- a/backend/onyx/redis/redis_usergroup.py
+++ b/backend/onyx/redis/redis_usergroup.py
@@ -24,6 +24,7 @@ class RedisUserGroup(RedisObjectHelper):
     FENCE_PREFIX = PREFIX + "_fence"
     FENCE_TTL = 7 * 24 * 60 * 60  # 7 days - defensive TTL to prevent memory leaks
     TASKSET_PREFIX = PREFIX + "_taskset"
+    TASKSET_TTL = FENCE_TTL
 
     def __init__(self, tenant_id: str, id: int) -> None:
         super().__init__(tenant_id, str(id))
@@ -97,6 +98,7 @@ class RedisUserGroup(RedisObjectHelper):
 
             # add to the set BEFORE creating the task.
             redis_client.sadd(self.taskset_key, custom_task_id)
+            redis_client.expire(self.taskset_key, self.TASKSET_TTL)
 
             celery_app.send_task(
                 OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Controlling more of the TTLs that we enforce and expires since it doesn't make sense to keep the taskset around if the fence is gone.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add defensive TTLs to Redis fence and taskset keys so tasksets expire when the fence is gone, preventing memory leaks and stale state across workflows.

- **Bug Fixes**
  - Set a 7-day TTL on fence keys and taskset keys (TASKSET_TTL = FENCE_TTL).
  - Apply expire() to taskset keys when adding task IDs.
  - Updated in document sync, connector deletion, connector prune, document set, and user group modules.

<sup>Written for commit 4df745b4bde4d77f2a3123544c1d26f4c785744f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

