### PR TITLE
fix(citations): enable citation sidebar w/ web_search-only assistants

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10365,6 +10365,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Description

Makes `retrievalEnabled` on the ChatPage consistent with `personaIncludesRetrieval`. In chats with only web searches, this `retrievalEnabled` was incorrectly being set to `false`.

I think we could also just always render this component? That way, the only logic involved with it appearing is whether the citation button is clicked, but this is the smallest, correct fix to resolve the issue for now.

Will be cherry-picking to `v2.9`, `v2.10`, and `v2.11`.

## How Has This Been Tested?

Created an assistant with only Web Search enabled and _not_ `Open URL` setting, submitted a prompt which executed a web search and confirmed the citation sidebar opens as expected.

This is very much something we could captured by saving such a query in the seeded db snapshot and ensure we can click and see the sidebar with playwright. Will thinking about it.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
Closes https://linear.app/onyx-app/issue/ENG-3520/the-sources-sidebar-is-broken
