### PR TITLE
fix(citations): enable citation sidebar w/ web_search-only assistants (#7888) to release v2.9

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -25,7 +25,6 @@ import { useDocumentSets } from "@/lib/hooks/useDocumentSets";
 import { useAgents } from "@/hooks/useAgents";
 import { ChatPopup } from "@/app/chat/components/ChatPopup";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
-import { SEARCH_TOOL_ID } from "@/app/chat/components/tools/constants";
 import { useUser } from "@/components/user/UserProvider";
 import NoAssistantModal from "@/components/modals/NoAssistantModal";
 import TextView from "@/components/chat/TextView";
@@ -378,9 +377,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
 
   const retrievalEnabled = useMemo(() => {
     if (liveAssistant) {
-      return liveAssistant.tools.some(
-        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
-      );
+      return personaIncludesRetrieval(liveAssistant);
     }
     return false;
   }, [liveAssistant]);


### PR DESCRIPTION
Cherry-pick of commit f73ce0632 to release/v2.9 branch.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes citation sidebar visibility for web_search-only assistants by using personaIncludesRetrieval to detect retrieval instead of a hardcoded tool ID. Users now see citations when chatting with web-search personas.

<sup>Written for commit bbcc441b58c733a670ad632001ff6d0cefbc5b56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

