### PR TITLE
fix(citations): enable citation sidebar w/ web_search-only assistants (#7888) to release v2.10

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -25,7 +25,6 @@ import { useDocumentSets } from "@/lib/hooks/useDocumentSets";
 import { useAgents } from "@/hooks/useAgents";
 import { ChatPopup } from "@/app/chat/components/ChatPopup";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
-import { SEARCH_TOOL_ID } from "@/app/chat/components/tools/constants";
 import { useUser } from "@/components/user/UserProvider";
 import NoAssistantModal from "@/components/modals/NoAssistantModal";
 import TextView from "@/components/chat/TextView";
@@ -378,9 +377,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
 
   const retrievalEnabled = useMemo(() => {
     if (liveAssistant) {
-      return liveAssistant.tools.some(
-        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
-      );
+      return personaIncludesRetrieval(liveAssistant);
     }
     return false;
   }, [liveAssistant]);


### PR DESCRIPTION
Cherry-pick of commit f73ce0632 to release/v2.10 branch.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing citation sidebar for web_search-only assistants by correctly detecting retrieval capability.

- **Bug Fixes**
  - Use personaIncludesRetrieval(liveAssistant) to set retrievalEnabled in ChatPage.
  - Remove SEARCH_TOOL_ID import and hard-coded tool ID check.

<sup>Written for commit 845a8e664332503f1e27e734503be2c2c93d8fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

