### PR TITLE
fix: sidebar items are title case

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -453,7 +453,7 @@ const MemoizedAppSidebarInner = memo(
         <ChatSearchCommandMenu
           trigger={
             <SidebarTab leftIcon={SvgSearchMenu} folded={folded}>
-              Search chats
+              Search Chats
             </SidebarTab>
           }
         />


### PR DESCRIPTION
## Description

Sidebar items appear to prefer title case:

<img width="2880" height="1920" alt="20260127_13h42m05s_grim" src="https://github.com/user-attachments/assets/7db721d3-b6e9-41e5-b5e0-ab5bab71440d" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Search sidebar tab to Title Case for consistency with other items. Changes the label from "Search chats" to "Search Chats".

<sup>Written for commit f6ec72fac1d3d8b31b9c78e3ee3416e829fc6d96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

