### PR TITLE
chore: remove pyproject config for pypandoc mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,12 +201,6 @@ include = ["backend"]
 exclude = ["backend/generated"]
 typeCheckingMode = "off"
 
-[tool.mypy]
-# NOTE: pypandoc doesn't provide type stubs or py.typed marker
-# See: https://github.com/JessicaTegner/pypandoc
-[tool.mypy-pypandoc]
-ignore_missing_imports = true
-
 [tool.setuptools.packages.find]
 where = ["backend"]
 include = ["onyx*", "tests*"]


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed obsolete mypy config for pypandoc from pyproject.toml to clean up our tooling. No runtime or build impact.

<sup>Written for commit a251221ceedf131576d05d871d80fbba05ea2193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

