### PR TITLE
fix(citations): enable citation sidebar w/ web_search-only assistants (#7888) to release v2.11

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -25,7 +25,6 @@ import { useDocumentSets } from "@/lib/hooks/useDocumentSets";
 import { useAgents } from "@/hooks/useAgents";
 import { ChatPopup } from "@/app/chat/components/ChatPopup";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
-import { SEARCH_TOOL_ID } from "@/app/chat/components/tools/constants";
 import { useUser } from "@/components/user/UserProvider";
 import NoAssistantModal from "@/components/modals/NoAssistantModal";
 import TextView from "@/components/chat/TextView";
@@ -382,9 +381,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
 
   const retrievalEnabled = useMemo(() => {
     if (liveAssistant) {
-      return liveAssistant.tools.some(
-        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
-      );
+      return personaIncludesRetrieval(liveAssistant);
     }
     return false;
   }, [liveAssistant]);


### PR DESCRIPTION
Cherry-pick of commit f73ce0632 to release/v2.11 branch.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the citation sidebar for assistants that only use web search. Retrieval detection now uses personaIncludesRetrieval(liveAssistant) instead of checking for SEARCH_TOOL_ID, so the sidebar shows when retrieval is supported.

<sup>Written for commit 944bbe43d49016f51e97686df168c3c2cda0f5ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

