### PR TITLE
fix: user count check (#7811) to release v2.11

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -10,6 +10,7 @@ from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import PASSWORD_MIN_LENGTH
+from onyx.configs.constants import AuthType
 from onyx.configs.constants import DEV_VERSION_PATTERN
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.configs.constants import STABLE_VERSION_PATTERN
@@ -30,13 +31,20 @@ def healthcheck() -> StatusResponse:
 
 @router.get("/auth/type", tags=PUBLIC_API_TAGS)
 async def get_auth_type() -> AuthTypeResponse:
-    user_count = await get_user_count()
+    # NOTE: This endpoint is critical for the multi-tenant flow and is hit before there is a tenant context
+    # The reason is this is used during the login flow, but we don't know which tenant the user is supposed to be
+    # associated with until they auth.
+    has_users = True
+    if AUTH_TYPE != AuthType.CLOUD:
+        user_count = await get_user_count()
+        has_users = user_count > 0
+
     return AuthTypeResponse(
         auth_type=AUTH_TYPE,
         requires_verification=user_needs_to_be_verified(),
         anonymous_user_enabled=anonymous_user_enabled(),
         password_min_length=PASSWORD_MIN_LENGTH,
-        has_users=user_count > 0,
+        has_users=has_users,
     )
 
 


### PR DESCRIPTION
Cherry-pick of commit 51ef28305db10fc4cde4d0dfd25daea2a875839d to release/v2.11 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the /auth/type user count logic to prevent tenantless DB queries during multi-tenant login. In CLOUD mode we skip get_user_count and return has_users=true; self-hosted continues to compute the real count.

<sup>Written for commit 1d80b9c9d47955ed05264bc1293f5d12de03dc41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

