### PR TITLE
fix: type ignore unrelated mypy for onyx craft head (#7843) to release v2.11

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1468,7 +1468,7 @@ class OAuth2AuthorizeResponse(BaseModel):
 
 def generate_state_token(
     data: Dict[str, str],
-    secret: SecretType,
+    secret: SecretType,  # type: ignore[valid-type]
     lifetime_seconds: int = STATE_TOKEN_LIFETIME_SECONDS,
 ) -> str:
     data["aud"] = STATE_TOKEN_AUDIENCE
@@ -1484,7 +1484,7 @@ def generate_csrf_token() -> str:
 def create_onyx_oauth_router(
     oauth_client: BaseOAuth2,
     backend: AuthenticationBackend,
-    state_secret: SecretType,
+    state_secret: SecretType,  # type: ignore[valid-type]
     redirect_url: Optional[str] = None,
     associate_by_email: bool = False,
     is_verified_by_default: bool = False,
@@ -1504,7 +1504,7 @@ def get_oauth_router(
     oauth_client: BaseOAuth2,
     backend: AuthenticationBackend,
     get_user_manager: UserManagerDependency[models.UP, models.ID],
-    state_secret: SecretType,
+    state_secret: SecretType,  # type: ignore[valid-type]
     redirect_url: Optional[str] = None,
     associate_by_email: bool = False,
     is_verified_by_default: bool = False,


### PR DESCRIPTION
Cherry-pick of commit a21af4b9060f75b1d6452222509dcb4564855c7d to release/v2.11 branch.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silenced unrelated mypy "valid-type" errors by adding inline type ignores to SecretType parameters in OAuth auth helpers. This unblocks CI for release/v2.11 with no runtime changes.

<sup>Written for commit eb9b10ed003158c00174d06610c0b28cfd4d26ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

