### PR TITLE
fix: Project Creation (#7851) to release v2.11

### DIFF
--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -47,7 +47,7 @@ class UserFileDeleteResult(BaseModel):
     assistant_names: list[str] = []
 
 
-@router.get("/", tags=PUBLIC_API_TAGS)
+@router.get("", tags=PUBLIC_API_TAGS)
 def get_projects(
     user: User | None = Depends(current_user),
     db_session: Session = Depends(get_session),

--- a/backend/tests/integration/common_utils/managers/project.py
+++ b/backend/tests/integration/common_utils/managers/project.py
@@ -31,7 +31,7 @@ class ProjectManager:
     ) -> List[UserProjectSnapshot]:
         """Get all projects for a user via API."""
         response = requests.get(
-            f"{API_SERVER_URL}/user/projects/",
+            f"{API_SERVER_URL}/user/projects",
             headers=user_performing_action.headers or GENERAL_HEADERS,
         )
         response.raise_for_status()
@@ -56,7 +56,7 @@ class ProjectManager:
     ) -> bool:
         """Verify that a project has been deleted by ensuring it's not in list."""
         response = requests.get(
-            f"{API_SERVER_URL}/user/projects/",
+            f"{API_SERVER_URL}/user/projects",
             headers=user_performing_action.headers or GENERAL_HEADERS,
         )
         response.raise_for_status()

--- a/web/src/app/chat/projects/projectsService.ts
+++ b/web/src/app/chat/projects/projectsService.ts
@@ -63,7 +63,7 @@ export type ProjectDetails = {
 };
 
 export async function fetchProjects(): Promise<Project[]> {
-  const response = await fetch("/api/user/projects/");
+  const response = await fetch("/api/user/projects");
   if (!response.ok) {
     handleRequestError("Fetch projects", response);
   }

--- a/web/src/lib/hooks/useProjects.ts
+++ b/web/src/lib/hooks/useProjects.ts
@@ -4,7 +4,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 
 export function useProjects() {
   const { data, error, mutate } = useSWR<Project[]>(
-    "/api/user/projects/",
+    "/api/user/projects",
     errorHandlingFetcher,
     {
       revalidateOnFocus: false,


### PR DESCRIPTION
Cherry-pick of commit 8a408e702341191b40915906cd0faecb37f58b67 to release/v2.11 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the user projects API to use a no-trailing-slash path to fix routing mismatches that blocked the project creation flow in v2.11. Backend, frontend, and tests now consistently use /api/user/projects.

- **Bug Fixes**
  - Backend: route changed to serve /user/projects without a trailing slash.
  - Frontend: fetch and SWR keys updated from /api/user/projects/ to /api/user/projects.
  - Tests: integration requests updated to the new path.

<sup>Written for commit 9e9bd370c08c27435766e207acf9f32f3ceb1813. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

