### PR TITLE
fix: connector details back button should nav back (#7869) to release v2.11

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -455,9 +455,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
         />
       )}
 
-      <BackButton
-        behaviorOverride={() => router.push("/admin/indexing/status")}
-      />
+      <BackButton />
       <div
         className="flex
         items-center


### PR DESCRIPTION
Cherry-pick of commit 90f8656afaa90a4dc989238e1a8583193755f472 to release/v2.11 branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the BackButton on the connector details page to use browser back navigation instead of forcing a redirect to /admin/indexing/status. This restores expected navigation and preserves user context, including deep links.

<sup>Written for commit 223bc182630115d584179c94ce59598dd8f73707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

