### PR TITLE
fix: demo data toggle race condition

### DIFF
--- a/web/src/app/build/v1/configure/page.tsx
+++ b/web/src/app/build/v1/configure/page.tsx
@@ -286,15 +286,24 @@ export default function BuildConfigPage() {
     config: connectors.find((c) => c.source === type) || null,
   }));
 
-  // Auto-enable demo data when no connectors have ever succeeded
+  // Auto-enable demo data when no connectors have ever succeeded.
+  // Guard against loading state to avoid a race condition: before the
+  // connector fetch completes, hasConnectorEverSucceeded is false (empty
+  // array fallback), which would incorrectly re-enable demo data.
   useEffect(() => {
+    if (isLoading) return;
     if (!hasConnectorEverSucceeded && !demoDataEnabled) {
       setDemoDataEnabled(true);
       // Also sync pending state so UI stays consistent
       setPendingDemoData(true);
       setOriginalDemoData(true);
     }
-  }, [hasConnectorEverSucceeded, demoDataEnabled, setDemoDataEnabled]);
+  }, [
+    isLoading,
+    hasConnectorEverSucceeded,
+    demoDataEnabled,
+    setDemoDataEnabled,
+  ]);
 
   const handleDeleteConfirm = async () => {
     if (!connectorToDelete) return;


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where demo data could re-enable before connector status finished loading. The auto-enable logic now waits for loading to complete, keeping the toggle and pending state consistent.

- Bug Fixes
  - Added isLoading guard and updated effect deps to prevent premature auto-enable; keep pending/original demo data states in sync.

<sup>Written for commit add7d55e5b4ff7bd036b5cf8bd97c0bd6698648e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

