### PR TITLE
chore(mypy): fix mypy cache issues switching between HEAD and release (#7732) to release v2.9

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -50,8 +50,9 @@ jobs:
         uses: runs-on/cache@50350ad4242587b6c8c2baa2e740b1bc11285ff4 # ratchet:runs-on/cache@v4
         with:
           path: backend/.mypy_cache
-          key: mypy-${{ runner.os }}-${{ hashFiles('**/*.py', '**/*.pyi', 'backend/pyproject.toml') }}
+          key: mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-${{ hashFiles('**/*.py', '**/*.pyi', 'backend/pyproject.toml') }}
           restore-keys: |
+            mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-
             mypy-${{ runner.os }}-
 
       - name: Run MyPy


### PR DESCRIPTION
Cherry-pick of commit b03634ecaaa9dba3ca73108bf7dde7e22e351ef7 to release/v2.10 branch.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale MyPy caches in the PR workflow when switching between branches. The cache key and restore-keys now include the base branch to avoid reusing incompatible caches and flaky type checks.

<sup>Written for commit 8e2c44ff034a9173848467aa8247de9541f11712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

