### PR TITLE
fix(craft): allow more lenient tag names (for versioning)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,7 +67,7 @@ jobs:
           BUILD_MODEL_SERVER=true
 
           # Determine tag type based on pattern matching (do regex checks once)
-          if [[ "$TAG" == craft-latest ]]; then
+          if [[ "$TAG" == craft-* ]]; then
             IS_CRAFT_LATEST=true
           fi
           if [[ "$TAG" == *cloud* ]]; then


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadened tag matching in the deployment workflow to treat any "craft-*" tag as a craft release, not just "craft-latest". This ensures versioned craft tags are recognized and follow the correct build/deploy path.

<sup>Written for commit 2802049192460afd0b7f791509dfc1ffdd7dbf2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

