### PR TITLE
fix: z index for output panel

### DIFF
--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -297,7 +297,7 @@ const BuildOutputPanel = memo(({ onClose, isOpen }: BuildOutputPanelProps) => {
   return (
     <div
       className={cn(
-        "absolute flex flex-col border rounded-12 border-border-01 bg-background-neutral-00 overflow-hidden transition-all duration-300 ease-in-out",
+        "absolute z-20 flex flex-col border rounded-12 border-border-01 bg-background-neutral-00 overflow-hidden transition-all duration-300 ease-in-out",
         isMaximized
           ? "top-4 right-16 bottom-4 w-[calc(100%-8rem)]"
           : "top-4 right-4 bottom-4 w-[calc(50%-2rem)]",


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the build output panel stays above other UI by setting its container z-index to 20. This fixes cases where the panel was hidden behind overlapping elements.

<sup>Written for commit 5c6277fae4f9d795a62a8fbf16c50ebb6f0ec0b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

