### PR TITLE
fix: kubernetes freezing

### DIFF
--- a/web/src/app/craft/hooks/useBuildSessionController.ts
+++ b/web/src/app/craft/hooks/useBuildSessionController.ts
@@ -126,6 +126,10 @@ export function useBuildSessionController({
     async function fetchSession() {
       if (!existingSessionId) return;
 
+      // Set ref BEFORE any async work to prevent duplicate calls
+      // if the effect re-runs while we're still loading
+      loadedSessionIdRef.current = existingSessionId;
+
       // Access sessions via getState() to avoid dependency on Map reference
       const currentState = useBuildSessionStore.getState();
       const cachedSession = currentState.sessions.get(existingSessionId);
@@ -133,13 +137,11 @@ export function useBuildSessionController({
       if (cachedSession?.isLoaded) {
         // Just switch to it
         setCurrentSession(existingSessionId);
-        loadedSessionIdRef.current = existingSessionId;
         return;
       }
 
       // Need to load from API
       await loadSession(existingSessionId);
-      loadedSessionIdRef.current = existingSessionId;
     }
 
     // Only fetch if we haven't already loaded this session


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kubernetes sandbox freezes by separating REST and streaming API clients and preventing duplicate session loads in the web app. This stabilizes pod exec operations and stops “Handshake status 200 OK” errors.

- **Bug Fixes**
  - Split Kubernetes ApiClient: REST for CRUD, dedicated client for stream/exec; route all exec calls through the streaming client to avoid WebSocket patch leakage.
  - Set loadedSessionIdRef before async work in useBuildSessionController to stop re-entrant fetches and duplicate loads.

<sup>Written for commit 0651dc811435e3b805588c242cc890bc73ec4c80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

