### PR TITLE
fix: Cloud Embedding Keys

### DIFF
--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -240,7 +240,6 @@ def unstructured_api_key_set(
     _: User | None = Depends(current_admin_user),
 ) -> bool:
     api_key = get_unstructured_api_key()
-    print(api_key)
     return api_key is not None
 
 


### PR DESCRIPTION
## Description

## How Has This Been Tested?
No longer!

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents exposure of cloud embedding API keys by masking them in admin/embedding responses. Also removes a stray debug print in search settings.

- **Bug Fixes**
  - Mask CloudEmbeddingProvider.api_key in list and upsert endpoints using mask_string.
  - Remove printing of Unstructured API key in search_settings.

<sup>Written for commit 5f679ff061ba33b7dc09bfec7994e7959b34a825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

