### PR TITLE
chore(api): Cleanup

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from datetime import timezone
+from typing import Any
 
 import boto3
 import httpx
@@ -106,14 +107,14 @@ def _mask_provider_credentials(provider_view: LLMProviderView) -> None:
 
     # Mask sensitive values in custom_config
     if provider_view.custom_config:
-        masked_config: dict[str, str] = {}
+        masked_config: dict[str, Any] = {}
         for key, value in provider_view.custom_config.items():
             # Check if key matches any sensitive pattern (case-insensitive)
             key_lower = key.lower()
             is_sensitive = any(
                 sensitive_key in key_lower for sensitive_key in _SENSITIVE_CONFIG_KEYS
             )
-            if is_sensitive and value:
+            if is_sensitive and isinstance(value, str) and value:
                 masked_config[key] = _mask_string(value)
             else:
                 masked_config[key] = value


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mask sensitive credentials in LLM provider responses to prevent secret leakage. Applies to api_key and sensitive fields in custom_config across list, update, and vision provider endpoints.

- **Bug Fixes**
  - Added masking helper to show only first/last 4 characters.
  - Masked common credential fields in custom_config (api_key, token, secret, password, AWS keys, vertex_credentials, etc.).
  - Replaced API-key-only masking with full credential masking and applied it in all relevant endpoints.

<sup>Written for commit 49c178828061838834d1d9884905a5f71a555c82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

