### PR TITLE
fix(craft): hide session limit

### DIFF
--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -342,8 +342,9 @@ const MemoizedBuildSidebarInner = memo(
     }, [refreshSessionHistory]);
 
     // Build section title with usage if cloud is enabled
+    // limit=0 indicates unlimited (local/self-hosted mode), so hide the count
     const sessionsTitle = useMemo(() => {
-      if (isEnabled && limits) {
+      if (isEnabled && limits && limits.limit > 0) {
         return `Sessions (${limits.messagesUsed}/${limits.limit})`;
       }
       return "Sessions";


### PR DESCRIPTION
## Description

hide session limit

## How Has This Been Tested?

locally
<img width="243" height="300" alt="Screenshot 2026-01-28 at 11 33 04" src="https://github.com/user-attachments/assets/493f20ad-962e-4761-af70-87a8cf9f363d" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows an upgrade modal when users hit Craft message limits and makes paid limits configurable with per-user overrides. Also hides the sessions count when limit is unlimited (limit=0).

- **New Features**
  - Added UpgradePlanModal that opens on 429 rate-limit errors or when a limited user tries to send a message; usage limits refresh after each send.
  - Implemented backend rate limit config: free users get 5 total messages; paid users get a weekly limit via CRAFT_PAID_USER_RATE_LIMIT (default 25); per-user overrides via CRAFT_USER_RATE_LIMIT_OVERRIDES (JSON), treated as weekly.
  - Added RateLimitError handling in the client and a SessionErrorCode to surface the upsell flow cleanly.

- **Migration**
  - Optional env vars: set CRAFT_PAID_USER_RATE_LIMIT and CRAFT_USER_RATE_LIMIT_OVERRIDES (JSON map of email -> limit).
  - Ensure NEXT_PUBLIC_CLOUD_ENABLED is true to fetch and display usage limits.

<sup>Written for commit 594a595063633d4391fd3be10250be3725742519. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



