### PR TITLE
refactor: New `sections/cards` directory to host all feature-specific cards.

### DIFF
--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState, useRef, useEffect } from "react";
-import AgentCard from "@/refresh-components/AgentCard";
+import AgentCard from "@/sections/cards/AgentCard";
 import { useUser } from "@/components/user/UserProvider";
 import { checkUserOwnsAssistant as checkUserOwnsAgent } from "@/lib/agents";
 import { useAgents } from "@/hooks/useAgents";

--- a/web/src/sections/cards/AgentCard.tsx
+++ b/web/src/sections/cards/AgentCard.tsx
@@ -27,7 +27,7 @@ import {
   SvgShare,
   SvgUser,
 } from "@opal/icons";
-import { useCreateModal } from "./contexts/ModalContext";
+import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import ShareAgentModal from "@/sections/modals/ShareAgentModal";
 import { usePopup } from "@/components/admin/connectors/Popup";
 interface IconLabelProps {

--- a/web/src/sections/cards/README.md
+++ b/web/src/sections/cards/README.md
@@ -1,0 +1,16 @@
+# Cards
+
+This directory contains feature-specific card components.
+
+Cards are self-contained UI components that display information about a specific entity (e.g., an agent, a document set, a connector) in a visually distinct, bounded container. They typically include:
+
+- Entity identification (name, avatar, icon)
+- Summary information
+- Quick actions (buttons, menus)
+
+## Guidelines
+
+- Each card should be focused on a single entity type
+- Cards should be reusable across different pages/contexts
+- Keep card-specific logic within the card component
+- Use shared components from `@/refresh-components` for common UI elements


### PR DESCRIPTION
## Description

Congregate all feature-specific cards into one singular directory, `/web/src/sections/cards`.

## How Has This Been Tested?

Code change only; no UI change.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Created a sections/cards directory for feature-specific cards and moved AgentCard there. Code-only refactor; no UI changes.

- **Refactors**
  - Moved AgentCard to web/src/sections/cards and updated imports.
  - Fixed useCreateModal import path in AgentCard.
  - Added README with card guidelines.

<sup>Written for commit 716b835a1e1121db1dc5becd82c7325dddcb49dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

