### PR TITLE
fix(craft): install script for craft will force pull latest image for any craft-* image tags

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -752,12 +752,16 @@ fi
 export HOST_PORT=$AVAILABLE_PORT
 print_success "Using port $AVAILABLE_PORT for nginx"
 
-# Determine if we're using the latest tag
+# Determine if we're using the latest tag or a craft tag (both should force pull)
 # Read IMAGE_TAG from .env file and remove any quotes or whitespace
 CURRENT_IMAGE_TAG=$(grep "^IMAGE_TAG=" "$ENV_FILE" | head -1 | cut -d'=' -f2 | tr -d ' "'"'"'')
-if [ "$CURRENT_IMAGE_TAG" = "latest" ]; then
+if [ "$CURRENT_IMAGE_TAG" = "latest" ] || [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
     USE_LATEST=true
-    print_info "Using 'latest' tag - will force pull and recreate containers"
+    if [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
+        print_info "Using craft tag '$CURRENT_IMAGE_TAG' - will force pull and recreate containers"
+    else
+        print_info "Using 'latest' tag - will force pull and recreate containers"
+    fi
 else
     USE_LATEST=false
 fi


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update install.sh to treat any craft-* IMAGE_TAG like "latest" and force pull + recreate containers. This ensures craft images are always up-to-date and prevents running stale builds.

<sup>Written for commit 889b7f0e245578c1f4635adf311cc140254321da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

