### PR TITLE
fix: exceptions trace modal

### DIFF
--- a/web/src/components/modals/ExceptionTraceModal.tsx
+++ b/web/src/components/modals/ExceptionTraceModal.tsx
@@ -21,6 +21,7 @@ export default function ExceptionTraceModal({
           icon={SvgAlertTriangle}
           title="Full Exception Trace"
           onClose={onOutsideClick}
+          height="fit"
         />
         <Modal.Body>
           <div className="mb-6">


### PR DESCRIPTION
## Description
<img width="2551" height="1302" alt="image" src="https://github.com/user-attachments/assets/5eb28ef8-61d0-4331-a5d0-b1a536a3bb4c" />
<img width="2551" height="1302" alt="image" src="https://github.com/user-attachments/assets/40fa12e1-cfec-4fbb-be87-84ba40513763" />

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the ExceptionTraceModal header height to fit content to fix layout issues. This prevents clipped titles and extra whitespace, so the full exception trace renders cleanly.

<sup>Written for commit 4b9f56b6828c953f60a67a46ce1fd140f34a95fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

