### PR TITLE
chore(deps): add pytest-repeat to dev

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -452,12 +452,15 @@ pytest==8.3.5
     #   pytest-alembic
     #   pytest-asyncio
     #   pytest-dotenv
+    #   pytest-repeat
     #   pytest-xdist
 pytest-alembic==0.12.1
     # via onyx
 pytest-asyncio==1.3.0
     # via onyx
 pytest-dotenv==0.5.2
+    # via onyx
+pytest-repeat==0.9.4
     # via onyx
 pytest-xdist==3.6.1
     # via onyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ dev = [
     "pytest-alembic==0.12.1",
     "pytest-asyncio==1.3.0",
     "pytest-dotenv==0.5.2",
+    "pytest-repeat==0.9.4",
     "pytest-xdist==3.6.1",
     "pytest==8.3.5",
     "release-tag==0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -4733,6 +4733,7 @@ dev = [
     { name = "pytest-alembic" },
     { name = "pytest-asyncio" },
     { name = "pytest-dotenv" },
+    { name = "pytest-repeat" },
     { name = "pytest-xdist" },
     { name = "release-tag" },
     { name = "reorder-python-imports-black" },
@@ -4873,6 +4874,7 @@ requires-dist = [
     { name = "pytest-dotenv", marker = "extra == 'dev'", specifier = "==0.5.2" },
     { name = "pytest-mock", marker = "extra == 'backend'", specifier = "==3.12.0" },
     { name = "pytest-playwright", marker = "extra == 'backend'", specifier = "==0.7.0" },
+    { name = "pytest-repeat", marker = "extra == 'dev'", specifier = "==0.9.4" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.6.1" },
     { name = "python-dateutil", marker = "extra == 'backend'", specifier = "==2.8.2" },
     { name = "python-docx", marker = "extra == 'backend'", specifier = "==1.1.2" },
@@ -6337,6 +6339,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/47/38e292ad92134a00ea05e6fc4fc44577baaa38b0922ab7ea56312b7a6663/pytest_playwright-0.7.0.tar.gz", hash = "sha256:b3f2ea514bbead96d26376fac182f68dcd6571e7cb41680a89ff1673c05d60b6", size = 16666, upload-time = "2025-01-31T11:06:05.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/96/5f8a4545d783674f3de33f0ebc4db16cc76ce77a4c404d284f43f09125e3/pytest_playwright-0.7.0-py3-none-any.whl", hash = "sha256:2516d0871fa606634bfe32afbcc0342d68da2dbff97fe3459849e9c428486da2", size = 16618, upload-time = "2025-01-31T11:06:08.075Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Allows repeating tests locally. Helps with identifying flakiness.

## How Has This Been Tested?

```
uv run --with pytest-repeat pytest --count=100 backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
```

<img width="2262" height="1306" alt="20260128_13h43m54s_grim" src="https://github.com/user-attachments/assets/a1dba8ff-e684-4edf-8300-1fdf3477254e" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added pytest-repeat to dev dependencies to let you repeat tests locally and catch flaky tests. To run a test 100 times: uv run --with pytest-repeat pytest --count=100 backend/tests/unit/onyx/indexing/test_indexing_pipeline.py.

<sup>Written for commit 29c8fd8665360bc59550b9f8fedb9564648c7a95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

