### PR TITLE
fix: Edit styling

### DIFF
--- a/web/src/app/css/card.css
+++ b/web/src/app/css/card.css
@@ -1,5 +1,5 @@
 .card {
-  @apply rounded-16 w-full overflow-hidden;
+  @apply rounded-16 w-full overflow-clip;
 }
 
 .card[data-variant="primary"] {


### PR DESCRIPTION
## Description

`overflow-hidden` does not apply height. The `ActionsTool` does not apply height either, which causes height-collapse through the entire chain. Using `overflow-clip` fixes this.

## Screenshots

### Before

<img width="818" height="469" alt="image" src="https://github.com/user-attachments/assets/21e49e10-63f7-4190-9621-355e6370519f" />

### After

<img width="800" height="459" alt="image" src="https://github.com/user-attachments/assets/92980e50-0e30-4991-9a5a-f5b8b6a5d87f" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced overflow-hidden with overflow-clip on the Card component to clip content without creating a scroll container, improving rounded corner rendering and preventing minor layout glitches.

<sup>Written for commit a381a4a0ff00e0d9720ef98d586af0f7a65cbf5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

