### PR TITLE
feat(craft): make last name optional in user info form

### DIFF
--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -217,10 +217,7 @@ export default function BuildOnboardingModal({
   const requiresLevel =
     workArea !== undefined && WORK_AREAS_REQUIRING_LEVEL.includes(workArea);
   const isUserInfoValid =
-    firstName.trim() &&
-    lastName.trim() &&
-    workArea &&
-    (!requiresLevel || level);
+    firstName.trim() && workArea && (!requiresLevel || level);
 
   const currentProviderConfig = PROVIDERS.find(
     (p) => p.key === selectedProvider
@@ -374,7 +371,7 @@ export default function BuildOnboardingModal({
 
       await onComplete({
         firstName: firstName.trim(),
-        lastName: lastName.trim(),
+        lastName: lastName.trim() || undefined,
         workArea,
         level: level || undefined,
       });

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -118,8 +118,10 @@ export function useOnboardingModal(): OnboardingModalController {
   // Complete user info callback
   const completeUserInfo = useCallback(
     async (info: BuildUserInfo) => {
-      // Save name via API
-      const fullName = `${info.firstName} ${info.lastName}`.trim();
+      // Save name via API (handle optional lastName)
+      const fullName = info.lastName
+        ? `${info.firstName} ${info.lastName}`.trim()
+        : info.firstName.trim();
       await updateUserPersonalization({ name: fullName });
 
       // Save persona to cookie

--- a/web/src/app/craft/onboarding/types.ts
+++ b/web/src/app/craft/onboarding/types.ts
@@ -2,7 +2,7 @@ import { WorkArea, Level } from "./constants";
 
 export interface BuildUserInfo {
   firstName: string;
-  lastName: string;
+  lastName?: string;
   workArea: WorkArea;
   level?: Level;
 }


### PR DESCRIPTION
- Update BuildUserInfo interface to make lastName optional
- Remove lastName from required validation in BuildOnboardingModal
- Handle undefined lastName in name concatenation logic

https://claude.ai/code/session_01RssUsNuBL9j76sKJ21EQP2

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes last name optional in the Craft onboarding user info form. Removes the last name requirement and updates name-saving logic to handle missing last names without blocking onboarding.

<sup>Written for commit 887639d056d75ca6fc3355ddc9adbd4a6b16a578. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

