### PR TITLE
fix: input masking

### DIFF
--- a/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
@@ -204,6 +204,7 @@ export default function ChangeCredentialsModal({
                 ) : (
                   <>
                     <input
+                      type="password"
                       className="border border-border rounded w-full py-2 px-3 bg-background-emphasis"
                       value={apiKey}
                       onChange={(e: any) => setApiKey(e.target.value)}

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -16,6 +16,10 @@ export function PHProvider({ children }: PHProviderProps) {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST!,
         person_profiles: "identified_only",
         capture_pageview: false,
+        session_recording: {
+          // Sensitive inputs should use data-ph-no-capture attribute
+          maskAllInputs: false,
+        },
       });
     }
   }, []);

--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
@@ -283,6 +283,7 @@ export default function PasswordInputTypeIn({
       variant={disabled ? "disabled" : error ? "error" : undefined}
       showClearButton={showClearButton}
       autoComplete="off"
+      data-ph-no-capture
       rightSection={
         showToggleButton ? (
           <IconButton


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix input masking for sensitive fields and session recordings. API keys are now hidden in the UI, and PostHog won’t record password inputs while non-sensitive fields remain visible.

- **Bug Fixes**
  - Mask API key in ChangeCredentialsModal by setting type="password".
  - Prevent PostHog capture of password inputs via data-ph-no-capture.
  - Configure PostHog session_recording with maskAllInputs: false so only marked sensitive fields are excluded.

<sup>Written for commit 017e45c20920373af2b45caab50303327c482cbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

