### PR TITLE
chore(fe): update baseline-browser-mapping

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -108,6 +108,7 @@
         "@types/uuid": "^9.0.8",
         "@typescript/native-preview": "7.0.0-dev.20251222.1",
         "babel-plugin-react-compiler": "^1.0.0",
+        "baseline-browser-mapping": "^2.9.19",
         "chromatic": "^11.25.2",
         "eslint": "^9.39.1",
         "eslint-config-next": "^16.0.1",
@@ -7861,7 +7862,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.25",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"

--- a/web/package.json
+++ b/web/package.json
@@ -124,6 +124,7 @@
     "@types/uuid": "^9.0.8",
     "@typescript/native-preview": "7.0.0-dev.20251222.1",
     "babel-plugin-react-compiler": "^1.0.0",
+    "baseline-browser-mapping": "^2.9.19",
     "chromatic": "^11.25.2",
     "eslint": "^9.39.1",
     "eslint-config-next": "^16.0.1",


### PR DESCRIPTION
## Description

The dev server warns about:

> [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`

on start, so run that command.

## How Has This Been Tested?

Captured by existing; confirmed no warnings when starting the dev server

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated baseline-browser-mapping to v2.9.19 to remove the dev server warning and keep Baseline data current. Verified the dev server starts clean with no warnings.

<sup>Written for commit 5e1244aa34c272e1e1eb1c94f422fd16f4f1d04d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

