### PR TITLE
fix(ce): documents sidebar spawns

### DIFF
--- a/web/src/app/app/nrf/NRFPage.tsx
+++ b/web/src/app/app/nrf/NRFPage.tsx
@@ -449,18 +449,16 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
       {/* Document sidebar - shown when sources are clicked */}
       <div
         className={cn(
-          "flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out absolute right-0 top-0 h-full z-20",
+          "absolute right-0 top-0 h-full z-20 overflow-hidden transition-all duration-300",
           documentSidebarVisible ? "w-[25rem]" : "w-0"
         )}
       >
-        <div className="h-full w-[25rem]">
-          <DocumentsSidebar
-            setPresentingDocument={setPresentingDocument}
-            modal={false}
-            closeSidebar={handleDocumentSidebarClose}
-            selectedDocuments={[]}
-          />
-        </div>
+        <DocumentsSidebar
+          setPresentingDocument={setPresentingDocument}
+          modal={false}
+          closeSidebar={handleDocumentSidebarClose}
+          selectedDocuments={[]}
+        />
       </div>
 
       {/* Text/document preview modal */}


### PR DESCRIPTION
## Description

add documents sidebar to chrome extension

## How Has This Been Tested?

locally
<img width="1915" height="932" alt="Screenshot 2026-01-29 at 16 27 49" src="https://github.com/user-attachments/assets/e8f8763d-da2c-458f-970f-fbe5789fb8a2" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the document sidebar in the NRF page so it opens from the right when a source is clicked and can be closed. Also adds a simple preview modal for the selected document.

- **Bug Fixes**
  - Wired DocumentsSidebar to the chat session store for open/close state.
  - Added a slide-in panel on the right with a close handler.
  - Passed setPresentingDocument to enable opening previews from source clicks.
  - Added TextView modal to preview the selected document.

<sup>Written for commit 3c82d0df62ce15ef560957b9493e3f20d1fbadcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



