### PR TITLE
chore(gha): build desktop app in CI

### DIFF
--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -37,10 +37,11 @@ jobs:
           #  os: macos-latest
           #  target: universal-apple-darwin
           #  args: "--target universal-apple-darwin"
-          - platform: windows
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-            args: ""
+          # TODO: Fix and enable the Windows build.
+          #- platform: windows
+          #  os: windows-latest
+          #  target: x86_64-pc-windows-msvc
+          #  args: ""
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

CI job to confirm the Desktop app builds

## How Has This Been Tested?

Should run on this PR

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that builds the Desktop app in CI to catch build issues early and publish artifacts for review. Runs on PRs, merge queues, and version tags.

- **New Features**
  - Triggers on PRs to main/release, merge_group, and v*.*.* tags; cancels superseded runs.
  - Builds on Linux (x86_64-unknown-linux-gnu) producing deb and rpm bundles; macOS and Windows temporarily disabled.
  - Uses Node 24, Rust stable, and npm/Cargo caching.
  - Installs Tauri Linux dependencies; runs npm ci and builds via Tauri in desktop/.
  - Uploads unsigned bundles from desktop/src-tauri/target/release/bundle as artifacts (kept 7 days).

<sup>Written for commit 3c65317522338016a6d84d9cfbb541308b5c4325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

