### PR TITLE
endpoint clean

### DIFF
--- a/backend/onyx/server/manage/web_search/api.py
+++ b/backend/onyx/server/manage/web_search/api.py
@@ -42,6 +42,7 @@ from onyx.tools.tool_implementations.web_search.providers import (
     build_search_provider_from_config,
 )
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.enums import WebContentProviderType
 from shared_configs.enums import WebSearchProviderType
 
@@ -378,6 +379,19 @@ def test_content_provider(
                 status_code=400,
                 detail="No stored API key found for this provider type.",
             )
+        if MULTI_TENANT:
+            stored_base_url = (
+                existing_provider.config.get("base_url")
+                if existing_provider.config
+                else None
+            )
+            request_base_url = request.config.base_url
+            if request_base_url != stored_base_url:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Base URL cannot differ from stored provider when using stored API key",
+                )
+
         api_key = existing_provider.api_key
 
     if not api_key:

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -13,8 +13,8 @@ from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
 
 
-def build_llm_model_config(llm: LLM, flow: str | None = None) -> dict[str, Any]:
-    model_config: dict[str, Any] = {
+def build_llm_model_config(llm: LLM, flow: str | None = None) -> dict[str, str]:
+    model_config: dict[str, str] = {
         "base_url": str(llm.config.api_base or ""),
         "model_provider": llm.config.model_provider,
     }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened endpoint security by blocking api_base/custom_config/base_url changes when reusing stored API keys in multi-tenant mode. Applied the checks across LLM, image generation, and web search endpoints, plus a small typing fix.

- **Bug Fixes**
  - Added shared validation to prevent endpoint/config changes without API key rotation (LLM provider test/put, image generation build/test/update, web search test).
  - In multi-tenant mode, return 400 if configs differ while using stored keys; otherwise behavior is unchanged.
  - Updated tracing utils to return dict[str, str] for LLM model config.

<sup>Written for commit 17588b502d048bb3edd021d0774d69f6ffb45187. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

