### PR TITLE
feat: Add `bottomSlot` to modal API

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -122,6 +122,9 @@ interface ModalContentProps
   preventAccidentalClose?: boolean;
   skipOverlay?: boolean;
   background?: "default" | "gray";
+  /** Content rendered below the modal card, floating with gap-4 (1rem) separation.
+   *  Stays inside DialogPrimitive.Content for proper focus management. */
+  bottomSlot?: React.ReactNode;
 }
 const ModalContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
@@ -135,6 +138,7 @@ const ModalContent = React.forwardRef<
       preventAccidentalClose = true,
       skipOverlay = false,
       background = "default",
+      bottomSlot,
       ...props
     },
     ref
@@ -249,6 +253,47 @@ const ModalContent = React.forwardRef<
       [preventAccidentalClose, hasModifiedInputs, hasAttemptedClose]
     );
 
+    const handleRef = (node: HTMLDivElement | null) => {
+      // Handle forwarded ref
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+      // Handle content ref with event listener
+      contentRef(node);
+    };
+
+    const animationClasses = cn(
+      "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+      "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+      "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
+      "duration-200"
+    );
+
+    const dialogEventHandlers = {
+      onOpenAutoFocus: (e: Event) => {
+        resetState();
+        props.onOpenAutoFocus?.(e);
+      },
+      onCloseAutoFocus: (e: Event) => {
+        resetState();
+        props.onCloseAutoFocus?.(e);
+      },
+      onEscapeKeyDown: handleInteractOutside,
+      onPointerDownOutside: handleInteractOutside,
+      ...(!hasDescription && { "aria-describedby": undefined }),
+      ...props,
+    };
+
+    const cardClasses = cn(
+      "overflow-hidden",
+      background === "gray" ? "bg-background-tint-01" : "bg-background-tint-00",
+      "border rounded-16 shadow-2xl",
+      "flex flex-col",
+      heightClasses[height]
+    );
+
     return (
       <ModalContext.Provider
         value={{
@@ -262,52 +307,51 @@ const ModalContent = React.forwardRef<
       >
         <DialogPrimitive.Portal>
           {!skipOverlay && <ModalOverlay />}
-          <DialogPrimitive.Content
-            ref={(node) => {
-              // Handle forwarded ref
-              if (typeof ref === "function") {
-                ref(node);
-              } else if (ref) {
-                ref.current = node;
-              }
-              // Handle content ref with event listener
-              contentRef(node);
-            }}
-            className={cn(
-              "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 overflow-hidden",
-              "z-modal",
-              background === "gray"
-                ? "bg-background-tint-01"
-                : "bg-background-tint-00",
-              "border rounded-16 shadow-2xl",
-              "flex flex-col",
-              // Never exceed viewport on small screens
-              "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
-              "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
-              "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
-              "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
-              "duration-200",
-              // Size classes
-              widthClasses[width],
-              heightClasses[height]
-            )}
-            onOpenAutoFocus={(e) => {
-              // Reset typing detection when modal opens
-              resetState();
-              props.onOpenAutoFocus?.(e);
-            }}
-            onCloseAutoFocus={(e) => {
-              // Reset typing detection when modal closes
-              resetState();
-              props.onCloseAutoFocus?.(e);
-            }}
-            onEscapeKeyDown={handleInteractOutside}
-            onPointerDownOutside={handleInteractOutside}
-            {...(!hasDescription && { "aria-describedby": undefined })}
-            {...props}
-          >
-            {children}
-          </DialogPrimitive.Content>
+          {bottomSlot ? (
+            // With bottomSlot: use asChild to wrap card + slot in a flex column
+            <DialogPrimitive.Content
+              asChild
+              ref={handleRef}
+              {...dialogEventHandlers}
+            >
+              <div
+                className={cn(
+                  "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2",
+                  "z-modal",
+                  "flex flex-col gap-4 items-center",
+                  "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
+                  animationClasses,
+                  widthClasses[width]
+                )}
+              >
+                <div className={cn(cardClasses, "w-full min-h-0")}>
+                  {children}
+                </div>
+                <div className="w-full flex-shrink-0">{bottomSlot}</div>
+              </div>
+            </DialogPrimitive.Content>
+          ) : (
+            // Without bottomSlot: original single-element rendering
+            <DialogPrimitive.Content
+              ref={handleRef}
+              className={cn(
+                "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 overflow-hidden",
+                "z-modal",
+                background === "gray"
+                  ? "bg-background-tint-01"
+                  : "bg-background-tint-00",
+                "border rounded-16 shadow-2xl",
+                "flex flex-col",
+                "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
+                animationClasses,
+                widthClasses[width],
+                heightClasses[height]
+              )}
+              {...dialogEventHandlers}
+            >
+              {children}
+            </DialogPrimitive.Content>
+          )}
         </DialogPrimitive.Portal>
       </ModalContext.Provider>
     );


### PR DESCRIPTION
## Description

This PR enables a floating "bottom-slot". Useful for the agent view-only modal.

## Screenshots

<img width="1488" height="1065" alt="image" src="https://github.com/user-attachments/assets/5235829f-75f1-42e3-a1b0-955e4c358fd4" />

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new bottomSlot prop to Modal to render a floating section below the modal card while preserving focus and keyboard behavior. Useful for the agent view-only modal.

- **New Features**
  - bottomSlot renders below the card with a 1rem gap, inside DialogPrimitive.Content for proper focus.
  - Uses asChild to wrap card + slot in a flex column, respecting width/height constraints.

- **Refactors**
  - Centralized ref handling (handleRef) and dialog event handlers.
  - Extracted animationClasses and cardClasses for reuse.
  - Conditional rendering path when bottomSlot is present vs original single-element rendering.

<sup>Written for commit e9dbaf5e4a2eabb7b8e17ee41142fad8230367f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

