### PR TITLE
chore(devserver): fix invalid customTheme require

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,15 +1,24 @@
 var merge = require("lodash/merge");
+var path = require("path");
+var fs = require("fs");
 
 // Use relative paths for imports
 const baseThemes = require("./tailwind-themes/tailwind.config.js");
 
-const customThemes = process.env.NEXT_PUBLIC_THEME
-  ? require(
-      process.env.NEXT_PUBLIC_THEME
-        ? `./tailwind-themes/custom/${process.env.NEXT_PUBLIC_THEME}/tailwind.config.js`
-        : "./tailwind-themes/custom/default/tailwind.config.js"
-    )
-  : null;
+let customThemes = null;
+
+// Determine which theme to load: custom theme if specified, otherwise default
+const themeName = process.env.NEXT_PUBLIC_THEME || "default";
+const customThemePath = path.join(
+  __dirname,
+  "tailwind-themes/custom",
+  themeName,
+  "tailwind.config.js"
+);
+
+if (fs.existsSync(customThemePath)) {
+  customThemes = require(customThemePath);
+}
 
 /** @type {import('tailwindcss').Config} */
 module.exports = customThemes ? merge(baseThemes, customThemes) : baseThemes;


### PR DESCRIPTION
## Description

The [next.js upgrade from 16.0 to 16.1](https://github.com/onyx-dot-app/onyx/pull/7882) included stricter static analysis which in turn caused this existing customThemes to fail to import since we don't provide any custom theming out-of-the-box -- this is only intended for whitelabeling.

```
⚠ ./tailwind.config.js:7:5
Module not found: Can't resolve <dynamic>
   5 |
   6 | const customThemes = process.env.NEXT_PUBLIC_THEME
>  7 |   ? require(
     |     ^^^^^^^^
>  8 |       process.env.NEXT_PUBLIC_THEME
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>  9 |         ? `./tailwind-themes/custom/${process.env.NEXT_PUBLIC_THEME}/tailwind.config.js`
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 10 |         : "./tailwind-themes/custom/default/tailwind.config.js"
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 11 |     )
     | ^^^^^^
  12 |   : null;
  13 |
  14 | /** @type {import('tailwindcss').Config} */
```

This instead only tries to import it if the file actually exists therefore satisfying this static, build-time check.

## How Has This Been Tested?

`npm run dev` and confirmed no warnings

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Next.js 16.1 static analysis errors by guarding the dynamic import of custom Tailwind themes. We now only load a custom theme if its config file exists; otherwise we use the base theme.

- **Bug Fixes**
  - Build the customThemePath with path.join and use NEXT_PUBLIC_THEME or "default".
  - Check fs.existsSync before requiring the custom theme.
  - Merge base and custom only when present to avoid build-time warnings.

<sup>Written for commit c1e087a3fee42deb960cf2410e538e16bc713dce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

