### PR TITLE
fix(ee): use set(ex=) instead of setex() for license cache updates

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -227,10 +227,10 @@ def update_license_cache(
         stripe_subscription_id=payload.stripe_subscription_id,
     )
 
-    redis_client.setex(
+    redis_client.set(
         LICENSE_METADATA_KEY,
-        LICENSE_CACHE_TTL_SECONDS,
         metadata.model_dump_json(),
+        ex=LICENSE_CACHE_TTL_SECONDS,
     )
 
     logger.info(f"License cache updated: {metadata.seats} seats, status={status.value}")


### PR DESCRIPTION
## Description

Fixes a multi-tenant cache key prefixing issue in license caching.

The `TenantRedis` wrapper only prefixes keys for methods in its `methods_to_wrap` list, which includes `set()` but not `setex()`. Using `setex()` caused the license cache key to be written without the tenant prefix, breaking multi-tenant deployments where tenants could inadvertently share cached license data.

Changed from:
```python
redis_client.setex(key, ttl, value)
```

To:
```python
redis_client.set(key, value, ex=ttl)
```

## How Has This Been Tested?

Local e2e testing with control-plane, multi-tenant data plane, and self hosted servers in the loop

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix license cache key prefixing in multi-tenant setups by replacing Redis setex() with set(ex=). Ensures TenantRedis adds the tenant prefix so caches stay isolated per tenant.

- **Bug Fixes**
  - Use set(..., ex=TTL) instead of setex() so TenantRedis prefixes the license cache key.
  - Prevents cross-tenant license cache collisions.

<sup>Written for commit 4191ee7a50ce394c1facfa708b40c1db919617ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

