### PR TITLE
feat(billing): add circuit breaker, license re-claim, and seats to checkout

### DIFF
--- a/backend/ee/onyx/server/billing/api.py
+++ b/backend/ee/onyx/server/billing/api.py
@@ -27,6 +27,7 @@ import httpx
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ee.onyx.auth.users import current_admin_user
@@ -56,6 +57,7 @@ from onyx.configs.app_configs import STRIPE_PUBLISHABLE_KEY_OVERRIDE
 from onyx.configs.app_configs import STRIPE_PUBLISHABLE_KEY_URL
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
+from onyx.redis.redis_pool import get_shared_redis_client
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
@@ -67,6 +69,63 @@ router = APIRouter(prefix="/admin/billing")
 # Cache for Stripe publishable key to avoid hitting S3 on every request
 _stripe_publishable_key_cache: str | None = None
 _stripe_key_lock = asyncio.Lock()
+
+# Redis key for billing circuit breaker (self-hosted only)
+# When set, billing requests to Stripe are disabled until user manually retries
+BILLING_CIRCUIT_BREAKER_KEY = "billing_circuit_open"
+# Circuit breaker auto-expires after 1 hour (user can manually retry sooner)
+BILLING_CIRCUIT_BREAKER_TTL_SECONDS = 3600
+
+
+def _is_billing_circuit_open() -> bool:
+    """Check if the billing circuit breaker is open (self-hosted only)."""
+    if MULTI_TENANT:
+        return False
+    try:
+        redis_client = get_shared_redis_client()
+        is_open = bool(redis_client.exists(BILLING_CIRCUIT_BREAKER_KEY))
+        logger.debug(
+            f"Circuit breaker check: key={BILLING_CIRCUIT_BREAKER_KEY}, is_open={is_open}"
+        )
+        return is_open
+    except Exception as e:
+        logger.error(f"Failed to check circuit breaker: {e}")
+        return False
+
+
+def _open_billing_circuit() -> None:
+    """Open the billing circuit breaker after a failure (self-hosted only)."""
+    if MULTI_TENANT:
+        return
+    try:
+        redis_client = get_shared_redis_client()
+        redis_client.set(
+            BILLING_CIRCUIT_BREAKER_KEY,
+            "1",
+            ex=BILLING_CIRCUIT_BREAKER_TTL_SECONDS,
+        )
+        # Verify it was set
+        exists = redis_client.exists(BILLING_CIRCUIT_BREAKER_KEY)
+        logger.warning(
+            f"Billing circuit breaker opened (TTL={BILLING_CIRCUIT_BREAKER_TTL_SECONDS}s, "
+            f"verified={exists}). Stripe billing requests are disabled until manually reset."
+        )
+    except Exception as e:
+        logger.error(f"Failed to open circuit breaker: {e}")
+
+
+def _close_billing_circuit() -> None:
+    """Close the billing circuit breaker (re-enable Stripe requests)."""
+    if MULTI_TENANT:
+        return
+    try:
+        redis_client = get_shared_redis_client()
+        redis_client.delete(BILLING_CIRCUIT_BREAKER_KEY)
+        logger.info(
+            "Billing circuit breaker closed. Stripe billing requests re-enabled."
+        )
+    except Exception as e:
+        logger.error(f"Failed to close circuit breaker: {e}")
 
 
 def _get_license_data(db_session: Session) -> str | None:
@@ -102,6 +161,7 @@ async def create_checkout_session(
     license_data = _get_license_data(db_session)
     tenant_id = _get_tenant_id()
     billing_period = request.billing_period if request else "monthly"
+    seats = request.seats if request else None
     email = request.email if request else None
 
     # Build redirect URL for after checkout completion
@@ -110,6 +170,7 @@ async def create_checkout_session(
     try:
         return await create_checkout_service(
             billing_period=billing_period,
+            seats=seats,
             email=email,
             license_data=license_data,
             redirect_url=redirect_url,
@@ -156,6 +217,8 @@ async def get_billing_information(
     """Get billing information for the current subscription.
 
     Returns subscription status and details from Stripe.
+    For self-hosted: If the circuit breaker is open (previous failure),
+    returns a 503 error without making the request.
     """
     license_data = _get_license_data(db_session)
     tenant_id = _get_tenant_id()
@@ -164,12 +227,22 @@ async def get_billing_information(
     if not MULTI_TENANT and not license_data:
         return SubscriptionStatusResponse(subscribed=False)
 
+    # Check circuit breaker (self-hosted only)
+    if _is_billing_circuit_open():
+        raise HTTPException(
+            status_code=503,
+            detail="Stripe connection temporarily disabled. Click 'Connect to Stripe' to retry.",
+        )
+
     try:
         return await get_billing_service(
             license_data=license_data,
             tenant_id=tenant_id,
         )
     except BillingServiceError as e:
+        # Open circuit breaker on connection failures (self-hosted only)
+        if e.status_code in (502, 503, 504):
+            _open_billing_circuit()
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
 
@@ -182,6 +255,8 @@ async def update_seats(
     """Update the seat count for the current subscription.
 
     Handles Stripe proration and license regeneration via control plane.
+    For self-hosted, the frontend should call /license/claim after a short delay
+    to fetch the regenerated license.
     """
     license_data = _get_license_data(db_session)
     tenant_id = _get_tenant_id()
@@ -191,11 +266,17 @@ async def update_seats(
         raise HTTPException(status_code=400, detail="No license found")
 
     try:
-        return await update_seat_service(
+        result = await update_seat_service(
             new_seat_count=request.new_seat_count,
             license_data=license_data,
             tenant_id=tenant_id,
         )
+
+        # Note: Don't store license here - the control plane may still be processing
+        # the subscription update. The frontend should call /license/claim after a
+        # short delay to get the freshly generated license.
+
+        return result
     except BillingServiceError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
@@ -262,3 +343,31 @@ async def get_stripe_publishable_key() -> StripePublishableKeyResponse:
                 status_code=500,
                 detail="Failed to fetch Stripe publishable key",
             )
+
+
+class ResetConnectionResponse(BaseModel):
+    success: bool
+    message: str
+
+
+@router.post("/reset-connection")
+async def reset_stripe_connection(
+    _: User = Depends(current_admin_user),
+) -> ResetConnectionResponse:
+    """Reset the Stripe connection circuit breaker.
+
+    Called when user clicks "Connect to Stripe" to retry after a previous failure.
+    This clears the circuit breaker flag, allowing billing requests to proceed again.
+    Self-hosted only - cloud deployments don't use the circuit breaker.
+    """
+    if MULTI_TENANT:
+        return ResetConnectionResponse(
+            success=True,
+            message="Circuit breaker not applicable for cloud deployments",
+        )
+
+    _close_billing_circuit()
+    return ResetConnectionResponse(
+        success=True,
+        message="Stripe connection reset. Billing requests re-enabled.",
+    )

--- a/backend/ee/onyx/server/billing/models.py
+++ b/backend/ee/onyx/server/billing/models.py
@@ -10,6 +10,7 @@ class CreateCheckoutSessionRequest(BaseModel):
     """Request to create a Stripe checkout session."""
 
     billing_period: Literal["monthly", "annual"] = "monthly"
+    seats: int | None = None
     email: str | None = None
 
 
@@ -67,6 +68,7 @@ class SeatUpdateResponse(BaseModel):
     current_seats: int
     used_seats: int
     message: str | None = None
+    license: str | None = None  # Regenerated license (self-hosted stores this)
 
 
 class StripePublishableKeyResponse(BaseModel):

--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -103,6 +103,7 @@ async def _make_billing_request(
     Raises:
         BillingServiceError: If request fails
     """
+
     base_url = _get_base_url()
     url = f"{base_url}{path}"
     headers = _get_headers(license_data)
@@ -134,6 +135,7 @@ async def _make_billing_request(
 
 async def create_checkout_session(
     billing_period: str = "monthly",
+    seats: int | None = None,
     email: str | None = None,
     license_data: str | None = None,
     redirect_url: str | None = None,
@@ -143,6 +145,7 @@ async def create_checkout_session(
 
     Args:
         billing_period: "monthly" or "annual"
+        seats: Number of seats to purchase (optional, uses default if not provided)
         email: Customer email for new subscriptions
         license_data: Existing license for renewals (self-hosted)
         redirect_url: URL to redirect after successful checkout
@@ -152,6 +155,8 @@ async def create_checkout_session(
         CreateCheckoutSessionResponse with checkout URL
     """
     body: dict = {"billing_period": billing_period}
+    if seats is not None:
+        body["seats"] = seats
     if email:
         body["email"] = email
     if redirect_url:
@@ -264,4 +269,5 @@ async def update_seat_count(
         current_seats=data.get("current_seats", 0),
         used_seats=data.get("used_seats", 0),
         message=data.get("message"),
+        license=data.get("license"),
     )

--- a/backend/ee/onyx/server/license/api.py
+++ b/backend/ee/onyx/server/license/api.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.auth.users import current_admin_user
 from ee.onyx.configs.app_configs import CLOUD_DATA_PLANE_URL
 from ee.onyx.db.license import delete_license as db_delete_license
+from ee.onyx.db.license import get_license
 from ee.onyx.db.license import get_license_metadata
 from ee.onyx.db.license import invalidate_license_cache
 from ee.onyx.db.license import refresh_license_cache
@@ -90,24 +91,21 @@ async def get_seat_usage(
 
 @router.post("/claim")
 async def claim_license(
-    session_id: str,
+    session_id: str | None = None,
     _: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
 ) -> LicenseResponse:
     """
-    Claim a license after Stripe checkout (self-hosted only).
+    Claim a license from the control plane (self-hosted only).
 
-    After a user completes Stripe checkout, they're redirected back with a
-    session_id. This endpoint exchanges that session_id for a signed license
-    via the cloud data plane proxy.
+    Two modes:
+    1. With session_id: After Stripe checkout, exchange session_id for license
+    2. Without session_id: Re-claim using existing license for auth
 
-    Flow:
-    1. Self-hosted frontend redirects to Stripe checkout (via cloud proxy)
-    2. User completes payment
-    3. Stripe redirects back to self-hosted instance with session_id
-    4. Frontend calls this endpoint with session_id
-    5. We call cloud data plane /proxy/claim-license to get the signed license
-    6. License is stored locally and cached
+    Use without session_id after:
+    - Updating seats via the billing API
+    - Returning from the Stripe customer portal
+    - Any operation that regenerates the license on control plane
     """
     if MULTI_TENANT:
         raise HTTPException(
@@ -116,14 +114,40 @@ async def claim_license(
         )
 
     try:
-        # Call cloud data plane to claim the license
-        url = f"{CLOUD_DATA_PLANE_URL}/proxy/claim-license"
-        response = requests.post(
-            url,
-            json={"session_id": session_id},
-            headers={"Content-Type": "application/json"},
-            timeout=30,
-        )
+        if session_id:
+            # Claim license after checkout using session_id
+            url = f"{CLOUD_DATA_PLANE_URL}/proxy/claim-license"
+            response = requests.post(
+                url,
+                json={"session_id": session_id},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+        else:
+            # Re-claim using existing license for auth
+            metadata = get_license_metadata(db_session)
+            if not metadata or not metadata.tenant_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="No license found. Provide session_id after checkout.",
+                )
+
+            license_row = get_license(db_session)
+            if not license_row or not license_row.license_data:
+                raise HTTPException(
+                    status_code=400, detail="No license found in database"
+                )
+
+            url = f"{CLOUD_DATA_PLANE_URL}/proxy/license/{metadata.tenant_id}"
+            response = requests.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {license_row.license_data}",
+                    "Content-Type": "application/json",
+                },
+                timeout=30,
+            )
+
         response.raise_for_status()
 
         data = response.json()

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -29,17 +29,13 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 
 from ee.onyx.configs.app_configs import LICENSE_ENFORCEMENT_ENABLED
-from ee.onyx.db.license import update_license_cache
-from ee.onyx.db.license import upsert_license
 from ee.onyx.server.billing.models import SeatUpdateRequest
 from ee.onyx.server.billing.models import SeatUpdateResponse
 from ee.onyx.server.license.models import LicensePayload
-from ee.onyx.server.license.models import LicenseSource
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.utils.license import is_license_valid
 from ee.onyx.utils.license import verify_license_signature
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
-from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -209,36 +205,6 @@ async def forward_to_control_plane(
         )
 
 
-def fetch_and_store_license(tenant_id: str, license_data: str) -> None:
-    """Store license in database and update Redis cache.
-
-    Args:
-        tenant_id: The tenant ID
-        license_data: Base64-encoded signed license blob
-    """
-    try:
-        # Verify before storing
-        payload = verify_license_signature(license_data)
-
-        # Store in database using the specific tenant's schema
-        with get_session_with_tenant(tenant_id=tenant_id) as db_session:
-            upsert_license(db_session, license_data)
-
-        # Update Redis cache
-        update_license_cache(
-            payload,
-            source=LicenseSource.AUTO_FETCH,
-            tenant_id=tenant_id,
-        )
-
-    except ValueError as e:
-        logger.error(f"Failed to verify license: {e}")
-        raise
-    except Exception:
-        logger.exception("Failed to store license")
-        raise
-
-
 # -----------------------------------------------------------------------------
 # Endpoints
 # -----------------------------------------------------------------------------
@@ -246,6 +212,7 @@ def fetch_and_store_license(tenant_id: str, license_data: str) -> None:
 
 class CreateCheckoutSessionRequest(BaseModel):
     billing_period: Literal["monthly", "annual"] = "monthly"
+    seats: int | None = None
     email: str | None = None
     # Redirect URL after successful checkout - self-hosted passes their instance URL
     redirect_url: str | None = None
@@ -277,6 +244,8 @@ async def proxy_create_checkout_session(
     }
     if tenant_id:
         body["tenant_id"] = tenant_id
+    if request_body.seats is not None:
+        body["seats"] = request_body.seats
     if request_body.email:
         body["email"] = request_body.email
     if request_body.redirect_url:
@@ -439,7 +408,6 @@ async def proxy_license_fetch(
 
     result = await forward_to_control_plane("GET", f"/license/{tenant_id}")
 
-    # Auto-store the refreshed license
     license_data = result.get("license")
     if not license_data:
         logger.error(f"Control plane returned incomplete license response: {result}")
@@ -448,8 +416,7 @@ async def proxy_license_fetch(
             detail="Control plane returned incomplete license data",
         )
 
-    fetch_and_store_license(tenant_id, license_data)
-
+    # Return license to caller - self-hosted instance stores it via /api/license/claim
     return LicenseFetchResponse(license=license_data, tenant_id=tenant_id)
 
 
@@ -462,6 +429,7 @@ async def proxy_seat_update(
 
     Auth: Valid (non-expired) license required.
     Handles Stripe proration and license regeneration.
+    Returns the regenerated license in the response for the caller to store.
     """
     if not license_payload.tenant_id:
         raise HTTPException(status_code=401, detail="License missing tenant_id")
@@ -477,9 +445,11 @@ async def proxy_seat_update(
         },
     )
 
+    # Return license in response - self-hosted instance stores it via /api/license/claim
     return SeatUpdateResponse(
         success=result.get("success", False),
         current_seats=result.get("current_seats", 0),
         used_seats=result.get("used_seats", 0),
         message=result.get("message"),
+        license=result.get("license"),
     )

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
@@ -309,3 +309,253 @@ class TestUpdateSeats:
 
         assert exc_info.value.status_code == 400
         assert "Cannot reduce below 10 seats" in exc_info.value.detail
+
+
+class TestCircuitBreaker:
+    """Tests for the billing circuit breaker functionality."""
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._is_billing_circuit_open")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_returns_503_when_circuit_open(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_circuit_open: MagicMock,
+    ) -> None:
+        """Should return 503 when circuit breaker is open."""
+        from fastapi import HTTPException
+
+        from ee.onyx.server.billing.api import get_billing_information
+
+        mock_get_license.return_value = "license_blob"
+        mock_get_tenant.return_value = None
+        mock_circuit_open.return_value = True
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_billing_information(_=MagicMock(), db_session=MagicMock())
+
+        assert exc_info.value.status_code == 503
+        assert "Connect to Stripe" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._open_billing_circuit")
+    @patch("ee.onyx.server.billing.api._is_billing_circuit_open")
+    @patch("ee.onyx.server.billing.api.get_billing_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_opens_circuit_on_502_error(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+        mock_circuit_open_check: MagicMock,
+        mock_open_circuit: MagicMock,
+    ) -> None:
+        """Should open circuit breaker on 502 error."""
+        from fastapi import HTTPException
+
+        from ee.onyx.server.billing.api import get_billing_information
+
+        mock_get_license.return_value = "license_blob"
+        mock_get_tenant.return_value = None
+        mock_circuit_open_check.return_value = False
+        mock_service.side_effect = BillingServiceError("Connection failed", 502)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_billing_information(_=MagicMock(), db_session=MagicMock())
+
+        assert exc_info.value.status_code == 502
+        mock_open_circuit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._open_billing_circuit")
+    @patch("ee.onyx.server.billing.api._is_billing_circuit_open")
+    @patch("ee.onyx.server.billing.api.get_billing_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_opens_circuit_on_503_error(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+        mock_circuit_open_check: MagicMock,
+        mock_open_circuit: MagicMock,
+    ) -> None:
+        """Should open circuit breaker on 503 error."""
+        from fastapi import HTTPException
+
+        from ee.onyx.server.billing.api import get_billing_information
+
+        mock_get_license.return_value = "license_blob"
+        mock_get_tenant.return_value = None
+        mock_circuit_open_check.return_value = False
+        mock_service.side_effect = BillingServiceError("Service unavailable", 503)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_billing_information(_=MagicMock(), db_session=MagicMock())
+
+        assert exc_info.value.status_code == 503
+        mock_open_circuit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._open_billing_circuit")
+    @patch("ee.onyx.server.billing.api._is_billing_circuit_open")
+    @patch("ee.onyx.server.billing.api.get_billing_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_opens_circuit_on_504_error(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+        mock_circuit_open_check: MagicMock,
+        mock_open_circuit: MagicMock,
+    ) -> None:
+        """Should open circuit breaker on 504 error."""
+        from fastapi import HTTPException
+
+        from ee.onyx.server.billing.api import get_billing_information
+
+        mock_get_license.return_value = "license_blob"
+        mock_get_tenant.return_value = None
+        mock_circuit_open_check.return_value = False
+        mock_service.side_effect = BillingServiceError("Gateway timeout", 504)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_billing_information(_=MagicMock(), db_session=MagicMock())
+
+        assert exc_info.value.status_code == 504
+        mock_open_circuit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._open_billing_circuit")
+    @patch("ee.onyx.server.billing.api._is_billing_circuit_open")
+    @patch("ee.onyx.server.billing.api.get_billing_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_does_not_open_circuit_on_400_error(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+        mock_circuit_open_check: MagicMock,
+        mock_open_circuit: MagicMock,
+    ) -> None:
+        """Should NOT open circuit breaker on 400 error (client error)."""
+        from fastapi import HTTPException
+
+        from ee.onyx.server.billing.api import get_billing_information
+
+        mock_get_license.return_value = "license_blob"
+        mock_get_tenant.return_value = None
+        mock_circuit_open_check.return_value = False
+        mock_service.side_effect = BillingServiceError("Bad request", 400)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_billing_information(_=MagicMock(), db_session=MagicMock())
+
+        assert exc_info.value.status_code == 400
+        mock_open_circuit.assert_not_called()
+
+
+class TestResetConnection:
+    """Tests for reset_stripe_connection endpoint."""
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.billing.api._close_billing_circuit")
+    async def test_closes_circuit_for_self_hosted(
+        self,
+        mock_close_circuit: MagicMock,
+    ) -> None:
+        """Should close circuit breaker for self-hosted deployment."""
+        from ee.onyx.server.billing.api import reset_stripe_connection
+
+        result = await reset_stripe_connection(_=MagicMock())
+
+        assert result.success is True
+        assert "re-enabled" in result.message.lower()
+        mock_close_circuit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.MULTI_TENANT", True)
+    @patch("ee.onyx.server.billing.api._close_billing_circuit")
+    async def test_noop_for_cloud(
+        self,
+        mock_close_circuit: MagicMock,
+    ) -> None:
+        """Should be no-op for cloud deployment."""
+        from ee.onyx.server.billing.api import reset_stripe_connection
+
+        result = await reset_stripe_connection(_=MagicMock())
+
+        assert result.success is True
+        assert "not applicable" in result.message.lower()
+        mock_close_circuit.assert_not_called()
+
+
+class TestCheckoutSessionWithSeats:
+    """Tests for checkout session with seats parameter."""
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.create_checkout_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_passes_seats_parameter(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+    ) -> None:
+        """Should pass seats parameter to service."""
+        from ee.onyx.server.billing.api import create_checkout_session
+        from ee.onyx.server.billing.models import CreateCheckoutSessionRequest
+
+        mock_get_license.return_value = None
+        mock_get_tenant.return_value = "tenant_123"
+        mock_service.return_value = CreateCheckoutSessionResponse(
+            stripe_checkout_url="https://checkout.stripe.com/session"
+        )
+
+        request = CreateCheckoutSessionRequest(billing_period="monthly", seats=25)
+        await create_checkout_session(
+            request=request, _=MagicMock(), db_session=MagicMock()
+        )
+
+        call_kwargs = mock_service.call_args[1]
+        assert call_kwargs["seats"] == 25
+
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.create_checkout_service")
+    @patch("ee.onyx.server.billing.api._get_tenant_id")
+    @patch("ee.onyx.server.billing.api._get_license_data")
+    async def test_seats_none_when_not_provided(
+        self,
+        mock_get_license: MagicMock,
+        mock_get_tenant: MagicMock,
+        mock_service: AsyncMock,
+    ) -> None:
+        """Should pass None for seats when not provided."""
+        from ee.onyx.server.billing.api import create_checkout_session
+        from ee.onyx.server.billing.models import CreateCheckoutSessionRequest
+
+        mock_get_license.return_value = None
+        mock_get_tenant.return_value = "tenant_123"
+        mock_service.return_value = CreateCheckoutSessionResponse(
+            stripe_checkout_url="https://checkout.stripe.com/session"
+        )
+
+        request = CreateCheckoutSessionRequest(billing_period="annual")
+        await create_checkout_session(
+            request=request, _=MagicMock(), db_session=MagicMock()
+        )
+
+        call_kwargs = mock_service.call_args[1]
+        assert call_kwargs["seats"] is None

--- a/backend/tests/unit/ee/onyx/server/tenants/test_proxy.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_proxy.py
@@ -444,3 +444,132 @@ class TestForwardToControlPlane:
 
             with pytest.raises(ValueError, match="Unsupported HTTP method"):
                 await forward_to_control_plane("DELETE", "/test")
+
+
+class TestProxyCheckoutSessionWithSeats:
+    """Tests for proxy checkout session with seats parameter."""
+
+    @pytest.mark.asyncio
+    async def test_includes_seats_in_body_when_provided(self) -> None:
+        """Should include seats in request body when provided."""
+        from ee.onyx.server.tenants.proxy import proxy_create_checkout_session
+        from ee.onyx.server.tenants.proxy import CreateCheckoutSessionRequest
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"url": "https://checkout.stripe.com/session"}
+        mock_response.raise_for_status = MagicMock()
+
+        license_payload = make_license_payload()
+
+        with (
+            LICENSE_ENABLED_PATCH,
+            patch(
+                "ee.onyx.server.tenants.proxy.generate_data_plane_token"
+            ) as mock_token,
+            patch("ee.onyx.server.tenants.proxy.httpx.AsyncClient") as mock_client,
+            patch(
+                "ee.onyx.server.tenants.proxy.CONTROL_PLANE_API_BASE_URL",
+                "https://control.example.com",
+            ),
+        ):
+            mock_token.return_value = "cp_token"
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            request = CreateCheckoutSessionRequest(
+                billing_period="monthly",
+                seats=25,
+                email="test@example.com",
+            )
+            await proxy_create_checkout_session(
+                request_body=request,
+                license_payload=license_payload,
+            )
+
+            # Verify seats was included in the body
+            call_kwargs = mock_post.call_args[1]
+            body = call_kwargs["json"]
+            assert body["seats"] == 25
+            assert body["billing_period"] == "monthly"
+            assert body["email"] == "test@example.com"
+            assert body["tenant_id"] == "tenant_123"
+
+    @pytest.mark.asyncio
+    async def test_excludes_seats_when_not_provided(self) -> None:
+        """Should not include seats in request body when not provided."""
+        from ee.onyx.server.tenants.proxy import proxy_create_checkout_session
+        from ee.onyx.server.tenants.proxy import CreateCheckoutSessionRequest
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"url": "https://checkout.stripe.com/session"}
+        mock_response.raise_for_status = MagicMock()
+
+        license_payload = make_license_payload()
+
+        with (
+            LICENSE_ENABLED_PATCH,
+            patch(
+                "ee.onyx.server.tenants.proxy.generate_data_plane_token"
+            ) as mock_token,
+            patch("ee.onyx.server.tenants.proxy.httpx.AsyncClient") as mock_client,
+            patch(
+                "ee.onyx.server.tenants.proxy.CONTROL_PLANE_API_BASE_URL",
+                "https://control.example.com",
+            ),
+        ):
+            mock_token.return_value = "cp_token"
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            request = CreateCheckoutSessionRequest(billing_period="annual")
+            await proxy_create_checkout_session(
+                request_body=request,
+                license_payload=license_payload,
+            )
+
+            # Verify seats was NOT included in the body
+            call_kwargs = mock_post.call_args[1]
+            body = call_kwargs["json"]
+            assert "seats" not in body
+            assert body["billing_period"] == "annual"
+
+    @pytest.mark.asyncio
+    async def test_includes_seats_for_new_customer(self) -> None:
+        """Should include seats for new customer without license."""
+        from ee.onyx.server.tenants.proxy import proxy_create_checkout_session
+        from ee.onyx.server.tenants.proxy import CreateCheckoutSessionRequest
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"url": "https://checkout.stripe.com/session"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            LICENSE_ENABLED_PATCH,
+            patch(
+                "ee.onyx.server.tenants.proxy.generate_data_plane_token"
+            ) as mock_token,
+            patch("ee.onyx.server.tenants.proxy.httpx.AsyncClient") as mock_client,
+            patch(
+                "ee.onyx.server.tenants.proxy.CONTROL_PLANE_API_BASE_URL",
+                "https://control.example.com",
+            ),
+        ):
+            mock_token.return_value = "cp_token"
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            request = CreateCheckoutSessionRequest(
+                billing_period="monthly",
+                seats=10,
+            )
+            # New customer has no license
+            await proxy_create_checkout_session(
+                request_body=request,
+                license_payload=None,
+            )
+
+            # Verify seats was included but no tenant_id
+            call_kwargs = mock_post.call_args[1]
+            body = call_kwargs["json"]
+            assert body["seats"] == 10
+            assert "tenant_id" not in body


### PR DESCRIPTION
## Description

Backend billing enhancements for self-hosted deployments:

**Circuit Breaker for Stripe Failures**
- Redis-based circuit breaker prevents request flooding when Stripe is unreachable
- Auto-opens on 502/503/504 errors from billing service
- New `POST /admin/billing/reset-connection` endpoint to manually retry
- 1-hour TTL auto-closes the circuit if not manually reset

**Seats Parameter in Checkout**
- Adds `seats` parameter to checkout session creation
- Allows specifying seat count during initial purchase flow

**License Re-claim Without Session ID**
- Enhanced `/license/claim` endpoint supports re-claiming using existing license for auth
- Enables refreshing license after Stripe portal actions (seat changes, plan updates)
- Uses existing license as Bearer token when no session_id provided

**Tenant Proxy Refactor**
- Returns license in response instead of auto-storing
- Self-hosted instance stores via `/api/license/claim` for explicit control

## How Has This Been Tested?

Local e2e testing with control-plane, multi-tenant data plane, and self hosted servers in the loop

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Redis-backed circuit breaker for Stripe outages and supports seats in checkout for self-hosted billing. Also enables license re-claim without a session_id and updates the flow so licenses are stored explicitly by the instance.

- **New Features**
  - Circuit breaker for Stripe failures (self-hosted): opens on 502/503/504, auto-closes after 1 hour, and can be manually reset via POST /admin/billing/reset-connection. When open, billing info returns 503 and no Stripe calls are made.
  - Checkout supports a seats parameter for initial purchases.
  - /license/claim accepts no session_id to re-claim using the existing license (use after seat changes or portal actions).
  - Tenant proxy now returns license data; the self-hosted instance stores it via /license/claim for explicit control.

- **Migration**
  - Add a “Connect to Stripe” action in the UI to call POST /admin/billing/reset-connection after a failed billing request.
  - After updating seats or exiting the Stripe portal, call POST /license/claim without a session_id to fetch and store the refreshed license.
  - When starting checkout, optionally pass seats to pre-set the seat count.

<sup>Written for commit cbb6ae92eb1eae2474a42347f3830bca21e6fb14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

