### PR TITLE
fix: onboarding model specification

### DIFF
--- a/web/src/refresh-components/onboarding/components/llmConnectionHelpers.ts
+++ b/web/src/refresh-components/onboarding/components/llmConnectionHelpers.ts
@@ -85,7 +85,10 @@ export const testApiKeyHelper = async (
     api_version: finalApiVersion,
     deployment_name: finalDeploymentName,
     provider: providerName,
+    // since this is used for onboarding, we always specify the
+    // API key and custom config
     api_key_changed: true,
+    custom_config_changed: true,
     custom_config: {
       ...(formValues?.custom_config ?? {}),
       ...(customConfigOverride ?? {}),


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

Created model locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure onboarding LLM connection tests always use the provided API key and custom config, fixing cases where the model/deployment wasn’t recognized. This prevents stale settings from being reused during onboarding.

- **Bug Fixes**
  - Set api_key_changed and custom_config_changed to true in testApiKeyHelper so the backend validates with the latest credentials and config.

<sup>Written for commit 6da2bb1b25a4a6dba4286045712229c5d5f973fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

