### PR TITLE
fix(asana): Workspace Team ID mismatch (#7674) to release v2.10

### DIFF
--- a/backend/onyx/connectors/asana/connector.py
+++ b/backend/onyx/connectors/asana/connector.py
@@ -25,11 +25,17 @@ class AsanaConnector(LoadConnector, PollConnector):
         batch_size: int = INDEX_BATCH_SIZE,
         continue_on_failure: bool = CONTINUE_ON_CONNECTOR_FAILURE,
     ) -> None:
-        self.workspace_id = asana_workspace_id
-        self.project_ids_to_index: list[str] | None = (
-            asana_project_ids.split(",") if asana_project_ids is not None else None
-        )
-        self.asana_team_id = asana_team_id
+        self.workspace_id = asana_workspace_id.strip()
+        if asana_project_ids:
+            project_ids = [
+                project_id.strip()
+                for project_id in asana_project_ids.split(",")
+                if project_id.strip()
+            ]
+            self.project_ids_to_index = project_ids or None
+        else:
+            self.project_ids_to_index = None
+        self.asana_team_id = (asana_team_id.strip() or None) if asana_team_id else None
         self.batch_size = batch_size
         self.continue_on_failure = continue_on_failure
         logger.info(

--- a/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
+++ b/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
@@ -1,0 +1,50 @@
+"""Tests for Asana connector configuration parsing."""
+
+import pytest
+
+from onyx.connectors.asana.connector import AsanaConnector
+
+
+@pytest.mark.parametrize(
+    "project_ids,expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (" 123 ", ["123"]),
+        (" 123 , , 456 , ", ["123", "456"]),
+    ],
+)
+def test_asana_connector_project_ids_normalization(
+    project_ids: str | None, expected: list[str] | None
+) -> None:
+    connector = AsanaConnector(
+        asana_workspace_id=" 1153293530468850 ",
+        asana_project_ids=project_ids,
+        asana_team_id=" 1210918501948021 ",
+    )
+
+    assert connector.workspace_id == "1153293530468850"
+    assert connector.project_ids_to_index == expected
+    assert connector.asana_team_id == "1210918501948021"
+
+
+@pytest.mark.parametrize(
+    "team_id,expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (" 1210918501948021 ", "1210918501948021"),
+    ],
+)
+def test_asana_connector_team_id_normalization(
+    team_id: str | None, expected: str | None
+) -> None:
+    connector = AsanaConnector(
+        asana_workspace_id="1153293530468850",
+        asana_project_ids=None,
+        asana_team_id=team_id,
+    )
+
+    assert connector.asana_team_id == expected


### PR DESCRIPTION
Cherry-pick of commit f9a648bb5f4b0f916c4e90c3f282e946dd3999c0 to release/v2.10 branch.

Original PR: #7674

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Asana Workspace/Team ID mismatch by normalizing connector inputs to prevent false mismatches and mis-scoped indexing. Adds unit tests to cover parsing for workspace, team, and project IDs.

- **Bug Fixes**
  - Trim whitespace for workspace_id and team_id; treat blank team_id as None.
  - Normalize asana_project_ids: split by comma, trim entries, drop empties; set to None if no valid IDs.
  - Added unit tests for project ID and team ID normalization.

<sup>Written for commit 3617380684776684707c0ccd3e301c4947590996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

