### PR TITLE
fix(craft): clear env vars from all sandboxes in file_sync pods

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -460,6 +460,12 @@ done
             volumes=volumes,
             restart_policy="Never",
             termination_grace_period_seconds=10,  # Fast pod termination
+            # CRITICAL: Disable service environment variable injection
+            # Without this, Kubernetes injects env vars for ALL services in the namespace,
+            # which can exceed ARG_MAX (2.6MB) when there are many sandbox pods.
+            # With 40+ sandboxes × 100 ports × 4 env vars each = ~16k env vars (~2.2MB)
+            # This causes "exec /bin/sh: argument list too long" errors.
+            enable_service_links=False,
             # Node selection for sandbox nodes
             node_selector={"onyx.app/workload": "sandbox"},
             tolerations=[


### PR DESCRIPTION
## Description

a big one. we were syncing all env vars from all sandboxes the SA was managing (100 ports * 4 env vars per port * number of sandboxes) = LOOOOOTS of env vars, this fixes that

Fixes the `exec /bin/sh: argument list too long`

## How Has This Been Tested?

careful review

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check
