### PR TITLE
fix(login): Clean up Sign up flow

### DIFF
--- a/web/src/app/auth/verify-email/Verify.tsx
+++ b/web/src/app/auth/verify-email/Verify.tsx
@@ -18,12 +18,17 @@ export default function Verify({ user }: VerifyProps) {
   const router = useRouter();
 
   const [error, setError] = useState("");
+  const hasSession = Boolean(user);
 
   const verify = useCallback(async () => {
     const token = searchParams?.get("token");
     const firstUser =
       searchParams?.get("first_user") && NEXT_PUBLIC_CLOUD_ENABLED;
     if (!token) {
+      if (!hasSession) {
+        window.location.href = "/auth/login";
+        return;
+      }
       setError(
         "Missing verification token. Try requesting a new verification email."
       );
@@ -42,14 +47,18 @@ export default function Verify({ user }: VerifyProps) {
       // Use window.location.href to force a full page reload,
       // ensuring app re-initializes with the new state (including
       // server-side provider values)
-      window.location.href = firstUser ? "/app?new_team=true" : "/app";
+      if (hasSession) {
+        window.location.href = firstUser ? "/app?new_team=true" : "/app";
+      } else {
+        window.location.href = "/auth/login";
+      }
     } else {
       const errorDetail = (await response.json()).detail;
       setError(
         `Failed to verify your email - ${errorDetail}. Please try requesting a new verification email.`
       );
     }
-  }, [searchParams, router]);
+  }, [hasSession, searchParams, router]);
 
   useEffect(() => {
     verify();


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
When a user tries to sign up and then clicks on the verification email in a different browser, they get hit with a schema issue which is both visually unpleasant but also leaves them in a stuck state. 

This PR aims to fix this and redirect the user in the case that they end up in this situation. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested this workflow locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sign-up verification flow when the email link is opened in a different browser. Resolves tenant context from the token and adds safe redirects to avoid schema errors and stuck states.

- **Bug Fixes**
  - Backend: Added a tenant-aware verify endpoint that decodes the token (audience fastapi-users:verify), resolves tenant by email, sets tenant context, and returns VERIFY_USER_BAD_TOKEN on failure.
  - Web: Updated the verify page to redirect to /auth/login when missing a token or session; after successful verify, redirect to /app (or /app?new_team=true) if a session exists, otherwise back to login.

<sup>Written for commit bc7d6f631dc6c96ce6d2eed36a701e7c302ee349. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

