### PR TITLE
chore(craft): bump sandbox image default value

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -87,9 +87,9 @@ ATTACHMENTS_DIRECTORY = "attachments"
 SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 
 # Container image for sandbox pods
-# Should include Next.js template and opencode CLI
+# Should include Next.js template, opencode CLI, and demo_data zip
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.0"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.1"
 )
 
 # S3 bucket for sandbox file storage (snapshots, knowledge files, uploads)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the default SANDBOX_CONTAINER_IMAGE to onyxdotapp/sandbox:v0.1.1 so new sandbox pods include the demo_data zip alongside the Next.js template and opencode CLI. Deployments that override SANDBOX_CONTAINER_IMAGE via env are unaffected.

<sup>Written for commit 47fdeb9e111555347c1c5ca0c9b57dc7a1e8f681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

