### PR TITLE
refactor(craft): make usage limit overrides feature flags instead of env vars

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -1,4 +1,3 @@
-import json
 import os
 from enum import Enum
 from pathlib import Path
@@ -116,15 +115,5 @@ ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 
 # Base rate limit for paid/subscribed users (messages per week)
 # Free users always get 5 messages total (not configurable)
+# Per-user overrides are managed via PostHog feature flag "craft-has-usage-limits"
 CRAFT_PAID_USER_RATE_LIMIT = int(os.environ.get("CRAFT_PAID_USER_RATE_LIMIT", "25"))
-
-# Per-user rate limit overrides (JSON map of email -> limit)
-# Example: {"admin@example.com": 100, "power-user@example.com": 50}
-# Users in this map get their specified limit instead of the default
-_user_limit_overrides_str = os.environ.get("CRAFT_USER_RATE_LIMIT_OVERRIDES", "{}")
-try:
-    CRAFT_USER_RATE_LIMIT_OVERRIDES: dict[str, int] = json.loads(
-        _user_limit_overrides_str
-    )
-except json.JSONDecodeError:
-    CRAFT_USER_RATE_LIMIT_OVERRIDES = {}

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -268,6 +268,10 @@ def validate_file(
 # Flag logic: True = enabled, False/null/not found = disabled
 ONYX_CRAFT_ENABLED_FLAG = "onyx-craft-enabled"
 
+# PostHog feature flag key for controlling whether a user has usage limits
+# Flag logic: True = user has usage limits (rate limits apply), False/null/not found = no limits (unlimited usage)
+CRAFT_HAS_USAGE_LIMITS = "craft-has-usage-limits"
+
 # Feature identifier in additional_data
 BUILD_MODE_FEATURE_ID = "build_mode"
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

logic :big_grin:

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Craft usage-limit overrides from env vars to a PostHog feature flag for easier, no-redeploy control. Users with the flag disabled get unlimited usage; others follow existing free/paid limits.

- **Refactors**
  - Replaced CRAFT_USER_RATE_LIMIT_OVERRIDES with PostHog flag "craft-has-usage-limits" (checked via get_default_feature_flag_provider).
  - Removed env-based override parsing; added CRAFT_HAS_USAGE_LIMITS constant.
  - Limit type now depends only on subscription: weekly for paid, total for free; self-hosted remains unlimited.

- **Migration**
  - Remove CRAFT_USER_RATE_LIMIT_OVERRIDES from env/infra (now ignored).
  - In PostHog, create "craft-has-usage-limits" with default True; set to False for users/tenants who should be unlimited (e.g., dev).

<sup>Written for commit b1f1d128900d4b95052cca8d97a65212f2041c7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

