### PR TITLE
chore(tests): Fix name for `test_expire_oauth_token`, loosen timing bounds a bit

### DIFF
--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -238,13 +238,13 @@ async def test_check_oauth_account_has_refresh_token(
 
 
 @pytest.mark.asyncio
-async def test_test_expire_oauth_token(
+async def test_expire_oauth_token(
     mock_user: MagicMock,
     mock_oauth_account: MagicMock,
     mock_user_manager: MagicMock,
     mock_db_session: AsyncSession,
 ) -> None:
-    """Test the testing utility function for token expiration."""
+    """Tests the testing utility function for token expiration."""
     # Set up the mock account
     mock_oauth_account.oauth_name = "google"
     mock_oauth_account.refresh_token = "test_refresh_token"
@@ -269,5 +269,5 @@ async def test_test_expire_oauth_token(
 
     # Now should be within 10-11 seconds of the set expiration
     now = datetime.now(timezone.utc).timestamp()
-    assert update_data["expires_at"] - now >= 8.9  # Allow 1 second for test execution
-    assert update_data["expires_at"] - now <= 11.1  # Allow 1 second for test execution
+    assert update_data["expires_at"] - now >= 8.8  # Allow ~1 second for test execution
+    assert update_data["expires_at"] - now <= 11.2  # Allow ~1 second for test execution


### PR DESCRIPTION
## Description
One of my PRs was bounced from the merge queue bc `assert (1769913114 - 1769913105.153482) >= 8.9` failed, which is dumb those numbers are off the 8.9 mark by like 0.1 seconds. This PR loosens those bounds a bit, hopefully making this test less flaky, also the test name had a typo in it.

## How Has This Been Tested?
CI.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced flakiness in the OAuth token expiration test by relaxing timing assertions and fixing the test name typo. This stabilizes CI and avoids merge queue failures from minor timing drift.

<sup>Written for commit 612ef0f8da28096fde2e747d6942d698c0714b55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

