### PR TITLE
feat(ee): fe - add BillingDetailsView component (3/5)

### DIFF
--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -1,0 +1,683 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Section, LineItemLayout } from "@/layouts/general-layouts";
+import * as InputLayouts from "@/layouts/input-layouts";
+import Card from "@/refresh-components/cards/Card";
+import Button from "@/refresh-components/buttons/Button";
+import Text from "@/refresh-components/texts/Text";
+import Message from "@/refresh-components/messages/Message";
+import InfoBlock from "@/refresh-components/messages/InfoBlock";
+import InputNumber from "@/refresh-components/inputs/InputNumber";
+import {
+  SvgUsers,
+  SvgExternalLink,
+  SvgArrowRight,
+  SvgPlus,
+  SvgWallet,
+  SvgFileText,
+} from "@opal/icons";
+import { BillingInformation, LicenseStatus } from "@/lib/billing/interfaces";
+import {
+  createCustomerPortalSession,
+  resetStripeConnection,
+  updateSeatCount,
+  claimLicense,
+  refreshLicenseCache,
+} from "@/lib/billing/svc";
+import { formatDateShort } from "@/lib/dateUtils";
+import { humanReadableFormatShort } from "@/lib/time";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import useUsers from "@/hooks/useUsers";
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const GRACE_PERIOD_DAYS = 30;
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function getExpirationState(
+  billing: BillingInformation,
+  license?: LicenseStatus
+) {
+  const isAnnualBilling = billing.billing_period === "annual";
+
+  // Check license expiration for self-hosted
+  if (license?.expires_at) {
+    const expiresAt = new Date(license.expires_at);
+    const now = new Date();
+    const daysRemaining = Math.ceil(
+      (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    if (daysRemaining <= 0 || license.status === "expired") {
+      const gracePeriodEnd = license.grace_period_end
+        ? new Date(license.grace_period_end)
+        : new Date(
+            expiresAt.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000
+          );
+      const daysUntilDeletion = Math.max(
+        0,
+        Math.ceil(
+          (gracePeriodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+        )
+      );
+      return {
+        variant: "error" as const,
+        daysRemaining: 0,
+        daysUntilDeletion,
+        expirationDate: humanReadableFormatShort(gracePeriodEnd),
+      };
+    }
+
+    // Only show warning for annual subscriptions (30 days before expiration)
+    if (isAnnualBilling && daysRemaining <= 30) {
+      return {
+        variant: "warning" as const,
+        daysRemaining,
+        expirationDate: humanReadableFormatShort(expiresAt),
+      };
+    }
+  }
+
+  // Check billing expiration for cloud (only show warnings for canceled subscriptions)
+  if (billing.cancel_at_period_end && billing.current_period_end) {
+    const expiresAt = new Date(billing.current_period_end);
+    const now = new Date();
+    const daysRemaining = Math.ceil(
+      (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    if (daysRemaining <= 0) {
+      const gracePeriodEnd = new Date(
+        expiresAt.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000
+      );
+      const daysUntilDeletion = Math.max(
+        0,
+        Math.ceil(
+          (gracePeriodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+        )
+      );
+      return {
+        variant: "error" as const,
+        daysRemaining: 0,
+        daysUntilDeletion,
+        expirationDate: humanReadableFormatShort(gracePeriodEnd),
+      };
+    }
+
+    // Only show warning for annual subscriptions (30 days before expiration)
+    // Monthly subscriptions auto-renew, so no warning needed
+    if (isAnnualBilling && daysRemaining <= 30) {
+      return {
+        variant: "warning" as const,
+        daysRemaining,
+        expirationDate: humanReadableFormatShort(expiresAt),
+      };
+    }
+  }
+
+  if (billing.status === "expired" || billing.status === "cancelled") {
+    return {
+      variant: "error" as const,
+      daysRemaining: 0,
+      daysUntilDeletion: GRACE_PERIOD_DAYS,
+      expirationDate: "",
+    };
+  }
+
+  return null;
+}
+
+// ----------------------------------------------------------------------------
+// SubscriptionCard
+// ----------------------------------------------------------------------------
+
+function SubscriptionCard({
+  billing,
+  license,
+  onViewPlans,
+  disabled,
+  onReconnect,
+}: {
+  billing?: BillingInformation;
+  license?: LicenseStatus;
+  onViewPlans: () => void;
+  disabled?: boolean;
+  onReconnect?: () => Promise<void>;
+}) {
+  const [isReconnecting, setIsReconnecting] = useState(false);
+
+  const planName = "Business Plan";
+  const expirationDate = billing?.current_period_end ?? license?.expires_at;
+  const formattedDate = formatDateShort(expirationDate);
+
+  const isExpiredFromBilling =
+    billing?.status === "expired" || billing?.status === "cancelled";
+  const isExpiredFromLicense =
+    license?.status === "expired" ||
+    license?.status === "gated_access" ||
+    (license?.expires_at && new Date(license.expires_at) < new Date());
+  const isExpired = isExpiredFromBilling || isExpiredFromLicense;
+  const isCanceling = billing?.cancel_at_period_end;
+
+  let subtitle: string;
+  if (isExpired) {
+    subtitle = `Expired on ${formattedDate}`;
+  } else if (isCanceling) {
+    subtitle = `Valid until ${formattedDate}`;
+  } else if (billing) {
+    subtitle = `Next payment on ${formattedDate}`;
+  } else {
+    subtitle = `Valid until ${formattedDate}`;
+  }
+
+  const handleManagePlan = async () => {
+    try {
+      const response = await createCustomerPortalSession({
+        return_url: `${window.location.origin}/admin/billing?portal_return=true`,
+      });
+      if (response.stripe_customer_portal_url) {
+        window.location.href = response.stripe_customer_portal_url;
+      }
+    } catch (error) {
+      console.error("Failed to open customer portal:", error);
+    }
+  };
+
+  const handleReconnect = async () => {
+    setIsReconnecting(true);
+    try {
+      await resetStripeConnection();
+      await onReconnect?.();
+    } catch (error) {
+      console.error("Failed to reconnect to Stripe:", error);
+    } finally {
+      setIsReconnecting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Section
+        flexDirection="row"
+        justifyContent="between"
+        alignItems="start"
+        height="auto"
+      >
+        <Section gap={0.25} alignItems="start" height="auto" width="auto">
+          <SvgUsers className="w-5 h-5 stroke-text-03" />
+          <Text headingH3Muted text04>
+            {planName}
+          </Text>
+          <Text secondaryBody text03>
+            {subtitle}
+          </Text>
+        </Section>
+        <Section
+          flexDirection="column"
+          gap={0.25}
+          alignItems="end"
+          height="auto"
+          width="fit"
+        >
+          {disabled ? (
+            <Button
+              main
+              secondary
+              onClick={handleReconnect}
+              rightIcon={SvgArrowRight}
+              disabled={isReconnecting}
+            >
+              {isReconnecting ? "Connecting..." : "Connect to Stripe"}
+            </Button>
+          ) : (
+            <Button
+              main
+              primary
+              onClick={handleManagePlan}
+              rightIcon={SvgExternalLink}
+            >
+              Manage Plan
+            </Button>
+          )}
+          <Button tertiary onClick={onViewPlans} className="billing-text-link">
+            <Text secondaryBody text03>
+              View Plan Details
+            </Text>
+          </Button>
+        </Section>
+      </Section>
+    </Card>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// SeatsCard
+// ----------------------------------------------------------------------------
+
+function SeatsCard({
+  billing,
+  license,
+  onRefresh,
+  disabled,
+}: {
+  billing?: BillingInformation;
+  license?: LicenseStatus;
+  onRefresh?: () => Promise<void>;
+  disabled?: boolean;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: usersData, isLoading: isLoadingUsers } = useUsers({
+    includeApiKeys: false,
+  });
+
+  const totalSeats = billing?.seats ?? license?.seats ?? 0;
+  const acceptedUsers = usersData?.accepted?.length ?? 0;
+  const slackUsers = usersData?.slack_users?.length ?? 0;
+  const usedSeats = acceptedUsers + slackUsers;
+  const pendingSeats = usersData?.invited?.length ?? 0;
+  const remainingSeats = Math.max(0, totalSeats - usedSeats - pendingSeats);
+
+  const [newSeatCount, setNewSeatCount] = useState(totalSeats);
+  const minRequiredSeats = usedSeats + pendingSeats;
+  const isBelowMinimum = newSeatCount < minRequiredSeats;
+
+  const handleStartEdit = () => {
+    setNewSeatCount(totalSeats);
+    setError(null);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setError(null);
+  };
+
+  const handleConfirm = async () => {
+    if (newSeatCount === totalSeats) {
+      setIsEditing(false);
+      return;
+    }
+    if (isBelowMinimum) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await updateSeatCount({ new_seat_count: newSeatCount });
+      if (!NEXT_PUBLIC_CLOUD_ENABLED) {
+        // Wait for control plane to process the subscription update before claiming
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        await claimLicense();
+        // Force refresh the Redis cache from the database
+        await refreshLicenseCache();
+      }
+      await onRefresh?.();
+      setIsEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update seats");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const seatDifference = newSeatCount - totalSeats;
+  const isAdding = seatDifference > 0;
+  const isRemoving = seatDifference < 0;
+  const nextBillingDate = formatDateShort(billing?.current_period_end);
+  const seatCount = Math.abs(seatDifference);
+  const seatWord = seatCount === 1 ? "seat" : "seats";
+
+  if (isEditing) {
+    return (
+      <Card
+        padding={0}
+        gap={0}
+        alignItems="stretch"
+        className="billing-card-enter"
+      >
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="start"
+          padding={1}
+          height="auto"
+        >
+          <LineItemLayout
+            title="Update Seats"
+            description="Add or remove seats to reflect your team size."
+          />
+          <Button main secondary onClick={handleCancel} disabled={isSubmitting}>
+            Cancel
+          </Button>
+        </Section>
+
+        <div className="billing-content-area">
+          <Section
+            flexDirection="column"
+            alignItems="stretch"
+            gap={0.25}
+            padding={1}
+            height="auto"
+          >
+            <InputLayouts.Vertical title="Seats">
+              <InputNumber
+                value={newSeatCount}
+                onChange={setNewSeatCount}
+                min={1}
+                defaultValue={totalSeats}
+                showReset
+                variant={isBelowMinimum ? "error" : "primary"}
+              />
+            </InputLayouts.Vertical>
+
+            {isBelowMinimum ? (
+              <InputLayouts.ErrorTextLayout type="error">
+                You cannot set seats below current{" "}
+                <span className="font-semibold">{minRequiredSeats}</span> seats
+                in use/pending.{" "}
+                <Link
+                  href="/admin/users"
+                  className="underline hover:no-underline"
+                >
+                  Remove users
+                </Link>{" "}
+                first before adjusting seats.
+              </InputLayouts.ErrorTextLayout>
+            ) : seatDifference !== 0 ? (
+              <Text secondaryBody text03>
+                {Math.abs(seatDifference)} seat
+                {Math.abs(seatDifference) !== 1 ? "s" : ""} to be{" "}
+                {isAdding ? "added" : "removed"}
+              </Text>
+            ) : null}
+
+            {error && (
+              <Text secondaryBody className="billing-error-text">
+                {error}
+              </Text>
+            )}
+          </Section>
+        </div>
+
+        <Section
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="between"
+          padding={1}
+          height="auto"
+        >
+          {isAdding ? (
+            <Text secondaryBody text03>
+              You will be billed for the{" "}
+              <Text secondaryBody text04>
+                {seatCount}
+              </Text>{" "}
+              additional {seatWord} at a pro-rated amount.
+            </Text>
+          ) : isRemoving ? (
+            <Text secondaryBody text03>
+              <Text secondaryBody text04>
+                {seatCount}
+              </Text>{" "}
+              {seatWord} will be removed on{" "}
+              <Text secondaryBody text04>
+                {nextBillingDate}
+              </Text>{" "}
+              (after current billing cycle).
+            </Text>
+          ) : (
+            <Text secondaryBody text03>
+              No changes to your billing.
+            </Text>
+          )}
+          <Button
+            main
+            primary
+            onClick={handleConfirm}
+            disabled={
+              isSubmitting || newSeatCount === totalSeats || isBelowMinimum
+            }
+          >
+            {isSubmitting ? "Saving..." : "Confirm Change"}
+          </Button>
+        </Section>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Section
+        flexDirection="row"
+        justifyContent="between"
+        alignItems="center"
+        height="auto"
+      >
+        <Section gap={0.25} alignItems="start" height="auto" width="auto">
+          <Text mainContentMuted text04>
+            {totalSeats} Seats
+          </Text>
+          <Text secondaryBody text03>
+            {usedSeats} in use • {pendingSeats} pending • {remainingSeats}{" "}
+            remaining
+          </Text>
+        </Section>
+        <Section
+          flexDirection="row"
+          gap={0.5}
+          justifyContent="end"
+          height="auto"
+          width="auto"
+        >
+          <Button main tertiary href="/admin/users" leftIcon={SvgExternalLink}>
+            View Users
+          </Button>
+          <Button
+            main
+            secondary
+            onClick={handleStartEdit}
+            leftIcon={SvgPlus}
+            disabled={isLoadingUsers || disabled || !billing}
+          >
+            Update Seats
+          </Button>
+        </Section>
+      </Section>
+    </Card>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// PaymentSection
+// ----------------------------------------------------------------------------
+
+function PaymentSection({ billing }: { billing: BillingInformation }) {
+  const handleOpenPortal = async () => {
+    try {
+      const response = await createCustomerPortalSession({
+        return_url: `${window.location.origin}/admin/billing?portal_return=true`,
+      });
+      if (response.stripe_customer_portal_url) {
+        window.location.href = response.stripe_customer_portal_url;
+      }
+    } catch (error) {
+      console.error("Failed to open customer portal:", error);
+    }
+  };
+
+  if (!billing.payment_method_enabled) return null;
+
+  const lastPaymentDate = formatDateShort(billing.current_period_start);
+
+  return (
+    <div className="billing-payment-section">
+      <Section alignItems="start" height="auto" width="full">
+        <Text mainContentEmphasis>Payment</Text>
+        <Section
+          flexDirection="row"
+          gap={0.5}
+          alignItems="stretch"
+          height="auto"
+        >
+          <Card className="billing-payment-card">
+            <Section
+              flexDirection="row"
+              justifyContent="between"
+              alignItems="start"
+              height="auto"
+            >
+              <InfoBlock
+                icon={SvgWallet}
+                title="Visa ending in 1234"
+                description="Payment method"
+              />
+              <Button
+                main
+                tertiary
+                onClick={handleOpenPortal}
+                rightIcon={SvgExternalLink}
+              >
+                Update
+              </Button>
+            </Section>
+          </Card>
+          {lastPaymentDate && (
+            <Card className="billing-payment-card">
+              <Section
+                flexDirection="row"
+                justifyContent="between"
+                alignItems="start"
+                height="auto"
+              >
+                <InfoBlock
+                  icon={SvgFileText}
+                  title={lastPaymentDate}
+                  description="Last payment"
+                />
+                <Button
+                  main
+                  tertiary
+                  onClick={handleOpenPortal}
+                  rightIcon={SvgExternalLink}
+                >
+                  View Invoice
+                </Button>
+              </Section>
+            </Card>
+          )}
+        </Section>
+      </Section>
+    </div>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// BillingDetailsView
+// ----------------------------------------------------------------------------
+
+interface BillingDetailsViewProps {
+  billing?: BillingInformation;
+  license?: LicenseStatus;
+  onViewPlans: () => void;
+  onRefresh?: () => Promise<void>;
+  isAirGapped?: boolean;
+  hasStripeError?: boolean;
+}
+
+export default function BillingDetailsView({
+  billing,
+  license,
+  onViewPlans,
+  onRefresh,
+  isAirGapped,
+  hasStripeError,
+}: BillingDetailsViewProps) {
+  const expirationState = billing ? getExpirationState(billing, license) : null;
+  const disableBillingActions = isAirGapped || hasStripeError;
+
+  return (
+    <Section gap={1} height="auto" width="full">
+      {/* Stripe connection error banner */}
+      {hasStripeError && (
+        <Message
+          static
+          warning
+          text="Unable to connect to Stripe payment portal."
+          description="Check your internet connection or manually provide a license."
+          close={false}
+          className="w-full"
+        />
+      )}
+
+      {/* Air-gapped mode info banner */}
+      {isAirGapped && !hasStripeError && (
+        <Message
+          static
+          info
+          text="Air-gapped deployment"
+          description="Online billing management is disabled. Contact support to update your subscription."
+          close={false}
+          className="w-full"
+        />
+      )}
+
+      {/* Expiration banner */}
+      {expirationState && (
+        <Message
+          static
+          warning={expirationState.variant === "warning"}
+          error={expirationState.variant === "error"}
+          text={
+            expirationState.variant === "error"
+              ? expirationState.daysUntilDeletion
+                ? `Your subscription has expired. Data will be deleted in ${expirationState.daysUntilDeletion} days.`
+                : "Your subscription has expired."
+              : `Your subscription is expiring in ${expirationState.daysRemaining} days.`
+          }
+          description={
+            expirationState.variant === "error"
+              ? expirationState.expirationDate
+                ? `Renew your subscription by ${expirationState.expirationDate} to restore access.`
+                : "Renew your subscription to restore access to paid features."
+              : `Renew your subscription by ${expirationState.expirationDate} to avoid disruption.`
+          }
+          close={false}
+          className="w-full"
+        />
+      )}
+
+      {/* Subscription card */}
+      {(billing || license?.has_license) && (
+        <SubscriptionCard
+          billing={billing}
+          license={license}
+          onViewPlans={onViewPlans}
+          disabled={disableBillingActions}
+          onReconnect={onRefresh}
+        />
+      )}
+
+      {/* Seats card */}
+      <SeatsCard
+        billing={billing}
+        license={license}
+        onRefresh={onRefresh}
+        disabled={disableBillingActions}
+      />
+
+      {/* Payment section */}
+      {/* TODO: Re-enable payment section when APIs for fetching payment details are implemented */}
+      {/* {billing?.payment_method_enabled && !isAirGapped && <PaymentSection billing={billing} />} */}
+    </Section>
+  );
+}

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -12,11 +12,7 @@ import { createCheckoutSession } from "@/lib/billing/svc";
 import { useUser } from "@/providers/UserProvider";
 import { formatDateShort } from "@/lib/dateUtils";
 import type { PlanType } from "@/lib/billing/interfaces";
-<<<<<<< HEAD
 import InputNumber from "@/refresh-components/inputs/InputNumber";
-=======
-import InputNumber from "../../../refresh-components/inputs/InputNumber";
->>>>>>> 95f271f76 (feat(ee): fe - add CheckoutView component for billing)
 import useUsers from "@/hooks/useUsers";
 
 // ----------------------------------------------------------------------------
@@ -39,19 +35,11 @@ function BillingOption({
   badge,
 }: BillingOptionProps) {
   return (
-<<<<<<< HEAD
     <Card
       onClick={onClick}
       className="billing-option"
       data-selected={selected}
       padding={0}
-=======
-    <button
-      type="button"
-      onClick={onClick}
-      className="billing-option"
-      data-selected={selected}
->>>>>>> 95f271f76 (feat(ee): fe - add CheckoutView component for billing)
     >
       <Section
         flexDirection="row"
@@ -95,11 +83,7 @@ function BillingOption({
           </Section>
         )}
       </Section>
-<<<<<<< HEAD
     </Card>
-=======
-    </button>
->>>>>>> 95f271f76 (feat(ee): fe - add CheckoutView component for billing)
   );
 }
 
@@ -169,11 +153,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
   };
 
   return (
-<<<<<<< HEAD
     <Card padding={0} gap={0} alignItems="stretch">
-=======
-    <Card padding={0} alignItems="stretch">
->>>>>>> 95f271f76 (feat(ee): fe - add CheckoutView component for billing)
       {/* Header */}
       <Section
         flexDirection="row"
@@ -277,10 +257,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
             After your 1-month free trial ends.
           </Text>
         ) : (
-<<<<<<< HEAD
           // Empty div to maintain space-between alignment
-=======
->>>>>>> 95f271f76 (feat(ee): fe - add CheckoutView component for billing)
           <div></div>
         )}
         <Button main primary onClick={handleSubmit} disabled={isSubmitting}>

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -255,7 +255,7 @@ function ErrorLayout({ name }: ErrorLayoutProps) {
 
 export type ErrorTextType = "error" | "warning";
 interface ErrorTextLayoutProps {
-  children?: string;
+  children?: React.ReactNode;
   type?: ErrorTextType;
 }
 function ErrorTextLayout({ children, type = "error" }: ErrorTextLayoutProps) {

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -78,6 +78,20 @@ export function humanReadableFormat(dateString: string): string {
   return formatter.format(date);
 }
 
+/**
+ * Format a date as "Jan 15, 2025" (short month name).
+ */
+export function humanReadableFormatShort(date: string | Date | null): string {
+  if (!date) return "";
+  const d = typeof date === "string" ? new Date(date) : date;
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return formatter.format(d);
+}
+
 export function humanReadableFormatWithTime(datetimeString: string): string {
   // Create a Date object from the dateString
   const date = new Date(datetimeString);


### PR DESCRIPTION
## Description

Third PR in a 5-part FE series to refactor the billing UI.

Adds the BillingDetailsView component that displays:
- Current subscription status and plan details
- Seat management with add/remove functionality
- Payment method and invoice history links
- License status for self-hosted deployments
- Expiration warnings and renewal prompts

Also adds `humanReadableFormatShort` utility function.

**PR Chain:**
1. Main page structure + PlansView + LicenseActivationCard
2. CheckoutView
3. **This PR** - BillingDetailsView
4. Supporting hooks and utilities
5. Enable new UI (flip sidebar link)

## How Has This Been Tested?

Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BillingDetailsView to show plan details, seat usage, and expiration status for both cloud and self-hosted billing. Includes Stripe portal actions, reconnect flow, and a short date formatter.

- **New Features**
  - Subscription card with “Manage Plan” and Stripe reconnect flow.
  - Seats management with minimum-seat validation, pro-rated additions, and end-of-cycle removals; updates self-hosted license and cache after changes.
  - Expiration alerts (warning/error) with 30-day grace period and deletion countdown.
  - Air-gapped and Stripe error banners that disable billing actions.
  - Adds humanReadableFormatShort for short date display.
  - Payment method and invoice links wired to the portal; payment section UI disabled until APIs are available.

<sup>Written for commit 870e524024675da998d8ba8dcad7e529547dd9dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

