### PR TITLE
feat(ee): fe - enable new billing UI (5/5)

### DIFF
--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -114,7 +114,7 @@ async def create_customer_portal_session(
 
     try:
         portal_url = fetch_customer_portal_session(tenant_id, return_url)
-        return {"url": portal_url}
+        return {"stripe_customer_portal_url": portal_url}
     except Exception as e:
         logger.exception("Failed to create customer portal session")
         raise HTTPException(status_code=500, detail=str(e))

--- a/web/lib/opal/src/icons/wallet.tsx
+++ b/web/lib/opal/src/icons/wallet.tsx
@@ -6,6 +6,7 @@ const SvgWallet = ({ size, ...props }: IconProps) => (
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
     {...props}
   >
     <path

--- a/web/src/app/admin/billing/PlansView.tsx
+++ b/web/src/app/admin/billing/PlansView.tsx
@@ -92,12 +92,13 @@ function PlanCard({
       gap={0}
       alignItems="stretch"
       aria-label={title + " plan card"}
+      className="plan-card"
     >
       <Section
         flexDirection="column"
         alignItems="stretch"
         padding={1}
-        height="full"
+        height="fit"
       >
         {/* Title */}
         <Section
@@ -133,11 +134,11 @@ function PlanCard({
         {/* Button */}
         <div className="plan-card-button">
           {isCurrentPlan ? (
-            <div className="plan-card-current-badge">
+            <Button tertiary transient className="pointer-events-none">
               <Text mainUiAction text03>
                 Your Current Plan
               </Text>
-            </div>
+            </Button>
           ) : href ? (
             <Button
               main

--- a/web/src/app/admin/billing/billing.css
+++ b/web/src/app/admin/billing/billing.css
@@ -9,18 +9,24 @@
  * Plan Card
  * -------------------------------------------------------------------------- */
 
+.plan-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  /* Let parent's align-items: stretch handle the height */
+  align-self: stretch;
+}
+
+/* Override Card's inner Section to grow and fill the card */
+.plan-card > div {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 .plan-card-button button,
 .plan-card-button a {
   width: 100%;
-}
-
-.plan-card-current-badge {
-  width: 100%;
-  background: var(--background-tint-01);
-  border: 1px solid var(--border-01);
-  padding: 0.5rem;
-  border-radius: 0.75rem;
-  text-align: center;
 }
 
 .plan-card-features-container {

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -1,12 +1,369 @@
 "use client";
 
-import { redirect } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import * as SettingsLayouts from "@/layouts/settings-layouts";
+import { Section } from "@/layouts/general-layouts";
+import Button from "@/refresh-components/buttons/Button";
+import Text from "@/refresh-components/texts/Text";
+import { SvgWallet } from "@opal/icons";
+import {
+  useBillingInformation,
+  useLicense,
+  BillingInformation,
+  hasActiveSubscription,
+  claimLicense,
+} from "@/lib/billing";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import { useUser } from "@/providers/UserProvider";
 
-// TODO: Remove this redirect once all billing UI PRs are merged
-// This page will contain the new billing UI, but for now we redirect
-// to the old EE billing page to maintain backwards compatibility.
-// PR 6 will remove this redirect and enable the new UI.
+import PlansView from "./PlansView";
+import CheckoutView from "./CheckoutView";
+import BillingDetailsView from "./BillingDetailsView";
+import LicenseActivationCard from "./LicenseActivationCard";
+import "./billing.css";
+
+// ----------------------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------------------
+
+type BillingView = "plans" | "details" | "checkout" | null;
+
+interface ViewConfig {
+  title: string;
+  description: string;
+  showBackButton: boolean;
+}
+
+// ----------------------------------------------------------------------------
+// FooterLinks (inlined)
+// ----------------------------------------------------------------------------
+
+const SUPPORT_EMAIL = "support@onyx.app";
+
+function FooterLinks({
+  hasSubscription,
+  onActivateLicense,
+  hideLicenseLink,
+}: {
+  hasSubscription?: boolean;
+  onActivateLicense?: () => void;
+  hideLicenseLink?: boolean;
+}) {
+  const { user } = useUser();
+  const licenseText = hasSubscription
+    ? "Update License Key"
+    : "Activate License Key";
+  const billingHelpHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+    `[Billing] support for ${user?.email ?? "unknown"}`
+  )}`;
+
+  return (
+    <Section flexDirection="row" justifyContent="center" gap={1} height="auto">
+      {onActivateLicense && !hideLicenseLink && (
+        <>
+          <Text secondaryBody text03>
+            Have a license key?
+          </Text>
+          <Button action tertiary onClick={onActivateLicense}>
+            <Text secondaryBody text03 className="underline">
+              {licenseText}
+            </Text>
+          </Button>
+        </>
+      )}
+      <Button
+        action
+        tertiary
+        href={billingHelpHref}
+        className="billing-text-link"
+      >
+        <Text secondaryBody text03 className="underline">
+          Billing Help
+        </Text>
+      </Button>
+    </Section>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// BillingPage
+// ----------------------------------------------------------------------------
 
 export default function BillingPage() {
-  redirect("/ee/admin/billing");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // Start with null view to prevent flash - will be set once data loads
+  const [view, setView] = useState<BillingView | null>(null);
+  const [showLicenseActivationInput, setShowLicenseActivationInput] =
+    useState(false);
+  const [licenseCardAutoOpened, setLicenseCardAutoOpened] = useState(false);
+  const [viewChangeId, setViewChangeId] = useState(0);
+  const [transitionType, setTransitionType] = useState<
+    "expand" | "collapse" | "fade"
+  >("fade");
+
+  const {
+    data: billingData,
+    isLoading: billingLoading,
+    error: billingError,
+    refresh: refreshBilling,
+  } = useBillingInformation();
+  const {
+    data: licenseData,
+    isLoading: licenseLoading,
+    refresh: refreshLicense,
+  } = useLicense();
+
+  const isLoading = billingLoading || licenseLoading;
+  const hasSubscription = billingData && hasActiveSubscription(billingData);
+  const billing = hasSubscription ? (billingData as BillingInformation) : null;
+  const currentPlan = billing?.plan_type ?? licenseData?.plan_type ?? undefined;
+  const isSelfHosted = !NEXT_PUBLIC_CLOUD_ENABLED;
+
+  // User is only air-gapped if they have a manual license AND Stripe is not connected
+  // Once Stripe connects successfully, they're no longer air-gapped
+  const hasManualLicense = licenseData?.source === "manual_upload";
+  const stripeConnected = billingData && !billingError;
+  const isAirGapped = hasManualLicense && !stripeConnected;
+  const hasStripeError = !!(
+    isSelfHosted &&
+    licenseData?.has_license &&
+    billingError &&
+    !hasManualLicense
+  );
+
+  // Set initial view based on subscription status (only once when data first loads)
+  useEffect(() => {
+    if (!isLoading && view === null) {
+      const shouldShowDetails =
+        hasSubscription || (isSelfHosted && licenseData?.has_license);
+      setView(shouldShowDetails ? "details" : "plans");
+    }
+  }, [
+    isLoading,
+    hasSubscription,
+    isSelfHosted,
+    licenseData?.has_license,
+    view,
+  ]);
+
+  // Show license activation card when there's a Stripe error
+  useEffect(() => {
+    if (hasStripeError && !showLicenseActivationInput) {
+      setLicenseCardAutoOpened(true);
+      setShowLicenseActivationInput(true);
+    }
+  }, [hasStripeError, showLicenseActivationInput]);
+
+  // Handle return from checkout or customer portal
+  useEffect(() => {
+    const sessionId = searchParams.get("session_id");
+    const portalReturn = searchParams.get("portal_return");
+
+    if (!sessionId && !portalReturn) return;
+
+    router.replace("/admin/billing", { scroll: false });
+
+    const handleBillingReturn = async () => {
+      if (!NEXT_PUBLIC_CLOUD_ENABLED) {
+        try {
+          // After checkout, exchange session_id for license; after portal, re-sync license
+          await claimLicense(sessionId ?? undefined);
+          refreshLicense();
+          // Refresh the page to update settings (including ee_features_enabled)
+          router.refresh();
+        } catch (error) {
+          console.error("Failed to sync license after billing return:", error);
+        }
+      }
+      refreshBilling();
+    };
+    handleBillingReturn();
+  }, [searchParams, router, refreshBilling, refreshLicense]);
+
+  const handleRefresh = async () => {
+    await Promise.all([
+      refreshBilling(),
+      isSelfHosted ? refreshLicense() : Promise.resolve(),
+    ]);
+  };
+
+  // Hide license activation card when Stripe connection is restored (only if auto-opened)
+  useEffect(() => {
+    if (
+      !hasStripeError &&
+      !isAirGapped &&
+      showLicenseActivationInput &&
+      licenseCardAutoOpened &&
+      !isLoading
+    ) {
+      if (billingData && hasActiveSubscription(billingData)) {
+        setLicenseCardAutoOpened(false);
+        setShowLicenseActivationInput(false);
+      }
+    }
+  }, [
+    hasStripeError,
+    isAirGapped,
+    showLicenseActivationInput,
+    licenseCardAutoOpened,
+    isLoading,
+    billingData,
+  ]);
+
+  const handleLicenseActivated = () => {
+    refreshLicense();
+    refreshBilling();
+    // Refresh the page to update settings (including ee_features_enabled)
+    router.refresh();
+  };
+
+  // View configuration
+  const getViewConfig = (): ViewConfig => {
+    if (isLoading || view === null) {
+      return {
+        title: "Plans & Billing",
+        description: "Loading billing information...",
+        showBackButton: false,
+      };
+    }
+    switch (view) {
+      case "checkout":
+        return {
+          title: "Upgrade Plan",
+          description: "Configure your Business Plan subscription",
+          showBackButton: false,
+        };
+      case "plans":
+        return {
+          title: hasSubscription ? "View Plans" : "Upgrade Plan",
+          description: hasSubscription
+            ? "Compare and manage your subscription plan"
+            : "Choose a plan to unlock premium features",
+          showBackButton: !!hasSubscription,
+        };
+      case "details":
+        return {
+          title: "Plans & Billing",
+          description: "Manage your subscription and billing settings",
+          showBackButton: false,
+        };
+    }
+  };
+
+  const viewConfig = getViewConfig();
+
+  // Handle view changes with transition
+  const changeView = (newView: "plans" | "details" | "checkout") => {
+    if (newView === view) return;
+    if (newView === "checkout" && view === "plans") {
+      setTransitionType("expand");
+    } else if (newView === "plans" && view === "checkout") {
+      setTransitionType("collapse");
+    } else {
+      setTransitionType("fade");
+    }
+    setViewChangeId((id) => id + 1);
+    setView(newView);
+  };
+
+  const handleBack = () => {
+    if (view === "checkout") {
+      changeView(hasSubscription ? "details" : "plans");
+    } else if (view === "plans" && hasSubscription) {
+      changeView("details");
+    }
+  };
+
+  const renderContent = () => {
+    if (isLoading || view === null) return null;
+
+    const animationClass =
+      transitionType === "expand"
+        ? "billing-view-expand"
+        : transitionType === "collapse"
+          ? "billing-view-collapse"
+          : "billing-view-enter";
+
+    const views: Record<typeof view, React.ReactNode> = {
+      checkout: <CheckoutView onAdjustPlan={() => changeView("plans")} />,
+      plans: (
+        <PlansView
+          currentPlan={currentPlan}
+          hasSubscription={!!hasSubscription}
+          onCheckout={() => changeView("checkout")}
+          hideFeatures={showLicenseActivationInput}
+        />
+      ),
+      details: (
+        <BillingDetailsView
+          billing={billing ?? undefined}
+          license={licenseData ?? undefined}
+          onViewPlans={() => changeView("plans")}
+          onRefresh={handleRefresh}
+          isAirGapped={isAirGapped}
+          hasStripeError={hasStripeError}
+        />
+      ),
+    };
+
+    return (
+      <div key={viewChangeId} className={`w-full ${animationClass}`}>
+        {views[view]}
+      </div>
+    );
+  };
+
+  // Render footer
+  const renderFooter = () => {
+    if (isLoading || view === null) return null;
+    return (
+      <>
+        {showLicenseActivationInput && (
+          <div className="w-full billing-card-enter">
+            <LicenseActivationCard
+              isOpen={showLicenseActivationInput}
+              onSuccess={handleLicenseActivated}
+              license={licenseData ?? undefined}
+              onClose={() => {
+                setLicenseCardAutoOpened(false);
+                setShowLicenseActivationInput(false);
+              }}
+            />
+          </div>
+        )}
+        <FooterLinks
+          hasSubscription={!!hasSubscription || !!licenseData?.has_license}
+          onActivateLicense={
+            isSelfHosted ? () => setShowLicenseActivationInput(true) : undefined
+          }
+          hideLicenseLink={
+            showLicenseActivationInput ||
+            (view === "plans" &&
+              (!!hasSubscription || !!licenseData?.has_license))
+          }
+        />
+      </>
+    );
+  };
+
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header
+        icon={SvgWallet}
+        title={viewConfig.title}
+        description={viewConfig.description}
+        backButton={viewConfig.showBackButton}
+        onBack={handleBack}
+        separator
+      />
+      <SettingsLayouts.Body>
+        <div className="flex flex-col items-center gap-6">
+          {renderContent()}
+          {renderFooter()}
+        </div>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
 }

--- a/web/src/app/admin/settings/interfaces.ts
+++ b/web/src/app/admin/settings/interfaces.ts
@@ -42,6 +42,10 @@ export interface Settings {
 
   // Onyx Craft (Build Mode) feature flag
   onyx_craft_enabled?: boolean;
+
+  // Enterprise features flag - controlled by license enforcement at runtime
+  // True when user has a valid license, False for community edition
+  ee_features_enabled?: boolean;
 }
 
 export enum NotificationType {

--- a/web/src/app/ee/admin/billing/BillingInformationPage.tsx
+++ b/web/src/app/ee/admin/billing/BillingInformationPage.tsx
@@ -63,6 +63,7 @@ export default function BillingInformationPage() {
   const handleManageSubscription = async () => {
     try {
       const response = await createCustomerPortalSession();
+      console.log("response", response);
       if (!response.stripe_customer_portal_url) {
         throw new Error("No portal URL returned from the server");
       }

--- a/web/src/app/ee/layout.tsx
+++ b/web/src/app/ee/layout.tsx
@@ -1,18 +1,41 @@
 import { SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED } from "@/lib/constants";
+import { fetchStandardSettingsSS } from "@/components/settings/lib";
 
 export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // First check build-time constant (fast path)
   if (!SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED) {
     return (
       <div className="flex h-screen">
         <div className="mx-auto my-auto text-lg font-bold text-red-500">
-          This funcitonality is only available in the Enterprise Edition :(
+          This functionality is only available in the Enterprise Edition :(
         </div>
       </div>
     );
+  }
+
+  // Then check runtime license status (for license enforcement mode)
+  // This allows gating EE features when user doesn't have a valid license
+  try {
+    const settingsResponse = await fetchStandardSettingsSS();
+    if (settingsResponse?.ok) {
+      const settings = await settingsResponse.json();
+      if (settings.ee_features_enabled === false) {
+        return (
+          <div className="flex h-screen">
+            <div className="mx-auto my-auto text-lg font-bold text-red-500">
+              This functionality requires an active Enterprise license.
+            </div>
+          </div>
+        );
+      }
+    }
+  } catch (error) {
+    // If settings fetch fails, allow access (fail open for better UX)
+    console.error("Failed to fetch settings for EE check:", error);
   }
 
   return children;

--- a/web/src/components/settings/usePaidEnterpriseFeaturesEnabled.ts
+++ b/web/src/components/settings/usePaidEnterpriseFeaturesEnabled.ts
@@ -2,7 +2,28 @@
 
 import { useSettingsContext } from "@/providers/SettingsProvider";
 
-export function usePaidEnterpriseFeaturesEnabled() {
+/**
+ * Hook to check if enterprise features should be enabled in the UI.
+ *
+ * When LICENSE_ENFORCEMENT_ENABLED=true on the backend:
+ * - Returns true if user has a valid license (ACTIVE, GRACE_PERIOD, PAYMENT_REMINDER)
+ * - Returns false if user has no license (community edition) or expired license (GATED_ACCESS)
+ *
+ * When LICENSE_ENFORCEMENT_ENABLED=false (legacy behavior):
+ * - Returns true if enterpriseSettings exists (build-time constant)
+ *
+ * This determines whether EE-only UI features like user groups, RBAC, etc. are shown.
+ */
+export function usePaidEnterpriseFeaturesEnabled(): boolean {
   const combinedSettings = useSettingsContext();
+
+  // Check the runtime license-based flag first
+  // This is set by the backend based on actual license status
+  if (combinedSettings.settings.ee_features_enabled !== undefined) {
+    return combinedSettings.settings.ee_features_enabled;
+  }
+
+  // Fallback to legacy behavior: check if enterprise settings exist
+  // This handles the case where LICENSE_ENFORCEMENT_ENABLED=false
   return combinedSettings.enterpriseSettings !== null;
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -50,7 +50,6 @@ const EE_ROUTES = [
   "/admin/performance/custom-analytics",
   "/admin/standard-answer",
   "/assistants/stats",
-  "/admin/billing",
 ];
 
 export async function proxy(request: NextRequest) {

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -10,12 +10,12 @@ import { useIsKGExposed } from "@/app/admin/kg/utils";
 import { useCustomAnalyticsEnabled } from "@/lib/hooks/useCustomAnalyticsEnabled";
 import { useUser } from "@/providers/UserProvider";
 import { UserRole } from "@/lib/types";
-import { MdOutlineCreditCard } from "react-icons/md";
 import {
   useBillingInformation,
   useLicense,
   hasActiveSubscription,
 } from "@/lib/billing";
+import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import {
   ClipboardIcon,
   NotebookIconSkeleton,
@@ -49,6 +49,7 @@ import {
   SvgZoomIn,
   SvgPaintBrush,
   SvgDiscordMono,
+  SvgWallet,
 } from "@opal/icons";
 import SvgMcp from "@opal/icons/mcp";
 import UserAvatarPopover from "@/sections/sidebar/UserAvatarPopover";
@@ -156,7 +157,7 @@ const collections = (
     name: "Custom Assistants",
     items: custom_assistants_items(isCurator, enableEnterprise),
   },
-  ...(isCurator
+  ...(isCurator && enableEnterprise
     ? [
         {
           name: "User Management",
@@ -300,11 +301,10 @@ const collections = (
                 ]
               : []),
             // Always show billing/upgrade - community users need access to upgrade
-            // TODO: PR 6 will change this to /admin/billing to enable new UI
             {
               name: hasSubscription ? "Plans & Billing" : "Upgrade Plan",
-              icon: hasSubscription ? MdOutlineCreditCard : SvgArrowUpCircle,
-              link: "/ee/admin/billing",
+              icon: hasSubscription ? SvgWallet : SvgArrowUpCircle,
+              link: "/admin/billing",
             },
           ],
         },
@@ -313,14 +313,9 @@ const collections = (
 ];
 
 interface AdminSidebarProps {
-  // These props are passed down from a server component (Layout.tsx) that
-  // determines feature availability server-side. We don't calculate these
-  // directly in this client component to avoid:
-  // 1. Unnecessary API calls on the client-side
-  // 2. Security concerns - preventing end-users from tampering with
-  //    feature flags by making direct API calls
-  // 3. Performance - avoiding refetches when the data is already available
+  // Cloud flag is passed from server component (Layout.tsx) since it's a build-time constant
   enableCloudSS: boolean;
+  // Enterprise flag is also passed but we override it with runtime license check below
   enableEnterpriseSS: boolean;
 }
 
@@ -336,6 +331,11 @@ export default function AdminSidebar({
   const { data: billingData } = useBillingInformation();
   const { data: licenseData } = useLicense();
 
+  // Use runtime license check for enterprise features
+  // This checks settings.ee_features_enabled (set by backend based on license status)
+  // Falls back to build-time check if LICENSE_ENFORCEMENT_ENABLED=false
+  const enableEnterprise = usePaidEnterpriseFeaturesEnabled();
+
   const isCurator =
     user?.role === UserRole.CURATOR || user?.role === UserRole.GLOBAL_CURATOR;
 
@@ -349,7 +349,7 @@ export default function AdminSidebar({
   const items = collections(
     isCurator,
     enableCloudSS,
-    enableEnterpriseSS,
+    enableEnterprise,
     settings,
     kgExposed,
     customAnalyticsEnabled,


### PR DESCRIPTION
## Description

Fifth and final PR in the FE series to refactor the billing UI.

Flips the switch to enable the new billing UI:
- Update sidebar link from /ee/admin/billing to /admin/billing
- Replace redirect with full billing page using new components
- Add runtime license check to usePaidEnterpriseFeaturesEnabled
- Add runtime license check to EE layout
- Add ee_features_enabled field to Settings interface

The new billing page includes:
- PlansView for plan selection
- CheckoutView for subscription checkout
- BillingDetailsView for managing existing subscriptions
- LicenseActivationCard for self-hosted deployments

**PR Chain:**
1. Main page structure + PlansView + LicenseActivationCard
2. CheckoutView
3. BillingDetailsView
4. Supporting hooks and utilities
5. **This PR** - Enable new UI (flip sidebar link)

## How Has This Been Tested?

Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the new billing UI at /admin/billing and gates enterprise features at runtime based on license status. Updates the sidebar link and replaces the old EE redirect with the full page experience.

- **New Features**
  - Full billing page with PlansView, CheckoutView, BillingDetailsView, and LicenseActivationCard.
  - Sidebar link updated to /admin/billing and enterprise features gated via usePaidEnterpriseFeaturesEnabled.
  - Runtime license enforcement in the EE layout; backend exposes settings.ee_features_enabled.
  - Post-checkout and portal-return handling to claim licenses, refresh billing, and update UI.
  - Stripe customer portal API now returns stripe_customer_portal_url.

<sup>Written for commit 6e35dc7fed48e64d914fe1f5168f18b237a9c5a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

