### PR TITLE
feat(ee): updating billing api

### DIFF
--- a/backend/ee/onyx/server/license/api.py
+++ b/backend/ee/onyx/server/license/api.py
@@ -106,6 +106,11 @@ async def claim_license(
     - Updating seats via the billing API
     - Returning from the Stripe customer portal
     - Any operation that regenerates the license on control plane
+    Claim a license from the control plane (self-hosted only).
+
+    Two modes:
+    1. With session_id: After Stripe checkout, exchange session_id for license
+    2. Without session_id: Re-claim using existing license for auth
     """
     if MULTI_TENANT:
         raise HTTPException(

--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -29,6 +29,7 @@ from ee.onyx.server.tenants.billing import fetch_billing_information
 from ee.onyx.server.tenants.billing import fetch_customer_portal_session
 from ee.onyx.server.tenants.billing import fetch_stripe_checkout_session
 from ee.onyx.server.tenants.models import BillingInformation
+from ee.onyx.server.tenants.models import CreateCheckoutSessionRequest
 from ee.onyx.server.tenants.models import CreateSubscriptionSessionRequest
 from ee.onyx.server.tenants.models import ProductGatingFullSyncRequest
 from ee.onyx.server.tenants.models import ProductGatingRequest
@@ -117,6 +118,24 @@ async def create_customer_portal_session(
         return {"stripe_customer_portal_url": portal_url}
     except Exception as e:
         logger.exception("Failed to create customer portal session")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/create-checkout-session")
+async def create_checkout_session(
+    request: CreateCheckoutSessionRequest | None = None,
+    _: User = Depends(current_admin_user),
+) -> dict:
+    """Create a Stripe checkout session via the control plane."""
+    tenant_id = get_current_tenant_id()
+    billing_period = request.billing_period if request else "monthly"
+    seats = request.seats if request else None
+
+    try:
+        checkout_url = fetch_stripe_checkout_session(tenant_id, billing_period, seats)
+        return {"stripe_checkout_url": checkout_url}
+    except Exception as e:
+        logger.exception("Failed to create checkout session")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/ee/onyx/server/tenants/models.py
+++ b/backend/ee/onyx/server/tenants/models.py
@@ -42,6 +42,12 @@ class BillingInformation(BaseModel):
     payment_method_enabled: bool
 
 
+class CreateCheckoutSessionRequest(BaseModel):
+    billing_period: Literal["monthly", "annual"] = "monthly"
+    seats: int | None = None
+    email: str | None = None
+
+
 class CheckoutSessionCreationResponse(BaseModel):
     id: str
 

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -57,6 +57,11 @@ class Settings(BaseModel):
     anonymous_user_enabled: bool | None = None
     deep_research_enabled: bool | None = None
 
+    # Enterprise features flag - set by license enforcement at runtime
+    # When LICENSE_ENFORCEMENT_ENABLED=true, this reflects license status
+    # When LICENSE_ENFORCEMENT_ENABLED=false, defaults to True (legacy behavior)
+    ee_features_enabled: bool = True
+
     temperature_override_enabled: bool | None = False
     auto_scroll: bool | None = False
     query_history_type: QueryHistoryType | None = None

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
@@ -244,6 +244,7 @@ class TestUpdateSeats:
         assert "No license found" in exc_info.value.detail
 
     @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.get_used_seats")
     @patch("ee.onyx.server.billing.api.update_seat_service")
     @patch("ee.onyx.server.billing.api._get_tenant_id")
     @patch("ee.onyx.server.billing.api._get_license_data")
@@ -252,6 +253,7 @@ class TestUpdateSeats:
         mock_get_license: MagicMock,
         mock_get_tenant: MagicMock,
         mock_service: AsyncMock,
+        mock_get_used_seats: MagicMock,
     ) -> None:
         """Should update seats with valid license."""
         from ee.onyx.server.billing.api import update_seats
@@ -259,6 +261,7 @@ class TestUpdateSeats:
 
         mock_get_license.return_value = "license_blob"
         mock_get_tenant.return_value = None
+        mock_get_used_seats.return_value = 5
         mock_service.return_value = SeatUpdateResponse(
             success=True,
             current_seats=15,
@@ -281,6 +284,7 @@ class TestUpdateSeats:
         )
 
     @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.get_used_seats")
     @patch("ee.onyx.server.billing.api.update_seat_service")
     @patch("ee.onyx.server.billing.api._get_tenant_id")
     @patch("ee.onyx.server.billing.api._get_license_data")
@@ -289,6 +293,7 @@ class TestUpdateSeats:
         mock_get_license: MagicMock,
         mock_get_tenant: MagicMock,
         mock_service: AsyncMock,
+        mock_get_used_seats: MagicMock,
     ) -> None:
         """Should convert BillingServiceError to HTTPException."""
         from fastapi import HTTPException
@@ -298,6 +303,7 @@ class TestUpdateSeats:
 
         mock_get_license.return_value = "license_blob"
         mock_get_tenant.return_value = None
+        mock_get_used_seats.return_value = 0
         mock_service.side_effect = BillingServiceError(
             "Cannot reduce below 10 seats", 400
         )
@@ -505,6 +511,7 @@ class TestCheckoutSessionWithSeats:
     """Tests for checkout session with seats parameter."""
 
     @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.api.get_used_seats")
     @patch("ee.onyx.server.billing.api.create_checkout_service")
     @patch("ee.onyx.server.billing.api._get_tenant_id")
     @patch("ee.onyx.server.billing.api._get_license_data")
@@ -513,6 +520,7 @@ class TestCheckoutSessionWithSeats:
         mock_get_license: MagicMock,
         mock_get_tenant: MagicMock,
         mock_service: AsyncMock,
+        mock_get_used_seats: MagicMock,
     ) -> None:
         """Should pass seats parameter to service."""
         from ee.onyx.server.billing.api import create_checkout_session
@@ -520,6 +528,7 @@ class TestCheckoutSessionWithSeats:
 
         mock_get_license.return_value = None
         mock_get_tenant.return_value = "tenant_123"
+        mock_get_used_seats.return_value = 5
         mock_service.return_value = CreateCheckoutSessionResponse(
             stripe_checkout_url="https://checkout.stripe.com/session"
         )


### PR DESCRIPTION
## Description

Backend changes to support the new billing UI (independent of FE stack).

- Add seat management endpoint (`/seats/update`)
- Add reset-connection endpoint for circuit breaker
- Add license claim endpoint for self-hosted checkout
- Add `ee_features_enabled` field to settings response
- Update settings API with license status checks
- Add billing API client for tenants

This PR can be merged independently of the FE billing PRs.

## How Has This Been Tested?

Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns on the new billing page and adds backend billing APIs with license-aware settings. Enforces seat limits, supports checkout/portal flows, and gates EE features based on license status.

- **New Features**
  - Seat management endpoint with validation against current used seats.
  - Create checkout session via the control plane (supports seats and billing period).
  - Validate checkout seats against current usage.
  - Stripe circuit breaker: auto-opens on 5xx; reset endpoint to retry connection.
  - License claim endpoint for self-hosted checkout and post-portal flows.
  - Settings now return ee_features_enabled, set from license status and applied in EE layout/hook.
  - Enable new /admin/billing UI (plans, checkout, details) and update sidebar link; handle checkout/portal returns with license sync.

- **Migration**
  - Use ee_features_enabled from settings to toggle EE UI.
  - After checkout, portal return, or seat update, call /license/claim (with or without session_id).
  - Pass seats to checkout; seat reductions below usage are blocked.
  - Customer portal API now returns stripe_customer_portal_url.

<sup>Written for commit 51d16d454b5c2bf7cc830786fe8de673d0413f18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

