### PR TITLE
chore: Tune web search

### DIFF
--- a/backend/onyx/tools/tool_implementations/open_url/firecrawl.py
+++ b/backend/onyx/tools/tool_implementations/open_url/firecrawl.py
@@ -33,7 +33,7 @@ class FirecrawlClient(WebContentProvider):
         api_key: str,
         *,
         base_url: str = FIRECRAWL_SCRAPE_URL,
-        timeout_seconds: int = 30,
+        timeout_seconds: int = 60,
     ) -> None:
 
         self._headers = {

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -114,7 +114,7 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "One or more queries to look up on the web. "
-                            "Do not include special whitespace characters like newlines, tabs, etc.",
+                            "Do not include null characters or special whitespace characters like newlines, tabs, etc.",
                         },
                     },
                     "required": [QUERIES_FIELD],


### PR DESCRIPTION
## Description
Sometimes GPT 5.2 produces null chars... very annoying

## How Has This Been Tested?
N/A

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved web search reliability by clarifying query input to avoid null characters and increasing Firecrawl scrape timeout from 30s to 60s. This helps prevent malformed requests and reduces timeouts on slow pages.

<sup>Written for commit 319f75e3906ba768002e8600c5d4f15d7305a6c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

