### PR TITLE
chore: OpenURL sometimes gives too many tokens

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/utils.py
+++ b/backend/onyx/tools/tool_implementations/web_search/utils.py
@@ -13,6 +13,8 @@ from onyx.tools.tool_implementations.web_search.models import WebSearchResult
 TRUNCATED_CONTENT_SUFFIX = " [...truncated]"
 TRUNCATED_CONTENT_PREFIX = "[...truncated] "
 
+MAX_CHARS_PER_URL = 15000
+
 
 def filter_web_search_results_with_no_title_or_snippet(
     results: list[WebSearchResult],
@@ -30,7 +32,9 @@ def filter_web_search_results_with_no_title_or_snippet(
     return filtered
 
 
-def truncate_search_result_content(content: str, max_chars: int = 15000) -> str:
+def truncate_search_result_content(
+    content: str, max_chars: int = MAX_CHARS_PER_URL
+) -> str:
     """Truncate search result content to a maximum number of characters"""
     if len(content) <= max_chars:
         return content
@@ -38,7 +42,7 @@ def truncate_search_result_content(content: str, max_chars: int = 15000) -> str:
 
 
 def _truncate_content_around_snippet(
-    content: str, snippet: str, max_chars: int = 15000
+    content: str, snippet: str, max_chars: int = MAX_CHARS_PER_URL
 ) -> str:
     """
     Truncates content around snippet with max_chars


### PR DESCRIPTION
## Description
Added a different type of cap to OpenURL. There is a preexisting single URL cap, this adds a cap to the set of URLs.

## How Has This Been Tested?
Tested locally with DR

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a total character budget across OpenURL results to prevent token spikes when many URLs are fetched. Also standardizes per-URL truncation with a shared constant.

- **Bug Fixes**
  - Enforce a global cap: MAX_CHARS_ACROSS_URLS = 10 × MAX_CHARS_PER_URL.
  - Truncate or skip document content based on remaining budget; require at least 200 chars to include a doc.
  - Count metadata size before content to stay within the budget.
  - Preserve citation numbering and still list fetched docs even if content is truncated.

- **Refactors**
  - Introduced MAX_CHARS_PER_URL (15000) and used it across web search utils to replace magic numbers.

<sup>Written for commit 38344c30a1965e47613532df199da0c02c4819cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

