### PR TITLE
chore: DR tool tuning

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -114,7 +114,7 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "One or more queries to look up on the web. "
-                            "Do not include null characters or special whitespace characters like newlines, tabs, etc.",
+                            "Must contain only printable characters",
                         },
                     },
                     "required": [QUERIES_FIELD],


### PR DESCRIPTION
## Description
Fix issue where Open URL sometimes times out due to retries

## How Has This Been Tested?
Local

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tuned Firecrawl fetches to prevent open_url batch timeouts by removing retries and lowering per-request timeout. Tightened web_search input validation to require printable characters.

- **Bug Fixes**
  - Set Firecrawl default timeout to 35s (fits under the 2-minute outer timeout with 4 workers).
  - Removed retry logic for Firecrawl crawls to avoid runaway retries and batch drops.
  - Updated web_search schema description: queries must contain only printable characters.

<sup>Written for commit 0c297702cd63234ec392fd709535935989f849cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

