### PR TITLE
chore: ensure ascii false

### DIFF
--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -329,7 +329,7 @@ def _convert_sections_to_llm_string_with_citations(
             result["document_identifier"] = document_id
 
         if chunk.metadata:
-            result["metadata"] = json.dumps(chunk.metadata)
+            result["metadata"] = json.dumps(chunk.metadata, ensure_ascii=False)
 
         # Calculate chars used by metadata fields (everything except content)
         metadata_chars = _estimate_result_chars(result)
@@ -354,7 +354,7 @@ def _convert_sections_to_llm_string_with_citations(
         total_chars += result_chars
 
     output = {"results": results}
-    return json.dumps(output, indent=2), citation_mapping
+    return json.dumps(output, indent=2, ensure_ascii=False), citation_mapping
 
 
 class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):


### PR DESCRIPTION
## Description
OpenURL docs and other docs may be in other languages, we dump it to a json to give the LLM structure to reference document ids and things but it doesn't actually need to be a json. So not translating the chars is best.

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserved non-ASCII characters in OpenURL tool JSON by setting ensure_ascii=False for metadata and the final results output. This prevents Unicode escaping and keeps multilingual document text intact for better citations and LLM context.

<sup>Written for commit d9dff5465bce979a23d7990766a014d5473d3810. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

