### PR TITLE
chore: ASCII in docs

### DIFF
--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -76,8 +76,11 @@ def convert_inference_sections_to_llm_string(
         if include_document_id:
             result["document_identifier"] = chunk.document_id
         if chunk.metadata:
-            result["metadata"] = json.dumps(chunk.metadata)
+            result["metadata"] = json.dumps(chunk.metadata, ensure_ascii=False)
         result["content"] = section.combined_content
         results.append(result)
 
-    return json.dumps({"results": results}, indent=4), citation_mapping
+    return (
+        json.dumps({"results": results}, indent=2, ensure_ascii=False),
+        citation_mapping,
+    )


### PR DESCRIPTION
## Description
Same as the previous PR but another few cases

## How Has This Been Tested?
N/A

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve non-ASCII characters in inference output by disabling ASCII escaping in JSON, and reduce JSON indentation to shrink payload size. This prevents Unicode escapes in metadata and keeps content accurate for international docs.

- **Bug Fixes**
  - Use ensure_ascii=False when serializing metadata and the results JSON.
  - Reduce JSON indentation from 4 to 2.

<sup>Written for commit 5dc6fd279d657ca5eb7a23d795682db4d532afdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

