### PR TITLE
fix(ollama): Fixing Content Skipping

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -152,13 +152,35 @@ def _patch_ollama_chunk_parser() -> None:
                     self.started_reasoning_content = True
             if chunk["message"].get("content") is not None:
                 message_content = chunk["message"].get("content")
+                # Track whether we are inside <think>...</think> tagged content.
+                in_think_tag_block = bool(getattr(self, "_in_think_tag_block", False))
                 if "<think>" in message_content:
                     message_content = message_content.replace("<think>", "")
                     self.started_reasoning_content = True
+                    self.finished_reasoning_content = False
+                    in_think_tag_block = True
                 if "</think>" in message_content and self.started_reasoning_content:
                     message_content = message_content.replace("</think>", "")
                     self.finished_reasoning_content = True
+                    in_think_tag_block = False
+
+                # For native Ollama "thinking" streams, content without active
+                # think tags indicates a transition into regular assistant output.
                 if (
+                    self.started_reasoning_content
+                    and not self.finished_reasoning_content
+                    and not in_think_tag_block
+                    and not thinking_content
+                ):
+                    self.finished_reasoning_content = True
+
+                self._in_think_tag_block = in_think_tag_block
+
+                # When Ollama returns both "thinking" and "content" in the same
+                # chunk, preserve both instead of classifying content as reasoning.
+                if thinking_content and not in_think_tag_block:
+                    content = message_content
+                elif (
                     self.started_reasoning_content
                     and not self.finished_reasoning_content
                 ):

--- a/backend/tests/unit/onyx/llm/test_factory.py
+++ b/backend/tests/unit/onyx/llm/test_factory.py
@@ -1,0 +1,30 @@
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.factory import _build_provider_extra_headers
+from onyx.llm.well_known_providers.constants import OLLAMA_API_KEY_CONFIG_KEY
+
+
+def test_build_provider_extra_headers_adds_bearer_for_ollama_api_key() -> None:
+    headers = _build_provider_extra_headers(
+        LlmProviderNames.OLLAMA_CHAT,
+        {OLLAMA_API_KEY_CONFIG_KEY: "  test-key  "},
+    )
+
+    assert headers == {"Authorization": "Bearer test-key"}
+
+
+def test_build_provider_extra_headers_keeps_existing_bearer_prefix() -> None:
+    headers = _build_provider_extra_headers(
+        LlmProviderNames.OLLAMA_CHAT,
+        {OLLAMA_API_KEY_CONFIG_KEY: "bearer test-key"},
+    )
+
+    assert headers == {"Authorization": "bearer test-key"}
+
+
+def test_build_provider_extra_headers_ignores_empty_ollama_api_key() -> None:
+    headers = _build_provider_extra_headers(
+        LlmProviderNames.OLLAMA_CHAT,
+        {OLLAMA_API_KEY_CONFIG_KEY: "   "},
+    )
+
+    assert headers == {}

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+from litellm.llms.ollama.chat.transformation import OllamaChatCompletionResponseIterator
+
+from onyx.llm.litellm_singleton.monkey_patches import apply_monkey_patches
+
+_UNSET = object()
+
+
+def _create_iterator() -> OllamaChatCompletionResponseIterator:
+    apply_monkey_patches()
+    return OllamaChatCompletionResponseIterator(
+        streaming_response=iter(()),
+        sync_stream=True,
+    )
+
+
+def _build_chunk(
+    *,
+    thinking: object = _UNSET,
+    content: object = _UNSET,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant"}
+    if thinking is not _UNSET:
+        message["thinking"] = thinking
+    if content is not _UNSET:
+        message["content"] = content
+
+    return {
+        "model": "llama3.1",
+        "message": message,
+        "done": False,
+        "prompt_eval_count": 0,
+        "eval_count": 0,
+    }
+
+
+def test_ollama_chunk_parser_transitions_from_native_thinking_to_content() -> None:
+    iterator = _create_iterator()
+
+    thinking_chunk = _build_chunk(thinking="Let me think")
+    content_chunk = _build_chunk(thinking="", content="Final answer")
+
+    thinking_response = iterator.chunk_parser(thinking_chunk)
+    content_response = iterator.chunk_parser(content_chunk)
+
+    assert thinking_response.choices[0].delta.reasoning_content == "Let me think"
+    assert thinking_response.choices[0].delta.content is None
+
+    assert getattr(content_response.choices[0].delta, "reasoning_content", None) is None
+    assert content_response.choices[0].delta.content == "Final answer"
+    assert iterator.finished_reasoning_content is True
+
+
+def test_ollama_chunk_parser_keeps_tagged_thinking_until_close_tag() -> None:
+    iterator = _create_iterator()
+
+    start_chunk = _build_chunk(content="<think>step 1")
+    middle_chunk = _build_chunk(content="step 2")
+    close_chunk = _build_chunk(content="final</think>")
+
+    start_response = iterator.chunk_parser(start_chunk)
+    middle_response = iterator.chunk_parser(middle_chunk)
+    close_response = iterator.chunk_parser(close_chunk)
+
+    assert start_response.choices[0].delta.reasoning_content == "step 1"
+    assert start_response.choices[0].delta.content is None
+
+    assert middle_response.choices[0].delta.reasoning_content == "step 2"
+    assert middle_response.choices[0].delta.content is None
+
+    assert getattr(close_response.choices[0].delta, "reasoning_content", None) is None
+    assert close_response.choices[0].delta.content == "final"
+    assert iterator.finished_reasoning_content is True
+
+
+def test_ollama_chunk_parser_handles_think_tag_after_native_thinking() -> None:
+    iterator = _create_iterator()
+
+    native_thinking_chunk = _build_chunk(thinking="native reasoning")
+    tagged_thinking_chunk = _build_chunk(content="<think>tagged reasoning")
+
+    iterator.chunk_parser(native_thinking_chunk)
+    tagged_response = iterator.chunk_parser(tagged_thinking_chunk)
+
+    assert tagged_response.choices[0].delta.reasoning_content == "tagged reasoning"
+    assert tagged_response.choices[0].delta.content is None
+
+
+def test_ollama_chunk_parser_preserves_content_when_thinking_and_content_coexist() -> (
+    None
+):
+    iterator = _create_iterator()
+
+    combined_chunk = _build_chunk(
+        thinking="Need one thought",
+        content="Visible answer token",
+    )
+
+    response = iterator.chunk_parser(combined_chunk)
+
+    assert response.choices[0].delta.reasoning_content == "Need one thought"
+    assert response.choices[0].delta.content == "Visible answer token"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There was an issue where Ollama would skip the content if there were thinking chunks. 

This would result in odd behavior but now we check both thinking and content chunks

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Ollama stream parsing so content is not skipped when thinking chunks or <think> tags appear, including handling empty thinking strings and preserving content when thinking and content coexist.

<sup>Written for commit 7f267b59caccdb895ff3e4de717bc31b47c93a74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

