### PR TITLE
fix(ui): Cleanup Card Span

### DIFF
--- a/web/src/layouts/expandable-card-layouts.tsx
+++ b/web/src/layouts/expandable-card-layouts.tsx
@@ -264,7 +264,7 @@ function ExpandableCardContent({
   }, [registerContent]);
 
   return (
-    <Collapsible open={!isFolded}>
+    <Collapsible open={!isFolded} className="w-full">
       <CollapsibleContent>
         <div
           className={cn(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Just some UI cleanup for the card

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

Before:
<img width="788" height="439" alt="Screenshot 2026-02-01 at 1 59 21 PM" src="https://github.com/user-attachments/assets/6a5f0864-7b69-421f-a234-04934845ae1b" />


After:
<img width="796" height="445" alt="Screenshot 2026-02-01 at 1 59 00 PM" src="https://github.com/user-attachments/assets/e130c349-ed62-4d81-ae43-8961ad146c61" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the expandable card content span the full width to fix narrow layouts and misaligned content. This keeps spacing consistent when toggling fold/unfold.

- **Bug Fixes**
  - Set the Collapsible wrapper to w-full in ExpandableCardContent to ensure consistent width and remove clipping/misalignment.

<sup>Written for commit 56d78beb03fa0a36b96afcc330fc0e9cd12683c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

