### PR TITLE
fix(ui): Agent Saving with other people files

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -997,9 +997,10 @@ export default function AgentEditorPage({
             const hasUploadingFiles = values.user_file_ids.some(
               (fileId: string) => {
                 const status = fileStatusMap.get(fileId);
-                return (
-                  status === undefined || status === UserFileStatus.UPLOADING
-                );
+                if (status === undefined) {
+                  return fileId.startsWith("temp_");
+                }
+                return status === UserFileStatus.UPLOADING;
               }
             );
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Trying to fix an issue where you can't save agents where the files uploaded don't belong to you.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Recreated this scenario locally by editing the DB state and confirmed this fixed the issue.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that blocked saving agents when attached files weren’t yours. Undefined file statuses are now treated as uploading only for fileIds starting with temp_, so shared/existing files don’t prevent saving.

<sup>Written for commit 5d0ab2ea9a8239d3520ccfc2053bdcf472ff85f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

