### PR TITLE
fix(craft): fix default dockerfile outputs_template_path and venv_template_path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -149,6 +149,11 @@ RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
         ENABLE_CRAFT=true /app/scripts/setup_craft_templates.sh; \
     fi
 
+# Set Craft template paths to the in-image locations
+# These match the paths where setup_craft_templates.sh creates the templates
+ENV OUTPUTS_TEMPLATE_PATH=/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs
+ENV VENV_TEMPLATE_PATH=/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv
+
 # Put logo in assets
 COPY --chown=onyx:onyx ./assets /app/assets
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default Craft template paths in the backend Dockerfile so Craft uses the in-image templates created during build. This fixes missing outputs/venv templates at runtime.

- **Bug Fixes**
  - Set OUTPUTS_TEMPLATE_PATH and VENV_TEMPLATE_PATH to /app/onyx/server/features/build/sandbox/kubernetes/docker/templates/{outputs,venv}.
  - Aligns defaults with setup_craft_templates.sh to avoid missing-template errors when ENABLE_CRAFT=true.

<sup>Written for commit e02027e6a7ecfe4d24627b85e48d7429f08177d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

