### PR TITLE
fix(ui): Agent Saving with other people files (#8095) to release v2.11

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -982,9 +982,10 @@ export default function AgentEditorPage({
             const hasUploadingFiles = values.user_file_ids.some(
               (fileId: string) => {
                 const status = fileStatusMap.get(fileId);
-                return (
-                  status === undefined || status === UserFileStatus.UPLOADING
-                );
+                if (status === undefined) {
+                  return fileId.startsWith("temp_");
+                }
+                return status === UserFileStatus.UPLOADING;
               }
             );
 


### PR DESCRIPTION
Cherry-pick of commit 15f0bc9c3ddb4af205edc9c5706a557baa286d63 to release/v2.11 branch.

Original PR: #8095

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent saves being blocked when an agent references files owned by other users. Only treat files with undefined status as uploading if the fileId starts with temp_, so existing/shared files no longer block saves.

<sup>Written for commit d013fb4057a3542670827b388adb0285a7bf5393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

