### PR TITLE
feat(desktop): Ensure that UI reflects Light/Dark Toggle (#7684) to release v2.11

### DIFF
--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -22,6 +22,17 @@
           BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       }
 
+      .dark {
+        --background-900: #1a1a1a;
+        --background-800: #262626;
+        --text-light-05: rgba(255, 255, 255, 0.95);
+        --text-light-03: rgba(255, 255, 255, 0.6);
+        --white-10: rgba(255, 255, 255, 0.08);
+        --white-15: rgba(255, 255, 255, 0.12);
+        --white-20: rgba(255, 255, 255, 0.15);
+        --white-30: rgba(255, 255, 255, 0.25);
+      }
+
       * {
         box-sizing: border-box;
         margin: 0;
@@ -30,7 +41,11 @@
 
       body {
         font-family: var(--font-hanken-grotesk);
-        background: linear-gradient(135deg, #f5f5f5 0%, #ffffff 100%);
+        background: linear-gradient(
+          135deg,
+          var(--background-900) 0%,
+          var(--background-800) 100%
+        );
         min-height: 100vh;
         color: var(--text-light-05);
         display: flex;
@@ -39,6 +54,9 @@
         padding: 20px;
         -webkit-user-select: none;
         user-select: none;
+        transition:
+          background 0.3s ease,
+          color 0.3s ease;
       }
 
       .titlebar {
@@ -69,16 +87,19 @@
       }
 
       .settings-panel {
-        background: linear-gradient(
-          to bottom,
-          rgba(255, 255, 255, 0.95),
-          rgba(245, 245, 245, 0.95)
-        );
+        background: var(--background-800);
         backdrop-filter: blur(24px);
         border-radius: 16px;
         border: 1px solid var(--white-10);
         overflow: hidden;
         box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+        transition:
+          background 0.3s ease,
+          border 0.3s ease;
+      }
+
+      .dark .settings-panel {
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
       }
 
       .settings-header {
@@ -93,17 +114,19 @@
         width: 40px;
         height: 40px;
         border-radius: 12px;
-        background: white;
+        background: var(--background-900);
         display: flex;
         align-items: center;
         justify-content: center;
         overflow: hidden;
+        transition: background 0.3s ease;
       }
 
       .settings-icon svg {
         width: 24px;
         height: 24px;
-        color: #000;
+        color: var(--text-light-05);
+        transition: color 0.3s ease;
       }
 
       .settings-title {
@@ -134,9 +157,10 @@
       }
 
       .settings-group {
-        background: rgba(0, 0, 0, 0.03);
+        background: var(--background-900);
         border-radius: 16px;
         padding: 4px;
+        transition: background 0.3s ease;
       }
 
       .setting-row {
@@ -176,7 +200,7 @@
         border: 1px solid var(--white-10);
         border-radius: 8px;
         font-size: 14px;
-        background: rgba(0, 0, 0, 0.05);
+        background: var(--background-800);
         color: var(--text-light-05);
         font-family: var(--font-hanken-grotesk);
         transition: all 0.2s;
@@ -186,8 +210,8 @@
       .input-field:focus {
         outline: none;
         border-color: var(--white-30);
-        background: rgba(0, 0, 0, 0.08);
-        box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.05);
+        background: var(--background-900);
+        box-shadow: 0 0 0 2px var(--white-10);
       }
 
       .input-field::placeholder {
@@ -231,7 +255,7 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: rgba(0, 0, 0, 0.15);
+        background-color: var(--white-15);
         transition: 0.3s;
         border-radius: 24px;
       }
@@ -243,14 +267,18 @@
         width: 18px;
         left: 3px;
         bottom: 3px;
-        background-color: white;
+        background-color: var(--background-800);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
         transition: 0.3s;
         border-radius: 50%;
       }
 
+      .dark .toggle-slider:before {
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+      }
+
       input:checked + .toggle-slider {
-        background-color: rgba(0, 0, 0, 0.3);
+        background-color: var(--white-30);
       }
 
       input:checked + .toggle-slider:before {
@@ -288,14 +316,15 @@
       }
 
       kbd {
-        background: rgba(0, 0, 0, 0.1);
-        border: 1px solid var(--white-10);
+        background: var(--white-10);
+        border: 1px solid var(--white-15);
         border-radius: 4px;
         padding: 2px 6px;
         font-family: monospace;
         font-weight: 500;
         color: var(--text-light-05);
         font-size: 11px;
+        transition: all 0.3s ease;
       }
     </style>
   </head>
@@ -372,9 +401,33 @@
       const errorMessage = document.getElementById("errorMessage");
       const saveBtn = document.getElementById("saveBtn");
 
+      // Theme detection based on system preferences
+      function applySystemTheme() {
+        const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+        function updateTheme(e) {
+          if (e.matches) {
+            document.documentElement.classList.add("dark");
+            document.body.classList.add("dark");
+          } else {
+            document.documentElement.classList.remove("dark");
+            document.body.classList.remove("dark");
+          }
+        }
+
+        // Apply initial theme
+        updateTheme(darkModeQuery);
+
+        // Listen for changes
+        darkModeQuery.addEventListener("change", updateTheme);
+      }
+
       function showSettings() {
         document.body.classList.add("show-settings");
       }
+
+      // Apply system theme immediately
+      applySystemTheme();
 
       // Initialize the app
       async function init() {

--- a/desktop/src/titlebar.js
+++ b/desktop/src/titlebar.js
@@ -113,6 +113,23 @@
     document.head.appendChild(style);
   }
 
+  function updateTitleBarTheme(isDark) {
+    const titleBar = document.getElementById(TITLEBAR_ID);
+    if (!titleBar) return;
+
+    if (isDark) {
+      titleBar.style.background =
+        "linear-gradient(180deg, rgba(18, 18, 18, 0.82) 0%, rgba(18, 18, 18, 0.72) 100%)";
+      titleBar.style.borderBottom = "1px solid rgba(255, 255, 255, 0.08)";
+      titleBar.style.boxShadow = "0 8px 28px rgba(0, 0, 0, 0.2)";
+    } else {
+      titleBar.style.background =
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.78) 100%)";
+      titleBar.style.borderBottom = "1px solid rgba(0, 0, 0, 0.06)";
+      titleBar.style.boxShadow = "0 8px 28px rgba(0, 0, 0, 0.04)";
+    }
+  }
+
   function buildTitleBar() {
     const titleBar = document.createElement("div");
     titleBar.id = TITLEBAR_ID;
@@ -133,6 +150,11 @@
         startWindowDrag();
       }
     });
+
+    // Apply initial styles matching current theme
+    const htmlHasDark = document.documentElement.classList.contains("dark");
+    const bodyHasDark = document.body?.classList.contains("dark");
+    const isDark = htmlHasDark || bodyHasDark;
 
     // Apply styles matching Onyx design system with translucent glass effect
     titleBar.style.cssText = `
@@ -156,7 +178,11 @@
       -webkit-backdrop-filter: blur(18px) saturate(180%);
       -webkit-app-region: drag;
       padding: 0 12px;
+      transition: background 0.3s ease, border-bottom 0.3s ease, box-shadow 0.3s ease;
     `;
+
+    // Apply correct theme
+    updateTitleBarTheme(isDark);
 
     return titleBar;
   }
@@ -168,6 +194,11 @@
 
     const existing = document.getElementById(TITLEBAR_ID);
     if (existing?.parentElement === document.body) {
+      // Update theme on existing titlebar
+      const htmlHasDark = document.documentElement.classList.contains("dark");
+      const bodyHasDark = document.body?.classList.contains("dark");
+      const isDark = htmlHasDark || bodyHasDark;
+      updateTitleBarTheme(isDark);
       return;
     }
 
@@ -178,6 +209,14 @@
     const titleBar = buildTitleBar();
     document.body.insertBefore(titleBar, document.body.firstChild);
     injectStyles();
+
+    // Ensure theme is applied immediately after mount
+    setTimeout(() => {
+      const htmlHasDark = document.documentElement.classList.contains("dark");
+      const bodyHasDark = document.body?.classList.contains("dark");
+      const isDark = htmlHasDark || bodyHasDark;
+      updateTitleBarTheme(isDark);
+    }, 0);
   }
 
   function syncViewportHeight() {
@@ -194,9 +233,66 @@
     }
   }
 
+  function observeThemeChanges() {
+    let lastKnownTheme = null;
+
+    function checkAndUpdateTheme() {
+      // Check both html and body for dark class (some apps use body)
+      const htmlHasDark = document.documentElement.classList.contains("dark");
+      const bodyHasDark = document.body?.classList.contains("dark");
+      const isDark = htmlHasDark || bodyHasDark;
+
+      if (lastKnownTheme !== isDark) {
+        lastKnownTheme = isDark;
+        updateTitleBarTheme(isDark);
+      }
+    }
+
+    // Immediate check on setup
+    checkAndUpdateTheme();
+
+    // Watch for theme changes on the HTML element
+    const themeObserver = new MutationObserver(() => {
+      checkAndUpdateTheme();
+    });
+
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    // Also observe body if it exists
+    if (document.body) {
+      const bodyObserver = new MutationObserver(() => {
+        checkAndUpdateTheme();
+      });
+      bodyObserver.observe(document.body, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
+    }
+
+    // Also check periodically in case classList is manipulated directly
+    // or the theme loads asynchronously after page load
+    const intervalId = setInterval(() => {
+      checkAndUpdateTheme();
+    }, 300);
+
+    // Clean up after 30 seconds once theme should be stable
+    setTimeout(() => {
+      clearInterval(intervalId);
+      // But keep checking every 2 seconds for manual theme changes
+      setInterval(() => {
+        checkAndUpdateTheme();
+      }, 2000);
+    }, 30000);
+  }
+
   function init() {
     mountTitleBar();
     syncViewportHeight();
+    observeThemeChanges();
+
     window.addEventListener("resize", syncViewportHeight, { passive: true });
     window.visualViewport?.addEventListener("resize", syncViewportHeight, {
       passive: true,


### PR DESCRIPTION
Cherry-pick of commit 13d1c3d86a618f74343b762049ad534a008b769f to release/v2.11 branch.

Original PR: #7684

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds system Light/Dark theme support across the desktop UI and keeps it in sync in real time. The title bar and settings panel now match the active theme with smooth transitions.

- **New Features**
  - Added dark-mode CSS variables and styles for backgrounds, text, inputs, toggles, and panel shadows.
  - Auto-detects system theme via prefers-color-scheme and toggles the .dark class; listens for changes.
  - Title bar now theme-aware via updateTitleBarTheme, applied on mount and on theme updates.
  - Observes html/body class changes and periodically checks to keep the title bar synchronized.

<sup>Written for commit b3b76a34fd16f13d293f40d7e4b9aca071e57b79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

