### PR TITLE
fix(ui): Search Connectors

### DIFF
--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -266,7 +266,7 @@ export default function Page() {
         value={rawSearchTerm} // keep the input bound to immediate state
         onChange={(event) => setSearchTerm(event.target.value)}
         onKeyDown={handleKeyPress}
-        className="w-96"
+        className="w-96 flex-none"
       />
 
       {dedupedPopular.length > 0 && (


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The span of the search connectors search bar was messed up.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Search Connectors input sizing on the Add Connector page by preventing flex growth so the input stays at w-96. This stops layout shifts and keeps adjacent elements aligned.

<sup>Written for commit 966c4d3dc00006ae0f14b62b74a59e493e1df89e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

