### PR TITLE
chore(opensearch): Some small cleanup around update

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -650,7 +650,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
                     # TODO(andrei): Fix the aforementioned race condition.
                     raise ValueError(
                         f"Tried to update document {doc_id} but its chunk count is not known. Older versions of the "
-                        "application used to permit this but is not a supported state for a document when using OpenSearch."
+                        "application used to permit this but is not a supported state for a document when using OpenSearch. "
                         "The document was likely just added to the indexing pipeline and the chunk count will be updated shortly."
                     )
                 if doc_chunk_count == 0:


### PR DESCRIPTION
## Description
We no longer raise if an update request contains no effective update. Also improved the error messaging around the no chunk count error case.

## How Has This Been Tested?
It was not.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OpenSearchDocumentIndex.update a no-op when no update fields are provided, logging a warning instead of raising. Improve error messaging and docs when a document’s chunk count is unknown, clarifying the indexing race condition and that callers should retry.

<sup>Written for commit b480183fadfe2aa9180f90d5a6b5a32219c997bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

