### PR TITLE
fix(craft): phantom pre-provisionsed sandboxes and poll for fresh session on welcome page

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -265,6 +265,14 @@ class RateLimitResponse(BaseModel):
     reset_timestamp: str | None = None
 
 
+# ===== Pre-Provisioned Session Check Models =====
+class PreProvisionedCheckResponse(BaseModel):
+    """Response for checking if a pre-provisioned session is still valid (empty)."""
+
+    valid: bool  # True if session exists and has no messages
+    session_id: str | None = None  # Session ID if valid, None otherwise
+
+
 # ===== Build Connector Models =====
 class BuildConnectorStatus(str, Enum):
     """Status of a build connector."""

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -1,7 +1,6 @@
 """Database operations for Build Mode sessions."""
 
 from datetime import datetime
-from datetime import timedelta
 from typing import Any
 from uuid import UUID
 
@@ -81,15 +80,19 @@ def get_user_build_sessions(
     db_session: Session,
     limit: int = 100,
 ) -> list[BuildSession]:
-    """Get all build sessions for a user that have at least 1 message.
+    """Get all build sessions for a user that have at least one message.
 
     Excludes empty (pre-provisioned) sessions from the listing.
     """
+    # Subquery to check if session has any messages
+    has_messages = exists().where(BuildMessage.session_id == BuildSession.id)
+
     return (
         db_session.query(BuildSession)
-        .join(BuildMessage)  # Inner join excludes empty sessions
-        .filter(BuildSession.user_id == user_id)
-        .group_by(BuildSession.id)
+        .filter(
+            BuildSession.user_id == user_id,
+            has_messages,  # Only sessions with messages
+        )
         .order_by(desc(BuildSession.created_at))
         .limit(limit)
         .all()
@@ -99,27 +102,24 @@ def get_user_build_sessions(
 def get_empty_session_for_user(
     user_id: UUID,
     db_session: Session,
-    max_age_minutes: int = 30,
     demo_data_enabled: bool | None = None,
 ) -> BuildSession | None:
-    """Get the user's empty session (0 messages) if one exists and is recent.
+    """Get an empty (pre-provisioned) session for the user if one exists.
+
+    Returns a session with no messages, or None if all sessions have messages.
 
     Args:
         user_id: The user ID
         db_session: Database session
-        max_age_minutes: Maximum age of session to consider (default 30)
         demo_data_enabled: Match sessions with this demo_data setting.
-                          This ensures pre-provisioned sessions match the user's current
-                          preferences. If None, matches any session regardless of setting.
-                          Note: None is only used internally for operations that need to
-                          match any session (e.g., deletion).
+                          If None, matches any session regardless of setting.
     """
-    cutoff = datetime.utcnow() - timedelta(minutes=max_age_minutes)
+    # Subquery to check if session has any messages
+    has_messages = exists().where(BuildMessage.session_id == BuildSession.id)
 
     query = db_session.query(BuildSession).filter(
         BuildSession.user_id == user_id,
-        BuildSession.created_at > cutoff,
-        ~exists().where(BuildMessage.session_id == BuildSession.id),
+        ~has_messages,  # Sessions with no messages only
     )
 
     if demo_data_enabled is not None:

--- a/web/src/app/craft/hooks/usePreProvisionPolling.ts
+++ b/web/src/app/craft/hooks/usePreProvisionPolling.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useBuildSessionStore } from "./useBuildSessionStore";
+import { checkPreProvisionedSession } from "../services/apiServices";
+
+/** Polling interval in milliseconds (5 seconds) */
+const POLLING_INTERVAL_MS = 5000;
+
+interface UsePreProvisionPollingOptions {
+  /** Only poll when enabled (should be true only on welcome page) */
+  enabled: boolean;
+}
+
+/**
+ * Hook that polls to verify the pre-provisioned session is still valid.
+ *
+ * When multiple browser tabs have the same pre-provisioned session,
+ * one tab may claim it by sending a message. This hook detects when
+ * that happens and triggers re-provisioning so the current tab gets
+ * a fresh session.
+ *
+ * Usage: Call this hook on the welcome page where pre-provisioned
+ * sessions are used. Pass enabled=true only on the welcome page.
+ */
+export function usePreProvisionPolling({
+  enabled,
+}: UsePreProvisionPollingOptions) {
+  const preProvisioning = useBuildSessionStore(
+    (state) => state.preProvisioning
+  );
+  const ensurePreProvisionedSession = useBuildSessionStore(
+    (state) => state.ensurePreProvisionedSession
+  );
+
+  // Extract sessionId only when status is "ready" (handles discriminated union)
+  const sessionId =
+    preProvisioning.status === "ready" ? preProvisioning.sessionId : null;
+
+  // Use ref to track if we're currently checking (prevents overlapping requests)
+  const isCheckingRef = useRef(false);
+
+  useEffect(() => {
+    // Only poll when enabled (welcome page) and we have a ready session
+    if (!enabled || !sessionId) {
+      return;
+    }
+
+    const checkValidity = async () => {
+      if (isCheckingRef.current) return;
+      isCheckingRef.current = true;
+
+      try {
+        const result = await checkPreProvisionedSession(sessionId);
+
+        if (!result.valid) {
+          console.log(
+            `[PreProvisionPolling] Session ${sessionId.slice(
+              0,
+              8
+            )} was used, re-provisioning...`
+          );
+          // Session was used by another tab - reset state and re-provision.
+          // Zustand setState is synchronous, so ensurePreProvisionedSession
+          // will immediately see the idle status (no setTimeout needed).
+          useBuildSessionStore.setState({
+            preProvisioning: { status: "idle" },
+          });
+          ensurePreProvisionedSession();
+        }
+      } catch (err) {
+        console.error("[PreProvisionPolling] Failed to check session:", err);
+        // On error, don't re-provision - might be a network issue
+      } finally {
+        isCheckingRef.current = false;
+      }
+    };
+
+    // Start polling
+    const intervalId = setInterval(checkValidity, POLLING_INTERVAL_MS);
+
+    // Also check immediately on mount (in case session was used while tab was inactive)
+    checkValidity();
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [enabled, sessionId, ensurePreProvisionedSession]);
+}

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -236,6 +236,28 @@ export async function restoreSession(
   return res.json();
 }
 
+/**
+ * Check if a pre-provisioned session is still valid (empty).
+ * Used for polling to detect when another tab has used the session.
+ *
+ * @returns { valid: true, session_id: string } if session is still empty
+ * @returns { valid: false, session_id: null } if session has messages or doesn't exist
+ */
+export async function checkPreProvisionedSession(
+  sessionId: string
+): Promise<{ valid: boolean; session_id: string | null }> {
+  const res = await fetch(
+    `${API_BASE}/sessions/${sessionId}/pre-provisioned-check`
+  );
+
+  if (!res.ok) {
+    // Treat errors as invalid session
+    return { valid: false, session_id: null };
+  }
+
+  return res.json();
+}
+
 // =============================================================================
 // Messages API
 // =============================================================================


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes phantom pre-provisioned Craft sandboxes by detecting when another tab claims the session and auto-provisioning a fresh one. Improves multi‑tab reliability on the welcome page and tightens session queries to hide empty sessions.

- Bug Fixes
  - Backend: added /sessions/{id}/pre-provisioned-check to verify a session is still empty, with exists(BuildMessage) checks and a simple response model.
  - Frontend: welcome page polls every 5s; if the session was used elsewhere, it clears state and re-provisions; also resets pre-provisioning state when returning to “new build.”
  - DB: session listing now excludes empty sessions via exists filter; get_empty_session_for_user returns truly empty sessions and drops the age constraint.

<sup>Written for commit c4fe357ca60cdc03cfc084b6687981b899a05347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

