### PR TITLE
feat(ui): Selecting all Models toggle

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/components/DisplayModels.tsx
+++ b/web/src/app/admin/configuration/llm/forms/components/DisplayModels.tsx
@@ -1,7 +1,6 @@
 import { ModelConfiguration, SimpleKnownModel } from "../../interfaces";
 import { FormikProps } from "formik";
 import { BaseLLMFormValues } from "../formUtils";
-import { useMemo } from "react";
 
 import Button from "@/refresh-components/buttons/Button";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
@@ -9,6 +8,7 @@ import Switch from "@/refresh-components/inputs/Switch";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { FieldLabel } from "@/components/Field";
+import { Section } from "@/layouts/general-layouts";
 
 interface AutoModeToggleProps {
   isAutoMode: boolean;
@@ -117,14 +117,8 @@ export function DisplayModels<T extends BaseLLMFormValues>({
 
   const selectedModels = formikProps.values.selected_model_names ?? [];
   const defaultModel = formikProps.values.default_model_name;
-  const selectedModelSet = useMemo(
-    () => new Set(selectedModels),
-    [selectedModels]
-  );
-  const allModelNames = useMemo(
-    () => modelConfigurations.map((model) => model.name),
-    [modelConfigurations]
-  );
+  const selectedModelSet = new Set(selectedModels);
+  const allModelNames = modelConfigurations.map((model) => model.name);
   const areAllModelsSelected =
     allModelNames.length > 0 &&
     allModelNames.every((modelName) => selectedModelSet.has(modelName));
@@ -175,8 +169,21 @@ export function DisplayModels<T extends BaseLLMFormValues>({
     <div className="flex flex-col gap-3">
       <DisplayModelHeader />
       {!isAutoMode && modelConfigurations.length > 0 && (
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="center"
+          height="auto"
+          gap={0.5}
+        >
+          <Section
+            flexDirection="row"
+            justifyContent="start"
+            alignItems="center"
+            height="auto"
+            width="fit"
+            gap={0.5}
+          >
             <Checkbox
               checked={areAllModelsSelected}
               indeterminate={areSomeModelsSelected && !areAllModelsSelected}
@@ -208,7 +215,7 @@ export function DisplayModels<T extends BaseLLMFormValues>({
                 Select all models
               </Text>
             </Button>
-          </div>
+          </Section>
           {areSomeModelsSelected && (
             <Button
               main
@@ -225,7 +232,7 @@ export function DisplayModels<T extends BaseLLMFormValues>({
               </Text>
             </Button>
           )}
-        </div>
+        </Section>
       )}
       <div className="border border-border-01 rounded-lg p-3">
         {shouldShowAutoUpdateToggle && (


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding a toggle to select all the models since some of the new providers have a ton of models to choose from.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally and made sure there are no regressions

None selected:
<img width="515" height="323" alt="Screenshot 2026-02-02 at 4 08 19 PM" src="https://github.com/user-attachments/assets/fbfacbd1-8381-48fd-898f-2ca07ed19197" />

All selected:
<img width="508" height="320" alt="Screenshot 2026-02-02 at 4 08 43 PM" src="https://github.com/user-attachments/assets/620004eb-93d1-4e66-9faf-9fd4b5a37f3f" />

Partially selected:
<img width="517" height="273" alt="Screenshot 2026-02-02 at 4 09 16 PM" src="https://github.com/user-attachments/assets/b5722918-d156-45c4-9960-c5b5d14ec559" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Select all models" toggle to the LLM model selector for quick bulk selection and clearing. Automatically ensures a valid default model when selecting all.

- **New Features**
  - Checkbox with indeterminate state and a "Select all models" action.
  - "Clear all (n)" button to deselect everything.
  - Automatically sets default to the recommended model (or first available) when selecting all; clears default when deselecting all.
  - Only shows in manual mode when models are available.

- **Refactors**
  - Replace custom auto mode toggle with the shared Switch component.
  - Use Set-based checks for selection; default handling uses null instead of empty string.

<sup>Written for commit b882d1f473fa71f9c1e5af7ce794992330867207. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

