### PR TITLE
fix(ui): Model Selection in Place

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/components/DisplayModels.tsx
+++ b/web/src/app/admin/configuration/llm/forms/components/DisplayModels.tsx
@@ -133,9 +133,6 @@ export function DisplayModels<T extends BaseLLMFormValues>({
   const selectedModels = formikProps.values.selected_model_names ?? [];
   const defaultModel = formikProps.values.default_model_name;
 
-  // Keep the provider's order stable so scrolling doesn't jump on selection.
-  const orderedModelConfigurations = modelConfigurations;
-
   if (modelConfigurations.length === 0) {
     return (
       <div>
@@ -231,7 +228,7 @@ export function DisplayModels<T extends BaseLLMFormValues>({
                 "overflow-y-auto"
               )}
             >
-              {orderedModelConfigurations.map((modelConfiguration) => {
+              {modelConfigurations.map((modelConfiguration) => {
                 const isSelected = selectedModels.includes(
                   modelConfiguration.name
                 );


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing the issue of jumping to the top of the model list when there are a ton of models for providers like Ollama and OpenRouter

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the model list order stable so selecting a model doesn't reflow the list or jump the scroll position in large provider lists (e.g., Ollama, OpenRouter). Removed the custom sort that elevated default/selected models; we now render in provider order.

<sup>Written for commit 88459ef4b1f6d7612132f4aa428411531e85c093. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

