### PR TITLE
fix(craft): wrong usage limit string

### DIFF
--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -345,7 +345,7 @@ const MemoizedBuildSidebarInner = memo(
     // limit=0 indicates unlimited (local/self-hosted mode), so hide the count
     const sessionsTitle = useMemo(() => {
       if (isEnabled && limits && limits.limit > 0) {
-        return `Sessions (${limits.messagesUsed}/${limits.limit})`;
+        return `Total Messages (${limits.messagesUsed}/${limits.limit})`;
       }
       return "Sessions";
     }, [isEnabled, limits]);


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Craft sidebar usage label to display “Total Messages (messagesUsed/limit)” when limits apply, instead of “Sessions,” to accurately reflect message quotas.

<sup>Written for commit 3bed5637754669563bd28711b109bedad5ee5fb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

