### PR TITLE
feat: Track reasoning in Braintrust

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -914,6 +914,10 @@ def run_llm_step_pkt_generator(
             )
             span_generation.span_data.output = [assistant_msg_no_tools.model_dump()]
 
+        # Record reasoning content for tracing (extended thinking from reasoning models)
+        if accumulated_reasoning:
+            span_generation.span_data.reasoning = accumulated_reasoning
+
     # This may happen if the custom token processor is used to modify other packets into reasoning
     # Then there won't necessarily be anything else to come after the reasoning tokens
     if reasoning_start:

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -172,13 +172,19 @@ class BraintrustTracingProcessor(TracingProcessor):
             if cost_cents > 0:
                 metrics["cost_cents"] = cost_cents
 
+        metadata: Dict[str, Any] = {
+            "model": span.span_data.model,
+            "model_config": span.span_data.model_config,
+        }
+
+        # Include reasoning in metadata if present
+        if span.span_data.reasoning:
+            metadata["reasoning"] = span.span_data.reasoning
+
         return {
             "input": span.span_data.input,
             "output": span.span_data.output,
-            "metadata": {
-                "model": span.span_data.model,
-                "model_config": span.span_data.model_config,
-            },
+            "metadata": metadata,
             "metrics": metrics,
         }
 

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -176,6 +176,7 @@ def function_span(
 def generation_span(
     input: Sequence[Mapping[str, Any]] | None = None,
     output: Sequence[Mapping[str, Any]] | None = None,
+    reasoning: str | None = None,
     model: str | None = None,
     model_config: Mapping[str, Any] | None = None,
     usage: dict[str, Any] | None = None,
@@ -195,6 +196,7 @@ def generation_span(
     Args:
         input: The sequence of input messages sent to the model.
         output: The sequence of output messages received from the model.
+        reasoning: The reasoning/thinking content from reasoning models (e.g., Claude extended thinking).
         model: The model identifier used for the generation.
         model_config: The model configuration (hyperparameters) used.
         usage: A dictionary of usage information (input tokens, output tokens, etc.).
@@ -213,6 +215,7 @@ def generation_span(
         span_data=GenerationSpanData(
             input=input,
             output=output,
+            reasoning=reasoning,
             model=model,
             model_config=model_config,
             usage=usage,

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -96,6 +96,7 @@ class GenerationSpanData(SpanData):
     __slots__ = (
         "input",
         "output",
+        "reasoning",
         "model",
         "model_config",
         "usage",
@@ -106,6 +107,7 @@ class GenerationSpanData(SpanData):
         self,
         input: Sequence[Mapping[str, Any]] | None = None,
         output: Sequence[Mapping[str, Any]] | None = None,
+        reasoning: str | None = None,
         model: str | None = None,
         model_config: Mapping[str, Any] | None = None,
         usage: dict[str, Any] | None = None,
@@ -113,6 +115,7 @@ class GenerationSpanData(SpanData):
     ):
         self.input = input
         self.output = output
+        self.reasoning = reasoning
         self.model = model
         self.model_config = model_config
         self.usage = usage
@@ -127,6 +130,7 @@ class GenerationSpanData(SpanData):
             "type": self.type,
             "input": self.input,
             "output": self.output,
+            "reasoning": self.reasoning,
             "model": self.model,
             "model_config": self.model_config,
             "usage": self.usage,

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -52,6 +52,7 @@ def record_llm_span_output(
     span: Span[GenerationSpanData],
     output: str | Sequence[Mapping[str, Any]] | None,
     usage: Any | None = None,
+    reasoning: str | None = None,
 ) -> None:
     if output is None:
         span.span_data.output = [{"content": None}]
@@ -63,6 +64,9 @@ def record_llm_span_output(
     usage_dict = _build_usage_dict(usage)
     if usage_dict:
         span.span_data.usage = usage_dict
+
+    if reasoning:
+        span.span_data.reasoning = reasoning
 
 
 def _build_usage_dict(usage: Any | None) -> dict[str, Any] | None:


### PR DESCRIPTION
## Description
^

## How Has This Been Tested?
Verified locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end support for capturing and sending LLM reasoning (e.g., extended thinking) to Braintrust. Improves trace visibility for reasoning models without breaking existing flows.

- **New Features**
  - Added reasoning to GenerationSpanData and export payload.
  - generation_span and record_llm_span_output now accept a reasoning field.
  - llm_step records accumulated_reasoning into the span.
  - Braintrust processor includes reasoning in metadata when present.

<sup>Written for commit e3017a97241312266ae381d85b0702ea63ff0558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

