### PR TITLE
chore: Remove auth log

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -76,7 +76,7 @@ WEB_DOMAIN = os.environ.get("WEB_DOMAIN") or "http://localhost:3000"
 #####
 # Upgrades users from disabled auth to basic auth and shows warning.
 _auth_type_str = (os.environ.get("AUTH_TYPE") or "").lower()
-if not _auth_type_str or _auth_type_str in ("disabled", "none"):
+if _auth_type_str == "disabled":
     logger.warning(
         "AUTH_TYPE='disabled' is no longer supported. "
         "Defaulting to 'basic'. Please update your configuration. "


### PR DESCRIPTION
## Description
Spooky log, not needed

## How Has This Been Tested?
N/A

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the auth deprecation warning to AUTH_TYPE='disabled' only, removing noisy logs when AUTH_TYPE is missing or set to 'none'. In those cases, auth still falls back to 'basic' without a warning.

<sup>Written for commit adb9541c65b449f927fc79d5fb41e1b25ea6ce52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

