### PR TITLE
fix: Back off to basic auth

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -83,7 +83,11 @@ if _auth_type_str == "disabled":
         "Your existing data will be migrated automatically."
     )
     _auth_type_str = AuthType.BASIC.value
-AUTH_TYPE = AuthType(_auth_type_str)
+try:
+    AUTH_TYPE = AuthType(_auth_type_str)
+except ValueError:
+    logger.error(f"Invalid AUTH_TYPE: {_auth_type_str}. Defaulting to 'basic'.")
+    AUTH_TYPE = AuthType.BASIC
 
 PASSWORD_MIN_LENGTH = int(os.getenv("PASSWORD_MIN_LENGTH", 8))
 PASSWORD_MAX_LENGTH = int(os.getenv("PASSWORD_MAX_LENGTH", 64))


### PR DESCRIPTION
## Description
^

## How Has This Been Tested?
N/A

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to basic auth when AUTH_TYPE is invalid, logging the error and preventing startup failures.

- **Bug Fixes**
  - Wrap AUTH_TYPE parsing in try/except; on ValueError, log the invalid value and default to basic auth.

<sup>Written for commit 260dd549618925899a17e42d8c835b382d76e6dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

