### PR TITLE
Revert "chore(document index): Remove offset"

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -122,6 +122,7 @@ class BasicChunkRequest(BaseModel):
     recency_bias_multiplier: float = 1.0
 
     limit: int | None = None
+    offset: int | None = None  # This one is not set currently
 
 
 class ChunkSearchRequest(BasicChunkRequest):

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -308,6 +308,7 @@ def search_pipeline(
         query_keywords=query_keywords,
         filters=filters,
         limit=chunk_search_request.limit,
+        offset=chunk_search_request.offset,
     )
 
     retrieved_chunks = search_chunks(

--- a/backend/onyx/context/search/retrieval/search_runner.py
+++ b/backend/onyx/context/search/retrieval/search_runner.py
@@ -69,6 +69,7 @@ def _embed_and_search(
             if hybrid_alpha <= 0.3
             else QueryExpansionType.SEMANTIC
         ),
+        offset=query_request.offset or 0,
     )
 
     return top_chunks

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -347,6 +347,7 @@ class HybridCapable(abc.ABC):
         time_decay_multiplier: float,
         num_to_retrieve: int,
         ranking_profile_type: QueryExpansionType,
+        offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunk]:
         """
@@ -371,6 +372,7 @@ class HybridCapable(abc.ABC):
         - time_decay_multiplier: how much to decay the document scores as they age. Some queries
                 based on the persona settings, will have this be a 2x or 3x of the default
         - num_to_retrieve: number of highest matching chunks to return
+        - offset: number of highest matching chunks to skip (kind of like pagination)
 
         Returns:
             best matching chunks based on weighted sum of keyword and vector/semantic search scores
@@ -398,6 +400,7 @@ class AdminCapable(abc.ABC):
         query_embedding: Embedding,
         filters: IndexFilters,
         num_to_retrieve: int = NUM_RETURNED_HITS,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         """
         Run the special search for the admin document explorer page
@@ -406,6 +409,7 @@ class AdminCapable(abc.ABC):
         - query: unmodified user query. Though in this flow probably unmodified is best
         - filters: standard filter object
         - num_to_retrieve: number of highest matching chunks to return
+        - offset: number of highest matching chunks to skip (kind of like pagination)
 
         Returns:
             list of best matching chunks for the explorer page query

--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -354,6 +354,7 @@ class HybridCapable(abc.ABC):
         # TODO(andrei): Make this more strict w.r.t. acl, temporary for now.
         filters: IndexFilters,
         num_to_retrieve: int,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         """Runs hybrid search and returns a list of inference chunks.
 
@@ -369,6 +370,8 @@ class HybridCapable(abc.ABC):
             filters: Filters for things like permissions, source type, time,
                 etc.
             num_to_retrieve: Number of highest matching chunks to return.
+            offset: Number of highest matching chunks to initially skip (kind of
+                like pagination). Defaults to 0.
 
         Returns:
             Score-ranked (highest first) list of highest matching chunks.

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -389,6 +389,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         time_decay_multiplier: float,
         num_to_retrieve: int,
         ranking_profile_type: QueryExpansionType = QueryExpansionType.SEMANTIC,
+        offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunk]:
         # Determine query type based on hybrid_alpha.
@@ -406,6 +407,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
             query_type=query_type,
             filters=filters,
             num_to_retrieve=num_to_retrieve,
+            offset=offset,
         )
 
     def admin_retrieval(
@@ -414,6 +416,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         query_embedding: Embedding,
         filters: IndexFilters,
         num_to_retrieve: int = NUM_RETURNED_HITS,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         return self._real_index.hybrid_retrieval(
             query=query,
@@ -422,6 +425,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
             query_type=QueryType.KEYWORD,
             filters=filters,
             num_to_retrieve=num_to_retrieve,
+            offset=offset,
         )
 
     def random_retrieval(
@@ -754,6 +758,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         query_type: QueryType,
         filters: IndexFilters,
         num_to_retrieve: int,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         logger.debug(
             f"[OpenSearchDocumentIndex] Hybrid retrieving {num_to_retrieve} chunks for index {self._index_name}."

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -773,6 +773,7 @@ class VespaIndex(DocumentIndex):
         time_decay_multiplier: float,
         num_to_retrieve: int,
         ranking_profile_type: QueryExpansionType = QueryExpansionType.SEMANTIC,
+        offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunk]:
         tenant_state = TenantState(
@@ -804,6 +805,7 @@ class VespaIndex(DocumentIndex):
             query_type,
             filters,
             num_to_retrieve,
+            offset,
         )
 
     def admin_retrieval(
@@ -812,6 +814,7 @@ class VespaIndex(DocumentIndex):
         query_embedding: Embedding,
         filters: IndexFilters,
         num_to_retrieve: int = NUM_RETURNED_HITS,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         vespa_where_clauses = build_vespa_filters(filters, include_hidden=True)
         yql = (
@@ -828,6 +831,7 @@ class VespaIndex(DocumentIndex):
             "yql": yql,
             "query": query,
             "hits": num_to_retrieve,
+            "offset": 0,
             "ranking.profile": "admin_search",
             "timeout": VESPA_TIMEOUT,
         }

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -549,6 +549,7 @@ class VespaDocumentIndex(DocumentIndex):
         query_type: QueryType,
         filters: IndexFilters,
         num_to_retrieve: int,
+        offset: int = 0,
     ) -> list[InferenceChunk]:
         vespa_where_clauses = build_vespa_filters(filters)
         # Needs to be at least as much as the rerank-count value set in the
@@ -594,6 +595,7 @@ class VespaDocumentIndex(DocumentIndex):
             "input.query(alpha)": hybrid_alpha,
             "input.query(title_content_ratio)": TITLE_CONTENT_RATIO,
             "hits": num_to_retrieve,
+            "offset": offset,
             "ranking.profile": ranking_profile,
             "timeout": VESPA_TIMEOUT,
         }


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#8144

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores offset-based pagination in document search by re-adding the offset parameter end-to-end. Fixes missing skip behavior in hybrid and admin retrieval across OpenSearch and Vespa (default 0).

- **Bug Fixes**
  - Added optional offset to BasicChunkRequest; passed through search_pipeline and search_runner.
  - Extended document index interfaces to accept offset for hybrid_retrieval and admin_retrieval.
  - Forwarded offset to OpenSearch and Vespa queries (including Vespa “offset”) to correctly skip initial results.

<sup>Written for commit 1f0cd0f27ef251e7c9cae67495b7c9401fadf60d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

