### PR TITLE
chore: firecrawl v2

### DIFF
--- a/backend/onyx/tools/tool_implementations/open_url/firecrawl.py
+++ b/backend/onyx/tools/tool_implementations/open_url/firecrawl.py
@@ -15,7 +15,7 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v1/scrape"
+FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v2/scrape"
 _DEFAULT_MAX_WORKERS = 5
 
 # Timeout is tuned to stay under the 2-minute outer timeout in
@@ -58,6 +58,7 @@ class FirecrawlClient(WebContentProvider):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             return list(executor.map(self._get_webpage_content_safe, urls))
 
+    # This allows the contents call to continue even if one URL fails, and return the results for the other URLs.
     def _get_webpage_content_safe(self, url: str) -> WebContent:
         try:
             return self._get_webpage_content(url)

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -320,14 +320,10 @@ def _convert_sections_to_llm_string_with_citations(
         }
         if updated_at_str is not None:
             result["updated_at"] = updated_at_str
-        result["source_type"] = chunk.source_type.value
         if chunk.source_links:
             link = next(iter(chunk.source_links.values()), None)
             if link:
                 result["url"] = link
-
-        if "url" not in result:
-            result["document_identifier"] = document_id
 
         if chunk.metadata:
             result["metadata"] = json.dumps(chunk.metadata, ensure_ascii=False)

--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -180,7 +180,7 @@ export default function Page() {
     provider?: WebContentProviderView
   ) => {
     const hasStoredKey = provider?.has_api_key ?? false;
-    const defaultFirecrawlBaseUrl = "https://api.firecrawl.dev/v1/scrape";
+    const defaultFirecrawlBaseUrl = "https://api.firecrawl.dev/v2/scrape";
 
     // For Exa content provider, check if we can use the shared Exa key
     const isExa = providerType === "exa";
@@ -774,7 +774,7 @@ export default function Page() {
     const storedBaseUrl = getSingleContentConfigFieldValueForForm(
       selectedContentProviderType,
       existingProvider,
-      "https://api.firecrawl.dev/v1/scrape"
+      "https://api.firecrawl.dev/v2/scrape"
     );
     const configChanged =
       selectedContentProviderType === "firecrawl" &&


### PR DESCRIPTION
## Description
Update firecrawl version. It's faster

## How Has This Been Tested?
Works locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Firecrawl integration to the v2 scrape endpoint for faster, more reliable web scraping. Also simplifies citation payload to reduce unused fields.

- **Refactors**
  - Point backend and admin defaults to https://api.firecrawl.dev/v2/scrape.
  - Remove source_type and document_identifier fallback from open_url tool output; include url when available.

- **Migration**
  - No action required for existing configs. To use v2 everywhere, update any stored Firecrawl base URLs in Admin settings.

<sup>Written for commit 38503d81afe2d4193e250f2d98015dd5bc8bcfc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

