### PR TITLE
fix(github): Fixing the Release Tags

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -223,8 +223,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.resolve-tag.outputs.release-tag }}
         run: |
-          if ! gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-            gh release create "${RELEASE_TAG}" \
+          if ! gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release create "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
               --draft \
               --title "${RELEASE_TAG}" \
               --notes "See the assets to download this version and install."
@@ -416,7 +416,7 @@ jobs:
           RELEASE_TAG: ${{ needs.create-release.outputs.release-tag }}
         shell: bash
         run: |
-          gh release upload "${RELEASE_TAG}" desktop/src-tauri/target/release/bundle/**/* --clobber
+          gh release upload "${RELEASE_TAG}" desktop/src-tauri/target/release/bundle/*/* --repo "${GITHUB_REPOSITORY}" --clobber
 
   build-web-amd64:
     needs: determine-builds


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Trying to fix the issue of the the duplicate tags being created. I suspect that the different desktop ships are competing and getting to the push their version thus creating multiple duplicate releases at times. 

The Beta tag is also always looking for `beta.X` so updating to handle just `beta` tag for some of the new tags we've been cutting. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Running in CI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI release tagging to stop duplicate releases and correctly detect beta tags. Releases now use the pushed tag name, and builds run one at a time to avoid races.

- **Bug Fixes**
  - Expand beta tag detection to match vX.Y.Z-beta and vX.Y.Z-beta.N.
  - Set max-parallel: 1 in the matrix to prevent concurrent runners from publishing the same tag.
  - Resolve the release tag from github.ref_name and pre-create a draft release; dev runs use v0.0.0-dev+<sha>, and assets are uploaded to that release.

<sup>Written for commit ccecbfe1d3cbfb7d94ebd7e832b9062a3b95bb84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

