### PR TITLE
fix(ci): Fix Bedrock Test

### DIFF
--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -9,7 +9,9 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from onyx.auth.users import current_admin_user
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import UserRole
 from onyx.main import fetch_versioned_implementation
 from onyx.utils.logger import setup_logger
 
@@ -29,6 +31,13 @@ def mock_get_session() -> Generator[MagicMock, None, None]:
     yield MagicMock()
 
 
+def mock_current_admin_user() -> MagicMock:
+    """Mock admin user for endpoints protected by current_admin_user."""
+    mock_admin = MagicMock()
+    mock_admin.role = UserRole.ADMIN
+    return mock_admin
+
+
 @pytest.fixture(scope="function")
 def client() -> Generator[TestClient, None, None]:
     # Set environment variables
@@ -42,6 +51,7 @@ def client() -> Generator[TestClient, None, None]:
     # Override the database session dependency with a mock
     # (these tests don't actually need DB access)
     app.dependency_overrides[get_session] = mock_get_session
+    app.dependency_overrides[current_admin_user] = mock_current_admin_user
 
     # Use TestClient as a context manager to properly trigger lifespan
     with TestClient(app) as client:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing the daily model test. There were updates to the other parts of the codebase that led to downstream affects here.

This one: https://onyx-company.slack.com/archives/C07K8KBMGKF/p1770221908691459

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran test locally.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the daily Bedrock model test by mocking the admin auth dependency so protected endpoints work in tests without real auth. Unblocks the CI job after recent auth changes.

- **Bug Fixes**
  - Added mock_current_admin_user that returns an ADMIN and wired it via dependency_overrides.
  - Imported current_admin_user and UserRole to support the mock.

<sup>Written for commit f006fd58ceb23a077a352787fbec75178fa8c757. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

