### PR TITLE
fix(craft): bump aws sync concurrent requests 10-->200

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -362,16 +362,39 @@ class KubernetesSandboxManager(SandboxManager):
             command=["/bin/sh", "-c"],
             args=[
                 f"""
-set -e
-
 # Handle SIGTERM for fast container termination
 trap 'echo "Received SIGTERM, exiting"; exit 0' TERM
 
 # Initial sync on startup - sync knowledge files for this user/tenant
 echo "Starting initial file sync for tenant: {tenant_id} / user: {user_id}"
-aws s3 sync "s3://{self._s3_bucket}/{tenant_id}/knowledge/{user_id}/" /workspace/files/
+echo "S3 source: s3://{self._s3_bucket}/{tenant_id}/knowledge/{user_id}/"
 
-echo "Initial sync complete, staying alive for incremental syncs"
+# Capture both stdout and stderr, track exit code
+# aws s3 sync returns exit code 1 even on success if there are warnings
+sync_exit_code=0
+sync_stderr=$(mktemp)
+aws s3 sync "s3://{self._s3_bucket}/{tenant_id}/knowledge/{user_id}/" /workspace/files/ 2>"$sync_stderr" || sync_exit_code=$?
+
+# Always show stderr if there was any output (for debugging)
+if [ -s "$sync_stderr" ]; then
+    echo "=== S3 sync stderr output ==="
+    cat "$sync_stderr"
+    echo "=== End stderr output ==="
+fi
+rm -f "$sync_stderr"
+
+# Report outcome
+echo "S3 sync finished with exit code: $sync_exit_code"
+
+# Exit codes 0 and 1 are both considered success
+# (exit code 1 = success with warnings, e.g., metadata/timestamp issues)
+if [ $sync_exit_code -eq 0 ] || [ $sync_exit_code -eq 1 ]; then
+    echo "Initial sync complete, staying alive for incremental syncs"
+else
+    echo "ERROR: Initial sync failed with exit code: $sync_exit_code"
+    exit $sync_exit_code
+fi
+
 # Stay alive - incremental sync commands will be executed via kubectl exec
 # Use 'wait' so shell can respond to signals while sleeping
 while true; do


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase AWS S3 sync concurrency to 200 and treat AWS CLI exit code 1 as success to prevent sandbox sync crashes.

<sup>Written for commit 01589df2c89eaa3f15b9d879da45665c6e6b7bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

