### PR TITLE
fix(ci): Allow for flexible beta tag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -82,7 +82,7 @@ jobs:
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             IS_STABLE=true
           fi
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta(\.[0-9]+)?$ ]]; then
             IS_BETA=true
           fi
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Updating the beta check tag to allow for cases like `v2.11.0-beta` as well.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the deployment workflow to accept flexible beta tags. The tag check now treats both vX.Y.Z-beta and vX.Y.Z-beta.N as beta releases.

<sup>Written for commit 551a55cda7e0accf973ac6483cd188ce3081af2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

