### PR TITLE
fix(ui): Additional LLM Config update

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/CustomForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/CustomForm.tsx
@@ -131,10 +131,15 @@ export function CustomForm({
                   return;
                 }
 
+                const selectedModelNames = modelConfigurations.map(
+                  (config) => config.name
+                );
+
                 await submitLLMProvider({
                   providerName: values.provider,
                   values: {
                     ...values,
+                    selected_model_names: selectedModelNames,
                     custom_config: customConfigProcessing(
                       values.custom_config_list
                     ),


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
A bug that has existed for a while but if a user tries to update their existing custom LLM Provider config and save, it will save but the additional model or models would be dropped. 

This isn't an issue when creating from scratch since all of the models are added at the same time. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
I setup a LiteLLM Proxy LLM Provider config locally and then tested that this worked as intended. 

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where editing an existing custom LLM provider config dropped additional models on save. The form now sends selected_model_names so all chosen models persist after update.

- **Bug Fixes**
  - Include selected_model_names from modelConfigurations in submitLLMProvider payload.
  - Manually verified with a local LiteLLM Proxy config.

<sup>Written for commit 25ebc51a1320d9a8580c5fd801d4c64e888e07a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

