### PR TITLE
fix(db): add cascade delete to search_query user_id foreign key

### DIFF
--- a/backend/alembic/versions/d5c86e2c6dc6_add_cascade_delete_to_search_query_user_.py
+++ b/backend/alembic/versions/d5c86e2c6dc6_add_cascade_delete_to_search_query_user_.py
@@ -1,0 +1,35 @@
+"""add_cascade_delete_to_search_query_user_id
+
+Revision ID: d5c86e2c6dc6
+Revises: 90b409d06e50
+Create Date: 2026-02-04 16:05:04.749804
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d5c86e2c6dc6"
+down_revision = "90b409d06e50"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("search_query_user_id_fkey", "search_query", type_="foreignkey")
+    op.create_foreign_key(
+        "search_query_user_id_fkey",
+        "search_query",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("search_query_user_id_fkey", "search_query", type_="foreignkey")
+    op.create_foreign_key(
+        "search_query_user_id_fkey", "search_query", "user", ["user_id"], ["id"]
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2648,7 +2648,9 @@ class SearchQuery(Base):
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True), primary_key=True, default=uuid4
     )
-    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("user.id"))
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("user.id", ondelete="CASCADE")
+    )
     query: Mapped[str] = mapped_column(String)
     query_expansions: Mapped[list[str] | None] = mapped_column(
         postgresql.ARRAY(String), nullable=True


### PR DESCRIPTION
## Description

Deleting a user fails with `ForeignKeyViolation` on the `search_query` table because `search_query.user_id` was created without `ondelete="CASCADE"`. This was missed in the original `1b8206b29c5d_add_user_delete_cascades` migration.

This PR adds a migration that drops and recreates the `search_query_user_id_fkey` constraint with `CASCADE`, and updates the SQLAlchemy model to match.

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ForeignKeyViolation when deleting a user by adding cascade delete to search_query.user_id. Deleting a user now also removes their search queries.

- **Bug Fixes**
  - Dropped and recreated search_query_user_id_fkey with ondelete="CASCADE".
  - Updated SearchQuery model to match the new constraint.

<sup>Written for commit 75deb295f7fcf60998388da39b2cb4e5c150b65a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

