### PR TITLE
chore: Slight tweaks of DR

### DIFF
--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -139,7 +139,7 @@ Provide inline citations in the format [1], [2], [3], etc. based on the citation
 
 
 USER_FINAL_REPORT_QUERY = f"""
-Provide a comprehensive answer to my previous query. CRITICAL: be as detailed as possible, stay on topic, and provide clear organization in your response.
+Provide a comprehensive, detailed, and insightful answer to my previous query. CRITICAL: be as detailed as possible, stay on topic, and provide clear organization in your response, addressing all aspects of the query.
 
 Ignore the format styles of the intermediate {RESEARCH_AGENT_TOOL_NAME} reports, those are not end user facing and different from your task.
 

--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -14,13 +14,12 @@ NEVER output normal response tokens, you must only call tools.
 For context, the date is {{current_datetime}}.
 
 # Tools
-You have a limited number of cycles of searches to complete your research but you do not have to use all cycles. \
-Each set of web searches increments the cycle by 1 (only web searches increment the cycle count). You are on cycle {{current_cycle_count}} of 3.\
+You have a limited number of cycles to complete your research and you do not have to use all cycles. You are on cycle {{current_cycle_count}} of {MAX_RESEARCH_CYCLES}.\
 {{optional_internal_search_tool_description}}\
 {{optional_web_search_tool_description}}\
 {{optional_open_url_tool_description}}
 ## {THINK_TOOL_NAME}
-CRITICAL - use the think tool after every set of searches and reads. \
+CRITICAL - use the think tool after every set of searches and reads (so search, read some pages, then think and repeat). \
 You MUST use the {THINK_TOOL_NAME} before calling the web_search tool for all calls to web_search except for the first call. \
 Use the {THINK_TOOL_NAME} before calling the {GENERATE_REPORT_TOOL_NAME} tool.
 
@@ -85,7 +84,7 @@ NEVER output normal response tokens, you must only call tools.
 For context, the date is {{current_datetime}}.
 
 # Tools
-You have a limited number of cycles of searches to complete your research but you do not have to use all cycles. Each set of web searches increments the cycle by 1. You are on cycle {{current_cycle_count}} of {MAX_RESEARCH_CYCLES}.\
+You have a limited number of cycles to complete your research and you do not have to use all cycles. You are on cycle {{current_cycle_count}} of {MAX_RESEARCH_CYCLES}.\
 {{optional_internal_search_tool_description}}\
 {{optional_web_search_tool_description}}\
 {{optional_open_url_tool_description}}

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -73,7 +73,7 @@ from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 logger = setup_logger()
 
 
-RESEARCH_CYCLE_CAP = 3
+RESEARCH_CYCLE_CAP = 8
 # 30 minute timeout per research agent
 RESEARCH_AGENT_TIMEOUT_SECONDS = 30 * 60
 RESEARCH_AGENT_TIMEOUT_MESSAGE = "Research Agent timed out after 30 minutes"
@@ -264,12 +264,9 @@ def run_research_agent_call(
                     break
 
                 if research_cycle_count == RESEARCH_CYCLE_CAP:
-                    # For the last cycle, do not use any more searches, only reason or generate a report
-                    current_tools = [
-                        tool
-                        for tool in tools
-                        if tool.name not in {SearchTool.NAME, WebSearchTool.NAME}
-                    ]
+                    # Auto-generate report on last cycle
+                    logger.debug("Auto-generating intermediate report on last cycle.")
+                    break
 
                 tools_by_name = {tool.name: tool for tool in current_tools}
 
@@ -386,13 +383,6 @@ def run_research_agent_call(
                     ]
 
                 just_ran_web_search = False
-
-                if any(
-                    tool_call.tool_name in {SearchTool.NAME, WebSearchTool.NAME}
-                    for tool_call in tool_calls
-                ):
-                    # Only the search actions increment the cycle for the max cycle count
-                    research_cycle_count += 1
 
                 special_tool_calls = check_special_tool_calls(tool_calls=tool_calls)
                 if special_tool_calls.generate_report_tool_call:
@@ -593,6 +583,7 @@ def run_research_agent_call(
                 # If it reached this point, it did not call reasoning, so here we wipe it to not save it to multiple turns
                 most_recent_reasoning = None
                 llm_cycle_count += 1
+                research_cycle_count += 1
 
             # If we've run out of cycles, just try to generate a report from everything so far
             final_report = generate_intermediate_report(


### PR DESCRIPTION
## Description
Change agent cycle count incrementing every web search to every cycle. Reason behind this:

When there is a long set of similar tool calls that repeat many times, the LLM can catch onto that pattern and will end up attempting to call tools in its history even when those tools are not present anymore in the tool config json. This happens especially with worse models but even with Claude 4.5 Opus it happens reliably across 100 deep research questions. This fix addresses it by having a different way of tracking cycles such that the last cycle isn't just removing web search, but it automatically goes into the report generation.

## How Has This Been Tested?
Ran locally many times

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch research cycle counting from per-search to per-cycle for clearer control, and raise the cycle cap to 8 with automatic report generation on the final cycle.

- **Refactors**
  - Cycle count now increments once per agent cycle, not per web search.
  - Increased RESEARCH_CYCLE_CAP from 3 to 8.
  - On the last cycle, auto-generate an intermediate report instead of continuing tool calls.
  - Updated prompts to reflect the new cycle logic and clarify Think tool cadence; improved final report instruction wording.

<sup>Written for commit d90ddd26977a395e2b3a62e23116e875f4c02eb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

