### PR TITLE
fix(openai): Fix reasoning

### DIFF
--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -30,7 +30,7 @@ class ReasoningEffort(str, Enum):
 # OpenAI reasoning effort mapping
 # Note: OpenAI API does not support "auto" - valid values are: none, minimal, low, medium, high, xhigh
 OPENAI_REASONING_EFFORT: dict[ReasoningEffort, str] = {
-    ReasoningEffort.AUTO: "medium",  # Default to medium when auto is requested
+    ReasoningEffort.AUTO: "low",  # Default to low when auto is requested
     ReasoningEffort.OFF: "none",
     ReasoningEffort.LOW: "low",
     ReasoningEffort.MEDIUM: "medium",


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
OpenAI based questions are currently broken.

Auto is not something that the OpenAPI supports

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Need to test first

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted OpenAI reasoning effort AUTO to low to fix API errors from the unsupported "auto" value. Restores OpenAI question handling without failures.

<sup>Written for commit a5fc532cb707265fd52cfb7987deb6cbcce1e8e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

