### PR TITLE
chore: bump default usage limits

### DIFF
--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -228,28 +228,28 @@ USAGE_LIMIT_WINDOW_SECONDS = int(os.environ.get("USAGE_LIMIT_WINDOW_SECONDS", "6
 # Per-week LLM usage cost limits in cents (e.g., 1000 = $10.00)
 # Trial users get lower limits than paid users
 USAGE_LIMIT_LLM_COST_CENTS_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_TRIAL", "800")  # $8.00 default
+    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_TRIAL", "3200")  # $32.00 default
 )
 USAGE_LIMIT_LLM_COST_CENTS_PAID = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_PAID", "1600")  # $16.00 default
+    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_PAID", "6400")  # $64.00 default
 )
 
 # Per-week chunks indexed limits
 USAGE_LIMIT_CHUNKS_INDEXED_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_TRIAL", 100_000)
+    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_TRIAL", 400_000)
 )
 USAGE_LIMIT_CHUNKS_INDEXED_PAID = int(
-    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_PAID", 1_000_000)
+    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_PAID", 4_000_000)
 )
 
 # Per-week API calls using API keys or Personal Access Tokens
-USAGE_LIMIT_API_CALLS_TRIAL = int(os.environ.get("USAGE_LIMIT_API_CALLS_TRIAL", "100"))
-USAGE_LIMIT_API_CALLS_PAID = int(os.environ.get("USAGE_LIMIT_API_CALLS_PAID", "10000"))
+USAGE_LIMIT_API_CALLS_TRIAL = int(os.environ.get("USAGE_LIMIT_API_CALLS_TRIAL", "400"))
+USAGE_LIMIT_API_CALLS_PAID = int(os.environ.get("USAGE_LIMIT_API_CALLS_PAID", "40000"))
 
 # Per-week non-streaming API calls (more expensive, so lower limits)
 USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL", "20")
+    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL", "80")
 )
 USAGE_LIMIT_NON_STREAMING_CALLS_PAID = int(
-    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_PAID", "40")
+    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_PAID", "160")
 )


### PR DESCRIPTION
## Description

Increase default usage limits so most users won't hit them

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised default weekly usage limits 4x so most users don’t hit caps. Applies to LLM cost, chunks indexed, API calls, and non-streaming calls.

- **Refactors**
  - LLM cost caps: trial $32, paid $64.
  - Chunks indexed: trial 400k, paid 4M.
  - API calls: trial 400, paid 40k.
  - Non-streaming calls: trial 80, paid 160.

<sup>Written for commit 308823da09e68a144e2d839e7af3bd34dcc6a04c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

