### PR TITLE
fix: don't run craft setup script unless it exists

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -118,7 +118,9 @@ services:
         - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
     command: >
       /bin/sh -c "
-      /app/scripts/setup_craft_templates.sh &&
+      if [ -f /app/scripts/setup_craft_templates.sh ]; then
+        /app/scripts/setup_craft_templates.sh;
+      fi &&
       if [ -f /etc/ssl/certs/custom-ca.crt ]; then
         update-ca-certificates;
       fi &&


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docker-compose to check for /app/scripts/setup_craft_templates.sh before running it. This prevents container startup failures when Craft is disabled or the script is absent.

<sup>Written for commit f29e75efddb727c468d74e3c1dcee20e2c7a6b3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

