### PR TITLE
chore(ruff): move config up a level

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,15 +39,3 @@ ignore_errors = true
 module = "transformers.*"
 follow_imports = "skip"
 ignore_errors = true
-
-[tool.ruff]
-line-length = 130
-target-version = "py311"
-
-[tool.ruff.lint]
-ignore = []
-select = [
-  "E",
-  "F",
-  "W",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,18 @@ include = ["backend"]
 exclude = ["backend/generated"]
 typeCheckingMode = "off"
 
+[tool.ruff]
+line-length = 130
+target-version = "py311"
+
+[tool.ruff.lint]
+ignore = []
+select = [
+  "E",
+  "F",
+  "W",
+]
+
 [tool.setuptools.packages.find]
 where = ["backend"]
 include = ["onyx*", "tests*"]


### PR DESCRIPTION
## Description

I have a `~/.ruff.toml` file which is supposed to be supplementary to project's ruff config i.e. a fallback. Because Onyx does not have a top-level ruff config, this global config takes precedence over `backend/pyproject.toml` which in turn causes my pre-commit hooks to fail often.

This also means that python files outside of the `backend/` directory, last I checked there were only 2 in `examples/`, now also use this same, standardized config.

## How Has This Been Tested?

`ruff check .`

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Ruff configuration to the top-level pyproject.toml so the project config takes precedence over a user's ~/.ruff.toml. This fixes inconsistent linting and prevents pre-commit failures.

<sup>Written for commit 8fa6e9da020dcb6b1378ffecfc40fd2efc151846. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

