### PR TITLE
chore(openai): Add Reasoning Specific Test

### DIFF
--- a/backend/tests/unit/onyx/llm/test_reasoning_effort_mapping.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_effort_mapping.py
@@ -25,11 +25,10 @@ def test_openai_reasoning_effort_mapping_has_valid_values() -> None:
 
 
 def test_openai_reasoning_effort_mapping_covers_all_effort_levels() -> None:
-    """Test that OPENAI_REASONING_EFFORT has mappings for all ReasoningEffort values except OFF.
+    """Test that OPENAI_REASONING_EFFORT has mappings for all ReasoningEffort values.
 
     This ensures we don't accidentally forget to add a mapping when new effort levels are added.
-    Note: ReasoningEffort.OFF is excluded because it maps to "none" and is handled separately
-    in multi_llm.py (the reasoning block is not added when effort is OFF).
+    Note: ReasoningEffort.OFF maps to "none" in the OpenAI API.
     """
     # These are the effort levels that should have OpenAI mappings
     expected_effort_levels = {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There was an issue with OpenAI being broken do to the reasoning values that were set.

This is a simple test to hopefully catch these issues in the future.

This is a direct followup of https://github.com/onyx-dot-app/onyx/pull/8183

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally to validate that tests past. 

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests to validate the OpenAI reasoning effort mapping so we don’t pass invalid values (like "auto") to the API. Ensures the mapping only uses supported API values and covers the expected effort levels.

<sup>Written for commit 759ebb858ce96b616576ad7aad7ae80a7b9184be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

