### PR TITLE
feat: recommend opus 4-6

### DIFF
--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0",
-  "updated_at": "2025-12-17T00:00:00Z",
+  "version": "1.1",
+  "updated_at": "2026-02-05T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": { "name": "gpt-5.2" },


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated recommended models to make Claude Opus 4.6 the Anthropic default and add both Claude Opus 4.6 and 4.5 to the visible options. New users default to 4.6; 4.5 remains selectable.

<sup>Written for commit f0c77e9922d5f168b1c46108779a4f6f686571d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

