### PR TITLE
fix: metadata hardening

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -187,7 +187,7 @@ class DocumentBase(BaseModel):
 
     # only filled in EE for connectors w/ permission sync enabled
     external_access: ExternalAccess | None = None
-    doc_metadata: dict[str, str | list[str]] | None = None
+    doc_metadata: dict[str, Any] | None = None
 
     # Parent hierarchy node raw ID - the folder/space/page containing this document
     # If None, document's hierarchy position is unknown or connector doesn't support hierarchy

--- a/backend/onyx/server/features/build/indexing/persistent_document_writer.py
+++ b/backend/onyx/server/features/build/indexing/persistent_document_writer.py
@@ -122,8 +122,10 @@ def build_document_subpath(doc: Document, replace_slash: bool = True) -> list[st
     parts.append(doc.source.value)
 
     # Get hierarchy from doc_metadata
-    hierarchy = doc.doc_metadata.get("hierarchy", {}) if doc.doc_metadata else {}
-    source_path = hierarchy.get("source_path", [])
+    hierarchy: dict[str, Any] = (
+        doc.doc_metadata.get("hierarchy", {}) if doc.doc_metadata else {}
+    )
+    source_path: list[str] = hierarchy.get("source_path", [])
 
     if source_path:
         parts.extend(


### PR DESCRIPTION
## Description

There aren't safeguards at the connector level that prevent saving metadata with a type that pydantic doesn't expect. Perhaps ideally every connector should be forced to provide str | list[str] as metadata values, but in practice I don't really want to go through every connector and enforce this. I think this is fine as an across-the-board solution

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict document metadata types (str | list[str]) and normalizes legacy non-string values during deserialization to prevent pydantic validation errors.

- **Bug Fixes**
  - Restrict Document.doc_metadata to dict[str, str | list[str]].
  - Convert legacy bool/number/None metadata to strings on read.
  - Coerce list items to strings and warn when conversions occur.

<sup>Written for commit 55ec81161c32520f8944b2bbaa380cb9346d0692. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

