### PR TITLE
chore(ruff): enable flake8s unused arg rules

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -57,7 +57,7 @@ if USE_IAM_AUTH:
 
 
 def include_object(
-    object: SchemaItem,
+    object: SchemaItem,  # noqa: ARG001
     name: str | None,
     type_: Literal[
         "schema",
@@ -67,8 +67,8 @@ def include_object(
         "unique_constraint",
         "foreign_key_constraint",
     ],
-    reflected: bool,
-    compare_to: SchemaItem | None,
+    reflected: bool,  # noqa: ARG001
+    compare_to: SchemaItem | None,  # noqa: ARG001
 ) -> bool:
     if type_ == "table" and name in EXCLUDE_TABLES:
         return False
@@ -244,7 +244,7 @@ def do_run_migrations(
 
 
 def provide_iam_token_for_alembic(
-    dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
+    dialect: Any, conn_rec: Any, cargs: Any, cparams: Any  # noqa: ARG001
 ) -> None:
     if USE_IAM_AUTH:
         # Database connection settings

--- a/backend/alembic_tenants/env.py
+++ b/backend/alembic_tenants/env.py
@@ -39,7 +39,7 @@ EXCLUDE_TABLES = {"kombu_queue", "kombu_message"}
 
 
 def include_object(
-    object: SchemaItem,
+    object: SchemaItem,  # noqa: ARG001
     name: str | None,
     type_: Literal[
         "schema",
@@ -49,8 +49,8 @@ def include_object(
         "unique_constraint",
         "foreign_key_constraint",
     ],
-    reflected: bool,
-    compare_to: SchemaItem | None,
+    reflected: bool,  # noqa: ARG001
+    compare_to: SchemaItem | None,  # noqa: ARG001
 ) -> bool:
     if type_ == "table" and name in EXCLUDE_TABLES:
         return False

--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -951,7 +951,7 @@ class PermissionSyncCallback(IndexingHeartbeatInterface):
 
         return False
 
-    def progress(self, tag: str, amount: int) -> None:
+    def progress(self, tag: str, amount: int) -> None:  # noqa: ARG002
         try:
             self.redis_connector.permissions.set_active()
 
@@ -982,7 +982,7 @@ class PermissionSyncCallback(IndexingHeartbeatInterface):
 
 
 def monitor_ccpair_permissions_taskset(
-    tenant_id: str, key_bytes: bytes, r: Redis, db_session: Session
+    tenant_id: str, key_bytes: bytes, r: Redis, db_session: Session  # noqa: ARG001
 ) -> None:
     fence_key = key_bytes.decode("utf-8")
     cc_pair_id_str = RedisConnector.get_id_from_fence_key(fence_key)

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -259,7 +259,7 @@ def check_for_external_group_sync(self: Task, *, tenant_id: str) -> bool | None:
 def try_creating_external_group_sync_task(
     app: Celery,
     cc_pair_id: int,
-    r: Redis,
+    r: Redis,  # noqa: ARG001
     tenant_id: str,
 ) -> str | None:
     """Returns an int if syncing is needed. The int represents the number of sync tasks generated.
@@ -344,7 +344,7 @@ def try_creating_external_group_sync_task(
     bind=True,
 )
 def connector_external_group_sync_generator_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     cc_pair_id: int,
     tenant_id: str,
 ) -> None:
@@ -590,8 +590,8 @@ def _perform_external_group_sync(
 
 def validate_external_group_sync_fences(
     tenant_id: str,
-    celery_app: Celery,
-    r: Redis,
+    celery_app: Celery,  # noqa: ARG001
+    r: Redis,  # noqa: ARG001
     r_replica: Redis,
     r_celery: Redis,
     lock_beat: RedisLock,

--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -40,7 +40,7 @@ def export_query_history_task(
     end: datetime,
     start_time: datetime,
     # Need to include the tenant_id since the TenantAwareTask needs this
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
 ) -> None:
     if not self.request.id:
         raise RuntimeError("No task id defined for this task; cannot identify it")

--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -43,7 +43,7 @@ _TENANT_PROVISIONING_TIME_LIMIT = 60 * 10  # 10 minutes
     trail=False,
     bind=True,
 )
-def check_available_tenants(self: Task) -> None:
+def check_available_tenants(self: Task) -> None:  # noqa: ARG001
     """
     Check if we have enough pre-provisioned tenants available.
     If not, trigger the pre-provisioning of new tenants.

--- a/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
@@ -21,9 +21,9 @@ logger = setup_logger()
     trail=False,
 )
 def generate_usage_report_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     *,
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
     user_id: str | None = None,
     period_from: str | None = None,
     period_to: str | None = None,

--- a/backend/ee/onyx/background/task_name_builders.py
+++ b/backend/ee/onyx/background/task_name_builders.py
@@ -7,7 +7,7 @@ QUERY_HISTORY_TASK_NAME_PREFIX = OnyxCeleryTask.EXPORT_QUERY_HISTORY_TASK
 
 
 def name_chat_ttl_task(
-    retention_limit_days: float, tenant_id: str | None = None
+    retention_limit_days: float, tenant_id: str | None = None  # noqa: ARG001
 ) -> str:
     return f"chat_ttl_{retention_limit_days}_days"
 

--- a/backend/ee/onyx/db/document_set.py
+++ b/backend/ee/onyx/db/document_set.py
@@ -54,7 +54,7 @@ def delete_document_set_privacy__no_commit(
 def fetch_document_sets(
     user_id: UUID | None,
     db_session: Session,
-    include_outdated: bool = True,  # Parameter only for versioned implementation, unused
+    include_outdated: bool = True,  # Parameter only for versioned implementation, unused  # noqa: ARG001
 ) -> list[tuple[DocumentSet, list[ConnectorCredentialPair]]]:
     assert user_id is not None
 

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -643,7 +643,7 @@ def add_users_to_user_group(
 
 def update_user_group(
     db_session: Session,
-    user: User,
+    user: User,  # noqa: ARG001
     user_group_id: int,
     user_group_update: UserGroupUpdate,
 ) -> UserGroup:

--- a/backend/ee/onyx/external_permissions/confluence/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/doc_sync.py
@@ -25,7 +25,7 @@ CONFLUENCE_DOC_SYNC_LABEL = "confluence_doc_sync"
 
 def confluence_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
     fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[ElementExternalAccess, None, None]:

--- a/backend/ee/onyx/external_permissions/github/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/github/doc_sync.py
@@ -34,7 +34,7 @@ GITHUB_DOC_SYNC_LABEL = "github_doc_sync"
 def github_doc_sync(
     cc_pair: ConnectorCredentialPair,
     fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
-    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
+    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
     callback: IndexingHeartbeatInterface | None = None,
 ) -> Generator[DocExternalAccess, None, None]:
     """

--- a/backend/ee/onyx/external_permissions/github/group_sync.py
+++ b/backend/ee/onyx/external_permissions/github/group_sync.py
@@ -12,7 +12,7 @@ logger = setup_logger()
 
 
 def github_group_sync(
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
 ) -> Generator[ExternalUserGroup, None, None]:
     github_connector: GithubConnector = GithubConnector(

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -91,7 +91,7 @@ class TeamInfo(BaseModel):
 
 
 def _fetch_organization_members(
-    github_client: Github, org_name: str, retry_count: int = 0
+    github_client: Github, org_name: str, retry_count: int = 0  # noqa: ARG001
 ) -> List[UserInfo]:
     """Fetch all organization members including owners and regular members."""
     org_members: List[UserInfo] = []
@@ -124,7 +124,7 @@ def _fetch_organization_members(
 
 
 def _fetch_repository_teams_detailed(
-    repo: Repository, github_client: Github, retry_count: int = 0
+    repo: Repository, github_client: Github, retry_count: int = 0  # noqa: ARG001
 ) -> List[TeamInfo]:
     """Fetch teams with access to the repository and their members."""
     teams_data: List[TeamInfo] = []
@@ -167,7 +167,7 @@ def _fetch_repository_teams_detailed(
 
 
 def fetch_repository_team_slugs(
-    repo: Repository, github_client: Github, retry_count: int = 0
+    repo: Repository, github_client: Github, retry_count: int = 0  # noqa: ARG001
 ) -> List[str]:
     """Fetch team slugs with access to the repository."""
     logger.info(f"Fetching team slugs for repository {repo.full_name}")

--- a/backend/ee/onyx/external_permissions/gmail/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/gmail/doc_sync.py
@@ -39,8 +39,8 @@ def _get_slim_doc_generator(
 
 def gmail_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
-    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[ElementExternalAccess, None, None]:
     """

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -282,8 +282,8 @@ def get_external_access_for_folder(
 
 def gdrive_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
-    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[ElementExternalAccess, None, None]:
     """

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -384,7 +384,7 @@ def _build_onyx_groups(
 
 
 def gdrive_group_sync(
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
 ) -> Generator[ExternalUserGroup, None, None]:
     # Initialize connector and build credential/service objects

--- a/backend/ee/onyx/external_permissions/jira/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/doc_sync.py
@@ -17,7 +17,7 @@ JIRA_DOC_SYNC_TAG = "jira_doc_sync"
 
 def jira_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
     fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
     callback: IndexingHeartbeatInterface | None = None,
 ) -> Generator[ElementExternalAccess, None, None]:

--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -102,7 +102,7 @@ def _build_group_member_email_map(
 
 
 def jira_group_sync(
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
 ) -> Generator[ExternalUserGroup, None, None]:
     """

--- a/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
+++ b/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
@@ -23,7 +23,7 @@ ContentRange = tuple[int, int | None]  # (start_index, end_index) None means to 
 
 # NOTE: Used for testing timing
 def _get_dummy_object_access_map(
-    object_ids: set[str], user_email: str, chunks: list[InferenceChunk]
+    object_ids: set[str], user_email: str, chunks: list[InferenceChunk]  # noqa: ARG001
 ) -> dict[str, bool]:
     time.sleep(0.15)
     # return {object_id: True for object_id in object_ids}

--- a/backend/ee/onyx/external_permissions/sharepoint/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/doc_sync.py
@@ -17,7 +17,7 @@ SHAREPOINT_DOC_SYNC_TAG = "sharepoint_doc_sync"
 
 def sharepoint_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
     fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
     callback: IndexingHeartbeatInterface | None = None,
 ) -> Generator[ElementExternalAccess, None, None]:

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -15,7 +15,7 @@ logger = setup_logger()
 
 
 def sharepoint_group_sync(
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
 ) -> Generator[ExternalUserGroup, None, None]:
     """Sync SharePoint groups and their members"""

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -103,7 +103,7 @@ def _fetch_channel_permissions(
 
 def _get_slack_document_access(
     slack_connector: SlackConnector,
-    channel_permissions: dict[str, ExternalAccess],
+    channel_permissions: dict[str, ExternalAccess],  # noqa: ARG001
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[DocExternalAccess, None, None]:
     slim_doc_generator = slack_connector.retrieve_all_slim_docs_perm_sync(
@@ -136,8 +136,8 @@ def _get_slack_document_access(
 
 def slack_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
-    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+    fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[DocExternalAccess, None, None]:
     """

--- a/backend/ee/onyx/external_permissions/sync_params.py
+++ b/backend/ee/onyx/external_permissions/sync_params.py
@@ -72,10 +72,10 @@ class SyncConfig(BaseModel):
 
 # Mock doc sync function for testing (no-op)
 def mock_doc_sync(
-    cc_pair: "ConnectorCredentialPair",
-    fetch_all_docs_fn: FetchAllDocumentsFunction,
-    fetch_all_docs_ids_fn: FetchAllDocumentsIdsFunction,
-    callback: Optional["IndexingHeartbeatInterface"],
+    cc_pair: "ConnectorCredentialPair",  # noqa: ARG001
+    fetch_all_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+    fetch_all_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
+    callback: Optional["IndexingHeartbeatInterface"],  # noqa: ARG001
 ) -> Generator["DocExternalAccess", None, None]:
     """Mock doc sync function for testing - returns empty list since permissions are fetched during indexing"""
     yield from []

--- a/backend/ee/onyx/external_permissions/teams/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/teams/doc_sync.py
@@ -18,7 +18,7 @@ TEAMS_DOC_SYNC_LABEL = "teams_doc_sync"
 
 def teams_doc_sync(
     cc_pair: ConnectorCredentialPair,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
     fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
     callback: IndexingHeartbeatInterface | None,
 ) -> Generator[ElementExternalAccess, None, None]:

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -139,7 +139,7 @@ def put_logo(
     upload_logo(file=file, is_logotype=is_logotype)
 
 
-def fetch_logo_helper(db_session: Session) -> Response:
+def fetch_logo_helper(db_session: Session) -> Response:  # noqa: ARG001
     try:
         file_store = get_default_file_store()
         onyx_file = file_store.get_file_with_mime_type(get_logo_filename())
@@ -155,7 +155,7 @@ def fetch_logo_helper(db_session: Session) -> Response:
         return Response(content=onyx_file.data, media_type=onyx_file.mime_type)
 
 
-def fetch_logotype_helper(db_session: Session) -> Response:
+def fetch_logotype_helper(db_session: Session) -> Response:  # noqa: ARG001
     try:
         file_store = get_default_file_store()
         onyx_file = file_store.get_file_with_mime_type(get_logotype_filename())

--- a/backend/ee/onyx/server/evals/api.py
+++ b/backend/ee/onyx/server/evals/api.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/evals")
 @router.post("/eval_run", response_model=EvalRunAck)
 def eval_run(
     request: EvalConfigurationOptions,
-    user: User = Depends(current_cloud_superuser),
+    user: User = Depends(current_cloud_superuser),  # noqa: ARG001
 ) -> EvalRunAck:
     """
     Run an evaluation with the given message and optional dataset.

--- a/backend/ee/onyx/server/oauth/confluence_cloud.py
+++ b/backend/ee/onyx/server/oauth/confluence_cloud.py
@@ -260,7 +260,7 @@ def confluence_oauth_accessible_resources(
     credential_id: int,
     user: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
-    tenant_id: str | None = Depends(get_current_tenant_id),
+    tenant_id: str | None = Depends(get_current_tenant_id),  # noqa: ARG001
 ) -> JSONResponse:
     """Atlassian's API is weird and does not supply us with enough info to be in a
     usable state after authorizing.  All API's require a cloud id. We have to list
@@ -323,7 +323,7 @@ def confluence_oauth_finalize(
     cloud_url: str,
     user: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
-    tenant_id: str | None = Depends(get_current_tenant_id),
+    tenant_id: str | None = Depends(get_current_tenant_id),  # noqa: ARG001
 ) -> JSONResponse:
     """Saves the info for the selected cloud site to the credential.
     This is the final step in the confluence oauth flow where after the traditional

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -78,7 +78,7 @@ def fetch_and_process_chat_session_history(
     db_session: Session,
     start: datetime,
     end: datetime,
-    limit: int | None = 500,
+    limit: int | None = 500,  # noqa: ARG001
 ) -> Generator[ChatSessionSnapshot]:
     PAGE_SIZE = 100
 

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -59,7 +59,7 @@ def generate_report(
 def read_usage_report(
     report_name: str,
     _: User = Depends(current_admin_user),
-    db_session: Session = Depends(get_session),
+    db_session: Session = Depends(get_session),  # noqa: ARG001
 ) -> Response:
     try:
         file = get_usage_report_data(report_name)

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -121,7 +121,9 @@ async def get_or_provision_tenant(
         )
 
 
-async def create_tenant(email: str, referral_source: str | None = None) -> str:
+async def create_tenant(
+    email: str, referral_source: str | None = None  # noqa: ARG001
+) -> str:
     """
     Create a new tenant on-demand when no pre-provisioned tenants are available.
     This is the fallback method when we can't use a pre-provisioned tenant.
@@ -675,7 +677,7 @@ async def setup_tenant(tenant_id: str) -> None:
 
 
 async def assign_tenant_to_user(
-    tenant_id: str, email: str, referral_source: str | None = None
+    tenant_id: str, email: str, referral_source: str | None = None  # noqa: ARG001
 ) -> None:
     """
     Assign a tenant to a user and perform necessary operations.

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -96,7 +96,7 @@ def get_access_for_documents(
     return versioned_get_access_for_documents_fn(document_ids, db_session)
 
 
-def _get_acl_for_user(user: User, db_session: Session) -> set[str]:
+def _get_acl_for_user(user: User, db_session: Session) -> set[str]:  # noqa: ARG001
     """Returns a list of ACL entries that the user has access to. This is meant to be
     used downstream to filter out documents that the user does not have access to. The
     user should have access to a document if at least one entry in the document's ACL

--- a/backend/onyx/access/hierarchy_access.py
+++ b/backend/onyx/access/hierarchy_access.py
@@ -4,7 +4,9 @@ from onyx.db.models import User
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 
 
-def _get_user_external_group_ids(db_session: Session, user: User) -> list[str]:
+def _get_user_external_group_ids(
+    db_session: Session, user: User  # noqa: ARG001
+) -> list[str]:
     return []
 
 

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -30,7 +30,7 @@ REFRESH_ENDPOINTS = {
 async def _test_expire_oauth_token(
     user: User,
     oauth_account: OAuthAccount,
-    db_session: AsyncSession,
+    db_session: AsyncSession,  # noqa: ARG001
     user_manager: BaseUserManager[User, Any],
     expire_in_seconds: int = 10,
 ) -> bool:
@@ -59,7 +59,7 @@ async def _test_expire_oauth_token(
 async def refresh_oauth_token(
     user: User,
     oauth_account: OAuthAccount,
-    db_session: AsyncSession,
+    db_session: AsyncSession,  # noqa: ARG001
     user_manager: BaseUserManager[User, Any],
 ) -> bool:
     """
@@ -182,7 +182,7 @@ async def check_and_refresh_oauth_tokens(
 
 
 async def check_oauth_account_has_refresh_token(
-    user: User,
+    user: User,  # noqa: ARG001
     oauth_account: OAuthAccount,
 ) -> bool:
     """

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -780,7 +780,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         )
 
     async def on_after_forgot_password(
-        self, user: User, token: str, request: Optional[Request] = None
+        self, user: User, token: str, request: Optional[Request] = None  # noqa: ARG002
     ) -> None:
         if not EMAIL_CONFIGURED:
             logger.error(
@@ -799,7 +799,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         send_forgot_password_email(user.email, tenant_id=tenant_id, token=token)
 
     async def on_after_request_verify(
-        self, user: User, token: str, request: Optional[Request] = None
+        self, user: User, token: str, request: Optional[Request] = None  # noqa: ARG002
     ) -> None:
         verify_email_domain(user.email)
 
@@ -983,7 +983,7 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
         except (exceptions.UserNotExists, exceptions.InvalidID, KeyError):
             return None
 
-    async def destroy_token(self, token: str, user: User) -> None:
+    async def destroy_token(self, token: str, user: User) -> None:  # noqa: ARG002
         """Properly delete the token from async redis."""
         redis = await get_async_redis_connection()
         await redis.delete(f"{self.key_prefix}{token}")

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -93,12 +93,12 @@ class TenantAwareTask(Task):
 
 @task_prerun.connect
 def on_task_prerun(
-    sender: Any | None = None,
-    task_id: str | None = None,
-    task: Task | None = None,
-    args: tuple[Any, ...] | None = None,
-    kwargs: dict[str, Any] | None = None,
-    **other_kwargs: Any,
+    sender: Any | None = None,  # noqa: ARG001
+    task_id: str | None = None,  # noqa: ARG001
+    task: Task | None = None,  # noqa: ARG001
+    args: tuple[Any, ...] | None = None,  # noqa: ARG001
+    kwargs: dict[str, Any] | None = None,  # noqa: ARG001
+    **other_kwargs: Any,  # noqa: ARG001
 ) -> None:
     # Reset any per-task logging context so that prefixes (e.g. pruning_ctx)
     # from a previous task executed in the same worker process do not leak
@@ -110,14 +110,14 @@ def on_task_prerun(
 
 
 def on_task_postrun(
-    sender: Any | None = None,
+    sender: Any | None = None,  # noqa: ARG001
     task_id: str | None = None,
     task: Task | None = None,
-    args: tuple | None = None,
+    args: tuple | None = None,  # noqa: ARG001
     kwargs: dict[str, Any] | None = None,
-    retval: Any | None = None,
+    retval: Any | None = None,  # noqa: ARG001
     state: str | None = None,
-    **kwds: Any,
+    **kwds: Any,  # noqa: ARG001
 ) -> None:
     """We handle this signal in order to remove completed tasks
     from their respective tasksets. This allows us to track the progress of document set
@@ -209,7 +209,9 @@ def on_task_postrun(
         return
 
 
-def on_celeryd_init(sender: str, conf: Any = None, **kwargs: Any) -> None:
+def on_celeryd_init(
+    sender: str, conf: Any = None, **kwargs: Any  # noqa: ARG001
+) -> None:
     """The first signal sent on celery worker startup"""
 
     # NOTE(rkuo): start method "fork" is unsafe and we really need it to be "spawn"
@@ -242,7 +244,7 @@ def on_celeryd_init(sender: str, conf: Any = None, **kwargs: Any) -> None:
     setup_braintrust_if_creds_available()
 
 
-def wait_for_redis(sender: Any, **kwargs: Any) -> None:
+def wait_for_redis(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     """Waits for redis to become ready subject to a hardcoded timeout.
     Will raise WorkerShutdown to kill the celery worker if the timeout
     is reached."""
@@ -285,7 +287,7 @@ def wait_for_redis(sender: Any, **kwargs: Any) -> None:
     return
 
 
-def wait_for_db(sender: Any, **kwargs: Any) -> None:
+def wait_for_db(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     """Waits for the db to become ready subject to a hardcoded timeout.
     Will raise WorkerShutdown to kill the celery worker if the timeout is reached."""
 
@@ -327,7 +329,7 @@ def wait_for_db(sender: Any, **kwargs: Any) -> None:
     return
 
 
-def on_secondary_worker_init(sender: Any, **kwargs: Any) -> None:
+def on_secondary_worker_init(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     logger.info(f"Running as a secondary celery worker: pid={os.getpid()}")
 
     # Set up variables for waiting on primary worker
@@ -359,7 +361,7 @@ def on_secondary_worker_init(sender: Any, **kwargs: Any) -> None:
     return
 
 
-def on_worker_ready(sender: Any, **kwargs: Any) -> None:
+def on_worker_ready(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     task_logger.info("worker_ready signal received.")
 
     # file based way to do readiness/liveness probes
@@ -372,7 +374,7 @@ def on_worker_ready(sender: Any, **kwargs: Any) -> None:
     logger.info(f"Readiness signal touched at {path}.")
 
 
-def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:
+def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     HttpxPool.close_all()
 
     hostname: str = cast(str, sender.hostname)
@@ -405,9 +407,9 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:
 def on_setup_logging(
     loglevel: int,
     logfile: str | None,
-    format: str,
-    colorize: bool,
-    **kwargs: Any,
+    format: str,  # noqa: ARG001
+    colorize: bool,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
 ) -> None:
     # TODO: could unhardcode format and colorize and accept these as options from
     # celery's config
@@ -508,18 +510,18 @@ class TenantContextFilter(logging.Filter):
 
 @task_postrun.connect
 def reset_tenant_id(
-    sender: Any | None = None,
-    task_id: str | None = None,
-    task: Task | None = None,
-    args: tuple[Any, ...] | None = None,
-    kwargs: dict[str, Any] | None = None,
-    **other_kwargs: Any,
+    sender: Any | None = None,  # noqa: ARG001
+    task_id: str | None = None,  # noqa: ARG001
+    task: Task | None = None,  # noqa: ARG001
+    args: tuple[Any, ...] | None = None,  # noqa: ARG001
+    kwargs: dict[str, Any] | None = None,  # noqa: ARG001
+    **other_kwargs: Any,  # noqa: ARG001
 ) -> None:
     """Signal handler to reset tenant ID in context var after task ends."""
     CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA)
 
 
-def wait_for_vespa_or_shutdown(sender: Any, **kwargs: Any) -> None:
+def wait_for_vespa_or_shutdown(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
     """Waits for Vespa to become ready subject to a timeout.
     Raises WorkerShutdown if the timeout is reached."""
 
@@ -553,12 +555,12 @@ class LivenessProbe(bootsteps.StartStopStep):
             priority=10,
         )
 
-    def stop(self, worker: Any) -> None:
+    def stop(self, worker: Any) -> None:  # noqa: ARG002
         self.path.unlink(missing_ok=True)
         if self.task_tref:
             self.task_tref.cancel()
 
-    def update_liveness_file(self, worker: Any) -> None:
+    def update_liveness_file(self, worker: Any) -> None:  # noqa: ARG002
         self.path.touch()
 
 

--- a/backend/onyx/background/celery/apps/background.py
+++ b/backend/onyx/background/celery/apps/background.py
@@ -102,7 +102,7 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:
 
 
 @worker_process_init.connect
-def init_worker(**kwargs: Any) -> None:
+def init_worker(**kwargs: Any) -> None:  # noqa: ARG001
     SqlEngine.reset_engine()
 
 

--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -91,7 +91,7 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:
 
 
 @worker_process_init.connect
-def init_worker(**kwargs: Any) -> None:
+def init_worker(**kwargs: Any) -> None:  # noqa: ARG001
     SqlEngine.reset_engine()
 
 

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -244,7 +244,7 @@ class HubPeriodicTask(bootsteps.StartStopStep):
     # it's unclear to me whether using the hub's timer or the bootstep timer is better
     requires = {"celery.worker.components:Hub"}
 
-    def __init__(self, worker: Any, **kwargs: Any) -> None:
+    def __init__(self, worker: Any, **kwargs: Any) -> None:  # noqa: ARG002
         self.interval = CELERY_PRIMARY_WORKER_LOCK_TIMEOUT / 8  # Interval in seconds
         self.task_tref = None
 
@@ -300,7 +300,7 @@ class HubPeriodicTask(bootsteps.StartStopStep):
         except Exception:
             task_logger.exception("Periodic task failed.")
 
-    def stop(self, worker: Any) -> None:
+    def stop(self, worker: Any) -> None:  # noqa: ARG002
         # Cancel the scheduled task when the worker stops
         if self.task_tref:
             self.task_tref.cancel()

--- a/backend/onyx/background/celery/apps/user_file_processing.py
+++ b/backend/onyx/background/celery/apps/user_file_processing.py
@@ -91,7 +91,7 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:
 
 
 @worker_process_init.connect
-def init_worker(**kwargs: Any) -> None:
+def init_worker(**kwargs: Any) -> None:  # noqa: ARG001
     SqlEngine.reset_engine()
 
 

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -366,7 +366,7 @@ def try_generate_document_cc_pair_cleanup_tasks(
 
 
 def monitor_connector_deletion_taskset(
-    tenant_id: str, key_bytes: bytes, r: Redis
+    tenant_id: str, key_bytes: bytes, r: Redis  # noqa: ARG001
 ) -> None:
     fence_key = key_bytes.decode("utf-8")
     cc_pair_id_str = RedisConnector.get_id_from_fence_key(fence_key)

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1071,7 +1071,7 @@ def check_for_checkpoint_cleanup(self: Task, *, tenant_id: str) -> None:
     bind=True,
 )
 def cleanup_checkpoint_task(
-    self: Task, *, index_attempt_id: int, tenant_id: str | None
+    self: Task, *, index_attempt_id: int, tenant_id: str | None  # noqa: ARG001
 ) -> None:
     """Clean up a checkpoint for a given index attempt"""
 
@@ -1160,7 +1160,7 @@ def check_for_index_attempt_cleanup(self: Task, *, tenant_id: str) -> None:
     bind=True,
 )
 def cleanup_index_attempt_task(
-    self: Task, *, index_attempt_ids: list[int], tenant_id: str
+    self: Task, *, index_attempt_ids: list[int], tenant_id: str  # noqa: ARG001
 ) -> None:
     """Clean up an index attempt"""
     start = time.monotonic()
@@ -1266,7 +1266,7 @@ def _resolve_indexing_document_errors(
     bind=True,
 )
 def docprocessing_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     index_attempt_id: int,
     cc_pair_id: int,
     tenant_id: str,

--- a/backend/onyx/background/celery/tasks/docprocessing/utils.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/utils.py
@@ -57,7 +57,7 @@ class IndexingCallbackBase(IndexingHeartbeatInterface):
         # TODO: Pass index_attempt_id to the callback and check cancellation using the db
         return bool(self.redis_connector.stop.fenced)
 
-    def progress(self, tag: str, amount: int) -> None:
+    def progress(self, tag: str, amount: int) -> None:  # noqa: ARG002
         """Amount isn't used yet."""
 
         # rkuo: this shouldn't be necessary yet because we spawn the process this runs inside

--- a/backend/onyx/background/celery/tasks/evals/tasks.py
+++ b/backend/onyx/background/celery/tasks/evals/tasks.py
@@ -26,7 +26,7 @@ logger = setup_logger()
     trail=False,
 )
 def eval_run_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     *,
     configuration_dict: dict[str, Any],
 ) -> None:
@@ -48,7 +48,7 @@ def eval_run_task(
     bind=True,
     trail=False,
 )
-def scheduled_eval_task(self: Task, **kwargs: Any) -> None:
+def scheduled_eval_task(self: Task, **kwargs: Any) -> None:  # noqa: ARG001
     """
     Scheduled task to run evaluations on configured datasets.
     Runs weekly on Sunday at midnight UTC.

--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -322,7 +322,7 @@ def _run_hierarchy_extraction(
     bind=True,
 )
 def connector_hierarchy_fetching_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     *,
     cc_pair_id: int,
     tenant_id: str,

--- a/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
@@ -17,7 +17,9 @@ from onyx.llm.well_known_providers.auto_update_service import (
     trail=False,
     bind=True,
 )
-def check_for_auto_llm_updates(self: Task, *, tenant_id: str) -> bool | None:
+def check_for_auto_llm_updates(
+    self: Task, *, tenant_id: str  # noqa: ARG001
+) -> bool | None:
     """Periodic task to fetch LLM model updates from GitHub
     and sync them to providers in Auto mode.
 

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -871,7 +871,7 @@ def cloud_monitor_celery_queues(
 
 
 @shared_task(name=OnyxCeleryTask.MONITOR_CELERY_QUEUES, ignore_result=True, bind=True)
-def monitor_celery_queues(self: Task, *, tenant_id: str) -> None:
+def monitor_celery_queues(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
     return monitor_celery_queues_helper(self)
 
 
@@ -952,7 +952,7 @@ def _get_cmdline_for_process(process: psutil.Process) -> str | None:
     queue=OnyxCeleryQueues.MONITORING,
     bind=True,
 )
-def monitor_process_memory(self: Task, *, tenant_id: str) -> None:
+def monitor_process_memory(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
     """
     Task to monitor memory usage of supervisor-managed processes.
     This periodically checks the memory usage of processes and logs information

--- a/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
+++ b/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
@@ -100,7 +100,7 @@ def _migrate_single_document(
     bind=True,
 )
 def check_for_documents_for_opensearch_migration_task(
-    self: Task, *, tenant_id: str
+    self: Task, *, tenant_id: str  # noqa: ARG001
 ) -> bool | None:
     """
     Periodic task to check for and add documents to the OpenSearch migration
@@ -211,7 +211,7 @@ def check_for_documents_for_opensearch_migration_task(
     bind=True,
 )
 def migrate_documents_from_vespa_to_opensearch_task(
-    self: Task,
+    self: Task,  # noqa: ARG001
     *,
     tenant_id: str,
 ) -> bool | None:

--- a/backend/onyx/background/celery/tasks/periodic/tasks.py
+++ b/backend/onyx/background/celery/tasks/periodic/tasks.py
@@ -24,7 +24,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
     bind=True,
     base=AbortableTask,
 )
-def kombu_message_cleanup_task(self: Any, tenant_id: str) -> int:
+def kombu_message_cleanup_task(self: Any, tenant_id: str) -> int:  # noqa: ARG001
     """Runs periodically to clean up the kombu_message table"""
 
     # we will select messages older than this amount to clean up

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -587,7 +587,7 @@ def connector_pruning_generator_task(
 
 
 def monitor_ccpair_pruning_taskset(
-    tenant_id: str, key_bytes: bytes, r: Redis, db_session: Session
+    tenant_id: str, key_bytes: bytes, r: Redis, db_session: Session  # noqa: ARG001
 ) -> None:
     fence_key = key_bytes.decode("utf-8")
     cc_pair_id_str = RedisConnector.get_id_from_fence_key(fence_key)

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -276,7 +276,7 @@ def document_by_cc_pair_cleanup_task(
 
 
 @shared_task(name=OnyxCeleryTask.CELERY_BEAT_HEARTBEAT, ignore_result=True, bind=True)
-def celery_beat_heartbeat(self: Task, *, tenant_id: str) -> None:
+def celery_beat_heartbeat(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
     """When this task runs, it writes a key to Redis with a TTL.
 
     An external observer can check this key to figure out if the celery beat is still running.

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -168,7 +168,9 @@ def check_user_file_processing(self: Task, *, tenant_id: str) -> None:
     bind=True,
     ignore_result=True,
 )
-def process_single_user_file(self: Task, *, user_file_id: str, tenant_id: str) -> None:
+def process_single_user_file(
+    self: Task, *, user_file_id: str, tenant_id: str  # noqa: ARG001
+) -> None:
     task_logger.info(f"process_single_user_file - Starting id={user_file_id}")
     start = time.monotonic()
 
@@ -391,7 +393,7 @@ def check_for_user_file_delete(self: Task, *, tenant_id: str) -> None:
     ignore_result=True,
 )
 def process_single_user_file_delete(
-    self: Task, *, user_file_id: str, tenant_id: str
+    self: Task, *, user_file_id: str, tenant_id: str  # noqa: ARG001
 ) -> None:
     """Process a single user file delete."""
     task_logger.info(f"process_single_user_file_delete - Starting id={user_file_id}")
@@ -542,7 +544,7 @@ def check_for_user_file_project_sync(self: Task, *, tenant_id: str) -> None:
     ignore_result=True,
 )
 def process_single_user_file_project_sync(
-    self: Task, *, user_file_id: str, tenant_id: str
+    self: Task, *, user_file_id: str, tenant_id: str  # noqa: ARG001
 ) -> None:
     """Process a single user file project sync."""
     task_logger.info(

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -174,7 +174,9 @@ class SimpleJobClient:
                 logger.debug(f"Cleaning up job with id: '{job.id}'")
                 del self.jobs[job.id]
 
-    def submit(self, func: Callable, *args: Any, pure: bool = True) -> SimpleJob | None:
+    def submit(
+        self, func: Callable, *args: Any, pure: bool = True  # noqa: ARG002
+    ) -> SimpleJob | None:
         """NOTE: `pure` arg is needed so this can be a drop in replacement for Dask"""
         self._cleanup_completed_jobs()
         if len(self.jobs) >= self.n_workers:

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -341,7 +341,7 @@ def create_temporary_persona(
 
 
 def process_kg_commands(
-    message: str, persona_name: str, tenant_id: str, db_session: Session
+    message: str, persona_name: str, tenant_id: str, db_session: Session  # noqa: ARG001
 ) -> None:
     # Temporarily, until we have a draft UI for the KG Operations/Management
     # TODO: move to api endpoint once we get frontend

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -331,7 +331,7 @@ def construct_message_history(
 
 def _create_project_files_message(
     project_files: ExtractedProjectFiles,
-    token_counter: Callable[[str], int] | None,
+    token_counter: Callable[[str], int] | None,  # noqa: ARG001
 ) -> ChatMessageSimple:
     """Convert project files to a ChatMessageSimple message.
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -741,7 +741,7 @@ def llm_loop_completion_handle(
     assistant_message: ChatMessage,
     llm: LLM,
     reserved_tokens: int,
-    processing_start_time: float | None = None,
+    processing_start_time: float | None = None,  # noqa: ARG001
 ) -> None:
     chat_session_id = assistant_message.chat_session_id
 

--- a/backend/onyx/connectors/asana/connector.py
+++ b/backend/onyx/connectors/asana/connector.py
@@ -54,7 +54,9 @@ class AsanaConnector(LoadConnector, PollConnector):
         return None
 
     def poll_source(
-        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch | None
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch | None,  # noqa: ARG002
     ) -> GenerateDocumentsOutput:
         start_time = datetime.datetime.fromtimestamp(start).isoformat()
         logger.info(f"Starting Asana poll from {start_time}")

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -891,8 +891,8 @@ class ConfluenceConnector(
 
     def _retrieve_all_slim_docs(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
         callback: IndexingHeartbeatInterface | None = None,
         include_permissions: bool = True,
     ) -> GenerateSlimDocumentOutput:

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -213,7 +213,7 @@ def process_attachment(
 
 
 def _process_image_attachment(
-    confluence_client: "OnyxConfluence",
+    confluence_client: "OnyxConfluence",  # noqa: ARG001
     attachment: dict[str, Any],
     raw_bytes: bytes,
     media_type: str,

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -239,7 +239,7 @@ class LocalFileConnector(LoadConnector):
     def __init__(
         self,
         file_locations: list[Path | str],
-        file_names: list[str] | None = None,
+        file_names: list[str] | None = None,  # noqa: ARG002
         zip_metadata: dict[str, Any] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:

--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -195,7 +195,7 @@ class FreshdeskConnector(PollConnector, LoadConnector):
         self.domain = domain
 
     def _fetch_tickets(
-        self, start: datetime | None = None, end: datetime | None = None
+        self, start: datetime | None = None, end: datetime | None = None  # noqa: ARG002
     ) -> Iterator[List[dict]]:
         """
         'end' is not currently used, so we may double fetch tickets created after the indexing

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -321,7 +321,7 @@ def _full_thread_from_id(
 def _slim_thread_from_id(
     thread_id: str,
     user_email: str,
-    gmail_service: GmailService,
+    gmail_service: GmailService,  # noqa: ARG001
 ) -> SlimDocument:
     return SlimDocument(
         id=thread_id,
@@ -432,7 +432,7 @@ class GmailConnector(
         time_range_end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
         page_token: str | None = None,
-        set_page_token: Callable[[str | None], None] = lambda x: None,
+        set_page_token: Callable[[str | None], None] = lambda x: None,  # noqa: ARG005
         is_slim: bool = False,
     ) -> Iterator[Document | ConnectorFailure] | GenerateSlimDocumentOutput:
         query = _build_time_range_query(time_range_start, time_range_end)
@@ -504,7 +504,7 @@ class GmailConnector(
         self,
         user_email: str,
         page_token: str | None = None,
-        set_page_token: Callable[[str | None], None] = lambda x: None,
+        set_page_token: Callable[[str | None], None] = lambda x: None,  # noqa: ARG005
         time_range_start: SecondsSinceUnixEpoch | None = None,
         time_range_end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
@@ -526,7 +526,7 @@ class GmailConnector(
         self,
         user_email: str,
         page_token: str | None = None,
-        set_page_token: Callable[[str | None], None] = lambda x: None,
+        set_page_token: Callable[[str | None], None] = lambda x: None,  # noqa: ARG005
         time_range_start: SecondsSinceUnixEpoch | None = None,
         time_range_end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -217,7 +217,7 @@ class GoogleDriveConnector(
         shared_folder_urls: str | None = None,
         specific_user_emails: str | None = None,
         exclude_domain_link_only: bool = False,
-        batch_size: int = INDEX_BATCH_SIZE,
+        batch_size: int = INDEX_BATCH_SIZE,  # noqa: ARG002
         # OLD PARAMETERS
         folder_paths: list[str] | None = None,
         include_shared: bool | None = None,

--- a/backend/onyx/connectors/highspot/connector.py
+++ b/backend/onyx/connectors/highspot/connector.py
@@ -361,9 +361,9 @@ class HighspotConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync)
 
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         """
         Retrieve all document IDs from the configured spots.

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -89,7 +89,7 @@ class BaseConnector(abc.ABC, Generic[CT]):
         based on the application level image analysis setting."""
 
     @classmethod
-    def normalize_url(cls, url: str) -> "NormalizationResult":
+    def normalize_url(cls, url: str) -> "NormalizationResult":  # noqa: ARG003
         """Normalize a URL to match the canonical Document.id format used during ingestion.
 
         Connectors that use URLs as document IDs should override this method.

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -831,7 +831,7 @@ class JiraConnector(
         self,
         start: SecondsSinceUnixEpoch | None = None,
         end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         one_day = timedelta(hours=24).total_seconds()
 

--- a/backend/onyx/connectors/linear/connector.py
+++ b/backend/onyx/connectors/linear/connector.py
@@ -84,7 +84,10 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
 
     @classmethod
     def oauth_authorization_url(
-        cls, base_domain: str, state: str, additional_kwargs: dict[str, str]
+        cls,
+        base_domain: str,
+        state: str,
+        additional_kwargs: dict[str, str],  # noqa: ARG003
     ) -> str:
         if not LINEAR_CLIENT_ID:
             raise ValueError("LINEAR_CLIENT_ID environment variable must be set")
@@ -102,7 +105,10 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
 
     @classmethod
     def oauth_code_to_token(
-        cls, base_domain: str, code: str, additional_kwargs: dict[str, str]
+        cls,
+        base_domain: str,
+        code: str,
+        additional_kwargs: dict[str, str],  # noqa: ARG003
     ) -> dict[str, Any]:
         data = {
             "code": code,

--- a/backend/onyx/connectors/mediawiki/family.py
+++ b/backend/onyx/connectors/mediawiki/family.py
@@ -70,7 +70,7 @@ class FamilyFileGeneratorInMemory(generate_family_file.FamilyFileGenerator):
         """
         return True
 
-    def writefile(self, verify: Any) -> None:
+    def writefile(self, verify: Any) -> None:  # noqa: ARG002
         """Write the family file.
 
         This overrides the method in the parent class to write the family definition to memory instead of to disk.

--- a/backend/onyx/connectors/mediawiki/wiki.py
+++ b/backend/onyx/connectors/mediawiki/wiki.py
@@ -146,7 +146,9 @@ class MediaWikiConnector(LoadConnector, PollConnector):
                 continue
             self.pages.append(pywikibot.Page(self.site, page))
 
-    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+    def load_credentials(
+        self, credentials: dict[str, Any]  # noqa: ARG002
+    ) -> dict[str, Any] | None:
         """Load credentials for a MediaWiki site.
 
         Note:

--- a/backend/onyx/connectors/mock_connector/connector.py
+++ b/backend/onyx/connectors/mock_connector/connector.py
@@ -45,7 +45,9 @@ class MockConnector(CheckpointedConnectorWithPermSync[MockConnectorCheckpoint]):
         self.connector_yields: list[SingleConnectorYield] | None = None
         self.current_yield_index: int = 0
 
-    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+    def load_credentials(
+        self, credentials: dict[str, Any]  # noqa: ARG002
+    ) -> dict[str, Any] | None:
         response = self.client.get(self._get_mock_server_url("get-documents"))
         response.raise_for_status()
         data = response.json()
@@ -67,8 +69,8 @@ class MockConnector(CheckpointedConnectorWithPermSync[MockConnectorCheckpoint]):
 
     def _load_from_checkpoint_common(
         self,
-        start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
+        start: SecondsSinceUnixEpoch,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch,  # noqa: ARG002
         checkpoint: MockConnectorCheckpoint,
         include_permissions: bool = False,
     ) -> CheckpointOutput[MockConnectorCheckpoint]:

--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -1134,9 +1134,9 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
 
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         doc_metadata_list: list[SlimDocument | HierarchyNode] = []
         for parent_object_type in self.parent_object_list:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1944,9 +1944,9 @@ class SharepointConnector(
 
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
 
         yield from self._fetch_slim_documents_from_sharepoint()

--- a/backend/onyx/connectors/sharepoint/connector_utils.py
+++ b/backend/onyx/connectors/sharepoint/connector_utils.py
@@ -22,7 +22,7 @@ def get_sharepoint_external_access(
         raise ValueError("DriveItem ID is required")
 
     # Get external access using the EE implementation
-    def noop_fallback(*args: Any, **kwargs: Any) -> ExternalAccess:
+    def noop_fallback(*args: Any, **kwargs: Any) -> ExternalAccess:  # noqa: ARG001
         return ExternalAccess.empty()
 
     get_external_access_func = fetch_versioned_implementation_with_fallback(

--- a/backend/onyx/connectors/slab/connector.py
+++ b/backend/onyx/connectors/slab/connector.py
@@ -242,9 +242,9 @@ class SlabConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
 
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         slim_doc_batch: list[SlimDocument | HierarchyNode] = []
         for post_id in get_all_post_ids(self.slab_bot_token):

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -828,8 +828,8 @@ class SlackConnector(
 
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
         callback: IndexingHeartbeatInterface | None = None,
     ) -> GenerateSlimDocumentOutput:
         if self.client is None:

--- a/backend/onyx/connectors/slack/onyx_retry_handler.py
+++ b/backend/onyx/connectors/slack/onyx_retry_handler.py
@@ -48,10 +48,10 @@ class OnyxRedisSlackRetryHandler(RetryHandler):
     def _can_retry(
         self,
         *,
-        state: RetryState,
-        request: HttpRequest,
+        state: RetryState,  # noqa: ARG002
+        request: HttpRequest,  # noqa: ARG002
         response: Optional[HttpResponse] = None,
-        error: Optional[Exception] = None,
+        error: Optional[Exception] = None,  # noqa: ARG002
     ) -> bool:
         return response is not None and response.status_code == 429
 
@@ -59,7 +59,7 @@ class OnyxRedisSlackRetryHandler(RetryHandler):
         self,
         *,
         state: RetryState,
-        request: HttpRequest,
+        request: HttpRequest,  # noqa: ARG002
         response: Optional[HttpResponse] = None,
         error: Optional[Exception] = None,
     ) -> None:

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -186,7 +186,7 @@ class TeamsConnector(
     def load_from_checkpoint(
         self,
         start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,  # noqa: ARG002
         checkpoint: TeamsCheckpoint,
     ) -> CheckpointOutput[TeamsCheckpoint]:
         if self.graph_client is None:

--- a/backend/onyx/connectors/testrail/connector.py
+++ b/backend/onyx/connectors/testrail/connector.py
@@ -349,7 +349,7 @@ class TestRailConnector(LoadConnector, PollConnector):
             if len(cases) < limit:
                 break
 
-    def _build_case_link(self, project_id: int, case_id: int) -> str:
+    def _build_case_link(self, project_id: int, case_id: int) -> str:  # noqa: ARG002
         # Standard UI link to a case
         return f"{self.base_url}/index.php?/cases/view/{case_id}"
 
@@ -357,7 +357,7 @@ class TestRailConnector(LoadConnector, PollConnector):
         self,
         project: dict[str, Any],
         case: dict[str, Any],
-        suite: dict[str, Any] | None = None,
+        suite: dict[str, Any] | None = None,  # noqa: ARG002
     ) -> Document | None:
         project_id = project.get("id")
         if not isinstance(project_id, int):

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -450,7 +450,7 @@ class WebConnector(LoadConnector):
         mintlify_cleanup: bool = True,  # Mostly ok to apply to other websites as well
         batch_size: int = INDEX_BATCH_SIZE,
         scroll_before_scraping: bool = False,
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ARG002
     ) -> None:
         self.mintlify_cleanup = mintlify_cleanup
         self.batch_size = batch_size

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -569,8 +569,8 @@ class ZendeskConnector(
     def retrieve_all_slim_docs_perm_sync(
         self,
         start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         slim_doc_batch: list[SlimDocument | HierarchyNode] = []
         if self.content_type == "articles":

--- a/backend/onyx/connectors/zulip/connector.py
+++ b/backend/onyx/connectors/zulip/connector.py
@@ -192,7 +192,9 @@ class ZulipConnector(LoadConnector, PollConnector):
             anchor = str(message.id)
 
     def _poll_source(
-        self, start: SecondsSinceUnixEpoch | None, end: SecondsSinceUnixEpoch | None
+        self,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,  # noqa: ARG002
     ) -> GenerateDocumentsOutput:
         # Since Zulip doesn't support searching by timestamp,
         # we have to always start from the newest message

--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -906,7 +906,7 @@ def slack_retrieval(
     query: ChunkIndexRequest,
     access_token: str,
     db_session: Session,
-    connector: FederatedConnectorDetail | None = None,
+    connector: FederatedConnectorDetail | None = None,  # noqa: ARG001
     entities: dict[str, Any] | None = None,
     limit: int | None = None,
     slack_event_context: SlackContext | None = None,

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -170,10 +170,10 @@ def get_document_sets_by_ids(
 
 
 def make_doc_set_private(
-    document_set_id: int,
+    document_set_id: int,  # noqa: ARG001
     user_ids: list[UUID] | None,
     group_ids: list[int] | None,
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     # May cause error if someone switches down to MIT from EE
     if user_ids or group_ids:
@@ -491,7 +491,9 @@ def delete_document_set_cc_pair_relationship__no_commit(
 
 
 def fetch_document_sets(
-    user_id: UUID | None, db_session: Session, include_outdated: bool = False
+    user_id: UUID | None,  # noqa: ARG001
+    db_session: Session,
+    include_outdated: bool = False,
 ) -> list[tuple[DocumentSetDBModel, list[ConnectorCredentialPair]]]:
     """Return is a list where each element contains a tuple of:
     1. The document set itself

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -89,7 +89,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
 
             @event.listens_for(_ASYNC_ENGINE.sync_engine, "do_connect")
             def provide_iam_token_async(
-                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
+                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any  # noqa: ARG001
             ) -> None:
                 # For async engine using asyncpg, we still need to set the IAM token here.
                 host = POSTGRES_HOST

--- a/backend/onyx/db/engine/iam_auth.py
+++ b/backend/onyx/db/engine/iam_auth.py
@@ -36,7 +36,9 @@ def configure_psycopg2_iam_auth(
     cparams["sslrootcert"] = SSL_CERT_FILE
 
 
-def provide_iam_token(dialect: Any, conn_rec: Any, cargs: Any, cparams: Any) -> None:
+def provide_iam_token(
+    dialect: Any, conn_rec: Any, cargs: Any, cparams: Any  # noqa: ARG001
+) -> None:
     if USE_IAM_AUTH:
         host = POSTGRES_HOST
         port = POSTGRES_PORT

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -66,7 +66,7 @@ def build_connection_string(
     db: str = POSTGRES_DB,
     app_name: str | None = None,
     use_iam_auth: bool = USE_IAM_AUTH,
-    region: str = "us-west-2",
+    region: str = "us-west-2",  # noqa: ARG001
 ) -> str:
     if use_iam_auth:
         base_conn_str = f"postgresql+{db_api}://{user}@{host}:{port}/{db}"
@@ -86,13 +86,13 @@ if LOG_POSTGRES_LATENCY:
 
     @event.listens_for(Engine, "before_cursor_execute")
     def before_cursor_execute(  # type: ignore
-        conn, cursor, statement, parameters, context, executemany
+        conn, cursor, statement, parameters, context, executemany  # noqa: ARG001
     ):
         conn.info["query_start_time"] = time.time()
 
     @event.listens_for(Engine, "after_cursor_execute")
     def after_cursor_execute(  # type: ignore
-        conn, cursor, statement, parameters, context, executemany
+        conn, cursor, statement, parameters, context, executemany  # noqa: ARG001
     ):
         total_time = time.time() - conn.info["query_start_time"]
         if total_time > 0.1:
@@ -106,7 +106,7 @@ if LOG_POSTGRES_CONN_COUNTS:
     checkin_count = 0
 
     @event.listens_for(Engine, "checkout")
-    def log_checkout(dbapi_connection, connection_record, connection_proxy):  # type: ignore
+    def log_checkout(dbapi_connection, connection_record, connection_proxy):  # type: ignore  # noqa: ARG001
         global checkout_count
         checkout_count += 1
 
@@ -122,7 +122,7 @@ if LOG_POSTGRES_CONN_COUNTS:
         )
 
     @event.listens_for(Engine, "checkin")
-    def log_checkin(dbapi_connection, connection_record):  # type: ignore
+    def log_checkin(dbapi_connection, connection_record):  # type: ignore  # noqa: ARG001
         global checkin_count
         checkin_count += 1
         logger.debug(f"Total connection checkins: {checkin_count}")
@@ -141,7 +141,7 @@ class SqlEngine:
         pool_size: int,
         # is really `pool_max_overflow`, but calling it `max_overflow` to stay consistent with SQLAlchemy
         max_overflow: int,
-        app_name: str | None = None,
+        app_name: str | None = None,  # noqa: ARG003
         db_api: str = SYNC_DB_API,
         use_iam: bool = USE_IAM_AUTH,
         connection_string: str | None = None,

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -456,8 +456,8 @@ def get_all_hierarchy_nodes_for_source(
 def _get_accessible_hierarchy_nodes_for_source(
     db_session: Session,
     source: DocumentSource,
-    user_email: str | None,
-    external_group_ids: list[str],
+    user_email: str | None,  # noqa: ARG001
+    external_group_ids: list[str],  # noqa: ARG001
 ) -> list[HierarchyNode]:
     """
     MIT version: Returns all hierarchy nodes for the source without permission filtering.

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -49,7 +49,7 @@ def get_mcp_servers_by_owner(owner_email: str, db_session: Session) -> list[MCPS
 
 
 def get_mcp_servers_for_persona(
-    persona_id: int, db_session: Session, user: User
+    persona_id: int, db_session: Session, user: User  # noqa: ARG001
 ) -> list[MCPServer]:
     """Get all MCP servers associated with a persona via its tools"""
     # Get the persona and its tools

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -120,12 +120,16 @@ class EncryptedString(TypeDecorator):
     # This type's behavior is fully deterministic and doesn't depend on any external factors.
     cache_ok = True
 
-    def process_bind_param(self, value: str | None, dialect: Dialect) -> bytes | None:
+    def process_bind_param(
+        self, value: str | None, dialect: Dialect  # noqa: ARG002
+    ) -> bytes | None:
         if value is not None:
             return encrypt_string_to_bytes(value)
         return value
 
-    def process_result_value(self, value: bytes | None, dialect: Dialect) -> str | None:
+    def process_result_value(
+        self, value: bytes | None, dialect: Dialect  # noqa: ARG002
+    ) -> str | None:
         if value is not None:
             return decrypt_bytes_to_string(value)
         return value
@@ -136,14 +140,16 @@ class EncryptedJson(TypeDecorator):
     # This type's behavior is fully deterministic and doesn't depend on any external factors.
     cache_ok = True
 
-    def process_bind_param(self, value: dict | None, dialect: Dialect) -> bytes | None:
+    def process_bind_param(
+        self, value: dict | None, dialect: Dialect  # noqa: ARG002
+    ) -> bytes | None:
         if value is not None:
             json_str = json.dumps(value)
             return encrypt_string_to_bytes(json_str)
         return value
 
     def process_result_value(
-        self, value: bytes | None, dialect: Dialect
+        self, value: bytes | None, dialect: Dialect  # noqa: ARG002
     ) -> dict | None:
         if value is not None:
             json_str = decrypt_bytes_to_string(value)
@@ -156,13 +162,17 @@ class NullFilteredString(TypeDecorator):
     # This type's behavior is fully deterministic and doesn't depend on any external factors.
     cache_ok = True
 
-    def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:
+    def process_bind_param(
+        self, value: str | None, dialect: Dialect  # noqa: ARG002
+    ) -> str | None:
         if value is not None and "\x00" in value:
             logger.warning(f"NUL characters found in value: {value}")
             return value.replace("\x00", "")
         return value
 
-    def process_result_value(self, value: str | None, dialect: Dialect) -> str | None:
+    def process_result_value(
+        self, value: str | None, dialect: Dialect  # noqa: ARG002
+    ) -> str | None:
         return value
 
 
@@ -273,7 +283,7 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     )
 
     @validates("email")
-    def validate_email(self, key: str, value: str) -> str:
+    def validate_email(self, key: str, value: str) -> str:  # noqa: ARG002
         return value.lower() if value else value
 
     @property
@@ -4173,7 +4183,7 @@ class UserTenantMapping(Base):
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
     @validates("email")
-    def validate_email(self, key: str, value: str) -> str:
+    def validate_email(self, key: str, value: str) -> str:  # noqa: ARG002
         return value.lower() if value else value
 
 

--- a/backend/onyx/db/pydantic_type.py
+++ b/backend/onyx/db/pydantic_type.py
@@ -18,14 +18,14 @@ class PydanticType(TypeDecorator):
         self.pydantic_model = pydantic_model
 
     def process_bind_param(
-        self, value: Optional[BaseModel], dialect: Any
+        self, value: Optional[BaseModel], dialect: Any  # noqa: ARG002
     ) -> Optional[dict]:
         if value is not None:
             return json.loads(value.json())
         return None
 
     def process_result_value(
-        self, value: Optional[dict], dialect: Any
+        self, value: Optional[dict], dialect: Any  # noqa: ARG002
     ) -> Optional[BaseModel]:
         if value is not None:
             return self.pydantic_model.parse_obj(value)
@@ -42,14 +42,14 @@ class PydanticListType(TypeDecorator):
         self.pydantic_model = pydantic_model
 
     def process_bind_param(
-        self, value: Optional[list[BaseModel]], dialect: Any
+        self, value: Optional[list[BaseModel]], dialect: Any  # noqa: ARG002
     ) -> Optional[list[dict]]:
         if value is not None:
             return [json.loads(item.model_dump_json()) for item in value]
         return None
 
     def process_result_value(
-        self, value: Optional[list[dict]], dialect: Any
+        self, value: Optional[list[dict]], dialect: Any  # noqa: ARG002
     ) -> Optional[list[BaseModel]]:
         if value is not None:
             return [self.pydantic_model.model_validate(item) for item in value]

--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -91,7 +91,9 @@ def create_slack_channel_persona(
     return persona
 
 
-def _no_ee_standard_answer_categories(*args: Any, **kwargs: Any) -> list:
+def _no_ee_standard_answer_categories(
+    *args: Any, **kwargs: Any  # noqa: ARG001
+) -> list:
     return []
 
 
@@ -162,7 +164,7 @@ def update_slack_channel_config(
     channel_config: ChannelConfig,
     standard_answer_category_ids: list[int],
     enable_auto_filters: bool,
-    disabled: bool,
+    disabled: bool,  # noqa: ARG001
 ) -> SlackChannelConfig:
     slack_channel_config = db_session.scalar(
         select(SlackChannelConfig).where(

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -187,7 +187,7 @@ def run_deep_research_llm_loop(
     state_container: ChatStateContainer,
     simple_chat_history: list[ChatMessageSimple],
     tools: list[Tool],
-    custom_agent_prompt: str | None,
+    custom_agent_prompt: str | None,  # noqa: ARG001
     llm: LLM,
     token_counter: Callable[[str], int],
     db_session: Session,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -240,10 +240,10 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         self,
         index_name: str,
         secondary_index_name: str | None,
-        large_chunks_enabled: bool,
-        secondary_large_chunks_enabled: bool | None,
+        large_chunks_enabled: bool,  # noqa: ARG002
+        secondary_large_chunks_enabled: bool | None,  # noqa: ARG002
         multitenant: bool = False,
-        httpx_client: httpx.Client | None = None,
+        httpx_client: httpx.Client | None = None,  # noqa: ARG002
     ) -> None:
         super().__init__(
             index_name=index_name,
@@ -279,8 +279,8 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         self,
         primary_embedding_dim: int,
         primary_embedding_precision: EmbeddingPrecision,
-        secondary_index_embedding_dim: int | None,
-        secondary_index_embedding_precision: EmbeddingPrecision | None,
+        secondary_index_embedding_dim: int | None,  # noqa: ARG002
+        secondary_index_embedding_precision: EmbeddingPrecision | None,  # noqa: ARG002
     ) -> None:
         # Only handle primary index for now, ignore secondary.
         return self._real_index.verify_and_create_index_if_necessary(
@@ -320,7 +320,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         self,
         doc_id: str,
         *,
-        tenant_id: str,
+        tenant_id: str,  # noqa: ARG002
         chunk_count: int | None,
     ) -> int:
         return self._real_index.delete(doc_id, chunk_count)
@@ -329,7 +329,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         self,
         doc_id: str,
         *,
-        tenant_id: str,
+        tenant_id: str,  # noqa: ARG002
         chunk_count: int | None,
         fields: VespaDocumentFields | None,
         user_fields: VespaDocumentUserFields | None,
@@ -364,7 +364,7 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         chunk_requests: list[VespaChunkRequest],
         filters: IndexFilters,
         batch_retrieval: bool = False,
-        get_large_chunks: bool = False,
+        get_large_chunks: bool = False,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         section_requests = [
             DocumentSectionRequest(
@@ -386,10 +386,10 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
         final_keywords: list[str] | None,
         filters: IndexFilters,
         hybrid_alpha: float,
-        time_decay_multiplier: float,
+        time_decay_multiplier: float,  # noqa: ARG002
         num_to_retrieve: int,
-        ranking_profile_type: QueryExpansionType = QueryExpansionType.SEMANTIC,
-        title_content_ratio: float | None = TITLE_CONTENT_RATIO,
+        ranking_profile_type: QueryExpansionType = QueryExpansionType.SEMANTIC,  # noqa: ARG002
+        title_content_ratio: float | None = TITLE_CONTENT_RATIO,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         # Determine query type based on hybrid_alpha.
         if hybrid_alpha >= 0.8:
@@ -458,7 +458,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
         self._os_client = OpenSearchClient(index_name=self._index_name)
 
     def verify_and_create_index_if_necessary(
-        self, embedding_dim: int, embedding_precision: EmbeddingPrecision
+        self,
+        embedding_dim: int,
+        embedding_precision: EmbeddingPrecision,  # noqa: ARG002
     ) -> None:
         """Verifies and creates the index if necessary.
 
@@ -518,7 +520,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
     def index(
         self,
         chunks: list[DocMetadataAwareIndexChunk],
-        indexing_metadata: IndexingMetadata,
+        indexing_metadata: IndexingMetadata,  # noqa: ARG002
     ) -> list[DocumentInsertionRecord]:
         logger.debug(
             f"[OpenSearchDocumentIndex] Indexing {len(chunks)} chunks for index {self._index_name}."
@@ -566,7 +568,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
 
         return document_indexing_results
 
-    def delete(self, document_id: str, chunk_count: int | None = None) -> int:
+    def delete(
+        self, document_id: str, chunk_count: int | None = None  # noqa: ARG002
+    ) -> int:
         """Deletes all chunks for a given document.
 
         Does nothing if the specified document ID does not exist.
@@ -701,7 +705,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         filters: IndexFilters,
         # TODO(andrei): Remove this from the new interface at some point; we
         # should not be exposing this.
-        batch_retrieval: bool = False,
+        batch_retrieval: bool = False,  # noqa: ARG002
         # TODO(andrei): Add a param for whether to retrieve hidden docs.
     ) -> list[InferenceChunk]:
         """
@@ -751,7 +755,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         query_embedding: Embedding,
         # TODO(andrei): This param is not great design, get rid of it.
         final_keywords: list[str] | None,
-        query_type: QueryType,
+        query_type: QueryType,  # noqa: ARG002
         filters: IndexFilters,
         num_to_retrieve: int,
     ) -> list[InferenceChunk]:
@@ -796,7 +800,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         self,
         filters: IndexFilters,
         num_to_retrieve: int = 10,
-        dirty: bool | None = None,
+        dirty: bool | None = None,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         logger.debug(
             f"[OpenSearchDocumentIndex] Randomly retrieving {num_to_retrieve} chunks for index {self._index_name}."

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -197,7 +197,9 @@ class DocumentChunk(BaseModel):
 
     @field_serializer("last_updated", mode="wrap")
     def serialize_datetime_fields_to_epoch_seconds(
-        self, value: datetime | None, handler: SerializerFunctionWrapHandler
+        self,
+        value: datetime | None,
+        handler: SerializerFunctionWrapHandler,  # noqa: ARG002
     ) -> int | None:
         """
         Serializes datetime fields to seconds since the Unix epoch.
@@ -231,7 +233,7 @@ class DocumentChunk(BaseModel):
 
     @field_serializer("tenant_id", mode="wrap")
     def serialize_tenant_state(
-        self, value: TenantState, handler: SerializerFunctionWrapHandler
+        self, value: TenantState, handler: SerializerFunctionWrapHandler  # noqa: ARG002
     ) -> str | None:
         """
         Serializes tenant_state to the tenant str if multitenant, or None if

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -735,7 +735,7 @@ class VespaIndex(DocumentIndex):
         chunk_requests: list[VespaChunkRequest],
         filters: IndexFilters,
         batch_retrieval: bool = False,
-        get_large_chunks: bool = False,
+        get_large_chunks: bool = False,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         tenant_state = TenantState(
             tenant_id=get_current_tenant_id(),
@@ -769,11 +769,11 @@ class VespaIndex(DocumentIndex):
         query_embedding: Embedding,
         final_keywords: list[str] | None,
         filters: IndexFilters,
-        hybrid_alpha: float,
-        time_decay_multiplier: float,
+        hybrid_alpha: float,  # noqa: ARG002
+        time_decay_multiplier: float,  # noqa: ARG002
         num_to_retrieve: int,
         ranking_profile_type: QueryExpansionType = QueryExpansionType.SEMANTIC,
-        title_content_ratio: float | None = TITLE_CONTENT_RATIO,
+        title_content_ratio: float | None = TITLE_CONTENT_RATIO,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         tenant_state = TenantState(
             tenant_id=get_current_tenant_id(),
@@ -809,7 +809,7 @@ class VespaIndex(DocumentIndex):
     def admin_retrieval(
         self,
         query: str,
-        query_embedding: Embedding,
+        query_embedding: Embedding,  # noqa: ARG002
         filters: IndexFilters,
         num_to_retrieve: int = NUM_RETURNED_HITS,
     ) -> list[InferenceChunk]:

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -604,7 +604,7 @@ class VespaDocumentIndex(DocumentIndex):
         self,
         filters: IndexFilters,
         num_to_retrieve: int = 100,
-        dirty: bool | None = None,
+        dirty: bool | None = None,  # noqa: ARG002
     ) -> list[InferenceChunk]:
         vespa_where_clauses = build_vespa_filters(filters, remove_trailing_and=True)
 

--- a/backend/onyx/evals/providers/local.py
+++ b/backend/onyx/evals/providers/local.py
@@ -73,7 +73,7 @@ class LocalEvalProvider(EvalProvider):
     def eval(
         self,
         task: Callable[[dict[str, Any]], EvalToolResult],
-        configuration: EvalConfigurationOptions,
+        configuration: EvalConfigurationOptions,  # noqa: ARG002
         data: list[dict[str, Any]] | None = None,
         remote_dataset_name: str | None = None,
         multi_turn_task: Callable[[dict[str, Any]], MultiTurnEvalResult] | None = None,

--- a/backend/onyx/feature_flags/interface.py
+++ b/backend/onyx/feature_flags/interface.py
@@ -62,9 +62,9 @@ class NoOpFeatureFlagProvider(FeatureFlagProvider):
 
     def feature_enabled(
         self,
-        flag_key: str,
-        user_id: UUID,
-        user_properties: dict[str, Any] | None = None,
+        flag_key: str,  # noqa: ARG002
+        user_id: UUID,  # noqa: ARG002
+        user_properties: dict[str, Any] | None = None,  # noqa: ARG002
     ) -> bool:
         environment = ENVIRONMENT
         if environment == "local":

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -388,7 +388,7 @@ class S3BackedFileStore(FileStore):
     def read_file(
         self,
         file_id: str,
-        mode: str | None = None,
+        mode: str | None = None,  # noqa: ARG002
         use_tempfile: bool = False,
         db_session: Session | None = None,
     ) -> IO[bytes]:

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -63,7 +63,7 @@ class UserFileIndexingAdapter:
         self.db_session = db_session
 
     def prepare(
-        self, documents: list[Document], ignore_time_skip: bool
+        self, documents: list[Document], ignore_time_skip: bool  # noqa: ARG002
     ) -> DocumentBatchPrepareContext:
         return DocumentBatchPrepareContext(
             updatable_docs=documents, id_to_boost_map={}  # TODO(subash): add boost map
@@ -237,8 +237,8 @@ class UserFileIndexingAdapter:
     def post_index(
         self,
         context: DocumentBatchPrepareContext,
-        updatable_chunk_data: list[UpdatableChunkData],
-        filtered_documents: list[Document],
+        updatable_chunk_data: list[UpdatableChunkData],  # noqa: ARG002
+        filtered_documents: list[Document],  # noqa: ARG002
         result: BuildMetadataAwareChunksResult,
     ) -> None:
         user_file_ids = [doc.id for doc in context.updatable_docs]

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -551,10 +551,10 @@ def _patch_azure_responses_should_fake_stream() -> None:
         return
 
     def _patched_should_fake_stream(
-        self: Any,
-        model: Optional[str],
-        stream: Optional[bool],
-        custom_llm_provider: Optional[str] = None,
+        self: Any,  # noqa: ARG001
+        model: Optional[str],  # noqa: ARG001
+        stream: Optional[bool],  # noqa: ARG001
+        custom_llm_provider: Optional[str] = None,  # noqa: ARG001
     ) -> bool:
         # Azure Responses API supports native streaming - never fake it
         return False
@@ -656,12 +656,12 @@ def _patch_logging_assembled_streaming_response() -> None:
         return
 
     def _patched_get_assembled_streaming_response(
-        self: Any,
+        self: Any,  # noqa: ARG001
         result: Any,
-        start_time: Any,
-        end_time: Any,
-        is_async: bool,
-        streaming_chunks: List[Any],
+        start_time: Any,  # noqa: ARG001
+        end_time: Any,  # noqa: ARG001
+        is_async: bool,  # noqa: ARG001
+        streaming_chunks: List[Any],  # noqa: ARG001
     ) -> Any:
         """
         Patched version that creates a copy before modifying usage.

--- a/backend/onyx/llm/prompt_cache/providers/anthropic.py
+++ b/backend/onyx/llm/prompt_cache/providers/anthropic.py
@@ -47,7 +47,7 @@ class AnthropicPromptCacheProvider(PromptCacheProvider):
         cacheable_prefix: LanguageModelInput | None,
         suffix: LanguageModelInput,
         continuation: bool,
-        cache_metadata: CacheMetadata | None,
+        cache_metadata: CacheMetadata | None,  # noqa: ARG002
     ) -> LanguageModelInput:
         """Prepare messages for Anthropic caching.
 
@@ -72,8 +72,8 @@ class AnthropicPromptCacheProvider(PromptCacheProvider):
 
     def extract_cache_metadata(
         self,
-        response: dict,
-        cache_key: str,
+        response: dict,  # noqa: ARG002
+        cache_key: str,  # noqa: ARG002
     ) -> CacheMetadata | None:
         """Extract cache metadata from Anthropic response.
 

--- a/backend/onyx/llm/prompt_cache/providers/noop.py
+++ b/backend/onyx/llm/prompt_cache/providers/noop.py
@@ -18,7 +18,7 @@ class NoOpPromptCacheProvider(PromptCacheProvider):
         cacheable_prefix: LanguageModelInput | None,
         suffix: LanguageModelInput,
         continuation: bool,
-        cache_metadata: CacheMetadata | None,
+        cache_metadata: CacheMetadata | None,  # noqa: ARG002
     ) -> LanguageModelInput:
         """Return messages unchanged (no caching support).
 
@@ -42,8 +42,8 @@ class NoOpPromptCacheProvider(PromptCacheProvider):
 
     def extract_cache_metadata(
         self,
-        response: dict,
-        cache_key: str,
+        response: dict,  # noqa: ARG002
+        cache_key: str,  # noqa: ARG002
     ) -> CacheMetadata | None:
         """No cache metadata to extract."""
         return None

--- a/backend/onyx/llm/prompt_cache/providers/openai.py
+++ b/backend/onyx/llm/prompt_cache/providers/openai.py
@@ -18,7 +18,7 @@ class OpenAIPromptCacheProvider(PromptCacheProvider):
         cacheable_prefix: LanguageModelInput | None,
         suffix: LanguageModelInput,
         continuation: bool,
-        cache_metadata: CacheMetadata | None,
+        cache_metadata: CacheMetadata | None,  # noqa: ARG002
     ) -> LanguageModelInput:
         """Prepare messages for OpenAI caching.
 
@@ -44,8 +44,8 @@ class OpenAIPromptCacheProvider(PromptCacheProvider):
 
     def extract_cache_metadata(
         self,
-        response: dict,
-        cache_key: str,
+        response: dict,  # noqa: ARG002
+        cache_key: str,  # noqa: ARG002
     ) -> CacheMetadata | None:
         """Extract cache metadata from OpenAI response.
 

--- a/backend/onyx/llm/prompt_cache/providers/vertex.py
+++ b/backend/onyx/llm/prompt_cache/providers/vertex.py
@@ -22,7 +22,7 @@ class VertexAIPromptCacheProvider(PromptCacheProvider):
         cacheable_prefix: LanguageModelInput | None,
         suffix: LanguageModelInput,
         continuation: bool,
-        cache_metadata: CacheMetadata | None,
+        cache_metadata: CacheMetadata | None,  # noqa: ARG002
     ) -> LanguageModelInput:
         """Prepare messages for Vertex AI caching.
 
@@ -53,8 +53,8 @@ class VertexAIPromptCacheProvider(PromptCacheProvider):
 
     def extract_cache_metadata(
         self,
-        response: dict,
-        cache_key: str,
+        response: dict,  # noqa: ARG002
+        cache_key: str,  # noqa: ARG002
     ) -> CacheMetadata | None:
         """Extract cache metadata from Vertex AI response.
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -245,7 +245,7 @@ def include_auth_router_with_prefix(
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     # Set recursion limit
     if SYSTEM_RECURSION_LIMIT is not None:
         sys.setrecursionlimit(SYSTEM_RECURSION_LIMIT)

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -703,8 +703,8 @@ class EmbeddingModel:
     async def _make_direct_api_call(
         self,
         embed_request: EmbedRequest,
-        tenant_id: str | None = None,
-        request_id: str | None = None,
+        tenant_id: str | None = None,  # noqa: ARG002
+        request_id: str | None = None,  # noqa: ARG002
     ) -> EmbedResponse:
         """Make direct API call to cloud provider, bypassing model server."""
         if self.provider_type is None:
@@ -1166,8 +1166,8 @@ def warm_up_retry(
     func: Callable[..., Any],
     tries: int = 20,
     delay: int = 5,
-    *args: Any,
-    **kwargs: Any,
+    *args: Any,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
 ) -> Callable[..., Any]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -124,7 +124,7 @@ def _build_qa_feedback_block(
 
 
 def _build_ephemeral_publication_block(
-    channel_id: str,
+    channel_id: str,  # noqa: ARG001
     chat_message_id: int,
     message_info: SlackMessageInfo,
     original_question_ts: str,

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -22,7 +22,7 @@ class SlackRenderer(HTMLRenderer):
             text = text.replace(special, replacement)
         return text
 
-    def heading(self, text: str, level: int, **attrs: Any) -> str:
+    def heading(self, text: str, level: int, **attrs: Any) -> str:  # noqa: ARG002
         return f"*{text}*\n"
 
     def emphasis(self, text: str) -> str:
@@ -34,7 +34,7 @@ class SlackRenderer(HTMLRenderer):
     def strikethrough(self, text: str) -> str:
         return f"~{text}~"
 
-    def list(self, text: str, ordered: bool, **attrs: Any) -> str:
+    def list(self, text: str, ordered: bool, **attrs: Any) -> str:  # noqa: ARG002
         lines = text.split("\n")
         count = 0
         for i, line in enumerate(lines):
@@ -63,7 +63,7 @@ class SlackRenderer(HTMLRenderer):
     def codespan(self, text: str) -> str:
         return f"`{text}`"
 
-    def block_code(self, code: str, info: str | None = None) -> str:
+    def block_code(self, code: str, info: str | None = None) -> str:  # noqa: ARG002
         return f"```\n{code}\n```\n"
 
     def paragraph(self, text: str) -> str:

--- a/backend/onyx/onyxbot/slack/handlers/handle_standard_answers.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_standard_answers.py
@@ -35,12 +35,12 @@ def handle_standard_answers(
 
 
 def _handle_standard_answers(
-    message_info: SlackMessageInfo,
-    receiver_ids: list[str] | None,
-    slack_channel_config: SlackChannelConfig,
-    logger: OnyxLoggingAdapter,
-    client: WebClient,
-    db_session: Session,
+    message_info: SlackMessageInfo,  # noqa: ARG001
+    receiver_ids: list[str] | None,  # noqa: ARG001
+    slack_channel_config: SlackChannelConfig,  # noqa: ARG001
+    logger: OnyxLoggingAdapter,  # noqa: ARG001
+    client: WebClient,  # noqa: ARG001
+    db_session: Session,  # noqa: ARG001
 ) -> bool:
     """
     Standard Answers are a paid Enterprise Edition feature. This is the fallback

--- a/backend/onyx/onyxbot/slack/handlers/utils.py
+++ b/backend/onyx/onyxbot/slack/handlers/utils.py
@@ -7,7 +7,7 @@ def send_team_member_message(
     client: WebClient,
     channel: str,
     thread_ts: str,
-    receiver_ids: list[str] | None = None,
+    receiver_ids: list[str] | None = None,  # noqa: ARG001
     send_as_ephemeral: bool = False,
 ) -> None:
     respond_in_thread_or_channel(

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -533,7 +533,9 @@ class SlackbotHandler:
                 f"{pod_id=} {tenant_id=} {slack_bot_id=}"
             )
 
-    def shutdown(self, signum: int | None, frame: FrameType | None) -> None:
+    def shutdown(
+        self, signum: int | None, frame: FrameType | None  # noqa: ARG002
+    ) -> None:
         if not self.running:
             return
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -227,7 +227,7 @@ def respond_in_thread_or_channel(
     receiver_ids: list[str] | None = None,
     metadata: Metadata | None = None,
     unfurl: bool = True,
-    send_as_ephemeral: bool | None = True,
+    send_as_ephemeral: bool | None = True,  # noqa: ARG001
 ) -> list[str]:
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")

--- a/backend/onyx/redis/redis_document_set.py
+++ b/backend/onyx/redis/redis_document_set.py
@@ -52,7 +52,7 @@ class RedisDocumentSet(RedisObjectHelper):
 
     def generate_tasks(
         self,
-        max_tasks: int,
+        max_tasks: int,  # noqa: ARG002
         celery_app: Celery,
         db_session: Session,
         redis_client: Redis,

--- a/backend/onyx/redis/redis_usergroup.py
+++ b/backend/onyx/redis/redis_usergroup.py
@@ -56,7 +56,7 @@ class RedisUserGroup(RedisObjectHelper):
 
     def generate_tasks(
         self,
-        max_tasks: int,
+        max_tasks: int,  # noqa: ARG002
         celery_app: Celery,
         db_session: Session,
         redis_client: Redis,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -567,7 +567,7 @@ def upload_files_api(
 @router.get("/admin/connector/{connector_id}/files", tags=PUBLIC_API_TAGS)
 def list_connector_files(
     connector_id: int,
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
     db_session: Session = Depends(get_session),
 ) -> ConnectorFilesResponse:
     """List all files in a file connector."""
@@ -629,7 +629,7 @@ def update_connector_files(
     connector_id: int,
     files: list[UploadFile] | None = File(None),
     file_ids_to_remove: str = Form("[]"),
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
     db_session: Session = Depends(get_session),
 ) -> FileUploadResponse:
     """

--- a/backend/onyx/server/features/build/api/subscription_check.py
+++ b/backend/onyx/server/features/build/api/subscription_check.py
@@ -12,7 +12,7 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 
-def is_user_subscribed(user: User, db_session: Session) -> bool:
+def is_user_subscribed(user: User, db_session: Session) -> bool:  # noqa: ARG001
     """
     Check if a user has an active subscription.
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -138,7 +138,9 @@ def get_idle_sandboxes(
     return list(db_session.execute(stmt).scalars().all())
 
 
-def get_running_sandbox_count_by_tenant(db_session: Session, tenant_id: str) -> int:
+def get_running_sandbox_count_by_tenant(
+    db_session: Session, tenant_id: str  # noqa: ARG001
+) -> int:
     """Get count of running sandboxes for a tenant (for limit enforcement).
 
     Note: tenant_id parameter is kept for API compatibility but is not used
@@ -193,7 +195,7 @@ def get_snapshots_for_session(db_session: Session, session_id: UUID) -> list[Sna
 
 
 def delete_old_snapshots(
-    db_session: Session, tenant_id: str, retention_days: int
+    db_session: Session, tenant_id: str, retention_days: int  # noqa: ARG001
 ) -> int:
     """Delete snapshots older than retention period, return count deleted.
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
@@ -683,7 +683,7 @@ class ACPExecClient:
             {"sessionId": self._state.current_session.session_id},
         )
 
-    def health_check(self, timeout: float = 5.0) -> bool:
+    def health_check(self, timeout: float = 5.0) -> bool:  # noqa: ARG002
         """Check if we can exec into the pod."""
         try:
             k8s = self._get_k8s_client()

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -764,7 +764,7 @@ done
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        llm_config: LLMProviderConfig,
+        llm_config: LLMProviderConfig,  # noqa: ARG002
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1063,7 +1063,7 @@ done
         session_id: UUID,
         llm_config: LLMProviderConfig,
         nextjs_port: int,
-        file_system_path: str | None = None,
+        file_system_path: str | None = None,  # noqa: ARG002
         snapshot_path: str | None = None,
         user_name: str | None = None,
         user_role: str | None = None,
@@ -1268,7 +1268,7 @@ echo "Session workspace setup complete"
         self,
         sandbox_id: UUID,
         session_id: UUID,
-        nextjs_port: int | None = None,
+        nextjs_port: int | None = None,  # noqa: ARG002
     ) -> None:
         """Clean up a session workspace (on session delete).
 
@@ -1455,7 +1455,7 @@ echo "Session cleanup complete"
         sandbox_id: UUID,
         session_id: UUID,
         snapshot_storage_path: str,
-        tenant_id: str,
+        tenant_id: str,  # noqa: ARG002
         nextjs_port: int,
     ) -> None:
         """Download snapshot from S3, extract into session workspace, and start NextJS.

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -157,7 +157,7 @@ class LocalSandboxManager(SandboxManager):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        llm_config: LLMProviderConfig,
+        llm_config: LLMProviderConfig,  # noqa: ARG002
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -265,7 +265,7 @@ class LocalSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         nextjs_port: int,
         file_system_path: str | None = None,
-        snapshot_path: str | None = None,
+        snapshot_path: str | None = None,  # noqa: ARG002
         user_name: str | None = None,
         user_role: str | None = None,
         user_work_area: str | None = None,
@@ -661,7 +661,7 @@ class LocalSandboxManager(SandboxManager):
         sandbox_id: UUID,
         session_id: UUID,
         snapshot_storage_path: str,
-        tenant_id: str,
+        tenant_id: str,  # noqa: ARG002
         nextjs_port: int,
     ) -> None:
         """Restore a snapshot into a session's workspace directory and start NextJS.
@@ -707,7 +707,9 @@ class LocalSandboxManager(SandboxManager):
                 f"Web directory not found at {web_dir}, skipping NextJS startup"
             )
 
-    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
+    def health_check(
+        self, sandbox_id: UUID, timeout: float = 60.0  # noqa: ARG002
+    ) -> bool:
         """Check if the sandbox is healthy (folder exists).
 
         Args:
@@ -1084,7 +1086,7 @@ class LocalSandboxManager(SandboxManager):
 
         return file_count, total_size
 
-    def get_webapp_url(self, sandbox_id: UUID, port: int) -> str:
+    def get_webapp_url(self, sandbox_id: UUID, port: int) -> str:  # noqa: ARG002
         """Get the webapp URL for a session's Next.js server.
 
         For local backend, returns localhost URL with port.
@@ -1101,8 +1103,8 @@ class LocalSandboxManager(SandboxManager):
     def sync_files(
         self,
         sandbox_id: UUID,
-        user_id: UUID,
-        tenant_id: str,
+        user_id: UUID,  # noqa: ARG002
+        tenant_id: str,  # noqa: ARG002
     ) -> bool:
         """No-op for local mode - files are directly accessible via symlink.
 

--- a/backend/onyx/server/features/build/sandbox/local/test_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/test_manager.py
@@ -88,7 +88,9 @@ def actual_sandbox_path(sandbox_record: Sandbox) -> Path:
 
 
 @pytest.fixture
-def test_user(db_session: Session, tenant_context: None) -> Generator[User, None, None]:
+def test_user(
+    db_session: Session, tenant_context: None  # noqa: ARG001
+) -> Generator[User, None, None]:
     """Create or get a test user for sandbox tests."""
     from sqlalchemy import select
 
@@ -122,7 +124,7 @@ def test_user(db_session: Session, tenant_context: None) -> Generator[User, None
 
 @pytest.fixture
 def sandbox_record(
-    db_session: Session, tenant_context: None, test_user: User
+    db_session: Session, tenant_context: None, test_user: User  # noqa: ARG001
 ) -> Generator[Sandbox, None, None]:
     """Create a real Sandbox record in the database and set up sandbox directory."""
     from sqlalchemy import select
@@ -161,7 +163,7 @@ def sandbox_record(
 
 @pytest.fixture
 def build_session_record(
-    db_session: Session, tenant_context: None, test_user: User
+    db_session: Session, tenant_context: None, test_user: User  # noqa: ARG001
 ) -> Generator[BuildSession, None, None]:
     """Create a BuildSession record for testing session-specific operations."""
     build_session = BuildSession(
@@ -240,10 +242,10 @@ class TestTerminate:
     def test_terminate_cleans_up_resources(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         sandbox_record: Sandbox,
-        temp_sandbox_dir: Path,
-        tenant_context: None,
+        temp_sandbox_dir: Path,  # noqa: ARG002
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that terminate cleans up sandbox resources.
 
@@ -260,10 +262,10 @@ class TestCreateSnapshot:
     def test_create_snapshot_archives_outputs(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
-        file_store_initialized: None,
+        tenant_context: None,  # noqa: ARG002
+        file_store_initialized: None,  # noqa: ARG002
     ) -> None:
         """Test that create_snapshot archives the session's outputs directory.
 
@@ -287,9 +289,9 @@ class TestHealthCheck:
     def test_health_check_returns_false_when_no_processes(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         sandbox_record: Sandbox,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that health_check returns False when no processes are running.
 
@@ -306,9 +308,9 @@ class TestListDirectory:
     def test_list_directory_returns_entries(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that list_directory returns filesystem entries."""
         sandbox, session_id = session_workspace
@@ -331,9 +333,9 @@ class TestReadFile:
     def test_read_file_returns_contents(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that read_file returns file contents as bytes."""
         sandbox, session_id = session_workspace
@@ -352,9 +354,9 @@ class TestSendMessage:
     def test_send_message_streams_events(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that send_message streams ACPEvent objects and ends with PromptResponse.
 
@@ -379,9 +381,9 @@ class TestSendMessage:
     def test_send_message_write_file(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that send_message can write files and emits edit tool calls."""
         sandbox, session_id = session_workspace
@@ -416,9 +418,9 @@ class TestSendMessage:
     def test_send_message_read_file(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that send_message can read files and emits read tool calls."""
         sandbox, session_id = session_workspace
@@ -456,9 +458,9 @@ class TestUploadFile:
     def test_upload_file_creates_file(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that upload_file creates a file in the attachments directory."""
         sandbox, session_id = session_workspace
@@ -481,9 +483,9 @@ class TestUploadFile:
     def test_upload_file_handles_collision(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that upload_file renames files on collision."""
         sandbox, session_id = session_workspace
@@ -505,9 +507,9 @@ class TestDeleteFile:
     def test_delete_file_removes_file(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that delete_file removes a file."""
         sandbox, session_id = session_workspace
@@ -532,9 +534,9 @@ class TestDeleteFile:
     def test_delete_file_returns_false_for_missing(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that delete_file returns False for non-existent file."""
         sandbox, session_id = session_workspace
@@ -548,9 +550,9 @@ class TestDeleteFile:
     def test_delete_file_rejects_path_traversal(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that delete_file rejects path traversal attempts."""
         sandbox, session_id = session_workspace
@@ -565,9 +567,9 @@ class TestGetUploadStats:
     def test_get_upload_stats_empty(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test get_upload_stats returns zeros for empty directory."""
         sandbox, session_id = session_workspace
@@ -582,9 +584,9 @@ class TestGetUploadStats:
     def test_get_upload_stats_with_files(
         self,
         sandbox_manager: LocalSandboxManager,
-        db_session: Session,
+        db_session: Session,  # noqa: ARG002
         session_workspace: tuple[Sandbox, UUID],
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test get_upload_stats returns correct count and size."""
         sandbox, session_id = session_workspace

--- a/backend/onyx/server/features/build/sandbox/manager/test_directory_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/test_directory_manager.py
@@ -72,7 +72,7 @@ class TestSetupOpencodeConfig:
     def test_openai_config_with_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that OpenAI provider includes reasoning configuration."""
         session_id = "test_openai_session"
@@ -106,7 +106,7 @@ class TestSetupOpencodeConfig:
     def test_anthropic_config_with_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that Anthropic provider includes thinking configuration."""
         session_id = "test_anthropic_session"
@@ -144,7 +144,7 @@ class TestSetupOpencodeConfig:
     def test_google_config_with_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that Google provider includes thinking configuration."""
         session_id = "test_google_session"
@@ -181,7 +181,7 @@ class TestSetupOpencodeConfig:
     def test_bedrock_config_with_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that Bedrock provider includes thinking configuration."""
         session_id = "test_bedrock_session"
@@ -218,7 +218,7 @@ class TestSetupOpencodeConfig:
     def test_azure_config_with_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that Azure provider includes thinking configuration."""
         session_id = "test_azure_session"
@@ -252,7 +252,7 @@ class TestSetupOpencodeConfig:
     def test_openai_config_with_api_base(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test OpenAI config with custom API base URL."""
         session_id = "test_openai_api_base"
@@ -280,7 +280,7 @@ class TestSetupOpencodeConfig:
     def test_anthropic_config_with_api_base(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test Anthropic config with custom API base URL."""
         session_id = "test_anthropic_api_base"
@@ -313,7 +313,7 @@ class TestSetupOpencodeConfig:
     def test_config_with_disabled_tools(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test config with disabled tools permissions."""
         session_id = "test_disabled_tools"
@@ -351,7 +351,7 @@ class TestSetupOpencodeConfig:
     def test_config_without_api_key(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test config without API key still includes thinking settings."""
         session_id = "test_no_api_key"
@@ -381,7 +381,7 @@ class TestSetupOpencodeConfig:
     def test_other_provider_no_thinking(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that other providers (non OpenAI/Anthropic/Google/Bedrock/Azure) don't get thinking configuration."""
         session_id = "test_other_provider"
@@ -409,7 +409,7 @@ class TestSetupOpencodeConfig:
     def test_config_overwritten_if_exists(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test that existing opencode.json is overwritten with new config."""
         session_id = "test_existing_config"
@@ -437,7 +437,7 @@ class TestSetupOpencodeConfig:
     def test_full_config_structure_openai(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test full OpenAI config structure matches expected format."""
         session_id = "test_full_openai"
@@ -468,7 +468,7 @@ class TestSetupOpencodeConfig:
     def test_full_config_structure_anthropic(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test full Anthropic config structure matches expected format."""
         session_id = "test_full_anthropic"
@@ -504,7 +504,7 @@ class TestSetupOpencodeConfig:
     def test_full_config_structure_google(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test full Google config structure matches expected format."""
         session_id = "test_full_google"
@@ -541,7 +541,7 @@ class TestSetupOpencodeConfig:
     def test_full_config_structure_bedrock(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test full Bedrock config structure matches expected format."""
         session_id = "test_full_bedrock"
@@ -572,7 +572,7 @@ class TestSetupOpencodeConfig:
     def test_full_config_structure_azure(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test full Azure config structure matches expected format."""
         session_id = "test_full_azure"
@@ -609,7 +609,7 @@ class TestSandboxDirectoryStructure:
     def test_create_complete_sandbox(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
     ) -> None:
         """Test creating a complete sandbox with all components including opencode.json."""
         session_id = "test_complete_sandbox"
@@ -646,7 +646,7 @@ class TestSandboxDirectoryStructure:
     def test_setup_skills_copies_and_overwrites(
         self,
         directory_manager: DirectoryManager,
-        temp_base_path: Path,
+        temp_base_path: Path,  # noqa: ARG002
         temp_templates: dict[str, Path],
     ) -> None:
         """Test that setup_skills copies skills and overwrites existing ones."""

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -36,7 +36,7 @@ TIMEOUT_SECONDS = 6000
     bind=True,
     ignore_result=True,
 )
-def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:
+def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
     """Put idle sandboxes to sleep after snapshotting all sessions.
 
     This task:
@@ -243,7 +243,9 @@ def _list_session_directories(
     bind=True,
     ignore_result=True,
 )
-def sync_sandbox_files(self: Task, *, user_id: str, tenant_id: str) -> bool:
+def sync_sandbox_files(
+    self: Task, *, user_id: str, tenant_id: str  # noqa: ARG001
+) -> bool:
     """Sync files from S3 to a user's running sandbox.
 
     This task is triggered after documents are written to S3 during indexing.

--- a/backend/onyx/server/features/build/skills/image-generation/scripts/generate.py
+++ b/backend/onyx/server/features/build/skills/image-generation/scripts/generate.py
@@ -43,7 +43,7 @@ def generate_image(
     output_path: str,
     model: str = "gemini-3-pro-image-preview",
     input_image: str | None = None,
-    aspect_ratio: str | None = None,
+    aspect_ratio: str | None = None,  # noqa: ARG001
     num_images: int = 1,
 ) -> list[str]:
     """

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1005,7 +1005,10 @@ def get_mcp_servers_for_user(
 
 
 def _get_connection_config(
-    mcp_server: DbMCPServer, is_admin: bool, user: User, db_session: Session
+    mcp_server: DbMCPServer,
+    is_admin: bool,  # noqa: ARG001
+    user: User,
+    db_session: Session,
 ) -> MCPConnectionConfig | None:
     """
     Get the connection config for an MCP server.
@@ -1566,7 +1569,7 @@ def get_mcp_server_detail(
 @admin_router.get("/tools")
 def get_all_mcp_tools(
     db: Session = Depends(get_session),
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
 ) -> list:
     """Get all tools associated with MCP servers, including both enabled and disabled tools"""
     from sqlalchemy import select

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -158,7 +158,7 @@ class ToolStatusUpdateResponse(BaseModel):
 def update_tools_status(
     update_data: ToolStatusUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
 ) -> ToolStatusUpdateResponse:
     """Enable or disable one or more tools.
 

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -33,9 +33,9 @@ logger = setup_logger()
 
 @router.post("/set-new-search-settings")
 def set_new_search_settings(
-    search_settings_new: SearchSettingsCreationRequest,
+    search_settings_new: SearchSettingsCreationRequest,  # noqa: ARG001
     _: User = Depends(current_admin_user),
-    db_session: Session = Depends(get_session),
+    db_session: Session = Depends(get_session),  # noqa: ARG001
 ) -> IdReturn:
     """Creates a new EmbeddingModel row and cancels the previous secondary indexing if any
     Gives an error if the same model name is used as the current or secondary index

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -1049,7 +1049,7 @@ async def search_chats(
 @router.post("/stop-chat-session/{chat_session_id}", tags=PUBLIC_API_TAGS)
 def stop_chat_session(
     chat_session_id: UUID,
-    user: User = Depends(current_user),
+    user: User = Depends(current_user),  # noqa: ARG001
     redis_client: Redis = Depends(get_redis_client),
 ) -> dict[str, str]:
     """

--- a/backend/onyx/server/query_and_chat/streaming_utils.py
+++ b/backend/onyx/server/query_and_chat/streaming_utils.py
@@ -29,7 +29,7 @@ _CANNOT_SHOW_STEP_RESULTS_STR = "[Cannot display step results]"
 
 
 def _adjust_message_text_for_agent_search_results(
-    adjusted_message_text: str, final_documents: list[SavedSearchDoc]
+    adjusted_message_text: str, final_documents: list[SavedSearchDoc]  # noqa: ARG001
 ) -> str:
     # Remove all [Q<integer>] patterns (sub-question citations)
     return re.sub(r"\[Q\d+\]", "", adjusted_message_text)

--- a/backend/onyx/server/tenant_usage_limits.py
+++ b/backend/onyx/server/tenant_usage_limits.py
@@ -47,7 +47,7 @@ class TenantUsageLimitOverrides(BaseModel):
 
 
 def get_tenant_usage_limit_overrides(
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
 ) -> TenantUsageLimitOverrides | None:
     """
     Get the usage limit overrides for a specific tenant.

--- a/backend/onyx/server/usage_limits.py
+++ b/backend/onyx/server/usage_limits.py
@@ -50,7 +50,7 @@ def is_usage_limits_enabled() -> bool:
     return USAGE_LIMITS_ENABLED
 
 
-def is_tenant_on_trial(tenant_id: str) -> bool:
+def is_tenant_on_trial(tenant_id: str) -> bool:  # noqa: ARG001
     """
     Determine if a tenant is currently on a trial subscription.
 

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -58,7 +58,7 @@ logger = setup_logger()
 
 
 def setup_onyx(
-    db_session: Session, tenant_id: str, cohere_enabled: bool = False
+    db_session: Session, tenant_id: str, cohere_enabled: bool = False  # noqa: ARG001
 ) -> None:
     """
     Setup Onyx for a particular tenant. In the Single Tenant case, it will set it up for the default schema

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -618,8 +618,8 @@ def run_research_agent_call(
 
 
 def _on_research_agent_timeout(
-    index: int,
-    func: Callable[..., Any],
+    index: int,  # noqa: ARG001
+    func: Callable[..., Any],  # noqa: ARG001
     args: tuple[Any, ...],
 ) -> ResearchAgentCallResult:
     """Callback for handling research agent timeouts.

--- a/backend/onyx/tools/interface.py
+++ b/backend/onyx/tools/interface.py
@@ -52,7 +52,7 @@ class Tool(abc.ABC, Generic[TOverride]):
         raise NotImplementedError
 
     @classmethod
-    def is_available(cls, db_session: "Session") -> bool:
+    def is_available(cls, db_session: "Session") -> bool:  # noqa: ARG003
         """
         Whether this tool is currently available for use given
         the state of the system. Default: available.

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -146,7 +146,7 @@ class CustomTool(Tool[None]):
     def run(
         self,
         placement: Placement,
-        override_kwargs: None = None,
+        override_kwargs: None = None,  # noqa: ARG002
         **llm_kwargs: Any,
     ) -> ToolResponse:
         request_body = llm_kwargs.get(REQUEST_BODY)

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -230,7 +230,7 @@ class ImageGenerationTool(Tool[None]):
     def run(
         self,
         placement: Placement,
-        override_kwargs: None = None,
+        override_kwargs: None = None,  # noqa: ARG002
         **llm_kwargs: Any,
     ) -> ToolResponse:
         if PROMPT_FIELD not in llm_kwargs:

--- a/backend/onyx/tools/tool_implementations/knowledge_graph/knowledge_graph_tool.py
+++ b/backend/onyx/tools/tool_implementations/knowledge_graph/knowledge_graph_tool.py
@@ -45,7 +45,7 @@ class KnowledgeGraphTool(Tool[None]):
         return self._DISPLAY_NAME
 
     @classmethod
-    def is_available(cls, db_session: Session) -> bool:
+    def is_available(cls, db_session: Session) -> bool:  # noqa: ARG003
         """Available only if KG is enabled and exposed."""
         kg_configs = get_kg_config_settings()
         return kg_configs.KG_ENABLED and kg_configs.KG_EXPOSED

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -108,7 +108,7 @@ class MCPTool(Tool[None]):
     def run(
         self,
         placement: Placement,
-        override_kwargs: None = None,
+        override_kwargs: None = None,  # noqa: ARG002
         **llm_kwargs: Any,
     ) -> ToolResponse:
         """Execute the MCP tool by calling the MCP server"""

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -522,7 +522,9 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
             # Track if timeout occurred for error reporting
             timeout_occurred = [False]  # Using list for mutability in closure
 
-            def _timeout_handler(index: int, func: Any, args: tuple[Any, ...]) -> None:
+            def _timeout_handler(
+                index: int, func: Any, args: tuple[Any, ...]  # noqa: ARG001
+            ) -> None:
                 timeout_occurred[0] = True
                 return None
 
@@ -759,7 +761,7 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         crawled_sections: list[InferenceSection],
         url_to_doc_id: dict[str, str],
         all_urls: list[str],
-        failed_web_urls: list[str],
+        failed_web_urls: list[str],  # noqa: ARG002
     ) -> list[InferenceSection]:
         """Merge indexed and crawled results, preferring indexed when available.
 

--- a/backend/onyx/utils/long_term_log.py
+++ b/backend/onyx/utils/long_term_log.py
@@ -98,7 +98,7 @@ class LongTermLogger:
         category: str,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
-        limit: int = 100,
+        limit: int = 100,  # noqa: ARG002
     ) -> list[JSON_ro]:
         category_path = self.log_file_path / category
         files = list(category_path.glob("*.json"))

--- a/backend/onyx/utils/middleware.py
+++ b/backend/onyx/utils/middleware.py
@@ -15,7 +15,9 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR
 
 
-def add_onyx_tenant_id_middleware(app: FastAPI, logger: logging.LoggerAdapter) -> None:
+def add_onyx_tenant_id_middleware(
+    app: FastAPI, logger: logging.LoggerAdapter  # noqa: ARG001
+) -> None:
     @app.middleware("http")
     async def set_tenant_id(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
@@ -29,7 +31,7 @@ def add_onyx_tenant_id_middleware(app: FastAPI, logger: logging.LoggerAdapter) -
 
 
 def add_onyx_request_id_middleware(
-    app: FastAPI, prefix: str, logger: logging.LoggerAdapter
+    app: FastAPI, prefix: str, logger: logging.LoggerAdapter  # noqa: ARG001
 ) -> None:
     @app.middleware("http")
     async def set_request_id(

--- a/backend/onyx/utils/variable_functionality.py
+++ b/backend/onyx/utils/variable_functionality.py
@@ -182,7 +182,7 @@ def fetch_ee_implementation_or_noop(
 
         else:
 
-            def sync_noop(*args: Any, **kwargs: Any) -> Any:
+            def sync_noop(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
                 return noop_return_value
 
             return sync_noop

--- a/backend/scripts/celery_purge_queue.py
+++ b/backend/scripts/celery_purge_queue.py
@@ -23,7 +23,7 @@ logger = getLogger(__name__)
 REDIS_PASSWORD = ""
 
 
-def celery_purge_queue(queue: str, tenant_id: str) -> None:
+def celery_purge_queue(queue: str, tenant_id: str) -> None:  # noqa: ARG001
     """Purging a celery queue is extremely difficult because the queue is a list
     and the only way an item can be removed from a list is by VALUE, which is
     a linear scan.  Therefore, to purge the list of many values is roughly

--- a/backend/scripts/tenant_cleanup/cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/cleanup_tenants.py
@@ -37,7 +37,7 @@ from scripts.tenant_cleanup.cleanup_utils import read_tenant_ids_from_csv
 from scripts.tenant_cleanup.cleanup_utils import TenantNotFoundInControlPlaneError
 
 
-def signal_handler(signum: int, frame: object) -> None:
+def signal_handler(signum: int, frame: object) -> None:  # noqa: ARG001
     """Handle termination signals by killing active subprocess."""
     sys.exit(1)
 

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -39,7 +39,7 @@ _print_lock: Lock = Lock()
 _csv_lock: Lock = Lock()
 
 
-def signal_handler(signum: int, frame: object) -> None:
+def signal_handler(signum: int, frame: object) -> None:  # noqa: ARG001
     """Handle termination signals by killing active subprocess."""
     sys.exit(1)
 

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -160,7 +160,7 @@ POSTGRES_DEFAULT_SCHEMA = (
 DEFAULT_REDIS_PREFIX = os.environ.get("DEFAULT_REDIS_PREFIX") or "default"
 
 
-async def async_return_default_schema(*args: Any, **kwargs: Any) -> str:
+async def async_return_default_schema(*args: Any, **kwargs: Any) -> str:  # noqa: ARG001
     return POSTGRES_DEFAULT_SCHEMA
 
 

--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -21,7 +21,7 @@ load_dotenv()
 
 
 @asynccontextmanager
-async def test_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def test_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     """No-op lifespan for tests that don't need database or other services."""
     yield
 

--- a/backend/tests/daily/connectors/airtable/test_airtable_basic.py
+++ b/backend/tests/daily/connectors/airtable/test_airtable_basic.py
@@ -193,7 +193,8 @@ def compare_documents(
 
 
 def test_airtable_connector_basic(
-    mock_get_unstructured_api_key: MagicMock, airtable_config: AirtableConfig
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    airtable_config: AirtableConfig,
 ) -> None:
     """Test behavior when all non-attachment fields are treated as metadata."""
     connector = AirtableConnector(
@@ -259,7 +260,8 @@ def test_airtable_connector_basic(
 
 
 def test_airtable_connector_all_metadata(
-    mock_get_unstructured_api_key: MagicMock, airtable_config: AirtableConfig
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    airtable_config: AirtableConfig,
 ) -> None:
     connector = AirtableConnector(
         base_id=airtable_config.base_id,
@@ -313,7 +315,8 @@ def test_airtable_connector_all_metadata(
 
 
 def test_airtable_connector_with_share_and_view(
-    mock_get_unstructured_api_key: MagicMock, airtable_config: AirtableConfig
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    airtable_config: AirtableConfig,
 ) -> None:
     """Test behavior when using share_id and view_id for URL generation."""
     SHARE_ID = "shrkfjEzDmLaDtK83"

--- a/backend/tests/daily/connectors/blob/test_blob_connector.py
+++ b/backend/tests/daily/connectors/blob/test_blob_connector.py
@@ -87,7 +87,7 @@ def blob_connector(request: pytest.FixtureRequest) -> BlobStorageConnector:
     "blob_connector", [(BlobType.S3, "onyx-connector-tests")], indirect=True
 )
 def test_blob_s3_connector(
-    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector
+    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector  # noqa: ARG001
 ) -> None:
     """
     Plain and document file types should be fully indexed.
@@ -129,7 +129,7 @@ def test_blob_s3_connector(
     "blob_connector", [(BlobType.S3, "s3-role-connector-test")], indirect=True
 )
 def test_blob_s3_cross_region_and_citation_link(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     blob_connector: BlobStorageConnector,
 ) -> None:
     """Buckets in a different region should be accessible and links should reflect the correct region.
@@ -183,7 +183,7 @@ def test_blob_s3_cross_region_and_citation_link(
     "blob_connector", [(BlobType.R2, "asia-pacific-bucket")], indirect=True
 )
 def test_blob_r2_connector(
-    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector
+    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector  # noqa: ARG001
 ) -> None:
     """Validate basic R2 connector creation and document loading"""
 
@@ -208,7 +208,7 @@ def test_blob_r2_connector(
     indirect=True,
 )
 def test_blob_r2_eu_residency_connector(
-    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector
+    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector  # noqa: ARG001
 ) -> None:
     """Validate R2 connector with European residency setting"""
 
@@ -231,7 +231,7 @@ def test_blob_r2_eu_residency_connector(
     "blob_connector", [(BlobType.GOOGLE_CLOUD_STORAGE, "onyx-test-1")], indirect=True
 )
 def test_blob_gcs_connector(
-    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector
+    mock_get_api_key: MagicMock, blob_connector: BlobStorageConnector  # noqa: ARG001
 ) -> None:
     all_docs: list[Document] = []
     for doc_batch in blob_connector.load_from_state():

--- a/backend/tests/daily/connectors/coda/test_coda_connector.py
+++ b/backend/tests/daily/connectors/coda/test_coda_connector.py
@@ -141,7 +141,7 @@ class TestLoadFromState:
         assert isinstance(gen, Generator), "load_from_state should return a Generator"
 
     def test_batch_sizes_respect_config(
-        self, connector: CodaConnector, reference_data: dict[str, Any]
+        self, connector: CodaConnector, reference_data: dict[str, Any]  # noqa: ARG002
     ) -> None:
         """Test that batches respect the configured batch_size."""
         batch_size = connector.batch_size
@@ -180,7 +180,7 @@ class TestLoadFromState:
         )
 
     def test_document_required_fields(
-        self, connector: CodaConnector, reference_data: dict[str, Any]
+        self, connector: CodaConnector, reference_data: dict[str, Any]  # noqa: ARG002
     ) -> None:
         """Test that all documents have required fields with valid values."""
         gen = connector.load_from_state()
@@ -250,7 +250,7 @@ class TestLoadFromState:
         ), f"Expected {reference_data['total_tables']} table documents, got {len(table_docs)}"
 
     def test_no_duplicate_documents(
-        self, connector: CodaConnector, reference_data: dict[str, Any]
+        self, connector: CodaConnector, reference_data: dict[str, Any]  # noqa: ARG002
     ) -> None:
         """Test that no documents are yielded twice."""
         document_ids = []
@@ -285,7 +285,7 @@ class TestLoadFromState:
         ), f"Not all docs with content were processed. Expected {expected_doc_ids_with_content}, got {processed_doc_ids}"
 
     def test_document_content_not_empty(
-        self, connector: CodaConnector, reference_data: dict[str, Any]
+        self, connector: CodaConnector, reference_data: dict[str, Any]  # noqa: ARG002
     ) -> None:
         """Test that all documents have meaningful content."""
         for doc in connector_doc_generator(connector):
@@ -410,7 +410,7 @@ class TestWorkspaceScoping:
         self,
         connector: CodaConnector,
         workspace_scoped_connector: CodaConnector,
-        reference_data: dict[str, Any],
+        reference_data: dict[str, Any],  # noqa: ARG002
     ) -> None:
         """Test that workspace-scoped connector loads a subset of documents."""
         all_docs = []

--- a/backend/tests/daily/connectors/confluence/test_confluence_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_basic.py
@@ -55,7 +55,8 @@ def confluence_connector_scoped(space: str) -> ConfluenceConnector:
     return_value=None,
 )
 def test_confluence_connector_basic(
-    mock_get_api_key: MagicMock, confluence_connector: ConfluenceConnector
+    mock_get_api_key: MagicMock,  # noqa: ARG001
+    confluence_connector: ConfluenceConnector,
 ) -> None:
     _test_confluence_connector_basic(confluence_connector)
 
@@ -66,7 +67,8 @@ def test_confluence_connector_basic(
     return_value=None,
 )
 def test_confluence_connector_basic_scoped(
-    mock_get_api_key: MagicMock, confluence_connector_scoped: ConfluenceConnector
+    mock_get_api_key: MagicMock,  # noqa: ARG001
+    confluence_connector_scoped: ConfluenceConnector,
 ) -> None:
     _test_confluence_connector_basic(
         confluence_connector_scoped, expect_attachments=True
@@ -181,7 +183,8 @@ def _test_confluence_connector_basic(
     return_value=None,
 )
 def test_confluence_connector_skip_images(
-    mock_get_api_key: MagicMock, confluence_connector: ConfluenceConnector
+    mock_get_api_key: MagicMock,  # noqa: ARG001
+    confluence_connector: ConfluenceConnector,
 ) -> None:
     confluence_connector.set_allow_images(False)
     result = load_all_from_connector(confluence_connector, 0, time.time())
@@ -203,7 +206,7 @@ def test_confluence_connector_skip_images(
 
 
 def mock_process_image_attachment(
-    *args: Any, **kwargs: Any
+    *args: Any, **kwargs: Any  # noqa: ARG001
 ) -> AttachmentProcessingResult:
     """We need this mock to bypass DB access happening in the connector. Which shouldn't
     be done as a rule to begin with, but life is not perfect. Fix it later"""
@@ -225,8 +228,8 @@ def mock_process_image_attachment(
     side_effect=mock_process_image_attachment,
 )
 def test_confluence_connector_allow_images(
-    mock_get_api_key: MagicMock,
-    mock_process_image_attachment: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
+    mock_process_image_attachment: MagicMock,  # noqa: ARG001
     confluence_connector: ConfluenceConnector,
 ) -> None:
     confluence_connector.set_allow_images(True)

--- a/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
@@ -43,9 +43,9 @@ def confluence_connector() -> ConfluenceConnector:
     return_value=None,
 )
 def test_confluence_connector_permissions(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     confluence_connector: ConfluenceConnector,
-    set_ee_on: None,
+    set_ee_on: None,  # noqa: ARG001
 ) -> None:
     # Get all doc IDs from the full connector
     all_full_doc_ids = set()
@@ -91,9 +91,9 @@ def test_confluence_connector_permissions(
     return_value=None,
 )
 def test_confluence_connector_restriction_handling(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     mock_db_provider_class: MagicMock,
-    set_ee_on: None,
+    set_ee_on: None,  # noqa: ARG001
 ) -> None:
     # Test space key
     test_space_key = "DailyPermS"
@@ -123,7 +123,7 @@ def test_confluence_connector_restriction_handling(
 
     # Call the confluence_doc_sync function directly with the mock cc_pair
     def mock_fetch_all_docs_fn(
-        sort_order: SortOrder | None = None,
+        sort_order: SortOrder | None = None,  # noqa: ARG001
     ) -> list[DocumentRow]:
         return []
 

--- a/backend/tests/daily/connectors/file/test_file_connector.py
+++ b/backend/tests/daily/connectors/file/test_file_connector.py
@@ -35,7 +35,7 @@ def mock_filestore_record() -> MagicMock:
     "onyx.file_processing.extract_file_text.get_unstructured_api_key", return_value=None
 )
 def test_single_text_file_with_metadata(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_get_session: MagicMock,
     mock_db_session: MagicMock,
     mock_file_store: MagicMock,
@@ -80,8 +80,8 @@ def test_single_text_file_with_metadata(
     "onyx.file_processing.extract_file_text.get_unstructured_api_key", return_value=None
 )
 def test_two_text_files_with_zip_metadata(
-    mock_get_unstructured_api_key: MagicMock,
-    mock_db_session: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_db_session: MagicMock,  # noqa: ARG001
     mock_file_store: MagicMock,
 ) -> None:
     file1_content = io.BytesIO(b"File 1 content")

--- a/backend/tests/daily/connectors/gmail/test_gmail_connector.py
+++ b/backend/tests/daily/connectors/gmail/test_gmail_connector.py
@@ -75,7 +75,7 @@ _THREAD_1_BY_ID: dict[str, dict[str, Any]] = {
     return_value=None,
 )
 def test_slim_docs_retrieval(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_gmail_service_acct_connector_factory: Callable[..., GmailConnector],
 ) -> None:
     print("\n\nRunning test_slim_docs_retrieval")
@@ -102,7 +102,7 @@ def test_slim_docs_retrieval(
     return_value=None,
 )
 def test_docs_retrieval(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_gmail_service_acct_connector_factory: Callable[..., GmailConnector],
 ) -> None:
     print("\n\nRunning test_docs_retrieval")

--- a/backend/tests/daily/connectors/gong/test_gong.py
+++ b/backend/tests/daily/connectors/gong/test_gong.py
@@ -28,7 +28,9 @@ def gong_connector() -> GongConnector:
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,
 )
-def test_gong_basic(mock_get_api_key: MagicMock, gong_connector: GongConnector) -> None:
+def test_gong_basic(
+    mock_get_api_key: MagicMock, gong_connector: GongConnector  # noqa: ARG001
+) -> None:
     doc_batch_generator = gong_connector.poll_source(0, time.time())
 
     doc_batch = next(doc_batch_generator)

--- a/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
@@ -75,7 +75,7 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     return_value=None,
 )
 def test_include_all(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_all")
@@ -145,7 +145,7 @@ def test_include_all(
     return_value=None,
 )
 def test_include_shared_drives_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_shared_drives_only")
@@ -205,7 +205,7 @@ def test_include_shared_drives_only(
     return_value=None,
 )
 def test_include_my_drives_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_my_drives_only")
@@ -246,7 +246,7 @@ def test_include_my_drives_only(
     return_value=None,
 )
 def test_drive_one_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_drive_one_only")
@@ -293,7 +293,7 @@ def test_drive_one_only(
     return_value=None,
 )
 def test_folder_and_shared_drive(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_folder_and_shared_drive")
@@ -360,7 +360,7 @@ def test_folder_and_shared_drive(
     return_value=None,
 )
 def test_folders_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_folders_only")
@@ -422,7 +422,7 @@ def test_folders_only(
     return_value=None,
 )
 def test_personal_folders_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_personal_folders_only")

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -99,7 +99,7 @@ def _build_connector(
 
 def test_gdrive_perm_sync_with_real_data(
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
-    set_ee_on: None,
+    set_ee_on: None,  # noqa: ARG001
 ) -> None:
     """
     Test gdrive_doc_sync and gdrive_group_sync with real data from the test drive.
@@ -136,7 +136,7 @@ def test_gdrive_perm_sync_with_real_data(
     ):
         # Call the function under test
         def mock_fetch_all_docs_fn(
-            sort_order: SortOrder | None = None,
+            sort_order: SortOrder | None = None,  # noqa: ARG001
         ) -> list[DocumentRow]:
             return []
 

--- a/backend/tests/daily/connectors/google_drive/test_sections.py
+++ b/backend/tests/daily/connectors/google_drive/test_sections.py
@@ -13,7 +13,7 @@ from tests.daily.connectors.google_drive.consts_and_utils import SECTIONS_FOLDER
     return_value=None,
 )
 def test_google_drive_sections(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -119,7 +119,7 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     return_value=None,
 )
 def test_include_all(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_all")
@@ -198,7 +198,7 @@ def test_include_all(
     return_value=None,
 )
 def test_include_shared_drives_only_with_size_threshold(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_shared_drives_only_with_size_threshold")
@@ -255,7 +255,7 @@ def test_include_shared_drives_only_with_size_threshold(
     return_value=None,
 )
 def test_include_shared_drives_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_shared_drives_only")
@@ -325,7 +325,7 @@ def test_include_shared_drives_only(
     return_value=None,
 )
 def test_include_my_drives_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_include_my_drives_only")
@@ -377,7 +377,7 @@ def test_include_my_drives_only(
     return_value=None,
 )
 def test_drive_one_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_drive_one_only")
@@ -425,7 +425,7 @@ def test_drive_one_only(
     return_value=None,
 )
 def test_folder_and_shared_drive(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_folder_and_shared_drive")
@@ -493,7 +493,7 @@ def test_folder_and_shared_drive(
     return_value=None,
 )
 def test_folders_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_folders_only")
@@ -613,7 +613,7 @@ def test_shared_with_me(
     return_value=None,
 )
 def test_specific_emails(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_specific_emails")
@@ -644,7 +644,7 @@ def test_specific_emails(
     return_value=None,
 )
 def get_specific_folders_in_my_drive(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning get_specific_folders_in_my_drive")
@@ -674,7 +674,7 @@ def get_specific_folders_in_my_drive(
     return_value=None,
 )
 def test_specific_user_emails_restricted_folder(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_specific_user_emails_restricted_folder")
@@ -714,7 +714,7 @@ def test_specific_user_emails_restricted_folder(
     return_value=None,
 )
 def test_specific_user_email_shared_with_me(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_specific_user_email_shared_with_me")

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -67,7 +67,7 @@ def _check_for_error(
     return_value=None,
 )
 def test_all(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_all")
@@ -117,7 +117,7 @@ def test_all(
     return_value=None,
 )
 def test_shared_drives_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_shared_drives_only")
@@ -162,7 +162,7 @@ def test_shared_drives_only(
     return_value=None,
 )
 def test_shared_with_me_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_shared_with_me_only")
@@ -203,7 +203,7 @@ def test_shared_with_me_only(
     return_value=None,
 )
 def test_my_drive_only(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_my_drive_only")
@@ -241,7 +241,7 @@ def test_my_drive_only(
     return_value=None,
 )
 def test_shared_my_drive_folder(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_shared_my_drive_folder")
@@ -278,7 +278,7 @@ def test_shared_my_drive_folder(
     return_value=None,
 )
 def test_shared_drive_folder(
-    mock_get_api_key: MagicMock,
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_oauth_uploaded_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_shared_drive_folder")

--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -49,7 +49,7 @@ def highspot_connector() -> HighspotConnector:
     return_value=None,
 )
 def test_highspot_connector_basic(
-    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector
+    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector  # noqa: ARG001
 ) -> None:
     """Test basic functionality of the Highspot connector."""
     all_docs: list[Document] = []
@@ -90,7 +90,7 @@ def test_highspot_connector_basic(
     return_value=None,
 )
 def test_highspot_connector_slim(
-    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector
+    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector  # noqa: ARG001
 ) -> None:
     """Test slim document retrieval."""
     # Get all doc IDs from the full connector
@@ -123,7 +123,7 @@ def test_highspot_connector_slim(
     return_value=None,
 )
 def test_highspot_connector_poll_source(
-    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector
+    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector  # noqa: ARG001
 ) -> None:
     """Test poll_source functionality with date range filtering."""
     # Define date range: April 3, 2025 to April 4, 2025

--- a/backend/tests/daily/connectors/jira/test_jira_basic.py
+++ b/backend/tests/daily/connectors/jira/test_jira_basic.py
@@ -62,7 +62,9 @@ def jira_connector_with_jql() -> JiraConnector:
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,
 )
-def test_jira_connector_basic(reset: None, jira_connector: JiraConnector) -> None:
+def test_jira_connector_basic(
+    reset: None, jira_connector: JiraConnector  # noqa: ARG001
+) -> None:
     _test_jira_connector_basic(jira_connector)
 
 
@@ -71,7 +73,7 @@ def test_jira_connector_basic(reset: None, jira_connector: JiraConnector) -> Non
     return_value=None,
 )
 def test_jira_connector_basic_scoped(
-    reset: None, jira_connector_scoped: JiraConnector
+    reset: None, jira_connector_scoped: JiraConnector  # noqa: ARG001
 ) -> None:
     _test_jira_connector_basic(jira_connector_scoped)
 
@@ -164,7 +166,7 @@ def _test_jira_connector_basic(jira_connector: JiraConnector) -> None:
     return_value=None,
 )
 def test_jira_connector_with_jql(
-    reset: None, jira_connector_with_jql: JiraConnector
+    reset: None, jira_connector_with_jql: JiraConnector  # noqa: ARG001
 ) -> None:
     """Test that JQL query functionality works correctly.
 

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -123,7 +123,7 @@ def sharepoint_credentials() -> dict[str, str]:
 
 
 def test_sharepoint_connector_all_sites__docs_only(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -150,7 +150,7 @@ def test_sharepoint_connector_all_sites__docs_only(
 
 
 def test_sharepoint_connector_all_sites__pages_only(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -177,7 +177,7 @@ def test_sharepoint_connector_all_sites__pages_only(
 
 
 def test_sharepoint_connector_specific_folder(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -219,7 +219,7 @@ def test_sharepoint_connector_specific_folder(
 
 
 def test_sharepoint_connector_root_folder__docs_only(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -255,7 +255,7 @@ def test_sharepoint_connector_root_folder__docs_only(
 
 
 def test_sharepoint_connector_other_library(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -297,7 +297,7 @@ def test_sharepoint_connector_other_library(
 
 
 def test_sharepoint_connector_poll(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -339,7 +339,7 @@ def test_sharepoint_connector_poll(
 
 
 def test_sharepoint_connector_pages(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
@@ -442,7 +442,7 @@ def verify_hierarchy_nodes(
 
 
 def test_sharepoint_connector_hierarchy_nodes(
-    mock_get_unstructured_api_key: MagicMock,
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:

--- a/backend/tests/daily/connectors/teams/test_teams_connector.py
+++ b/backend/tests/daily/connectors/teams/test_teams_connector.py
@@ -179,7 +179,7 @@ def set_ee_on() -> Generator[None, None, None]:
 
 def test_load_from_checkpoint_with_perm_sync(
     teams_connector: TeamsConnector,
-    set_ee_on: None,
+    set_ee_on: None,  # noqa: ARG001
 ) -> None:
     """Test that load_from_checkpoint_with_perm_sync returns documents with external_access.
 

--- a/backend/tests/external_dependency_unit/answer/conftest.py
+++ b/backend/tests/external_dependency_unit/answer/conftest.py
@@ -46,8 +46,8 @@ def mock_nlp_embeddings_post() -> Iterator[None]:
     def _mock_post(
         url: str,
         json: Mapping[str, Any] | None = None,
-        headers: Mapping[str, str] | None = None,
-        **kwargs: Any,
+        headers: Mapping[str, str] | None = None,  # noqa: ARG001
+        **kwargs: Any,  # noqa: ARG001
     ) -> MagicMock:
         resp = MagicMock()
         if "encoder/bi-encoder-embed" in url:
@@ -89,7 +89,7 @@ def mock_file_store() -> Iterator[None]:
     """Mock the file store to avoid S3/storage dependencies in tests."""
     global _mock_file_id_counter
 
-    def _mock_save_file(*args: Any, **kwargs: Any) -> str:
+    def _mock_save_file(*args: Any, **kwargs: Any) -> str:  # noqa: ARG001
         global _mock_file_id_counter
         _mock_file_id_counter += 1
         # Return a predictable file ID for tests
@@ -108,10 +108,10 @@ def mock_file_store() -> Iterator[None]:
 
 @pytest.fixture
 def mock_external_deps(
-    mock_nlp_embeddings_post: None,
-    mock_gpu_status: None,
-    mock_vespa_query: None,
-    mock_file_store: None,
+    mock_nlp_embeddings_post: None,  # noqa: ARG001
+    mock_gpu_status: None,  # noqa: ARG001
+    mock_vespa_query: None,  # noqa: ARG001
+    mock_file_store: None,  # noqa: ARG001
 ) -> Iterator[None]:
     """Convenience fixture to enable all common external dependency mocks."""
     yield

--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -27,8 +27,8 @@ from tests.external_dependency_unit.conftest import create_test_user
 
 def test_answer_with_only_anthropic_provider(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     """Ensure chat still streams answers when only an Anthropic provider is configured."""
 

--- a/backend/tests/external_dependency_unit/answer/test_current_datetime_replacement.py
+++ b/backend/tests/external_dependency_unit/answer/test_current_datetime_replacement.py
@@ -18,7 +18,9 @@ from tests.external_dependency_unit.conftest import create_test_user
 
 
 def test_stream_chat_current_date_response(
-    db_session: Session, full_deployment_setup: None, mock_external_deps: None
+    db_session: Session,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     """Smoke test that asking for current date yields a streamed response.
 

--- a/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
+++ b/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
@@ -67,8 +67,8 @@ from tests.external_dependency_unit.mock_search_provider import use_mock_web_pro
 
 def test_stream_chat_with_answer(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     """Test that the stream chat with answer endpoint returns a valid answer."""
     ensure_default_llm_provider(db_session)
@@ -114,8 +114,8 @@ def test_stream_chat_with_answer(
 
 def test_stream_chat_with_answer_create_chat(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     ensure_default_llm_provider(db_session)
     test_user = create_test_user(
@@ -165,8 +165,8 @@ def test_stream_chat_with_answer_create_chat(
 
 def test_stream_chat_with_search_and_openurl_tools(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     ensure_default_llm_provider(db_session)
     test_user = create_test_user(
@@ -411,8 +411,8 @@ def test_stream_chat_with_search_and_openurl_tools(
 
 def test_image_generation_tool_no_reasoning(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     ensure_default_llm_provider(db_session)
     test_user = create_test_user(db_session, email_prefix="test_image_generation_tool")
@@ -538,8 +538,8 @@ def test_image_generation_tool_no_reasoning(
 
 def test_parallel_internal_and_web_search_tool_calls(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     """
     User asks a question

--- a/backend/tests/external_dependency_unit/answer/test_stream_chat_message_objects.py
+++ b/backend/tests/external_dependency_unit/answer/test_stream_chat_message_objects.py
@@ -24,8 +24,8 @@ from tests.external_dependency_unit.conftest import create_test_user
 @pytest.mark.skip(reason="Temporarily disabled")
 def test_stream_chat_message_objects_without_web_search(
     db_session: Session,
-    full_deployment_setup: None,
-    mock_external_deps: None,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
 ) -> None:
     """
     Test that when web search is requested but the persona has no web search tool,
@@ -37,8 +37,8 @@ def test_stream_chat_message_objects_without_web_search(
     def mock_post(
         url: str,
         json: dict[str, Any] | None = None,
-        headers: dict[str, str] | None = None,
-        **kwargs: Any,
+        headers: dict[str, str] | None = None,  # noqa: ARG001
+        **kwargs: Any,  # noqa: ARG001
     ) -> MagicMock:
         """Mock requests.post for model server embedding calls"""
         mock_response = MagicMock()

--- a/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
+++ b/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
@@ -160,13 +160,13 @@ class TestDocprocessingPriorityInDocumentExtraction:
     @patch("onyx.background.indexing.run_docfetching.cache_hierarchy_nodes_batch")
     def test_docprocessing_priority_based_on_last_successful_index_time(
         self,
-        mock_cache_hierarchy_nodes_batch: MagicMock,
+        mock_cache_hierarchy_nodes_batch: MagicMock,  # noqa: ARG002
         mock_get_node_id_from_raw_id: MagicMock,
         mock_get_source_node_id_from_cache: MagicMock,
         mock_ensure_source_node_exists: MagicMock,
         mock_get_redis_client: MagicMock,
         mock_get_latest_valid_checkpoint: MagicMock,
-        mock_save_checkpoint: MagicMock,
+        mock_save_checkpoint: MagicMock,  # noqa: ARG002
         mock_get_last_successful_attempt_poll_range_end: MagicMock,
         mock_get_recent_completed_attempts: MagicMock,
         mock_get_connector_runner: MagicMock,

--- a/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
@@ -114,7 +114,7 @@ class TestPerformExternalGroupSync:
         ]
 
         def mock_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             for group in mock_groups:
                 yield group
@@ -180,7 +180,7 @@ class TestPerformExternalGroupSync:
 
         # Initial sync with original groups
         def initial_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email, user2.email])
             yield ExternalUserGroup(id="group2", user_emails=[user2.email])
@@ -211,7 +211,7 @@ class TestPerformExternalGroupSync:
 
             # Updated sync with modified groups
             def updated_group_sync_func(
-                tenant_id: str, cc_pair: ConnectorCredentialPair
+                tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # group1 now has user1 and user3 (user2 removed, user3 added)
                 yield ExternalUserGroup(
@@ -274,7 +274,7 @@ class TestPerformExternalGroupSync:
 
         # Initial sync with multiple groups
         def initial_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email, user2.email])
             yield ExternalUserGroup(id="group2", user_emails=[user1.email])
@@ -310,7 +310,7 @@ class TestPerformExternalGroupSync:
 
             # Updated sync with only one group remaining
             def updated_group_sync_func(
-                tenant_id: str, cc_pair: ConnectorCredentialPair
+                tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # Only group1 remains, group2 and public_group are removed
                 yield ExternalUserGroup(
@@ -356,7 +356,7 @@ class TestPerformExternalGroupSync:
 
         # Initial sync with groups
         def initial_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email])
 
@@ -381,7 +381,7 @@ class TestPerformExternalGroupSync:
 
             # Updated sync with no groups
             def empty_group_sync_func(
-                tenant_id: str, cc_pair: ConnectorCredentialPair
+                tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # No groups yielded
                 return
@@ -411,7 +411,7 @@ class TestPerformExternalGroupSync:
 
         # Create a large group with many users
         def large_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(
                 id="large_group", user_emails=[user.email for user in users]
@@ -448,7 +448,7 @@ class TestPerformExternalGroupSync:
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         def mixed_group_sync_func(
-            tenant_id: str, cc_pair: ConnectorCredentialPair
+            tenant_id: str, cc_pair: ConnectorCredentialPair  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(
                 id="regular_group", user_emails=[user1.email, user2.email]

--- a/backend/tests/external_dependency_unit/connectors/jira/test_jira_doc_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/jira/test_jira_doc_sync.py
@@ -95,7 +95,7 @@ def test_jira_doc_sync(
 
         # Mock functions - we don't have existing docs in the test DB
         def fetch_all_existing_docs_fn(
-            sort_order: SortOrder | None = None,
+            sort_order: SortOrder | None = None,  # noqa: ARG001
         ) -> list[DocumentRow]:
             return []
 
@@ -191,7 +191,7 @@ def test_jira_doc_sync_with_specific_permissions(
 
         # Mock functions
         def fetch_all_existing_docs_fn(
-            sort_order: SortOrder | None = None,
+            sort_order: SortOrder | None = None,  # noqa: ARG001
         ) -> list[DocumentRow]:
             return []
 

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -36,7 +36,7 @@ def tenant_context() -> Generator[None, None, None]:
 
 
 @pytest.fixture(scope="function")
-def test_user(db_session: Session, tenant_context: None) -> User:
+def test_user(db_session: Session, tenant_context: None) -> User:  # noqa: ARG001
     """Create a test user for build session tests."""
     unique_email = f"build_test_{uuid4().hex[:8]}@example.com"
 
@@ -61,7 +61,7 @@ def test_user(db_session: Session, tenant_context: None) -> User:
 
 @pytest.fixture(scope="function")
 def build_session(
-    db_session: Session, test_user: User, tenant_context: None
+    db_session: Session, test_user: User, tenant_context: None  # noqa: ARG001
 ) -> BuildSession:
     """Create a test build session."""
     session = BuildSession(

--- a/backend/tests/external_dependency_unit/craft/test_build_packet_storage.py
+++ b/backend/tests/external_dependency_unit/craft/test_build_packet_storage.py
@@ -26,7 +26,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test creating a message with JSON metadata and turn_index."""
         user_message_metadata = {
@@ -54,7 +54,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test creating multiple messages with correct turn_index values."""
         # First user message (turn 0)
@@ -120,7 +120,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test storing only completed tool calls."""
         # Create a user message first
@@ -162,7 +162,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test upserting agent plan - only latest should be kept."""
         # Create a user message first
@@ -229,7 +229,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test upserting agent plan when we don't know the existing ID."""
         # Create a user message first
@@ -277,7 +277,7 @@ class TestBuildMessageStorage:
         self,
         db_session: Session,
         build_session: BuildSession,
-        tenant_context: None,
+        tenant_context: None,  # noqa: ARG002
     ) -> None:
         """Test that streaming flow creates correct number of DB messages.
 

--- a/backend/tests/external_dependency_unit/craft/test_file_upload.py
+++ b/backend/tests/external_dependency_unit/craft/test_file_upload.py
@@ -30,7 +30,9 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(scope="function")
-def sandbox(db_session: Session, test_user: User, tenant_context: None) -> Sandbox:
+def sandbox(
+    db_session: Session, test_user: User, tenant_context: None  # noqa: ARG001
+) -> Sandbox:
     """Create a test sandbox for the user (sandboxes are per-user, not per-session)."""
     sandbox = Sandbox(
         id=uuid4(),
@@ -45,7 +47,10 @@ def sandbox(db_session: Session, test_user: User, tenant_context: None) -> Sandb
 
 @pytest.fixture(scope="function")
 def build_session_with_user(
-    db_session: Session, test_user: User, sandbox: Sandbox, tenant_context: None
+    db_session: Session,
+    test_user: User,
+    sandbox: Sandbox,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
 ) -> BuildSession:
     """Create a test build session for a user who has a sandbox."""
     session = BuildSession(
@@ -123,7 +128,7 @@ class TestFileUpload:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -146,7 +151,7 @@ class TestFileUpload:
     def test_upload_file_session_not_found(
         self,
         test_user: User,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         session_manager_with_mock: "SessionManager",
     ) -> None:
         """Test that uploading to a non-existent session raises ValueError."""
@@ -166,7 +171,7 @@ class TestFileUploadLimits:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -193,7 +198,7 @@ class TestFileUploadLimits:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -218,7 +223,7 @@ class TestFileUploadLimits:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -272,7 +277,7 @@ class TestFileDelete:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -290,7 +295,7 @@ class TestFileDelete:
     def test_delete_file_session_not_found(
         self,
         test_user: User,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         session_manager_with_mock: "SessionManager",
     ) -> None:
         """Test that deleting from a non-existent session raises ValueError."""
@@ -309,7 +314,7 @@ class TestPathSanitization:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -330,7 +335,7 @@ class TestPathSanitization:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -350,7 +355,7 @@ class TestPathSanitization:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -381,7 +386,7 @@ class TestPathSanitization:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -405,7 +410,7 @@ class TestFilenameCollision:
         self,
         test_user: User,
         build_session_with_user: BuildSession,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         mock_sandbox_manager: MagicMock,
         session_manager_with_mock: "SessionManager",
     ) -> None:
@@ -457,7 +462,7 @@ class TestGetUploadStats:
     def test_get_upload_stats_session_not_found(
         self,
         test_user: User,
-        sandbox: Sandbox,
+        sandbox: Sandbox,  # noqa: ARG002
         session_manager_with_mock: "SessionManager",
     ) -> None:
         """Test that getting stats for non-existent session raises ValueError."""

--- a/backend/tests/external_dependency_unit/db/test_tag_race_condition.py
+++ b/backend/tests/external_dependency_unit/db/test_tag_race_condition.py
@@ -41,7 +41,7 @@ class TestTagRaceCondition:
     """Tests for tag creation race condition handling."""
 
     def test_concurrent_tag_creation_single_tag(
-        self, db_session: Session, tenant_context: None
+        self, db_session: Session, tenant_context: None  # noqa: ARG002
     ) -> None:
         """
         Test that multiple concurrent calls to create_or_add_document_tag
@@ -119,7 +119,7 @@ class TestTagRaceCondition:
         assert len(tag_count) == 1, f"Expected 1 tag, found {len(tag_count)}"
 
     def test_concurrent_tag_list_creation(
-        self, db_session: Session, tenant_context: None
+        self, db_session: Session, tenant_context: None  # noqa: ARG002
     ) -> None:
         """
         Test that multiple concurrent calls to create_or_add_document_tag_list
@@ -197,7 +197,7 @@ class TestTagRaceCondition:
         ), f"Expected {len(test_tag_values)} tags, found {len(tags)}"
 
     def test_concurrent_mixed_tag_operations(
-        self, db_session: Session, tenant_context: None
+        self, db_session: Session, tenant_context: None  # noqa: ARG002
     ) -> None:
         """
         Test that concurrent single tag and tag list operations on the same

--- a/backend/tests/external_dependency_unit/discord_bot/test_discord_events.py
+++ b/backend/tests/external_dependency_unit/discord_bot/test_discord_events.py
@@ -242,7 +242,7 @@ class TestGuildRegistrationCommand:
     @pytest.mark.asyncio
     async def test_register_syncs_forum_channels(
         self,
-        mock_discord_message: MagicMock,
+        mock_discord_message: MagicMock,  # noqa: ARG002
         mock_discord_guild: MagicMock,
     ) -> None:
         """Forum channels are included in sync."""
@@ -254,7 +254,7 @@ class TestGuildRegistrationCommand:
     @pytest.mark.asyncio
     async def test_register_private_channel_detection(
         self,
-        mock_discord_message: MagicMock,
+        mock_discord_message: MagicMock,  # noqa: ARG002
         mock_discord_guild: MagicMock,
     ) -> None:
         """Private channels are marked correctly."""
@@ -441,7 +441,7 @@ class TestThreadCreationAndResponseRouting:
     @pytest.mark.asyncio
     async def test_response_in_existing_thread(
         self,
-        mock_bot_user: MagicMock,
+        mock_bot_user: MagicMock,  # noqa: ARG002
     ) -> None:
         """Message in thread - response appended to thread."""
         thread = MagicMock(spec=discord.Thread)
@@ -462,7 +462,7 @@ class TestThreadCreationAndResponseRouting:
     async def test_response_creates_thread_thread_only_mode(
         self,
         mock_discord_message: MagicMock,
-        mock_bot_user: MagicMock,
+        mock_bot_user: MagicMock,  # noqa: ARG002
     ) -> None:
         """thread_only_mode=true creates new thread for response."""
         mock_thread = MagicMock()
@@ -483,7 +483,7 @@ class TestThreadCreationAndResponseRouting:
     async def test_response_replies_inline(
         self,
         mock_discord_message: MagicMock,
-        mock_bot_user: MagicMock,
+        mock_bot_user: MagicMock,  # noqa: ARG002
     ) -> None:
         """thread_only_mode=false uses message.reply()."""
         # Make sure it's not a thread
@@ -498,7 +498,7 @@ class TestThreadCreationAndResponseRouting:
     @pytest.mark.asyncio
     async def test_thread_name_truncation(
         self,
-        mock_bot_user: MagicMock,
+        mock_bot_user: MagicMock,  # noqa: ARG002
     ) -> None:
         """Thread name is truncated to 100 chars."""
         msg = MagicMock(spec=discord.Message)
@@ -546,7 +546,9 @@ class TestBotLifecycle:
         from onyx.onyxbot.discord.client import OnyxDiscordClient
 
         with (
-            patch.object(OnyxDiscordClient, "__init__", lambda self: None),
+            patch.object(
+                OnyxDiscordClient, "__init__", lambda self: None  # noqa: ARG005
+            ),
             patch(
                 "onyx.onyxbot.discord.client.DiscordCacheManager",
                 return_value=mock_cache_manager,
@@ -575,7 +577,11 @@ class TestBotLifecycle:
         """setup_hook calls api_client.initialize()."""
         from onyx.onyxbot.discord.client import OnyxDiscordClient
 
-        with (patch.object(OnyxDiscordClient, "__init__", lambda self: None),):
+        with (
+            patch.object(
+                OnyxDiscordClient, "__init__", lambda self: None  # noqa: ARG005
+            ),
+        ):
             bot = OnyxDiscordClient()
             bot.cache = mock_cache_manager
             bot.api_client = mock_api_client
@@ -596,7 +602,9 @@ class TestBotLifecycle:
         from onyx.onyxbot.discord.client import OnyxDiscordClient
 
         with (
-            patch.object(OnyxDiscordClient, "__init__", lambda self: None),
+            patch.object(
+                OnyxDiscordClient, "__init__", lambda self: None  # noqa: ARG005
+            ),
             patch.object(OnyxDiscordClient, "is_closed", return_value=True),
         ):
             bot = OnyxDiscordClient()

--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -109,7 +109,9 @@ def _get_all_backend_configs() -> List[BackendConfig]:
     ids=lambda config: config["backend_name"],
 )
 def file_store(
-    request: pytest.FixtureRequest, db_session: Session, tenant_context: None
+    request: pytest.FixtureRequest,
+    db_session: Session,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
 ) -> Generator[S3BackedFileStore, None, None]:
     """Create an S3BackedFileStore instance for testing with parametrized backend"""
     backend_config: BackendConfig = request.param

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider.py
@@ -79,7 +79,7 @@ class TestLLMConfigurationEndpoint:
     def test_successful_llm_test_with_new_provider(
         self,
         db_session: Session,
-        provider_name: str,
+        provider_name: str,  # noqa: ARG002
     ) -> None:
         """
         Test that a successful LLM test returns normally (no exception).
@@ -130,7 +130,7 @@ class TestLLMConfigurationEndpoint:
     def test_failed_llm_test_raises_http_exception(
         self,
         db_session: Session,
-        provider_name: str,
+        provider_name: str,  # noqa: ARG002
     ) -> None:
         """
         Test that a failed LLM test raises an HTTPException with status 400.
@@ -140,7 +140,7 @@ class TestLLMConfigurationEndpoint:
         """
         error_message = "Invalid API key: Authentication failed"
 
-        def mock_test_llm_failure(llm: LLM) -> str | None:
+        def mock_test_llm_failure(llm: LLM) -> str | None:  # noqa: ARG001
             """Mock test_llm that always fails."""
             return error_message
 
@@ -581,7 +581,7 @@ class TestDefaultProviderEndpoint:
         provider_name = f"test-provider-{uuid4().hex[:8]}"
         error_message = "Connection to LLM provider failed"
 
-        def mock_test_llm_failure(llm: LLM) -> str | None:
+        def mock_test_llm_failure(llm: LLM) -> str | None:  # noqa: ARG001
             """Mock test_llm that always fails."""
             return error_message
 

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -151,7 +151,7 @@ def _validate_vertex_credentials_file(credentials_path: Path) -> None:
     reason="OpenAI API key not available",
 )
 def test_openai_prompt_caching_reduces_costs(
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     """Test that OpenAI prompt caching reduces costs on subsequent calls.
 
@@ -275,7 +275,7 @@ def test_openai_prompt_caching_reduces_costs(
     reason="Anthropic API key not available",
 )
 def test_anthropic_prompt_caching_reduces_costs(
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     """Test that Anthropic prompt caching reduces costs on subsequent calls.
 
@@ -399,7 +399,7 @@ def test_anthropic_prompt_caching_reduces_costs(
 )
 @pytest.mark.skip(reason="Vertex AI prompt caching is disabled for now")
 def test_google_genai_prompt_caching_reduces_costs(
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     """Test that Litellm Gemini prompt caching reduces costs on subsequent calls.
 
@@ -574,7 +574,7 @@ def test_google_genai_prompt_caching_reduces_costs(
     reason="OpenAI API key not available",
 )
 def test_prompt_caching_with_conversation_history(
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     """Test that prompt caching works with multi-turn conversations.
 
@@ -689,7 +689,7 @@ def test_prompt_caching_with_conversation_history(
     reason="OpenAI API key not available",
 )
 def test_no_caching_without_process_with_prompt_cache(
-    db_session: Session,
+    db_session: Session,  # noqa: ARG001
 ) -> None:
     """Test baseline: without using process_with_prompt_cache, no special caching occurs.
 

--- a/backend/tests/external_dependency_unit/mock_image_provider.py
+++ b/backend/tests/external_dependency_unit/mock_image_provider.py
@@ -44,7 +44,7 @@ class MockImageGenerationProvider(
     @classmethod
     def validate_credentials(
         cls,
-        credentials: ImageGenerationProviderCredentials,
+        credentials: ImageGenerationProviderCredentials,  # noqa: ARG003
     ) -> bool:
         return True
 
@@ -58,11 +58,11 @@ class MockImageGenerationProvider(
     def generate_image(
         self,
         prompt: str,
-        model: str,
-        size: str,
-        n: int,
-        quality: str | None = None,
-        **kwargs: Any,
+        model: str,  # noqa: ARG002
+        size: str,  # noqa: ARG002
+        n: int,  # noqa: ARG002
+        quality: str | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
     ) -> ImageResponse:
         image_data = self._images.pop(0)
         delay = self._delays.pop(0)

--- a/backend/tests/external_dependency_unit/mock_llm.py
+++ b/backend/tests/external_dependency_unit/mock_llm.py
@@ -315,14 +315,14 @@ class MockLLM(LLM, MockLLMController):
 
     def stream(
         self,
-        prompt: LanguageModelInput,
-        tools: list[dict] | None = None,
-        tool_choice: ToolChoiceOptions | None = None,
-        structured_response_format: dict | None = None,
-        timeout_override: int | None = None,
-        max_tokens: int | None = None,
-        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
-        user_identity: LLMUserIdentity | None = None,
+        prompt: LanguageModelInput,  # noqa: ARG002
+        tools: list[dict] | None = None,  # noqa: ARG002
+        tool_choice: ToolChoiceOptions | None = None,  # noqa: ARG002
+        structured_response_format: dict | None = None,  # noqa: ARG002
+        timeout_override: int | None = None,  # noqa: ARG002
+        max_tokens: int | None = None,  # noqa: ARG002
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,  # noqa: ARG002
+        user_identity: LLMUserIdentity | None = None,  # noqa: ARG002
     ) -> Iterator[ModelResponseStream]:
         if not self.stream_controller:
             return

--- a/backend/tests/external_dependency_unit/mock_search_pipeline.py
+++ b/backend/tests/external_dependency_unit/mock_search_pipeline.py
@@ -20,9 +20,9 @@ from onyx.llm.interfaces import LLM
 def run_functions_tuples_sequential(
     functions_with_args: list[tuple[Callable, tuple]],
     allow_failures: bool = False,
-    max_workers: int | None = None,
-    timeout: float | None = None,
-    timeout_callback: Callable | None = None,
+    max_workers: int | None = None,  # noqa: ARG001
+    timeout: float | None = None,  # noqa: ARG001
+    timeout_callback: Callable | None = None,  # noqa: ARG001
 ) -> list[Any]:
     """
     A sequential replacement for run_functions_tuples_in_parallel.
@@ -112,29 +112,33 @@ def use_mock_search_pipeline(
     """
     controller = SearchPipelineController()
 
-    def mock_check_connectors_exist(db_session: Session) -> bool:
+    def mock_check_connectors_exist(db_session: Session) -> bool:  # noqa: ARG001
         return len(connectors) > 0
 
-    def mock_check_federated_connectors_exist(db_session: Session) -> bool:
+    def mock_check_federated_connectors_exist(
+        db_session: Session,  # noqa: ARG001
+    ) -> bool:
         # For now, federated connectors are not mocked as available
         return False
 
-    def mock_check_user_files_exist(db_session: Session) -> bool:
+    def mock_check_user_files_exist(db_session: Session) -> bool:  # noqa: ARG001
         # For now, user files are not mocked as available
         return False
 
-    def mock_fetch_unique_document_sources(db_session: Session) -> list[DocumentSource]:
+    def mock_fetch_unique_document_sources(
+        db_session: Session,  # noqa: ARG001
+    ) -> list[DocumentSource]:
         return connectors
 
     def override_search_pipeline(
         chunk_search_request: ChunkSearchRequest,
-        document_index: DocumentIndex,
-        user: User | None,
-        persona: Persona | None,
-        db_session: Session,
-        auto_detect_filters: bool = False,
-        llm: LLM | None = None,
-        project_id: int | None = None,
+        document_index: DocumentIndex,  # noqa: ARG001
+        user: User | None,  # noqa: ARG001
+        persona: Persona | None,  # noqa: ARG001
+        db_session: Session,  # noqa: ARG001
+        auto_detect_filters: bool = False,  # noqa: ARG001
+        llm: LLM | None = None,  # noqa: ARG001
+        project_id: int | None = None,  # noqa: ARG001
     ) -> list[InferenceChunk]:
         return controller.get_search_results(chunk_search_request.query)
 

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -122,7 +122,9 @@ def opensearch_available() -> None:
 
 
 @pytest.fixture(scope="function")
-def test_client(opensearch_available: None) -> Generator[OpenSearchClient, None, None]:
+def test_client(
+    opensearch_available: None,  # noqa: ARG001
+) -> Generator[OpenSearchClient, None, None]:
     """Creates an OpenSearch client for testing with automatic cleanup."""
     test_index_name = f"test_index_{uuid.uuid4().hex[:8]}"
     client = OpenSearchClient(index_name=test_index_name)
@@ -586,7 +588,7 @@ class TestOpenSearchClient:
     def test_hybrid_search_with_pipeline(
         self,
         test_client: OpenSearchClient,
-        search_pipeline: None,
+        search_pipeline: None,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Tests hybrid search with a normalization pipeline."""
@@ -668,7 +670,7 @@ class TestOpenSearchClient:
     def test_search_empty_index(
         self,
         test_client: OpenSearchClient,
-        search_pipeline: None,
+        search_pipeline: None,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Tests search on an empty index returns an empty list."""
@@ -708,7 +710,7 @@ class TestOpenSearchClient:
     def test_hybrid_search_with_pipeline_and_filters(
         self,
         test_client: OpenSearchClient,
-        search_pipeline: None,
+        search_pipeline: None,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
@@ -829,7 +831,7 @@ class TestOpenSearchClient:
     def test_hybrid_search_with_pipeline_and_filters_returns_chunks_with_related_content_first(
         self,
         test_client: OpenSearchClient,
-        search_pipeline: None,
+        search_pipeline: None,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
@@ -1226,7 +1228,7 @@ class TestOpenSearchClient:
     def test_time_cutoff_filter(
         self,
         test_client: OpenSearchClient,
-        search_pipeline: None,
+        search_pipeline: None,  # noqa: ARG002
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Tests the time cutoff filter works."""

--- a/backend/tests/external_dependency_unit/opensearch_migration/test_opensearch_migration_tasks.py
+++ b/backend/tests/external_dependency_unit/opensearch_migration/test_opensearch_migration_tasks.py
@@ -251,7 +251,7 @@ def full_deployment_setup() -> Generator[None, None, None]:
 
 @pytest.fixture(scope="module")
 def db_session(
-    full_deployment_setup: None,
+    full_deployment_setup: None,  # noqa: ARG001
 ) -> Generator[Session, None, None]:
     """
     NOTE: We deliberately duplicate this logic from
@@ -267,7 +267,7 @@ def db_session(
 @pytest.fixture(scope="module")
 def vespa_document_index(
     db_session: Session,
-    full_deployment_setup: None,
+    full_deployment_setup: None,  # noqa: ARG001
 ) -> Generator[VespaDocumentIndex, None, None]:
     """Creates a Vespa document index for the test tenant."""
     active = get_active_search_settings(db_session)
@@ -281,7 +281,7 @@ def vespa_document_index(
 @pytest.fixture(scope="module")
 def opensearch_client(
     db_session: Session,
-    full_deployment_setup: None,
+    full_deployment_setup: None,  # noqa: ARG001
 ) -> Generator[OpenSearchClient, None, None]:
     """Creates an OpenSearch client for the test tenant."""
     active = get_active_search_settings(db_session)
@@ -300,7 +300,7 @@ def opensearch_available(
 
 @pytest.fixture(scope="module")
 def vespa_available(
-    full_deployment_setup: None,
+    full_deployment_setup: None,  # noqa: ARG001
 ) -> Generator[None, None, None]:
     """Verifies Vespa is running, fails the test if not."""
     # Try 90 seconds for testing in CI.
@@ -398,8 +398,8 @@ class TestCheckForDocumentsForOpenSearchMigrationTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that migration records are created for documents in the DB."""
         # Under test.
@@ -425,8 +425,8 @@ class TestCheckForDocumentsForOpenSearchMigrationTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that pagination picks up from the last migrated document ID."""
         # Precondition.
@@ -461,8 +461,8 @@ class TestCheckForDocumentsForOpenSearchMigrationTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """
         Tests that task runs successfully when all documents already have
@@ -483,7 +483,7 @@ class TestCheckForDocumentsForOpenSearchMigrationTask:
 
     def test_returns_none_when_feature_disabled(
         self,
-        disable_opensearch_indexing_for_onyx: None,
+        disable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that task returns None when feature is disabled."""
         # Under test.
@@ -498,8 +498,8 @@ class TestCheckForDocumentsForOpenSearchMigrationTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that counter increments when no records to populate."""
         # Precondition.
@@ -536,10 +536,10 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
         vespa_document_index: VespaDocumentIndex,
         opensearch_client: OpenSearchClient,
         test_embedding_dimension: int,
-        clean_migration_tables: None,
-        clean_vespa: None,
-        clean_opensearch: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        clean_vespa: None,  # noqa: ARG002
+        clean_opensearch: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests successful migration of a document from Vespa to OpenSearch."""
         # Precondition.
@@ -605,10 +605,10 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
         vespa_document_index: VespaDocumentIndex,
         opensearch_client: OpenSearchClient,
         test_embedding_dimension: int,
-        clean_migration_tables: None,
-        clean_vespa: None,
-        clean_opensearch: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        clean_vespa: None,  # noqa: ARG002
+        clean_opensearch: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that documents are marked as FAILED when migration fails."""
         # Precondition.
@@ -688,8 +688,8 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """
         Tests that documents are marked as PERMANENTLY_FAILED after max
@@ -734,8 +734,8 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
         self,
         db_session: Session,
         test_documents: list[Document],
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that migration fails if document has no chunk_count."""
         # Precondition.
@@ -770,7 +770,7 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
 
     def test_returns_none_when_feature_disabled(
         self,
-        disable_opensearch_indexing_for_onyx: None,
+        disable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that task returns None when feature is disabled."""
         # Under test.
@@ -784,8 +784,8 @@ class TestMigrateDocumentsFromVespaToOpenSearchTask:
     def test_increments_counter_when_no_documents_to_migrate(
         self,
         db_session: Session,
-        clean_migration_tables: None,
-        enable_opensearch_indexing_for_onyx: None,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
     ) -> None:
         """Tests that counter increments when no documents need migration."""
         # Precondition.

--- a/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
+++ b/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
@@ -1,3 +1,5 @@
+# NOTE: ruff and black disagree after applying this noqa, so we just set file-level.
+# ruff: noqa: ARG005
 import os
 from typing import Any
 from unittest.mock import MagicMock
@@ -104,7 +106,7 @@ def _create_mock_slack_request(
 
 
 def _create_mock_slack_client(
-    channel_id: str = "C1234567890", slack_bot_id: int = 12345
+    channel_id: str = "C1234567890", slack_bot_id: int = 12345  # noqa: ARG001
 ) -> Mock:
     """Create a mock Slack client"""
     mock_client = Mock()
@@ -309,7 +311,7 @@ class TestSlackBotFederatedSearch:
         mock_get_query_embeddings.return_value = [[0.1] * 768]  # 768-dimensional vector
 
     def _setup_slack_api_mocks(
-        self, mock_search_messages: Mock, mock_conversations_info: Mock
+        self, mock_search_messages: Mock, mock_conversations_info: Mock  # noqa: ARG002
     ) -> None:
         """Setup Slack API mocks to return controlled data for testing filtering"""
         mock_search_response = Mock()
@@ -359,15 +361,15 @@ class TestSlackBotFederatedSearch:
         from onyx.context.search.federated.slack_search import SlackQueryResult
 
         def mock_query_slack_capture_params(
-            query_string: str,
-            access_token: str,
-            limit: int | None = None,
+            query_string: str,  # noqa: ARG001
+            access_token: str,  # noqa: ARG001
+            limit: int | None = None,  # noqa: ARG001
             allowed_private_channel: str | None = None,
-            bot_token: str | None = None,
+            bot_token: str | None = None,  # noqa: ARG001
             include_dm: bool = False,
-            entities: dict | None = None,
-            available_channels: list | None = None,
-            channel_metadata_dict: dict | None = None,
+            entities: dict | None = None,  # noqa: ARG001
+            available_channels: list | None = None,  # noqa: ARG001
+            channel_metadata_dict: dict | None = None,  # noqa: ARG001
         ) -> SlackQueryResult:
             self._captured_filtering_params = {
                 "allowed_private_channel": allowed_private_channel,
@@ -380,12 +382,12 @@ class TestSlackBotFederatedSearch:
         mock_query_slack.side_effect = mock_query_slack_capture_params
 
     def _setup_channel_type_mock(
-        self, mock_get_channel_type_from_id: Mock, channel_name: str
+        self, mock_get_channel_type_from_id: Mock, channel_name: str  # noqa: ARG002
     ) -> None:
         """Setup get_channel_type_from_id mock to return correct channel types"""
 
         def mock_channel_type_response(
-            web_client: Mock, channel_id: str
+            web_client: Mock, channel_id: str  # noqa: ARG001
         ) -> ChannelType:
             if channel_id == "C1234567890":  # general - public
                 return ChannelType.PUBLIC_CHANNEL
@@ -435,7 +437,10 @@ class TestSlackBotFederatedSearch:
         "onyx.document_index.vespa.index.VespaIndex.hybrid_retrieval", return_value=[]
     )
     def test_slack_bot_public_channel_filtering(
-        self, mock_vespa: Mock, mock_gpu_status: Mock, db_session: Session
+        self,
+        mock_vespa: Mock,  # noqa: ARG002
+        mock_gpu_status: Mock,  # noqa: ARG002
+        db_session: Session,
     ) -> None:
         """Test that slack bot in public channel sees only public channel messages"""
         self._setup_llm_provider(db_session)
@@ -490,7 +495,10 @@ class TestSlackBotFederatedSearch:
         "onyx.document_index.vespa.index.VespaIndex.hybrid_retrieval", return_value=[]
     )
     def test_slack_bot_private_channel_filtering(
-        self, mock_vespa: Mock, mock_gpu_status: Mock, db_session: Session
+        self,
+        mock_vespa: Mock,  # noqa: ARG002
+        mock_gpu_status: Mock,  # noqa: ARG002
+        db_session: Session,
     ) -> None:
         """Test that slack bot in private channel sees private + public channel messages"""
         self._setup_llm_provider(db_session)
@@ -545,7 +553,10 @@ class TestSlackBotFederatedSearch:
         "onyx.document_index.vespa.index.VespaIndex.hybrid_retrieval", return_value=[]
     )
     def test_slack_bot_dm_filtering(
-        self, mock_vespa: Mock, mock_gpu_status: Mock, db_session: Session
+        self,
+        mock_vespa: Mock,  # noqa: ARG002
+        mock_gpu_status: Mock,  # noqa: ARG002
+        db_session: Session,
     ) -> None:
         """Test that slack bot in DM sees all messages (no filtering)"""
         self._setup_llm_provider(db_session)
@@ -612,7 +623,9 @@ def test_missing_scope_resilience(
     # Track which channel types were attempted
     attempted_types: list[str] = []
 
-    def mock_conversations_list(types: str | None = None, **kwargs: Any) -> MagicMock:
+    def mock_conversations_list(
+        types: str | None = None, **kwargs: Any  # noqa: ARG001
+    ) -> MagicMock:
         if types:
             attempted_types.append(types)
 
@@ -700,7 +713,9 @@ def test_multiple_missing_scopes_resilience(
     # Track attempts
     attempted_types: list[str] = []
 
-    def mock_conversations_list(types: str | None = None, **kwargs: Any) -> MagicMock:
+    def mock_conversations_list(
+        types: str | None = None, **kwargs: Any  # noqa: ARG001
+    ) -> MagicMock:
         if types:
             attempted_types.append(types)
 

--- a/backend/tests/external_dependency_unit/tools/test_mcp_passthrough_oauth.py
+++ b/backend/tests/external_dependency_unit/tools/test_mcp_passthrough_oauth.py
@@ -373,11 +373,11 @@ class TestMCPPassThroughOAuth:
         mocked_response = {"result": "mocked_response"}
 
         def mock_call_mcp_tool(
-            server_url: str,
-            tool_name: str,
-            kwargs: dict[str, Any],
+            server_url: str,  # noqa: ARG001
+            tool_name: str,  # noqa: ARG001
+            kwargs: dict[str, Any],  # noqa: ARG001
             connection_headers: dict[str, str],
-            transport: MCPTransport,
+            transport: MCPTransport,  # noqa: ARG001
         ) -> dict[str, Any]:
             captured_headers.update(connection_headers)
             return mocked_response

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -84,7 +84,7 @@ def reset() -> None:
 
 
 @pytest.fixture
-def new_admin_user(reset: None) -> DATestUser | None:
+def new_admin_user(reset: None) -> DATestUser | None:  # noqa: ARG001
     try:
         return UserManager.create(name=ADMIN_USER_NAME)
     except Exception:
@@ -132,7 +132,7 @@ def admin_user() -> DATestUser:
 def basic_user(
     # make sure the admin user exists first to ensure this new user
     # gets the BASIC role
-    admin_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
 ) -> DATestUser:
     try:
         user = UserManager.create(name=BASIC_USER_NAME)
@@ -221,11 +221,13 @@ def document_builder(admin_user: DATestUser) -> DocumentBuilderType:
     return _document_builder
 
 
-def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+def pytest_runtest_logstart(
+    nodeid: str, location: tuple[str, int | None, str]  # noqa: ARG001
+) -> None:
     print(f"\nTest start: {nodeid}")
 
 
 def pytest_runtest_logfinish(
-    nodeid: str, location: tuple[str, int | None, str]
+    nodeid: str, location: tuple[str, int | None, str]  # noqa: ARG001
 ) -> None:
     print(f"\nTest end: {nodeid}")

--- a/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
+++ b/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
@@ -131,7 +131,9 @@ class GoogleDriveManager:
         ).execute()
 
     @staticmethod
-    def remove_file_permissions(drive_service: Any, file_id: str, email: str) -> None:
+    def remove_file_permissions(
+        drive_service: Any, file_id: str, email: str  # noqa: ARG004
+    ) -> None:
         permissions = (
             drive_service.permissions()
             .list(fileId=file_id, supportsAllDrives=True)

--- a/backend/tests/integration/connector_job_tests/google/test_google_drive_permission_sync.py
+++ b/backend/tests/integration/connector_job_tests/google/test_google_drive_permission_sync.py
@@ -108,8 +108,8 @@ def google_drive_test_env_setup() -> Generator[
 
 @pytest.mark.xfail(reason="Needs to be tested for flakiness")
 def test_google_permission_sync(
-    reset: None,
-    vespa_client: vespa_fixture,
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,  # noqa: ARG001
     google_drive_test_env_setup: tuple[
         GoogleDriveService, str, DATestCCPair, DATestUser, DATestUser, DATestUser
     ],

--- a/backend/tests/integration/connector_job_tests/jira/test_jira_permission_sync_full.py
+++ b/backend/tests/integration/connector_job_tests/jira/test_jira_permission_sync_full.py
@@ -14,7 +14,7 @@ from tests.integration.connector_job_tests.jira.conftest import JiraTestEnvSetup
 )
 @pytest.mark.xfail(reason="Needs to be tested for flakiness")
 def test_jira_permission_sync_full(
-    reset: None,
+    reset: None,  # noqa: ARG001
     jira_test_env_setup: JiraTestEnvSetupTuple,
 ) -> None:
     (

--- a/backend/tests/integration/connector_job_tests/slack/test_permission_sync.py
+++ b/backend/tests/integration/connector_job_tests/slack/test_permission_sync.py
@@ -32,8 +32,8 @@ from tests.integration.connector_job_tests.slack.slack_api_utils import SlackMan
     reason="Permission tests are enterprise only",
 )
 def test_slack_permission_sync(
-    reset: None,
-    vespa_client: vespa_fixture,
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,  # noqa: ARG001
     slack_test_setup: tuple[ChannelType, ChannelType],
 ) -> None:
     public_channel, private_channel = slack_test_setup
@@ -233,8 +233,8 @@ def test_slack_permission_sync(
     reason="Permission tests are enterprise only",
 )
 def test_slack_group_permission_sync(
-    reset: None,
-    vespa_client: vespa_fixture,
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,  # noqa: ARG001
     slack_test_setup: tuple[ChannelType, ChannelType],
 ) -> None:
     """

--- a/backend/tests/integration/connector_job_tests/slack/test_prune.py
+++ b/backend/tests/integration/connector_job_tests/slack/test_prune.py
@@ -26,8 +26,8 @@ from tests.integration.connector_job_tests.slack.slack_api_utils import SlackMan
 
 @pytest.mark.xfail(reason="flaky - see DAN-986 for details", strict=False)
 def test_slack_prune(
-    reset: None,
-    vespa_client: vespa_fixture,
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,  # noqa: ARG001
     slack_test_setup: tuple[ChannelType, ChannelType],
 ) -> None:
     public_channel, private_channel = slack_test_setup

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
@@ -11,7 +11,7 @@ from fastmcp.server.server import FunctionTool
 def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
     def make_tool(i: int) -> FunctionTool:
         @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
-        def tool_name(name: str) -> str:
+        def tool_name(name: str) -> str:  # noqa: ARG001
             """Get secret value."""
             return f"Secret value {200 - i}!"
 

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
@@ -16,7 +16,7 @@ def hello(name: str) -> str:
 def make_many_tools() -> list[FunctionTool]:
     def make_tool(i: int) -> FunctionTool:
         @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
-        def tool_name(name: str) -> str:
+        def tool_name(name: str) -> str:  # noqa: ARG001
             """Get secret value."""
             return f"Secret value {100 - i}!"
 

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
@@ -40,7 +40,7 @@ Enable authorization code and store the client id and secret.
 def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
     def make_tool(i: int) -> FunctionTool:
         @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
-        def tool_name(name: str) -> str:
+        def tool_name(name: str) -> str:  # noqa: ARG001
             """Get secret value."""
             return f"Secret value {500 - i}!"
 

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -96,7 +96,7 @@ class ApiKeyVerifier(TokenVerifier):
 def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
     def make_tool(i: int) -> FunctionTool:
         @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
-        def tool_name(name: str) -> str:
+        def tool_name(name: str) -> str:  # noqa: ARG001
             """Get secret value."""
             return f"Secret value {400 - i}!"
 

--- a/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
+++ b/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
@@ -95,7 +95,7 @@ class TestGuildDataIsolation:
     """Tests for guild data isolation between tenants via API."""
 
     def test_tenant_cannot_see_other_tenant_guilds(
-        self, reset_multitenant: None
+        self, reset_multitenant: None  # noqa: ARG002
     ) -> None:
         """Guilds created in tenant 1 are not visible from tenant 2.
 
@@ -158,7 +158,9 @@ class TestGuildDataIsolation:
                 headers=admin_user1.headers,
             )
 
-    def test_guild_list_returns_only_own_tenant(self, reset_multitenant: None) -> None:
+    def test_guild_list_returns_only_own_tenant(
+        self, reset_multitenant: None  # noqa: ARG002
+    ) -> None:
         """List guilds returns exactly the guilds for that tenant.
 
         Creates 1 guild in each tenant, registers them with different data,
@@ -338,7 +340,7 @@ class TestGuildAccessIsolation:
     """Tests for guild access isolation between tenants."""
 
     def test_tenant_cannot_access_other_tenant_guild(
-        self, reset_multitenant: None
+        self, reset_multitenant: None  # noqa: ARG002
     ) -> None:
         """Tenant 2 cannot access or modify tenant 1's guild by ID.
 

--- a/backend/tests/integration/multitenant_tests/invitation/test_user_invitation.py
+++ b/backend/tests/integration/multitenant_tests/invitation/test_user_invitation.py
@@ -8,7 +8,7 @@ INVITED_BASIC_USER = "basic_user"
 INVITED_BASIC_USER_EMAIL = "basic_user@example.com"
 
 
-def test_admin_can_invite_users(reset_multitenant: None) -> None:
+def test_admin_can_invite_users(reset_multitenant: None) -> None:  # noqa: ARG001
     """Test that an admin can invite both registered and non-registered users."""
     # Create first user (admin)
     unique = uuid4().hex
@@ -30,7 +30,9 @@ def test_admin_can_invite_users(reset_multitenant: None) -> None:
     ], f"User {invited_user.email} not found in invited users list"
 
 
-def test_non_registered_user_gets_basic_role(reset_multitenant: None) -> None:
+def test_non_registered_user_gets_basic_role(
+    reset_multitenant: None,  # noqa: ARG001
+) -> None:
     """Test that a non-registered user gets a BASIC role when they register after being invited."""
     # Create admin user
     unique = uuid4().hex
@@ -48,7 +50,7 @@ def test_non_registered_user_gets_basic_role(reset_multitenant: None) -> None:
     assert UserManager.is_role(invited_basic_user, UserRole.BASIC)
 
 
-def test_user_can_accept_invitation(reset_multitenant: None) -> None:
+def test_user_can_accept_invitation(reset_multitenant: None) -> None:  # noqa: ARG001
     """Test that a user can accept an invitation and join the organization with BASIC role."""
     # Create admin user
     unique = uuid4().hex

--- a/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
+++ b/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
@@ -15,7 +15,7 @@ from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.test_models import ToolName
 
 
-def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:
+def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:  # noqa: ARG001
     """Helper function to set up test tenants with documents and users."""
     unique = uuid4().hex
     # Creating an admin user for Tenant 1

--- a/backend/tests/integration/multitenant_tests/tenants/test_tenant_creation.py
+++ b/backend/tests/integration/multitenant_tests/tenants/test_tenant_creation.py
@@ -17,7 +17,7 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_first_user_is_admin(reset_multitenant: None) -> None:
+def test_first_user_is_admin(reset_multitenant: None) -> None:  # noqa: ARG001
     """Test that the first user of a tenant is automatically assigned ADMIN role."""
     unique = uuid4().hex
     test_user: DATestUser = UserManager.create(
@@ -26,7 +26,7 @@ def test_first_user_is_admin(reset_multitenant: None) -> None:
     assert UserManager.is_role(test_user, UserRole.ADMIN)
 
 
-def test_admin_can_create_credential(reset_multitenant: None) -> None:
+def test_admin_can_create_credential(reset_multitenant: None) -> None:  # noqa: ARG001
     """Test that an admin user can create a credential in their tenant."""
     # Create admin user
     unique = uuid4().hex
@@ -45,7 +45,7 @@ def test_admin_can_create_credential(reset_multitenant: None) -> None:
     assert test_credential is not None
 
 
-def test_admin_can_create_connector(reset_multitenant: None) -> None:
+def test_admin_can_create_connector(reset_multitenant: None) -> None:  # noqa: ARG001
     """Test that an admin user can create a connector in their tenant."""
     # Create admin user
     unique = uuid4().hex
@@ -64,7 +64,9 @@ def test_admin_can_create_connector(reset_multitenant: None) -> None:
     assert test_connector is not None
 
 
-def test_admin_can_create_and_verify_cc_pair(reset_multitenant: None) -> None:
+def test_admin_can_create_and_verify_cc_pair(
+    reset_multitenant: None,  # noqa: ARG001
+) -> None:
     """Test that an admin user can create and verify a connector-credential pair in their tenant."""
     # Create admin user
     unique = uuid4().hex
@@ -111,7 +113,9 @@ def test_settings_access() -> None:
     assert response.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_image_gen_config_created_on_tenant_provision(reset_multitenant: None) -> None:
+def test_image_gen_config_created_on_tenant_provision(
+    reset_multitenant: None,  # noqa: ARG001
+) -> None:
     """Test that image generation config is automatically created when a tenant is provisioned."""
     unique = uuid4().hex
     test_user: DATestUser = UserManager.create(

--- a/backend/tests/integration/tests/anonymous_user/test_anonymous_user.py
+++ b/backend/tests/integration/tests/anonymous_user/test_anonymous_user.py
@@ -4,7 +4,7 @@ from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_limited(reset: None) -> None:
+def test_limited(reset: None) -> None:  # noqa: ARG001
     """Verify that with a limited role key, limited endpoints are accessible and
     others are not."""
 

--- a/backend/tests/integration/tests/api_key/test_api_key.py
+++ b/backend/tests/integration/tests/api_key/test_api_key.py
@@ -8,7 +8,7 @@ from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_limited(reset: None) -> None:
+def test_limited(reset: None) -> None:  # noqa: ARG001
     """Verify that with a limited role key, limited endpoints are accessible and
     others are not."""
 

--- a/backend/tests/integration/tests/auth/test_saml_user_conversion.py
+++ b/backend/tests/integration/tests/auth/test_saml_user_conversion.py
@@ -13,7 +13,7 @@ from tests.integration.common_utils.test_models import DATestUser
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="SAML tests are enterprise only",
 )
-def test_saml_user_conversion(reset: None) -> None:
+def test_saml_user_conversion(reset: None) -> None:  # noqa: ARG001
     """
     Test that SAML login correctly converts users with non-authenticated roles
     (SLACK_USER or EXT_PERM_USER) to authenticated roles (BASIC).

--- a/backend/tests/integration/tests/chat/test_chat_deletion.py
+++ b/backend/tests/integration/tests/chat/test_chat_deletion.py
@@ -22,7 +22,7 @@ def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
 
 
 def test_soft_delete_chat_session(
-    basic_user: DATestUser, llm_provider: DATestLLMProvider
+    basic_user: DATestUser, llm_provider: DATestLLMProvider  # noqa: ARG001
 ) -> None:
     """
     Test soft deletion of a chat session.
@@ -76,7 +76,7 @@ def test_soft_delete_chat_session(
 
 
 def test_hard_delete_chat_session(
-    basic_user: DATestUser, llm_provider: DATestLLMProvider
+    basic_user: DATestUser, llm_provider: DATestLLMProvider  # noqa: ARG001
 ) -> None:
     """
     Test hard deletion of a chat session.
@@ -136,7 +136,7 @@ def test_hard_delete_chat_session(
 
 
 def test_multiple_soft_deletions(
-    basic_user: DATestUser, llm_provider: DATestLLMProvider
+    basic_user: DATestUser, llm_provider: DATestLLMProvider  # noqa: ARG001
 ) -> None:
     """
     Test multiple chat session soft deletions to ensure proper handling
@@ -183,7 +183,7 @@ def test_multiple_soft_deletions(
 
 
 def test_multiple_hard_deletions_with_agent_data(
-    basic_user: DATestUser, llm_provider: DATestLLMProvider
+    basic_user: DATestUser, llm_provider: DATestLLMProvider  # noqa: ARG001
 ) -> None:
     """
     Test multiple chat session hard deletions to ensure CASCADE deletes work correctly
@@ -230,7 +230,7 @@ def test_multiple_hard_deletions_with_agent_data(
 
 
 def test_soft_vs_hard_delete_edge_cases(
-    basic_user: DATestUser, llm_provider: DATestLLMProvider
+    basic_user: DATestUser, llm_provider: DATestLLMProvider  # noqa: ARG001
 ) -> None:
     """
     Test edge cases for both soft and hard deletion to ensure robustness.

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -22,7 +22,7 @@ def reset_for_module() -> None:
 
 
 @pytest.fixture
-def second_user(admin_user: DATestUser) -> DATestUser:
+def second_user(admin_user: DATestUser) -> DATestUser:  # noqa: ARG001
     # Ensure admin exists so this new user is created with BASIC role.
     try:
         return UserManager.create(name="second_basic_user")

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -14,7 +14,7 @@ from tests.integration.common_utils.test_models import DATestUser
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
-def test_chat_retention(reset: None, admin_user: DATestUser) -> None:
+def test_chat_retention(reset: None, admin_user: DATestUser) -> None:  # noqa: ARG001
     """Test that chat sessions are deleted after the retention period expires."""
 
     # Set chat retention period to 10 seconds

--- a/backend/tests/integration/tests/connector/test_connector_creation.py
+++ b/backend/tests/integration/tests/connector/test_connector_creation.py
@@ -9,7 +9,7 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_connector_creation(reset: None) -> None:
+def test_connector_creation(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -28,7 +28,7 @@ def test_connector_creation(reset: None) -> None:
     assert cc_pair_info.creator_email == admin_user.email
 
 
-def test_overlapping_connector_creation(reset: None) -> None:
+def test_overlapping_connector_creation(reset: None) -> None:  # noqa: ARG001
     """Tests that connectors indexing the same documents don't interfere with each other.
     A previous bug involved document by cc pair entries not being added for new connectors
     when the docs existed already via another connector and were up to date relative to the source.
@@ -86,7 +86,7 @@ def test_overlapping_connector_creation(reset: None) -> None:
     assert info_1.num_docs_indexed == info_2.num_docs_indexed
 
 
-def test_connector_pause_while_indexing(reset: None) -> None:
+def test_connector_pause_while_indexing(reset: None) -> None:  # noqa: ARG001
     """Tests that we can pause a connector while indexing is in progress and that
     tasks end early or abort as a result.
 

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -33,7 +33,9 @@ from tests.integration.common_utils.test_models import DATestUserGroup
 from tests.integration.common_utils.vespa import vespa_fixture
 
 
-def test_connector_deletion(reset: None, vespa_client: vespa_fixture) -> None:
+def test_connector_deletion(
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
+) -> None:
     user_group_1: DATestUserGroup
     user_group_2: DATestUserGroup
 
@@ -224,7 +226,7 @@ def test_connector_deletion(reset: None, vespa_client: vespa_fixture) -> None:
 
 
 def test_connector_deletion_for_overlapping_connectors(
-    reset: None, vespa_client: vespa_fixture
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
 ) -> None:
     """Checks to make sure that connectors with overlapping documents work properly. Specifically, that the overlapping
     document (1) still exists and (2) has the right document set / group post-deletion of one of the connectors.

--- a/backend/tests/integration/tests/dev_apis/test_knowledge_chat.py
+++ b/backend/tests/integration/tests/dev_apis/test_knowledge_chat.py
@@ -19,7 +19,7 @@ from tests.integration.common_utils.test_models import DATestUser
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="/chat/send-message-simple-with-history is enterprise only",
 )
-def test_all_stream_chat_message_objects_outputs(reset: None) -> None:
+def test_all_stream_chat_message_objects_outputs(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/dev_apis/test_simple_chat_api.py
+++ b/backend/tests/integration/tests/dev_apis/test_simple_chat_api.py
@@ -17,9 +17,9 @@ from tests.integration.conftest import DocumentBuilderType
     reason="/chat/send-message-simple-with-history tests are enterprise only",
 )
 def test_send_message_simple_with_history(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
     document_builder: DocumentBuilderType,
 ) -> None:
     # create documents using the document builder
@@ -62,9 +62,9 @@ def test_send_message_simple_with_history(
     reason="/chat/send-message-simple-with-history tests are enterprise only",
 )
 def test_using_reference_docs_with_simple_with_history_api_flow(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
     document_builder: DocumentBuilderType,
 ) -> None:
     # SEEDING DOCUMENTS
@@ -128,9 +128,9 @@ def test_using_reference_docs_with_simple_with_history_api_flow(
     reason="/chat/send-message-simple-with-history tests are enterprise only",
 )
 def test_send_message_simple_with_history_strict_json(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
 
     response = requests.post(
@@ -213,9 +213,9 @@ def test_send_message_simple_with_history_strict_json(
     reason="/query/answer-with-citation tests are enterprise only",
 )
 def test_answer_with_citation_api(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
     document_builder: DocumentBuilderType,
 ) -> None:
 

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_api.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_api.py
@@ -17,7 +17,7 @@ from tests.integration.common_utils.test_models import DATestUser
 class TestBotConfigEndpoints:
     """Tests for /manage/admin/discord-bot/config endpoints."""
 
-    def test_get_bot_config_not_configured(self, reset: None) -> None:
+    def test_get_bot_config_not_configured(self, reset: None) -> None:  # noqa: ARG002
         """GET /config returns configured=False when no config exists."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -29,7 +29,7 @@ class TestBotConfigEndpoints:
         assert config["configured"] is False
         assert "created_at" not in config or config.get("created_at") is None
 
-    def test_create_bot_config(self, reset: None) -> None:
+    def test_create_bot_config(self, reset: None) -> None:  # noqa: ARG002
         """POST /config creates a new bot config."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -47,7 +47,9 @@ class TestBotConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
-    def test_create_bot_config_already_exists(self, reset: None) -> None:
+    def test_create_bot_config_already_exists(
+        self, reset: None  # noqa: ARG002
+    ) -> None:
         """POST /config returns 409 if config already exists."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -70,7 +72,7 @@ class TestBotConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
-    def test_delete_bot_config(self, reset: None) -> None:
+    def test_delete_bot_config(self, reset: None) -> None:  # noqa: ARG002
         """DELETE /config removes the bot config."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -89,7 +91,7 @@ class TestBotConfigEndpoints:
         config = DiscordBotManager.get_bot_config(admin_user)
         assert config["configured"] is False
 
-    def test_delete_bot_config_not_found(self, reset: None) -> None:
+    def test_delete_bot_config_not_found(self, reset: None) -> None:  # noqa: ARG002
         """DELETE /config returns 404 if no config exists."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -106,7 +108,7 @@ class TestBotConfigEndpoints:
 class TestGuildConfigEndpoints:
     """Tests for /manage/admin/discord-bot/guilds endpoints."""
 
-    def test_create_guild_config(self, reset: None) -> None:
+    def test_create_guild_config(self, reset: None) -> None:  # noqa: ARG002
         """POST /guilds creates a new guild config with registration key."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -119,7 +121,7 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_list_guilds(self, reset: None) -> None:
+    def test_list_guilds(self, reset: None) -> None:  # noqa: ARG002
         """GET /guilds returns all guild configs."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -137,7 +139,7 @@ class TestGuildConfigEndpoints:
         DiscordBotManager.delete_guild_if_exists(guild1.id, admin_user)
         DiscordBotManager.delete_guild_if_exists(guild2.id, admin_user)
 
-    def test_get_guild_config(self, reset: None) -> None:
+    def test_get_guild_config(self, reset: None) -> None:  # noqa: ARG002
         """GET /guilds/{config_id} returns the specific guild config."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -153,14 +155,14 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_get_guild_config_not_found(self, reset: None) -> None:
+    def test_get_guild_config_not_found(self, reset: None) -> None:  # noqa: ARG002
         """GET /guilds/{config_id} returns 404 for non-existent guild."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
         result = DiscordBotManager.get_guild_or_none(999999, admin_user)
         assert result is None
 
-    def test_update_guild_config(self, reset: None) -> None:
+    def test_update_guild_config(self, reset: None) -> None:  # noqa: ARG002
         """PATCH /guilds/{config_id} updates the guild config."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -182,7 +184,7 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_delete_guild_config(self, reset: None) -> None:
+    def test_delete_guild_config(self, reset: None) -> None:  # noqa: ARG002
         """DELETE /guilds/{config_id} removes the guild config."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -195,7 +197,7 @@ class TestGuildConfigEndpoints:
         # Verify it's gone
         assert DiscordBotManager.get_guild_or_none(guild.id, admin_user) is None
 
-    def test_delete_guild_config_not_found(self, reset: None) -> None:
+    def test_delete_guild_config_not_found(self, reset: None) -> None:  # noqa: ARG002
         """DELETE /guilds/{config_id} returns 404 for non-existent guild."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -204,7 +206,7 @@ class TestGuildConfigEndpoints:
 
         assert exc_info.value.response.status_code == 404
 
-    def test_registration_key_format(self, reset: None) -> None:
+    def test_registration_key_format(self, reset: None) -> None:  # noqa: ARG002
         """Registration key has proper format with tenant encoded."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -223,7 +225,7 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_each_registration_key_is_unique(self, reset: None) -> None:
+    def test_each_registration_key_is_unique(self, reset: None) -> None:  # noqa: ARG002
         """Each created guild gets a unique registration key."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -240,7 +242,7 @@ class TestGuildConfigEndpoints:
 class TestChannelConfigEndpoints:
     """Tests for /manage/admin/discord-bot/guilds/{id}/channels endpoints."""
 
-    def test_list_channels_empty(self, reset: None) -> None:
+    def test_list_channels_empty(self, reset: None) -> None:  # noqa: ARG002
         """GET /guilds/{id}/channels returns empty list when no channels exist."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -257,7 +259,7 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_list_channels_with_data(self, reset: None) -> None:
+    def test_list_channels_with_data(self, reset: None) -> None:  # noqa: ARG002
         """GET /guilds/{id}/channels returns channel configs."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -290,7 +292,7 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_enabled(self, reset: None) -> None:
+    def test_update_channel_enabled(self, reset: None) -> None:  # noqa: ARG002
         """PATCH /guilds/{id}/channels/{id} updates enabled status."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -326,7 +328,7 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_thread_only_mode(self, reset: None) -> None:
+    def test_update_channel_thread_only_mode(self, reset: None) -> None:  # noqa: ARG002
         """PATCH /guilds/{id}/channels/{id} updates thread_only_mode."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -357,7 +359,9 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_require_bot_invocation(self, reset: None) -> None:
+    def test_update_channel_require_bot_invocation(
+        self, reset: None  # noqa: ARG002
+    ) -> None:
         """PATCH /guilds/{id}/channels/{id} updates require_bot_invocation."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -388,7 +392,7 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_not_found(self, reset: None) -> None:
+    def test_update_channel_not_found(self, reset: None) -> None:  # noqa: ARG002
         """PATCH /guilds/{id}/channels/{id} returns 404 for non-existent channel."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 
@@ -415,7 +419,9 @@ class TestChannelConfigEndpoints:
 class TestServiceApiKeyCleanup:
     """Tests for service API key cleanup when bot/guild configs are deleted."""
 
-    def test_delete_bot_config_also_deletes_service_api_key(self, reset: None) -> None:
+    def test_delete_bot_config_also_deletes_service_api_key(
+        self, reset: None  # noqa: ARG002
+    ) -> None:
         """DELETE /config also deletes the service API key (self-hosted flow)."""
         admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
@@ -156,7 +156,9 @@ class TestRegistrationKeyAPI:
         delete_guild_config(db_session, config.id)
         db_session.commit()
 
-    def test_registration_key_is_unique(self, db_session: Session) -> None:
+    def test_registration_key_is_unique(
+        self, db_session: Session  # noqa: ARG002
+    ) -> None:
         """Each generated key is unique."""
         keys = [generate_discord_registration_key("tenant") for _ in range(5)]
         assert len(set(keys)) == 5

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -11,7 +11,7 @@ from tests.integration.common_utils.vespa import vespa_fixture
 
 
 def test_multiple_document_sets_syncing_same_connnector(
-    reset: None, vespa_client: vespa_fixture
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
 ) -> None:
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
@@ -66,7 +66,9 @@ def test_multiple_document_sets_syncing_same_connnector(
     )
 
 
-def test_removing_connector(reset: None, vespa_client: vespa_fixture) -> None:
+def test_removing_connector(
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
+) -> None:
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -25,7 +25,7 @@ DOCX_FILE_NAME = "three_images.docx"
 
 
 def test_image_indexing(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     vespa_client: vespa_fixture,
 ) -> None:
@@ -118,7 +118,7 @@ def test_image_indexing(
 
 
 def test_docx_image_indexing(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     vespa_client: vespa_fixture,
 ) -> None:

--- a/backend/tests/integration/tests/index_attempt/test_index_attempt_pagination.py
+++ b/backend/tests/integration/tests/index_attempt/test_index_attempt_pagination.py
@@ -51,7 +51,7 @@ def _verify_index_attempt_pagination(
     assert all_expected_attempts == all_retrieved_attempts
 
 
-def test_index_attempt_pagination(reset: None) -> None:
+def test_index_attempt_pagination(reset: None) -> None:  # noqa: ARG001
     MAX_WAIT = 60
     all_attempt_ids: list[int] = []
 

--- a/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
+++ b/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
@@ -34,8 +34,8 @@ TEST_METADATA_FILE = f"{TEST_FILES_BASE}/.onyx_metadata.json"
     ],
 )
 def test_zip_metadata_handling(
-    reset: None,
-    vespa_client: vespa_fixture,
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,  # noqa: ARG001
     zip_path: str,
     has_metadata: bool,
 ) -> None:

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -142,7 +142,7 @@ def test_mock_connector_initial_permission_sync(
 )
 def test_permission_sync_attempt_tracking_integration(
     mock_server_client: httpx.Client,
-    vespa_client: vespa_fixture,
+    vespa_client: vespa_fixture,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test that permission sync attempts are properly tracked during real sync workflows."""
@@ -225,7 +225,7 @@ def test_permission_sync_attempt_tracking_integration(
 )
 def test_permission_sync_attempt_tracking_with_mocked_failure(
     mock_server_client: httpx.Client,
-    vespa_client: vespa_fixture,
+    vespa_client: vespa_fixture,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test that permission sync attempts are properly tracked when sync fails."""
@@ -307,7 +307,7 @@ def test_permission_sync_attempt_tracking_with_mocked_failure(
 )
 def test_permission_sync_attempt_status_success(
     mock_server_client: httpx.Client,
-    vespa_client: vespa_fixture,
+    vespa_client: vespa_fixture,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test that permission sync attempts are marked as SUCCESS when sync completes without errors."""

--- a/backend/tests/integration/tests/indexing/test_polling.py
+++ b/backend/tests/integration/tests/indexing/test_polling.py
@@ -20,7 +20,7 @@ from tests.integration.common_utils.test_models import DATestUser
 
 def _setup_mock_connector(
     mock_server_client: httpx.Client,
-    admin_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
 ) -> None:
     test_doc = create_test_document()
     successful_response = {

--- a/backend/tests/integration/tests/ingestion/test_ingestion_api.py
+++ b/backend/tests/integration/tests/ingestion/test_ingestion_api.py
@@ -10,7 +10,9 @@ from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.vespa import vespa_fixture
 
 
-def test_ingestion_api_crud(reset: None, vespa_client: vespa_fixture) -> None:
+def test_ingestion_api_crud(
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
+) -> None:
     """Test create, list, and delete via the ingestion API."""
     admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
     cc_pair = CCPairManager.create_from_scratch(

--- a/backend/tests/integration/tests/kg/test_kg_api.py
+++ b/backend/tests/integration/tests/kg/test_kg_api.py
@@ -50,7 +50,7 @@ def connectors() -> None:
         create_connector(db_session, connector_data)
 
 
-def test_kg_enable_and_disable(connectors: None) -> None:
+def test_kg_enable_and_disable(connectors: None) -> None:  # noqa: ARG001
     admin_user = UserManager.create(name="admin_user")
 
     # Enable KG
@@ -141,7 +141,7 @@ def test_kg_enable_with_missing_fields_should_fail() -> None:
     assert res.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_update_kg_entity_types(connectors: None) -> None:
+def test_update_kg_entity_types(connectors: None) -> None:  # noqa: ARG001
     admin_user = UserManager.create(name="admin_user")
 
     # Enable kg and populate default entity types
@@ -234,7 +234,9 @@ def test_update_kg_entity_types(connectors: None) -> None:
     assert new_entity_types == expected_entity_types
 
 
-def test_update_invalid_kg_entity_type_should_do_nothing(connectors: None) -> None:
+def test_update_invalid_kg_entity_type_should_do_nothing(
+    connectors: None,  # noqa: ARG001
+) -> None:
     admin_user = UserManager.create(name="admin_user")
 
     # Enable kg and populate default entity types

--- a/backend/tests/integration/tests/llm_auto_update/test_auto_llm_update.py
+++ b/backend/tests/integration/tests/llm_auto_update/test_auto_llm_update.py
@@ -132,7 +132,7 @@ def wait_for_model_sync(
 
 
 def test_auto_mode_provider_gets_synced_from_github_config(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """
@@ -230,7 +230,7 @@ def test_auto_mode_provider_gets_synced_from_github_config(
 
 
 def test_manual_mode_provider_not_affected_by_auto_sync(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -171,7 +171,7 @@ def assert_response_is_equivalent(
     ],
 )
 def test_create_llm_provider(
-    reset: None,
+    reset: None,  # noqa: ARG001
     default_model_name: str,
     model_configurations: list[ModelConfigurationUpsertRequest],
     expected: list[ModelConfigurationUpsertRequest],
@@ -264,7 +264,7 @@ def test_create_llm_provider(
     ],
 )
 def test_update_model_configurations(
-    reset: None,
+    reset: None,  # noqa: ARG001
     initial: tuple[str, list[ModelConfigurationUpsertRequest]],
     initial_expected: list[ModelConfigurationUpsertRequest],
     updated: tuple[str, list[ModelConfigurationUpsertRequest]],
@@ -375,7 +375,7 @@ def test_update_model_configurations(
     ],
 )
 def test_delete_llm_provider(
-    reset: None,
+    reset: None,  # noqa: ARG001
     default_model_name: str,
     model_configurations: list[ModelConfigurationUpsertRequest],
 ) -> None:
@@ -413,7 +413,7 @@ def test_delete_llm_provider(
     assert provider_data is None
 
 
-def test_model_visibility_preserved_on_edit(reset: None) -> None:
+def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG001
     """
     Test that model visibility flags are correctly preserved when editing an LLM provider.
 
@@ -723,7 +723,7 @@ def _validate_provider_data(
     )
 
 
-def test_default_model_persistence_and_update(reset: None) -> None:
+def test_default_model_persistence_and_update(reset: None) -> None:  # noqa: ARG001
     """
     Test that the default model is correctly set, persisted, and can be updated.
 
@@ -936,7 +936,7 @@ def _find_default_vision_provider(providers: list[dict]) -> dict | None:
     return next((p for p in providers if p.get("is_default_vision_provider")), None)
 
 
-def test_multiple_providers_default_switching(reset: None) -> None:
+def test_multiple_providers_default_switching(reset: None) -> None:  # noqa: ARG001
     """
     Test switching default providers and models across multiple LLM providers.
 
@@ -1273,7 +1273,9 @@ def test_multiple_providers_default_switching(reset: None) -> None:
     )
 
 
-def test_default_provider_and_vision_provider_selection(reset: None) -> None:
+def test_default_provider_and_vision_provider_selection(
+    reset: None,  # noqa: ARG001
+) -> None:
     """
     Test setting separate default providers for regular LLM and vision capabilities.
 
@@ -1491,7 +1493,9 @@ def test_default_provider_and_vision_provider_selection(reset: None) -> None:
     ), "Default provider and vision provider should be different providers (basic endpoint)"
 
 
-def test_default_provider_is_not_default_vision_provider(reset: None) -> None:
+def test_default_provider_is_not_default_vision_provider(
+    reset: None,  # noqa: ARG001
+) -> None:
     """
     Test that setting a provider as the default provider does NOT make it
     the default vision provider.
@@ -1662,7 +1666,7 @@ def _delete_image_gen_config(admin_user: DATestUser, image_provider_id: str) -> 
     assert response.status_code == 200
 
 
-def test_all_three_provider_types_no_mixup(reset: None) -> None:
+def test_all_three_provider_types_no_mixup(reset: None) -> None:  # noqa: ARG001
     """
     Test that regular LLM providers, vision providers, and image generation providers
     are all tracked separately with no mixup.

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider_access_control.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider_access_control.py
@@ -87,7 +87,7 @@ def _create_persona(
 
 
 @pytest.fixture()
-def users(reset: None) -> tuple[DATestUser, DATestUser]:
+def users(reset: None) -> tuple[DATestUser, DATestUser]:  # noqa: ARG001
     admin_user = UserManager.create(name="admin_user")
     basic_user = UserManager.create(name="basic_user")
     return admin_user, basic_user
@@ -366,7 +366,7 @@ def test_list_llm_provider_basics_excludes_non_public_unrestricted(
     assert non_public_provider.name in admin_provider_names
 
 
-def test_provider_delete_clears_persona_references(reset: None) -> None:
+def test_provider_delete_clears_persona_references(reset: None) -> None:  # noqa: ARG001
     """Test that deleting a provider automatically clears persona references."""
     admin_user = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider_persona_access.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider_persona_access.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture()
 def users_and_groups(
-    reset: None,
+    reset: None,  # noqa: ARG001
 ) -> tuple[DATestUser, DATestUser, int, int]:
     """Create admin, basic user, and two user groups."""
     admin_user = UserManager.create(name="admin_user")

--- a/backend/tests/integration/tests/mcp/test_mcp_client_no_auth_flow.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_client_no_auth_flow.py
@@ -83,11 +83,11 @@ def ensure_mcp_server_exists() -> None:
 
 
 def test_mcp_client_no_auth_flow(
-    mcp_no_auth_server: None,
-    reset: None,
+    mcp_no_auth_server: None,  # noqa: ARG001
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     basic_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
     # Step a) Create a no-auth MCP server via the admin API
     create_response = requests.post(

--- a/backend/tests/integration/tests/mcp/test_mcp_server_auth.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_auth.py
@@ -10,7 +10,7 @@ from tests.integration.common_utils.test_models import DATestUser
 STREAMABLE_HTTP_URL = f"{MCP_SERVER_URL.rstrip('/')}/?transportType=streamable-http"
 
 
-def test_mcp_server_health_check(reset: None) -> None:
+def test_mcp_server_health_check(reset: None) -> None:  # noqa: ARG001
     """Test MCP server health check endpoint."""
     response = requests.get(f"{MCP_SERVER_URL}/health", timeout=10)
     assert response.status_code == 200
@@ -18,13 +18,13 @@ def test_mcp_server_health_check(reset: None) -> None:
     assert response.json()["service"] == "mcp_server"
 
 
-def test_mcp_server_auth_missing_token(reset: None) -> None:
+def test_mcp_server_auth_missing_token(reset: None) -> None:  # noqa: ARG001
     """Test MCP server rejects requests without credentials."""
     response = requests.post(STREAMABLE_HTTP_URL)
     assert response.status_code == 401
 
 
-def test_mcp_server_auth_invalid_token(reset: None) -> None:
+def test_mcp_server_auth_invalid_token(reset: None) -> None:  # noqa: ARG001
     """Test MCP server rejects requests with an invalid bearer token."""
     response = requests.post(
         STREAMABLE_HTTP_URL,
@@ -34,7 +34,9 @@ def test_mcp_server_auth_invalid_token(reset: None) -> None:
     assert response.status_code == 401
 
 
-def test_mcp_server_auth_valid_token(reset: None, admin_user: DATestUser) -> None:
+def test_mcp_server_auth_valid_token(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test MCP server accepts requests with a valid bearer token."""
     pat = PATManager.create(
         name="Test MCP Token",

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -120,7 +120,9 @@ def _seed_document_and_wait_for_indexing(
     )
 
 
-def test_mcp_document_search_flow(reset: None, admin_user: DATestUser) -> None:
+def test_mcp_document_search_flow(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test the complete MCP search flow: initialization, resources, tools, and search."""
     # LLM provider is required for the document-search endpoint
     LLMProviderManager.create(user_performing_action=admin_user)
@@ -184,7 +186,9 @@ def test_mcp_document_search_flow(reset: None, admin_user: DATestUser) -> None:
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group permissions are Enterprise-only",
 )
-def test_mcp_search_respects_acl_filters(reset: None, admin_user: DATestUser) -> None:
+def test_mcp_search_respects_acl_filters(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test that search respects ACL filters - privileged users can access, others cannot."""
     # LLM provider is required for the document-search endpoint
     LLMProviderManager.create(user_performing_action=admin_user)

--- a/backend/tests/integration/tests/pat/test_pat_api.py
+++ b/backend/tests/integration/tests/pat/test_pat_api.py
@@ -24,7 +24,7 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_pat_lifecycle_happy_path(reset: None) -> None:
+def test_pat_lifecycle_happy_path(reset: None) -> None:  # noqa: ARG001
     """Complete PAT lifecycle: create, authenticate, revoke."""
     user: DATestUser = UserManager.create(name="pat_user")
 
@@ -75,7 +75,7 @@ def test_pat_lifecycle_happy_path(reset: None) -> None:
     assert len(tokens_after_revoke) == 0
 
 
-def test_pat_user_isolation_and_authentication(reset: None) -> None:
+def test_pat_user_isolation_and_authentication(reset: None) -> None:  # noqa: ARG001
     """
     PATs authenticate as real users, and users can only see/manage their own tokens.
     """
@@ -139,7 +139,7 @@ def test_pat_user_isolation_and_authentication(reset: None) -> None:
     assert delete_fake.status_code == 404
 
 
-def test_pat_expiration_flow(reset: None) -> None:
+def test_pat_expiration_flow(reset: None) -> None:  # noqa: ARG001
     """Expiration timestamp is end-of-day (23:59:59 UTC); never-expiring tokens work; revoked tokens fail."""
     user: DATestUser = UserManager.create(name="expiration_user")
 
@@ -188,7 +188,7 @@ def test_pat_expiration_flow(reset: None) -> None:
     assert revoked_auth_response.status_code == 403
 
 
-def test_pat_validation_errors(reset: None) -> None:
+def test_pat_validation_errors(reset: None) -> None:  # noqa: ARG001
     """Validate input errors: empty name, name too long, negative/zero expiration."""
     user: DATestUser = UserManager.create(name="validation_user")
 
@@ -248,7 +248,7 @@ def test_pat_validation_errors(reset: None) -> None:
     assert missing_name_response.status_code == 422
 
 
-def test_pat_sorting_and_last_used(reset: None) -> None:
+def test_pat_sorting_and_last_used(reset: None) -> None:  # noqa: ARG001
     """PATs are sorted by created_at DESC; last_used_at updates after authentication."""
     user: DATestUser = UserManager.create(name="sorting_user")
 
@@ -306,7 +306,7 @@ def test_pat_sorting_and_last_used(reset: None) -> None:
     assert token3_after_use.last_used_at is None
 
 
-def test_pat_role_based_access_control(reset: None) -> None:
+def test_pat_role_based_access_control(reset: None) -> None:  # noqa: ARG001
     """
     PATs inherit user roles and permissions:
     - Admin PAT: Full access to admin-only endpoints

--- a/backend/tests/integration/tests/permissions/test_cc_pair_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_cc_pair_permissions.py
@@ -22,7 +22,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and User Group tests are enterprise only",
 )
-def test_cc_pair_permissions(reset: None) -> None:
+def test_cc_pair_permissions(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/permissions/test_connector_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_connector_permissions.py
@@ -20,7 +20,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and user group tests are enterprise only",
 )
-def test_connector_permissions(reset: None) -> None:
+def test_connector_permissions(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/permissions/test_credential_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_credential_permissions.py
@@ -19,7 +19,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and user group tests are enterprise only",
 )
-def test_credential_permissions(reset: None) -> None:
+def test_credential_permissions(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/permissions/test_doc_set_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_doc_set_permissions.py
@@ -16,7 +16,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and user group tests are enterprise only",
 )
-def test_doc_set_permissions_setup(reset: None) -> None:
+def test_doc_set_permissions_setup(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/permissions/test_persona_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_persona_permissions.py
@@ -20,7 +20,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and user group tests are enterprise only",
 )
-def test_persona_permissions(reset: None) -> None:
+def test_persona_permissions(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -29,7 +29,7 @@ class UserFileTestSetup(NamedTuple):
 
 
 @pytest.fixture
-def user_file_setup(reset: None) -> UserFileTestSetup:
+def user_file_setup(reset: None) -> UserFileTestSetup:  # noqa: ARG001
     """
     Common setup for user file permission tests.
     Creates users, files, and a public assistant with files.

--- a/backend/tests/integration/tests/permissions/test_user_role_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_role_permissions.py
@@ -17,7 +17,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator and user group tests are enterprise only",
 )
-def test_user_role_setting_permissions(reset: None) -> None:
+def test_user_role_setting_permissions(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
     assert UserManager.is_role(admin_user, UserRole.ADMIN)

--- a/backend/tests/integration/tests/permissions/test_whole_curator_flow.py
+++ b/backend/tests/integration/tests/permissions/test_whole_curator_flow.py
@@ -21,7 +21,7 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator tests are enterprise only",
 )
-def test_whole_curator_flow(reset: None) -> None:
+def test_whole_curator_flow(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
     assert UserManager.is_role(admin_user, UserRole.ADMIN)
@@ -102,7 +102,7 @@ def test_whole_curator_flow(reset: None) -> None:
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Curator tests are enterprise only",
 )
-def test_global_curator_flow(reset: None) -> None:
+def test_global_curator_flow(reset: None) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
     assert UserManager.is_role(admin_user, UserRole.ADMIN)

--- a/backend/tests/integration/tests/personalization/test_personalization_flow.py
+++ b/backend/tests/integration/tests/personalization/test_personalization_flow.py
@@ -28,7 +28,7 @@ def _patch_personalization(headers: dict, cookies: dict, payload: dict) -> None:
     response.raise_for_status()
 
 
-def test_personalization_round_trip(reset: None) -> None:
+def test_personalization_round_trip(reset: None) -> None:  # noqa: ARG001
     user = UserManager.create()
     headers, cookies = _get_auth_headers(user)
 

--- a/backend/tests/integration/tests/personas/test_persona_categories.py
+++ b/backend/tests/integration/tests/personas/test_persona_categories.py
@@ -11,7 +11,7 @@ from tests.integration.common_utils.test_models import DATestPersonaLabel
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_persona_label_management(reset: None) -> None:
+def test_persona_label_management(reset: None) -> None:  # noqa: ARG001
     admin_user: DATestUser = UserManager.create(name="admin_user")
 
     persona_label = DATestPersonaLabel(

--- a/backend/tests/integration/tests/personas/test_persona_creation.py
+++ b/backend/tests/integration/tests/personas/test_persona_creation.py
@@ -28,7 +28,7 @@ def _share_persona(
 
 
 def test_persona_create_update_share_delete(
-    reset: None, admin_user: DATestUser, basic_user: DATestUser
+    reset: None, admin_user: DATestUser, basic_user: DATestUser  # noqa: ARG001
 ) -> None:
     # TODO: refactor `PersonaManager.verify`, not a good pattern
     # Create a persona as admin and verify it can be fetched

--- a/backend/tests/integration/tests/personas/test_persona_label_updates.py
+++ b/backend/tests/integration/tests/personas/test_persona_label_updates.py
@@ -11,7 +11,7 @@ from tests.integration.common_utils.test_models import DATestUser
 
 
 def test_update_persona_with_null_label_ids_preserves_labels(
-    reset: None, admin_user: DATestUser
+    reset: None, admin_user: DATestUser  # noqa: ARG001
 ) -> None:
     persona_label = PersonaLabelManager.create(
         label=DATestPersonaLabel(name=f"Test label {uuid4()}"),

--- a/backend/tests/integration/tests/personas/test_persona_pagination.py
+++ b/backend/tests/integration/tests/personas/test_persona_pagination.py
@@ -56,7 +56,9 @@ def _get_agents_admin_paginated(
     return response.json(), response.status_code
 
 
-def test_persona_pagination_basic(reset: None, admin_user: DATestUser) -> None:
+def test_persona_pagination_basic(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test basic pagination - verify correct items and total count."""
     # Preconditions
     personas_to_create = 25
@@ -90,7 +92,9 @@ def test_persona_pagination_basic(reset: None, admin_user: DATestUser) -> None:
     assert page_beyond["total_items"] >= personas_to_create  # Total doesn't change.
 
 
-def test_persona_pagination_ordering(reset: None, admin_user: DATestUser) -> None:
+def test_persona_pagination_ordering(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test ordering - display_priority ASC nulls last, then ID ASC."""
     # Preconditions
     # Create personas with specific display_priority values.
@@ -139,7 +143,9 @@ def test_persona_pagination_ordering(reset: None, admin_user: DATestUser) -> Non
         assert our_expected_ordered_persona_ids[i] == our_personas_in_results[i]["id"]
 
 
-def test_persona_pagination_admin_endpoint(reset: None, admin_user: DATestUser) -> None:
+def test_persona_pagination_admin_endpoint(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test admin paginated endpoint returns PersonaSnapshot format."""
     # Preconditions
     personas_to_create = 5
@@ -167,7 +173,9 @@ def test_persona_pagination_admin_endpoint(reset: None, admin_user: DATestUser) 
     assert "user_file_ids" in first_persona
 
 
-def test_persona_pagination_with_deleted(reset: None, admin_user: DATestUser) -> None:
+def test_persona_pagination_with_deleted(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test pagination with include_deleted parameter."""
     # Preconditions
     # Create and delete a persona.
@@ -197,7 +205,7 @@ def test_persona_pagination_with_deleted(reset: None, admin_user: DATestUser) ->
 
 
 def test_persona_pagination_page_size_limits(
-    reset: None, admin_user: DATestUser
+    reset: None, admin_user: DATestUser  # noqa: ARG001
 ) -> None:
     """Test page_size parameter validation (max 1000)."""
     # Preconditions
@@ -227,7 +235,9 @@ def test_persona_pagination_page_size_limits(
     assert status_code == 422  # Validation error
 
 
-def test_persona_pagination_count_accuracy(reset: None, admin_user: DATestUser) -> None:
+def test_persona_pagination_count_accuracy(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """Test that total_items count is consistent across pages."""
     # Preconditions
     # Create 15 personas.
@@ -264,7 +274,7 @@ def test_persona_pagination_count_accuracy(reset: None, admin_user: DATestUser) 
 
 
 def test_persona_pagination_user_permissions(
-    reset: None, admin_user: DATestUser, basic_user: DATestUser
+    reset: None, admin_user: DATestUser, basic_user: DATestUser  # noqa: ARG001
 ) -> None:
     """Test that pagination respects user permissions."""
     # Preconditions

--- a/backend/tests/integration/tests/personas/test_unified_assistant.py
+++ b/backend/tests/integration/tests/personas/test_unified_assistant.py
@@ -4,7 +4,7 @@ from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_unified_assistant(reset: None, admin_user: DATestUser) -> None:
+def test_unified_assistant(reset: None, admin_user: DATestUser) -> None:  # noqa: ARG001
     """Combined test verifying unified assistant existence, tools, and starter messages."""
     # Fetch all personas
     personas = PersonaManager.get_all(admin_user)

--- a/backend/tests/integration/tests/projects/test_projects.py
+++ b/backend/tests/integration/tests/projects/test_projects.py
@@ -18,9 +18,9 @@ def reset_for_module() -> None:
 
 
 def test_projects_flow(
-    reset_for_module: None,
+    reset_for_module: None,  # noqa: ARG001
     basic_user: DATestUser,
-    llm_provider: DATestLLMProvider,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
     """End-to-end project flow covering creation, listing, files, instructions, deletion, and edge cases."""
     # Case 1: Project creation and listing

--- a/backend/tests/integration/tests/pruning/test_pruning.py
+++ b/backend/tests/integration/tests/pruning/test_pruning.py
@@ -98,7 +98,7 @@ def http_server_context(
         server_thread.join()
 
 
-def test_web_pruning(reset: None, vespa_client: vespa_fixture) -> None:
+def test_web_pruning(reset: None, vespa_client: vespa_fixture) -> None:  # noqa: ARG001
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/query_history/test_query_history.py
+++ b/backend/tests/integration/tests/query_history/test_query_history.py
@@ -18,7 +18,7 @@ from tests.integration.common_utils.test_models import DATestUser
 
 
 @pytest.fixture
-def setup_chat_session(reset: None) -> tuple[DATestUser, str]:
+def setup_chat_session(reset: None) -> tuple[DATestUser, str]:  # noqa: ARG001
     # Create admin user and required resources
     admin_user: DATestUser = UserManager.create(name="admin_user")
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
@@ -69,7 +69,7 @@ def setup_chat_session(reset: None) -> tuple[DATestUser, str]:
     reason="Chat history tests are enterprise only",
 )
 def test_chat_history_endpoints(
-    reset: None, setup_chat_session: tuple[DATestUser, str]
+    reset: None, setup_chat_session: tuple[DATestUser, str]  # noqa: ARG001
 ) -> None:
     admin_user, first_chat_id = setup_chat_session
 
@@ -126,7 +126,7 @@ def test_chat_history_endpoints(
     reason="Chat history tests are enterprise only",
 )
 def test_chat_history_csv_export(
-    reset: None, setup_chat_session: tuple[DATestUser, str]
+    reset: None, setup_chat_session: tuple[DATestUser, str]  # noqa: ARG001
 ) -> None:
     admin_user, _ = setup_chat_session
 

--- a/backend/tests/integration/tests/query_history/test_query_history_pagination.py
+++ b/backend/tests/integration/tests/query_history/test_query_history_pagination.py
@@ -54,7 +54,7 @@ def _verify_query_history_pagination(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Query history tests are enterprise only",
 )
-def test_query_history_pagination(reset: None) -> None:
+def test_query_history_pagination(reset: None) -> None:  # noqa: ARG001
     (
         admin_user,
         chat_sessions_by_feedback_type,

--- a/backend/tests/integration/tests/query_history/test_usage_reports.py
+++ b/backend/tests/integration/tests/query_history/test_usage_reports.py
@@ -7,7 +7,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.seeding.chat_history_seeding import seed_chat_history
 
 
-def test_usage_reports(reset: None) -> None:
+def test_usage_reports(reset: None) -> None:  # noqa: ARG001
     EXPECTED_SESSIONS = 2048
     MESSAGES_PER_SESSION = 4
 

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -22,7 +22,9 @@ from tests.integration.common_utils.test_models import DATestUser
     reason="Usage export is an enterprise feature",
 )
 class TestUsageExportAPI:
-    def test_generate_usage_report(self, reset: None, admin_user: DATestUser) -> None:
+    def test_generate_usage_report(
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
+    ) -> None:
         # Seed some chat history data for the report
         seed_chat_history(num_sessions=10, num_messages=4, days=30)
 
@@ -71,7 +73,7 @@ class TestUsageExportAPI:
         assert new_report["report_name"].endswith(".zip")
 
     def test_generate_usage_report_with_date_range(
-        self, reset: None, admin_user: DATestUser
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Seed some chat history data
         seed_chat_history(num_sessions=20, num_messages=4, days=60)
@@ -129,7 +131,7 @@ class TestUsageExportAPI:
         assert new_report["period_to"] is not None
 
     def test_generate_usage_report_invalid_dates(
-        self, reset: None, admin_user: DATestUser
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Test with invalid date format
         response = requests.post(
@@ -142,7 +144,9 @@ class TestUsageExportAPI:
         )
         assert response.status_code == 400
 
-    def test_fetch_usage_reports(self, reset: None, admin_user: DATestUser) -> None:
+    def test_fetch_usage_reports(
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
+    ) -> None:
         # First generate a report to ensure we have at least one
         seed_chat_history(num_sessions=5, num_messages=4, days=30)
 
@@ -196,7 +200,9 @@ class TestUsageExportAPI:
         report_metadata = UsageReportMetadata(**first_report)
         assert report_metadata.report_name.endswith(".zip")
 
-    def test_read_usage_report(self, reset: None, admin_user: DATestUser) -> None:
+    def test_read_usage_report(
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
+    ) -> None:
         # First generate a report
         seed_chat_history(num_sessions=5, num_messages=4, days=30)
 
@@ -301,7 +307,9 @@ class TestUsageExportAPI:
                     int(first_row["number_of_tokens"]) >= 0
                 ), "number_of_tokens should be non-negative"
 
-    def test_read_nonexistent_report(self, reset: None, admin_user: DATestUser) -> None:
+    def test_read_nonexistent_report(
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
+    ) -> None:
         # Try to download a report that doesn't exist
         response = requests.get(
             f"{API_SERVER_URL}/admin/usage-report/nonexistent_report.zip",
@@ -310,7 +318,7 @@ class TestUsageExportAPI:
         assert response.status_code == 404
 
     def test_non_admin_cannot_generate_report(
-        self, reset: None, basic_user: DATestUser
+        self, reset: None, basic_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Try to generate a report as non-admin
         response = requests.post(
@@ -321,7 +329,7 @@ class TestUsageExportAPI:
         assert response.status_code == 403
 
     def test_non_admin_cannot_fetch_reports(
-        self, reset: None, basic_user: DATestUser
+        self, reset: None, basic_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Try to fetch reports as non-admin
         response = requests.get(
@@ -331,7 +339,7 @@ class TestUsageExportAPI:
         assert response.status_code == 403
 
     def test_non_admin_cannot_download_report(
-        self, reset: None, basic_user: DATestUser
+        self, reset: None, basic_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Try to download a report as non-admin
         response = requests.get(
@@ -341,7 +349,7 @@ class TestUsageExportAPI:
         assert response.status_code == 403
 
     def test_concurrent_report_generation(
-        self, reset: None, admin_user: DATestUser
+        self, reset: None, admin_user: DATestUser  # noqa: ARG002
     ) -> None:
         # Seed some data
         seed_chat_history(num_sessions=10, num_messages=4, days=30)

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_stream.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_stream.py
@@ -60,7 +60,9 @@ def test_send_two_messages(basic_user: DATestUser) -> None:
     ), "Chat session should have 1 system message, 2 user messages, and 2 assistant messages"
 
 
-def test_send_message_simple_with_history(reset: None, admin_user: DATestUser) -> None:
+def test_send_message_simple_with_history(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     LLMProviderManager.create(user_performing_action=admin_user)
 
     test_chat_session = ChatSessionManager.create(user_performing_action=admin_user)
@@ -76,7 +78,9 @@ def test_send_message_simple_with_history(reset: None, admin_user: DATestUser) -
 
 
 def test_send_message__basic_searches(
-    reset: None, admin_user: DATestUser, document_builder: DocumentBuilderType
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    document_builder: DocumentBuilderType,
 ) -> None:
     MESSAGE = "run a search for 'test'. Use the internal search tool."
     SHORT_DOC_CONTENT = "test"
@@ -116,7 +120,7 @@ def test_send_message__basic_searches(
 
 
 def test_send_message_disconnect_and_cleanup(
-    reset: None, admin_user: DATestUser
+    reset: None, admin_user: DATestUser  # noqa: ARG001
 ) -> None:
     """
     Test that when a client disconnects mid-stream:

--- a/backend/tests/integration/tests/tags/test_tags.py
+++ b/backend/tests/integration/tests/tags/test_tags.py
@@ -11,7 +11,7 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def test_tag_creation_and_update(reset: None) -> None:
+def test_tag_creation_and_update(reset: None) -> None:  # noqa: ARG001
     # create admin user
     admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
 
@@ -120,7 +120,7 @@ def test_tag_creation_and_update(reset: None) -> None:
     assert doc1_new_metadata == doc1_new_expected_metadata
 
 
-def test_tag_sharing(reset: None) -> None:
+def test_tag_sharing(reset: None) -> None:  # noqa: ARG001
     # create admin user
     admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
 

--- a/backend/tests/integration/tests/tools/test_force_tool_use.py
+++ b/backend/tests/integration/tests/tools/test_force_tool_use.py
@@ -16,7 +16,7 @@ from tests.integration.common_utils.test_models import ToolName
 
 def test_force_tool_use(
     basic_user: DATestUser,
-    image_generation_config: DATestImageGenerationConfig,
+    image_generation_config: DATestImageGenerationConfig,  # noqa: ARG001
 ) -> None:
     with get_session_with_current_tenant() as db_session:
         image_generation_tool = db_session.execute(

--- a/backend/tests/integration/tests/tools/test_image_generation_streaming.py
+++ b/backend/tests/integration/tests/tools/test_image_generation_streaming.py
@@ -22,8 +22,8 @@ ART_PERSONA_ID = -3
 
 def test_image_generation_streaming(
     basic_user: DATestUser,
-    llm_provider: DATestLLMProvider,
-    image_generation_config: DATestImageGenerationConfig,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    image_generation_config: DATestImageGenerationConfig,  # noqa: ARG001
 ) -> None:
     """
     Test image generation to verify:

--- a/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
+++ b/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
@@ -16,7 +16,7 @@ from tests.integration.common_utils.test_models import DATestUserGroup
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group(reset: None) -> None:
+def test_add_users_to_group(reset: None) -> None:  # noqa: ARG001
     admin_user: DATestUser = UserManager.create(name="admin_for_add_user")
     user_to_add: DATestUser = UserManager.create(name="basic_user_to_add")
 
@@ -46,7 +46,7 @@ def test_add_users_to_group(reset: None) -> None:
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group_invalid_user(reset: None) -> None:
+def test_add_users_to_group_invalid_user(reset: None) -> None:  # noqa: ARG001
     admin_user: DATestUser = UserManager.create(name="admin_for_add_user_invalid")
 
     user_group: DATestUserGroup = UserGroupManager.create(

--- a/backend/tests/integration/tests/usergroup/test_user_group_deletion.py
+++ b/backend/tests/integration/tests/usergroup/test_user_group_deletion.py
@@ -34,7 +34,9 @@ from tests.integration.common_utils.vespa import vespa_fixture
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_user_group_deletion(reset: None, vespa_client: vespa_fixture) -> None:
+def test_user_group_deletion(
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
+) -> None:
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
+++ b/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
@@ -19,7 +19,9 @@ from tests.integration.common_utils.vespa import vespa_fixture
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_removing_connector(reset: None, vespa_client: vespa_fixture) -> None:
+def test_removing_connector(
+    reset: None, vespa_client: vespa_fixture  # noqa: ARG001
+) -> None:
     # Creating an admin user (first user created is automatically an admin)
     admin_user: DATestUser = UserManager.create(name="admin_user")
 

--- a/backend/tests/integration/tests/users/test_user_pagination.py
+++ b/backend/tests/integration/tests/users/test_user_pagination.py
@@ -43,7 +43,7 @@ def _verify_user_pagination(
     assert all_expected_emails == all_retrieved_emails
 
 
-def test_user_pagination(reset: None) -> None:
+def test_user_pagination(reset: None) -> None:  # noqa: ARG001
     # Create an admin user to perform actions
     user_performing_action: DATestUser = UserManager.create(
         name="admin_performing_action"

--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -264,7 +264,7 @@ def _activate_exa_provider(admin_user: DATestUser) -> int:
 
 @pytestmark_exa
 def test_web_search_endpoints_with_exa(
-    reset: None,
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     provider_id = _activate_exa_provider(admin_user)

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
@@ -118,7 +118,7 @@ class TestCreateCustomerPortalSession:
         self,
         mock_get_license: MagicMock,
         mock_get_tenant: MagicMock,
-        mock_service: AsyncMock,
+        mock_service: AsyncMock,  # noqa: ARG002
     ) -> None:
         """Should reject self-hosted without license."""
         from fastapi import HTTPException

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -97,7 +97,9 @@ class TestLicenseEnforcementMiddleware:
         logger = MagicMock()
         captured_middleware: Any = None
 
-        def capture_middleware(middleware_type: str) -> Callable[[Any], Any]:
+        def capture_middleware(
+            middleware_type: str,  # noqa: ARG001
+        ) -> Callable[[Any], Any]:
             def decorator(func: Any) -> Any:
                 nonlocal captured_middleware
                 captured_middleware = func
@@ -108,7 +110,7 @@ class TestLicenseEnforcementMiddleware:
         app.middleware = capture_middleware
         add_license_enforcement_middleware(app, logger)
 
-        async def call_next(req: Request) -> Response:
+        async def call_next(req: Request) -> Response:  # noqa: ARG001
             response = MagicMock()
             response.status_code = 200
             return response
@@ -185,7 +187,7 @@ class TestLicenseEnforcementMiddleware:
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
         mock_refresh: MagicMock,
-        mock_get_session: MagicMock,
+        mock_get_session: MagicMock,  # noqa: ARG002
         middleware_harness: MiddlewareHarness,
     ) -> None:
         """No license blocks EE-only paths with 402."""
@@ -216,7 +218,7 @@ class TestLicenseEnforcementMiddleware:
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
         mock_refresh: MagicMock,
-        mock_get_session: MagicMock,
+        mock_get_session: MagicMock,  # noqa: ARG002
         middleware_harness: MiddlewareHarness,
     ) -> None:
         """No license allows community features (non-EE paths)."""

--- a/backend/tests/unit/file_store/test_file_store.py
+++ b/backend/tests/unit/file_store/test_file_store.py
@@ -104,7 +104,9 @@ class TestExternalStorageFileStore:
             assert call_kwargs["aws_secret_access_key"] == "test-secret"
             assert call_kwargs["region_name"] == "us-west-2"
 
-    def test_s3_client_initialization_with_iam_role(self, db_session: Session) -> None:
+    def test_s3_client_initialization_with_iam_role(
+        self, db_session: Session  # noqa: ARG002
+    ) -> None:
         """Test S3 client initialization with IAM role (no explicit credentials)"""
         with patch("boto3.client") as mock_boto3:
             file_store = S3BackedFileStore(
@@ -194,7 +196,10 @@ class TestExternalStorageFileStore:
 
     @patch("boto3.client")
     def test_s3_save_file_mock(
-        self, mock_boto3: MagicMock, db_session: Session, sample_file_io: BytesIO
+        self,
+        mock_boto3: MagicMock,
+        db_session: Session,  # noqa: ARG002
+        sample_file_io: BytesIO,
     ) -> None:
         """Test S3 file saving with mocked S3 client"""
         # Setup S3 mock

--- a/backend/tests/unit/model_server/test_embedding.py
+++ b/backend/tests/unit/model_server/test_embedding.py
@@ -50,7 +50,7 @@ async def test_embed_text_local_model() -> None:
 
 @pytest.mark.asyncio
 async def test_concurrent_embeddings() -> None:
-    def mock_encode(*args: Any, **kwargs: Any) -> List[List[float]]:
+    def mock_encode(*args: Any, **kwargs: Any) -> List[List[float]]:  # noqa: ARG001
         time.sleep(5)
         return [[0.1, 0.2, 0.3]]
 

--- a/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
@@ -61,7 +61,7 @@ async def test_get_or_create_user_updates_expiry(
     monkeypatch.setattr(
         users_module,
         "SQLAlchemyUserAdminDB",
-        lambda *args, **kwargs: MagicMock(),
+        lambda *args, **kwargs: MagicMock(),  # noqa: ARG005
     )
 
     result = await users_module._get_or_create_user_from_jwt(
@@ -109,7 +109,7 @@ async def test_get_or_create_user_skips_inactive(
     monkeypatch.setattr(
         users_module,
         "SQLAlchemyUserAdminDB",
-        lambda *args, **kwargs: MagicMock(),
+        lambda *args, **kwargs: MagicMock(),  # noqa: ARG005
     )
 
     result = await users_module._get_or_create_user_from_jwt(
@@ -150,14 +150,14 @@ async def test_get_or_create_user_handles_race_conditions(
             self.get_calls += 1
             return inactive_user
 
-        async def create(self, *args: Any, **kwargs: Any) -> MagicMock:
+        async def create(self, *args: Any, **kwargs: Any) -> MagicMock:  # noqa: ARG002
             raise users_module.exceptions.UserAlreadyExists()
 
     monkeypatch.setattr(users_module, "UserManager", StubUserManager)
     monkeypatch.setattr(
         users_module,
         "SQLAlchemyUserAdminDB",
-        lambda *args, **kwargs: MagicMock(),
+        lambda *args, **kwargs: MagicMock(),  # noqa: ARG005
     )
 
     result = await users_module._get_or_create_user_from_jwt(
@@ -195,7 +195,7 @@ async def test_get_or_create_user_provisions_new_user(
         async def get_by_email(self, _email: str) -> MagicMock:
             raise users_module.exceptions.UserNotExists()
 
-        async def create(self, user_create, safe=False, request=None):  # type: ignore[no-untyped-def]
+        async def create(self, user_create, safe=False, request=None):  # type: ignore[no-untyped-def]  # noqa: ARG002
             recorded["user_create"] = user_create
             recorded["request"] = request
             return created_user
@@ -204,7 +204,7 @@ async def test_get_or_create_user_provisions_new_user(
     monkeypatch.setattr(
         users_module,
         "SQLAlchemyUserAdminDB",
-        lambda *args, **kwargs: MagicMock(),
+        lambda *args, **kwargs: MagicMock(),  # noqa: ARG005
     )
 
     request = MagicMock()

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -77,8 +77,8 @@ class TestDisposableEmailValidation:
     @patch("onyx.auth.users.get_user_count", new_callable=AsyncMock)
     async def test_blocks_disposable_email_before_tenant_provision(
         self,
-        mock_get_user_count: MagicMock,
-        mock_session_manager: MagicMock,
+        mock_get_user_count: MagicMock,  # noqa: ARG002
+        mock_session_manager: MagicMock,  # noqa: ARG002
         mock_fetch_ee: MagicMock,
         mock_is_disposable: MagicMock,
         mock_user_create: UserCreate,
@@ -161,8 +161,8 @@ class TestMultiTenantInviteLogic:
         mock_get_user_count: MagicMock,
         mock_session_manager: MagicMock,
         mock_fetch_ee: MagicMock,
-        mock_verify_domain: MagicMock,
-        mock_is_disposable: MagicMock,
+        mock_verify_domain: MagicMock,  # noqa: ARG002
+        mock_is_disposable: MagicMock,  # noqa: ARG002
         mock_sql_alchemy_db: MagicMock,
         mock_user_create: UserCreate,
         mock_async_session: MagicMock,
@@ -209,8 +209,8 @@ class TestMultiTenantInviteLogic:
         mock_get_user_count: MagicMock,
         mock_session_manager: MagicMock,
         mock_fetch_ee: MagicMock,
-        mock_verify_domain: MagicMock,
-        mock_is_disposable: MagicMock,
+        mock_verify_domain: MagicMock,  # noqa: ARG002
+        mock_is_disposable: MagicMock,  # noqa: ARG002
         mock_sql_alchemy_db: MagicMock,
         mock_user_create: UserCreate,
         mock_async_session: MagicMock,
@@ -260,8 +260,8 @@ class TestSingleTenantInviteLogic:
         mock_get_user_count: MagicMock,
         mock_session_manager: MagicMock,
         mock_fetch_ee: MagicMock,
-        mock_verify_domain: MagicMock,
-        mock_is_disposable: MagicMock,
+        mock_verify_domain: MagicMock,  # noqa: ARG002
+        mock_is_disposable: MagicMock,  # noqa: ARG002
         mock_user_create: UserCreate,
         mock_async_session: MagicMock,
     ) -> None:
@@ -404,7 +404,7 @@ class TestCaseInsensitiveEmailMatching:
         mock_session_manager: MagicMock,
         mock_fetch_ee: MagicMock,
         mock_verify_domain: MagicMock,
-        mock_is_disposable: MagicMock,
+        mock_is_disposable: MagicMock,  # noqa: ARG002
         mock_async_session: MagicMock,
     ) -> None:
         """Existing user check should use case-insensitive email comparison."""

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -657,7 +657,7 @@ def test_citation_not_in_mapping_skipped(
 
 
 def test_invalid_citation_format_skipped(
-    mock_search_docs: CitationMapping, caplog: pytest.LogCaptureFixture
+    mock_search_docs: CitationMapping, caplog: pytest.LogCaptureFixture  # noqa: ARG001
 ) -> None:
     """Test that invalid citation number formats are skipped."""
     processor = DynamicCitationProcessor()
@@ -683,7 +683,7 @@ def test_empty_citation_content_handled(mock_search_docs: CitationMapping) -> No
 
 
 def test_citation_with_non_integer_skipped(
-    mock_search_docs: CitationMapping, caplog: pytest.LogCaptureFixture
+    mock_search_docs: CitationMapping, caplog: pytest.LogCaptureFixture  # noqa: ARG001
 ) -> None:
     """Test that citations with non-integer content are skipped."""
     processor = DynamicCitationProcessor()
@@ -790,7 +790,9 @@ def test_citation_inside_code_block_not_processed(
     assert "```plaintext" in output
 
 
-def test_code_block_plaintext_added(mock_search_docs: CitationMapping) -> None:
+def test_code_block_plaintext_added(
+    mock_search_docs: CitationMapping,  # noqa: ARG001
+) -> None:
     """Test that code blocks with ``` followed by \\n get 'plaintext' added."""
     processor = DynamicCitationProcessor()
 
@@ -953,7 +955,9 @@ def test_none_token_flushes_remaining_segment(
     assert "Remaining text" in output
 
 
-def test_very_long_citation_numbers(mock_search_docs: CitationMapping) -> None:
+def test_very_long_citation_numbers(
+    mock_search_docs: CitationMapping,  # noqa: ARG001
+) -> None:
     """Test citations with very long citation numbers."""
     processor = DynamicCitationProcessor()
     # Create a doc with a high citation number
@@ -2021,7 +2025,7 @@ class TestCitationModeEdgeCases:
         assert len(citations) == 0
 
     def test_hyperlink_mode_citation_with_special_chars_in_url(
-        self, mock_search_docs: CitationMapping
+        self, mock_search_docs: CitationMapping  # noqa: ARG002
     ) -> None:
         """Test HYPERLINK mode with special characters in URL."""
         special_doc = create_test_search_doc(
@@ -2037,7 +2041,7 @@ class TestCitationModeEdgeCases:
         assert len(citations) == 1
 
     def test_hyperlink_mode_citation_with_no_url(
-        self, mock_search_docs: CitationMapping
+        self, mock_search_docs: CitationMapping  # noqa: ARG002
     ) -> None:
         """Test HYPERLINK mode when document has no URL."""
         no_url_doc = create_test_search_doc(
@@ -2107,7 +2111,9 @@ class TestCitationModeEdgeCases:
         assert "[1]" not in output
         # Tab should be handled appropriately
 
-    def test_citation_number_zero(self, mock_search_docs: CitationMapping) -> None:
+    def test_citation_number_zero(
+        self, mock_search_docs: CitationMapping  # noqa: ARG002
+    ) -> None:
         """Test handling of citation number 0."""
         zero_doc = create_test_search_doc(
             document_id="zero_doc", link="https://zero.com"
@@ -2121,7 +2127,9 @@ class TestCitationModeEdgeCases:
         assert len(citations) == 1
         assert citations[0].citation_number == 0
 
-    def test_large_citation_numbers(self, mock_search_docs: CitationMapping) -> None:
+    def test_large_citation_numbers(
+        self, mock_search_docs: CitationMapping  # noqa: ARG002
+    ) -> None:
         """Test handling of large citation numbers."""
         large_doc = create_test_search_doc(
             document_id="large_doc", link="https://large.com"

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -231,8 +231,8 @@ def test_cql_paginate_all_expansions_handles_internal_pagination_error(
 
     def get_side_effect(
         path: str,
-        params: dict[str, Any] | None = None,
-        advanced_mode: bool = False,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
     ) -> requests.Response:
         path = path.strip("/")
         mock_get_call_paths.append(path)
@@ -469,8 +469,8 @@ def test_paginated_cql_retrieval_handles_pagination_error(
 
     def get_side_effect(
         path: str,
-        params: dict[str, Any] | None = None,
-        advanced_mode: bool = False,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
     ) -> requests.Response:
         path = path.strip("/")
         mock_get_call_paths.append(path)
@@ -612,8 +612,8 @@ def test_paginated_cql_retrieval_skips_completely_failing_page(
 
     def get_side_effect(
         path: str,
-        params: dict[str, Any] | None = None,
-        advanced_mode: bool = False,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
     ) -> requests.Response:
         path = path.strip("/")
         mock_get_call_paths.append(path)
@@ -727,8 +727,8 @@ def test_paginated_cql_retrieval_cloud_no_retry_on_error(
 
     def get_side_effect(
         path: str,
-        params: dict[str, Any] | None = None,
-        advanced_mode: bool = False,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
     ) -> requests.Response:
         path = path.strip("/")
         mock_get_call_paths.append(path)

--- a/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
@@ -739,7 +739,9 @@ def test_load_from_checkpoint_cursor_pagination_completion(
                 if lambda_call_count_for_current_repo == 1:
                     pl_for_offset_failure = MagicMock(spec=PaginatedList)
 
-                    def get_page_raises_exception(page_num: int) -> list[PullRequest]:
+                    def get_page_raises_exception(
+                        page_num: int,  # noqa: ARG001
+                    ) -> list[PullRequest]:
                         raise GithubException(422, message="use cursor pagination")
 
                     pl_for_offset_failure.get_page.side_effect = (
@@ -791,7 +793,8 @@ def test_load_from_checkpoint_cursor_pagination_completion(
     mock_github_client.get_repo.side_effect = get_repo_side_effect
 
     def to_repository_side_effect(
-        self_serialized_repo: SerializedRepository, requester_arg: Requester
+        self_serialized_repo: SerializedRepository,
+        requester_arg: Requester,  # noqa: ARG001
     ) -> Repository:
         if self_serialized_repo.id == mock_repo1.id:
             return mock_repo1

--- a/backend/tests/unit/onyx/connectors/gmail/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/gmail/test_connector.py
@@ -129,7 +129,7 @@ def test_gmail_checkpoint_progression() -> None:
             *,
             userId: str,
             fields: str,
-            q: str | None = None,
+            q: str | None = None,  # noqa: ARG002
             pageToken: str | None = None,
             **_: object,
         ) -> MockRequest:

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
@@ -257,7 +257,7 @@ def test_load_from_checkpoint_with_issue_processing_error(
 
     # Mock process_jira_issue to succeed for some issues and fail for others
     def mock_process_side_effect(
-        jira_base_url: str, issue: Issue, *args: Any, **kwargs: Any
+        jira_base_url: str, issue: Issue, *args: Any, **kwargs: Any  # noqa: ARG001
     ) -> Document | None:
         if issue.key in ["TEST-1", "TEST-3"]:
             return Document(

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
@@ -75,7 +75,7 @@ def mock_jira_api_version() -> Generator[Any, Any, Any]:
 
 @pytest.fixture
 def patched_environment(
-    mock_jira_api_version: MockFixture,
+    mock_jira_api_version: MockFixture,  # noqa: ARG001
 ) -> Generator[Any, Any, Any]:
     yield
 
@@ -83,7 +83,7 @@ def patched_environment(
 def test_fetch_jira_issues_batch_small_ticket(
     mock_jira_client: MagicMock,
     mock_issue_small: MagicMock,
-    patched_environment: MockFixture,
+    patched_environment: MockFixture,  # noqa: ARG001
 ) -> None:
     mock_jira_client.search_issues.return_value = [mock_issue_small]
 
@@ -108,7 +108,7 @@ def test_fetch_jira_issues_batch_small_ticket(
 def test_fetch_jira_issues_batch_large_ticket(
     mock_jira_client: MagicMock,
     mock_issue_large: MagicMock,
-    patched_environment: MockFixture,
+    patched_environment: MockFixture,  # noqa: ARG001
 ) -> None:
     mock_jira_client.search_issues.return_value = [mock_issue_large]
 
@@ -127,7 +127,7 @@ def test_fetch_jira_issues_batch_mixed_tickets(
     mock_jira_client: MagicMock,
     mock_issue_small: MagicMock,
     mock_issue_large: MagicMock,
-    patched_environment: MockFixture,
+    patched_environment: MockFixture,  # noqa: ARG001
 ) -> None:
     mock_jira_client.search_issues.return_value = [mock_issue_small, mock_issue_large]
 
@@ -150,7 +150,7 @@ def test_fetch_jira_issues_batch_custom_size_limit(
     mock_jira_client: MagicMock,
     mock_issue_small: MagicMock,
     mock_issue_large: MagicMock,
-    patched_environment: MockFixture,
+    patched_environment: MockFixture,  # noqa: ARG001
 ) -> None:
     mock_jira_client.search_issues.return_value = [mock_issue_small, mock_issue_large]
 

--- a/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
+++ b/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
@@ -67,9 +67,9 @@ class MockPage(pywikibot.Page):
 
     def categories(
         self,
-        with_sort_key: bool = False,
-        total: int | None = None,
-        content: bool = False,
+        with_sort_key: bool = False,  # noqa: ARG002
+        total: int | None = None,  # noqa: ARG002
+        content: bool = False,  # noqa: ARG002
     ) -> Iterable[pywikibot.Page]:
         if not self._has_categories:
             return []

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -31,8 +31,8 @@ class _FakeFolder:
         return self
 
     def get_files(
-        self, *, recursive: bool, page_size: int
-    ) -> _FakeQuery:  # noqa: ARG002
+        self, *, recursive: bool, page_size: int  # noqa: ARG002
+    ) -> _FakeQuery:
         return _FakeQuery(self._items)
 
 
@@ -140,11 +140,11 @@ def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -
     captured_drive_names: list[str] = []
 
     def fake_get_drive_items(
-        self: SharepointConnector,
-        site_descriptor: SiteDescriptor,
+        self: SharepointConnector,  # noqa: ARG001
+        site_descriptor: SiteDescriptor,  # noqa: ARG001
         drive_name: str,
-        start: datetime | None,
-        end: datetime | None,
+        start: datetime | None,  # noqa: ARG001
+        end: datetime | None,  # noqa: ARG001
     ) -> tuple[list[SimpleNamespace], str | None]:
         assert drive_name == "Documents"
         return (
@@ -159,12 +159,12 @@ def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -
         )
 
     def fake_convert(
-        driveitem: SimpleNamespace,
+        driveitem: SimpleNamespace,  # noqa: ARG001
         drive_name: str,
-        ctx: Any,
-        graph_client: Any,
-        include_permissions: bool,
-        parent_hierarchy_raw_node_id: str | None = None,
+        ctx: Any,  # noqa: ARG001
+        graph_client: Any,  # noqa: ARG001
+        include_permissions: bool,  # noqa: ARG001
+        parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
     ) -> SimpleNamespace:
         captured_drive_names.append(drive_name)
         return SimpleNamespace(sections=["content"])

--- a/backend/tests/unit/onyx/connectors/teams/test_collect_teams.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_collect_teams.py
@@ -18,7 +18,7 @@ def test_special_characters_in_team_names() -> None:
     # Mock successful responses for client-side filtering
     mock_team_collection = MagicMock()
     mock_team_collection.has_next = False
-    mock_team_collection.__iter__ = lambda self: iter([mock_team])
+    mock_team_collection.__iter__ = lambda self: iter([mock_team])  # noqa: ARG005
 
     mock_get_query = MagicMock()
     mock_top_query = MagicMock()
@@ -48,7 +48,7 @@ def test_single_quote_escaping() -> None:
     # Mock successful responses
     mock_team_collection = MagicMock()
     mock_team_collection.has_next = False
-    mock_team_collection.__iter__ = lambda self: iter([])
+    mock_team_collection.__iter__ = lambda self: iter([])  # noqa: ARG005
 
     mock_get_query = MagicMock()
     mock_filter_query = MagicMock()

--- a/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_rate_limit.py
+++ b/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_rate_limit.py
@@ -56,7 +56,9 @@ def test_zendesk_client_per_minute_rate_limiting(
     # Stub out requests.get to avoid network and return a minimal valid payload
     calls: list[str] = []
 
-    def _fake_get(url: str, auth: Any, params: Dict[str, Any]) -> _FakeResponse:
+    def _fake_get(
+        url: str, auth: Any, params: Dict[str, Any]  # noqa: ARG001
+    ) -> _FakeResponse:
         calls.append(url)
         # minimal Zendesk list response (articles path)
         return _FakeResponse({"articles": [], "meta": {"has_more": False}})

--- a/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
+++ b/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
@@ -216,7 +216,7 @@ class TestFetchThreadContextsWithRateLimitHandling:
     def test_batch_processing_respects_batch_size(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that messages are processed in batches of specified size."""
         messages = [
@@ -246,7 +246,7 @@ class TestFetchThreadContextsWithRateLimitHandling:
     def test_rate_limit_stops_further_batches(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that rate limiting stops processing of subsequent batches."""
         messages = [
@@ -296,7 +296,7 @@ class TestFetchThreadContextsWithRateLimitHandling:
     def test_other_errors_dont_stop_processing(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that non-rate-limit errors don't stop batch processing."""
         messages = [
@@ -345,7 +345,7 @@ class TestMaxMessagesLimit:
     def test_max_messages_limits_context_fetches(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that only top N messages get thread context when max_messages is set."""
         messages = [
@@ -388,7 +388,7 @@ class TestMaxMessagesLimit:
     def test_max_messages_none_fetches_all(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that max_messages=None fetches context for all messages."""
         messages = [
@@ -420,7 +420,7 @@ class TestMaxMessagesLimit:
     def test_max_messages_greater_than_total_fetches_all(
         self,
         mock_parallel: MagicMock,
-        mock_fetch_context: MagicMock,
+        mock_fetch_context: MagicMock,  # noqa: ARG002
     ) -> None:
         """Test that max_messages > total messages fetches all."""
         messages = [

--- a/backend/tests/unit/onyx/db/test_persona_display_priority.py
+++ b/backend/tests/unit/onyx/db/test_persona_display_priority.py
@@ -20,7 +20,7 @@ def test_update_display_priority_updates_subset(
     user = MagicMock()
     monkeypatch.setattr(
         "onyx.db.persona.get_raw_personas_for_user",
-        lambda user, db_session, **kwargs: [persona_a, persona_b],
+        lambda user, db_session, **kwargs: [persona_a, persona_b],  # noqa: ARG005
     )
 
     # Under test
@@ -41,7 +41,7 @@ def test_update_display_priority_invalid_ids(monkeypatch: pytest.MonkeyPatch) ->
     user = MagicMock()
     monkeypatch.setattr(
         "onyx.db.persona.get_raw_personas_for_user",
-        lambda user, db_session, **kwargs: [persona_a],
+        lambda user, db_session, **kwargs: [persona_a],  # noqa: ARG005
     )
 
     # Under test

--- a/backend/tests/unit/onyx/indexing/conftest.py
+++ b/backend/tests/unit/onyx/indexing/conftest.py
@@ -11,7 +11,7 @@ class MockHeartbeat(IndexingHeartbeatInterface):
     def should_stop(self) -> bool:
         return False
 
-    def progress(self, tag: str, amount: int) -> None:
+    def progress(self, tag: str, amount: int) -> None:  # noqa: ARG002
         self.call_count += 1
 
 

--- a/backend/tests/unit/onyx/indexing/test_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_chunker.py
@@ -46,7 +46,7 @@ def test_chunk_document(
 
     mock_llm_invoke_count = 0
 
-    def mock_llm_invoke(self: Any, *args: Any, **kwargs: Any) -> Mock:
+    def mock_llm_invoke(self: Any, *args: Any, **kwargs: Any) -> Mock:  # noqa: ARG001
         nonlocal mock_llm_invoke_count
         mock_llm_invoke_count += 1
         m = Mock()

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -173,7 +173,7 @@ def test_contextual_rag(
     mock_llm_invoke_count = 0
     counter_lock = threading.Lock()
 
-    def mock_llm_invoke(*args: Any, **kwargs: Any) -> ModelResponse:
+    def mock_llm_invoke(*args: Any, **kwargs: Any) -> ModelResponse:  # noqa: ARG001
         nonlocal mock_llm_invoke_count
         with counter_lock:
             mock_llm_invoke_count += 1

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -46,7 +46,7 @@ async def test_cloud_embedding_explicit_close() -> None:
 
 @pytest.mark.asyncio
 async def test_openai_embedding(
-    mock_http_client: AsyncMock, sample_embeddings: List[List[float]]
+    mock_http_client: AsyncMock, sample_embeddings: List[List[float]]  # noqa: ARG001
 ) -> None:
     with patch("openai.AsyncOpenAI") as mock_openai:
         mock_client = AsyncMock()

--- a/backend/tests/unit/onyx/onyxbot/discord/conftest.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/conftest.py
@@ -94,7 +94,7 @@ def mock_discord_guild() -> MagicMock:
 
 
 @pytest.fixture
-def mock_discord_message(mock_bot_user: MagicMock) -> MagicMock:
+def mock_discord_message(mock_bot_user: MagicMock) -> MagicMock:  # noqa: ARG001
     """Mock Discord message for testing."""
     msg = MagicMock(spec=discord.Message)
     msg.id = 555555555
@@ -141,7 +141,7 @@ def mock_thread_with_messages(mock_bot_user: MagicMock) -> MagicMock:
     ]
 
     # Setup async iterator for history
-    def history(**kwargs: Any) -> AsyncIteratorMock:
+    def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
         return AsyncIteratorMock(messages)
 
     thread.history = history

--- a/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
@@ -386,7 +386,7 @@ class TestGatedTenantHandling:
         mock_config_t2.guild_id = 222222
         mock_config_t2.enabled = True
 
-        def mock_get_configs(db: MagicMock) -> list[MagicMock]:
+        def mock_get_configs(db: MagicMock) -> list[MagicMock]:  # noqa: ARG001
             # Track which tenant this was called for
             return [mock_config_t1]  # Always return same for simplicity
 

--- a/backend/tests/unit/onyx/onyxbot/discord/test_context_builders.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_context_builders.py
@@ -91,7 +91,7 @@ class TestThreadContextBuilder:
             mock_message(content="Reply 2", message_id=2),
         ]
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -129,7 +129,7 @@ class TestThreadContextBuilder:
             side_effect=discord.NotFound(MagicMock(), "")
         )
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -165,7 +165,7 @@ class TestThreadContextBuilder:
             side_effect=discord.NotFound(MagicMock(), "")
         )
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -195,7 +195,7 @@ class TestThreadContextBuilder:
             side_effect=discord.NotFound(MagicMock(), "")
         )
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -223,7 +223,7 @@ class TestThreadContextBuilder:
         # Set up mock before calling function so we can verify it wasn't called
         thread.parent.fetch_message = AsyncMock()
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -253,7 +253,7 @@ class TestThreadContextBuilder:
             side_effect=discord.NotFound(MagicMock(), "Not found")
         )
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -284,7 +284,7 @@ class TestThreadContextBuilder:
         thread.parent = MagicMock(spec=discord.TextChannel)
         thread.parent.fetch_message = AsyncMock(return_value=starter)
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history
@@ -483,7 +483,7 @@ class TestCombinedContext:
             mock_message(content="Thread msg 2", message_id=2),
         ]
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(thread_messages)
 
         thread.history = history
@@ -522,7 +522,7 @@ class TestCombinedContext:
 
         messages = [mock_message(content="Thread msg")]
 
-        def history(**kwargs: Any) -> AsyncIteratorMock:
+        def history(**kwargs: Any) -> AsyncIteratorMock:  # noqa: ARG001
             return AsyncIteratorMock(messages)
 
         thread.history = history

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
@@ -27,12 +27,12 @@ def test_fetch_url_pdf_with_content_type(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
     monkeypatch.setattr(
         crawler_module,
         "extract_pdf_text",
-        lambda *args, **kwargs: ("pdf text", {"Title": "Doc Title"}),
+        lambda *args, **kwargs: ("pdf text", {"Title": "Doc Title"}),  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/report.pdf")
@@ -53,12 +53,12 @@ def test_fetch_url_pdf_with_signature(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
     monkeypatch.setattr(
         crawler_module,
         "extract_pdf_text",
-        lambda *args, **kwargs: ("pdf text", {}),
+        lambda *args, **kwargs: ("pdf text", {}),  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/files/file.pdf")
@@ -81,7 +81,7 @@ def test_fetch_url_decodes_html_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/page.html")
@@ -102,7 +102,7 @@ def test_fetch_url_pdf_exceeds_size_limit(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/large.pdf")
@@ -124,12 +124,12 @@ def test_fetch_url_pdf_within_size_limit(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
     monkeypatch.setattr(
         crawler_module,
         "extract_pdf_text",
-        lambda *args, **kwargs: ("pdf text", {"Title": "Doc Title"}),
+        lambda *args, **kwargs: ("pdf text", {"Title": "Doc Title"}),  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/small.pdf")
@@ -151,7 +151,7 @@ def test_fetch_url_html_exceeds_size_limit(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/large.html")
@@ -174,7 +174,7 @@ def test_fetch_url_html_within_size_limit(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         crawler_module,
         "ssrf_safe_get",
-        lambda *args, **kwargs: response,
+        lambda *args, **kwargs: response,  # noqa: ARG005
     )
 
     result = crawler._fetch_url("https://example.com/small.html")

--- a/backend/tests/unit/onyx/utils/test_vespa_tasks.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_tasks.py
@@ -14,7 +14,7 @@ class _StubRedisDocumentSet:
         parts = key.split("_")
         return parts[-1] if len(parts) == 3 else None
 
-    def __init__(self, tenant_id: str, object_id: str) -> None:
+    def __init__(self, tenant_id: str, object_id: str) -> None:  # noqa: ARG002
         self.taskset_key = f"documentset_taskset_{object_id}"
         self._payload = 0
 
@@ -38,15 +38,15 @@ def _setup_common_patches(monkeypatch: Any, document_set: Any) -> dict[str, bool
     monkeypatch.setattr(
         vespa_tasks,
         "get_document_set_by_id",
-        lambda db_session, document_set_id: document_set,
+        lambda db_session, document_set_id: document_set,  # noqa: ARG005
     )
 
-    def _delete(document_set_row: Any, db_session: Any) -> None:
+    def _delete(document_set_row: Any, db_session: Any) -> None:  # noqa: ARG001
         calls["deleted"] = True
 
     monkeypatch.setattr(vespa_tasks, "delete_document_set", _delete)
 
-    def _mark(document_set_id: Any, db_session: Any) -> None:
+    def _mark(document_set_id: Any, db_session: Any) -> None:  # noqa: ARG001
         calls["synced"] = True
 
     monkeypatch.setattr(vespa_tasks, "mark_document_set_as_synced", _mark)
@@ -54,7 +54,7 @@ def _setup_common_patches(monkeypatch: Any, document_set: Any) -> dict[str, bool
     monkeypatch.setattr(
         vespa_tasks,
         "update_sync_record_status",
-        lambda db_session, entity_id, sync_type, sync_status, num_docs_synced: None,
+        lambda db_session, entity_id, sync_type, sync_status, num_docs_synced: None,  # noqa: ARG005
     )
 
     return calls
@@ -71,7 +71,7 @@ def test_monitor_preserves_federated_only_document_set(monkeypatch: Any) -> None
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_1",
-        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]
+        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]  # noqa: ARG005
         db_session=SimpleNamespace(),  # type: ignore[arg-type]
     )
 
@@ -90,7 +90,7 @@ def test_monitor_deletes_document_set_with_no_connectors(monkeypatch: Any) -> No
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_2",
-        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]
+        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]  # noqa: ARG005
         db_session=SimpleNamespace(),  # type: ignore[arg-type]
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ target-version = "py311"
 [tool.ruff.lint]
 ignore = []
 select = [
+  "ARG",
   "E",
   "F",
   "W",


### PR DESCRIPTION
## Description

Enables https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg

The only non-mechanical changes are in `pyproject.toml` and `backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py`

## How Has This Been Tested?

`prek run --all-files`

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled Ruff’s flake8-unused-arguments rules and annotated intentional unused parameters across the backend. This tightens linting without changing behavior.

- **Refactors**
  - Added `# noqa: ARG001/ARG002/ARG003/ARG005` to function signatures where frameworks require unused params (Celery signals/tasks, FastAPI endpoints, connectors, DB engines/models, indexing, utilities).
  - Tweaked signatures to clearly mark placeholder args/kwargs as unused to satisfy new lint rules.

<sup>Written for commit b23b8421cfbe322e96d04701f4ba6aac48d6851b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

