### PR TITLE
chore: bump sandbox cpu and memory limits

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -412,8 +412,8 @@ done
             ],
             resources=client.V1ResourceRequirements(
                 # Reduced resources since sidecar is mostly idle (sleeping)
-                requests={"cpu": "50m", "memory": "128Mi"},
-                limits={"cpu": "8000m", "memory": "8Gi"},
+                requests={"cpu": "250m", "memory": "256Mi"},
+                limits={"cpu": "4000m", "memory": "6Gi"},
             ),
         )
 


### PR DESCRIPTION
## Description
Note: there is no quota constraint on limit vs request

### sandbox-nodes-firewalled Nodegroup Resources
  **Total Nodegroup Capacity:**
  - 5 nodes × 8 cores = 40 total CPU cores
  - 5 nodes × ~30 GB = ~150 GB total memory
  - Current utilization: ~1% CPU, 14-18% memory (all pods synced and basically dormant, maybe some use)

  **Per-Node Resources:**
  - CPU Allocatable: 7.91 cores (7910m)
  - Memory Allocatable: ~29.9 GB (30624976Ki)
  - Current CPU requests: 19-26% reserved per node
  - Available burst capacity: ~5.8-6.3 cores per node

### Changes: file-sync Sidecar Resource Limits

  Updated the file-sync sidecar container to enable faster S3 downloads during pod initialization:

  **Previous:**
  - CPU limit: 1 core
  - Memory limit: 4 GB
  - Init time: ~22 minutes for 850 MB (145k files)

  **New:**
  - CPU limit: 8 cores
  - Memory limit: 8 GB
  - Expected init time: ~4-6 minutes (4-5x faster)

  **Rationale:**
  - Uses s5cmd with high parallelism (100+ concurrent workers)
  - Sidecar only bursts during initialization, then idles
  - Low CPU requests (500m) ensure efficient pod scheduling
  - Nodes are currently underutilized with ample burst capacity

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Kubernetes sandbox pod resource limits to reduce CPU throttling and OOMs during heavier workloads.

Limits raised from 1000m CPU to 4000m and from 4Gi memory to 6Gi; requests increased from 50m CPU/128Mi to 250m CPU/256Mi.

<sup>Written for commit 47b06df110f2775d64cad5cf9b40f461478bf3f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



