### PR TITLE
fix: GPT -chat models

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -315,7 +315,7 @@ class LitellmLLM(LLM):
                         "summary": "auto",
                     }
 
-            if is_claude_model:
+            elif is_claude_model:
                 budget_tokens: int | None = ANTHROPIC_REASONING_EFFORT_BUDGET.get(
                     reasoning_effort
                 )


### PR DESCRIPTION
## Description
They don't actually accept a variable reasoning param.

## How Has This Been Tested?
N/A Must be correct

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only apply Anthropic reasoning effort to Claude models, so GPT chat models never receive a variable reasoning param. This fixes invalid-parameter errors during completions for GPT chat models.

<sup>Written for commit 4eafda8b556a3ecfac54702abc09e1eeb68d0e56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

