### PR TITLE
chore(openai): Add test for Chat Models

### DIFF
--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -473,8 +473,12 @@ def test_openai_chat_omits_reasoning_params() -> None:
 
     with (
         patch("litellm.completion") as mock_completion,
-        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
-        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=True),
+        patch(
+            "onyx.llm.multi_llm.model_is_reasoning_model", return_value=True
+        ) as mock_is_reasoning,
+        patch(
+            "onyx.llm.multi_llm.is_true_openai_model", return_value=True
+        ) as mock_is_openai,
     ):
         mock_response = litellm.ModelResponse(
             id="chatcmpl-123",
@@ -499,6 +503,8 @@ def test_openai_chat_omits_reasoning_params() -> None:
         assert kwargs["model"] == "openai/responses/gpt-5-chat"
         assert "reasoning" not in kwargs
         assert "reasoning_effort" not in kwargs
+        assert mock_is_reasoning.called
+        assert mock_is_openai.called
 
 
 def test_user_identity_metadata_enabled(default_multi_llm: LitellmLLM) -> None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
We needed to ensure that we are handling tests properly. This is to properly test the issue with chat based models for OpenAI

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
This is just a test

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for OpenAI chat models to ensure reasoning options are not sent and the request routes to the responses endpoint. Uses gpt-5-chat and asserts no reasoning fields, model == "openai/responses/gpt-5-chat", and that the reasoning/OpenAI checks are called.

<sup>Written for commit ca5316222beea5fc0c0e4e12fa28587ecedce433. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

