### PR TITLE
fix(craft): upload to s3 before marking docs as indexed in db

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -683,10 +683,6 @@ def connector_document_extraction(
                     # skip chunking/embedding/Vespa but still track documents in DB
 
                     # IMPORTANT: Write to S3 FIRST, before marking as indexed in DB.
-                    # This ensures that if the S3 write fails or times out, the docs
-                    # won't be marked as indexed and will be retried on the next sync.
-                    # Previously, docs were marked as indexed before S3 write, causing
-                    # ~65k docs to be lost when a sync timed out mid-batch.
 
                     # Write documents to persistent file system
                     # Use creator_id for user-segregated storage paths (sandbox isolation)


### PR DESCRIPTION
## Description

- failures during indexing may have marked docs as indexed before they were fully uploaded to s3

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write documents to S3 before marking them as indexed in the DB to prevent data loss and ensure failed uploads are retried on the next sync. Fixes cases where timeouts marked docs complete without a successful upload.

- **Bug Fixes**
  - Reordered file-system-only flow: upload to S3 first, then create index metadata and mark docs indexed.
  - Validate creator_id and use it for user-scoped storage paths.

<sup>Written for commit db110d697725a27120a6428600104bbd39bcee7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



