### PR TITLE
fix(db): null out document set and persona ownership on user deletion

### DIFF
--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -17,7 +17,9 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
 from onyx.configs.constants import NO_AUTH_PLACEHOLDER_USER_EMAIL
 from onyx.db.api_key import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+from onyx.db.models import DocumentSet
 from onyx.db.models import DocumentSet__User
+from onyx.db.models import Persona
 from onyx.db.models import Persona__User
 from onyx.db.models import SamlAccount
 from onyx.db.models import User
@@ -332,6 +334,15 @@ def delete_user_from_db(
     db_session.query(SamlAccount).filter(
         SamlAccount.user_id == user_to_delete.id
     ).delete()
+    # Null out ownership on document sets and personas so they're
+    # preserved for other users instead of being cascade-deleted
+    db_session.query(DocumentSet).filter(
+        DocumentSet.user_id == user_to_delete.id
+    ).update({DocumentSet.user_id: None})
+    db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).update(
+        {Persona.user_id: None}
+    )
+
     db_session.query(DocumentSet__User).filter(
         DocumentSet__User.user_id == user_to_delete.id
     ).delete()

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -84,7 +84,8 @@ def patch_document_set(
         user=user,
         target_group_ids=document_set_update_request.groups,
         object_is_public=document_set_update_request.is_public,
-        object_is_owned_by_user=user and document_set.user_id == user.id,
+        object_is_owned_by_user=user
+        and (document_set.user_id is None or document_set.user_id == user.id),
     )
     try:
         update_document_set(
@@ -125,7 +126,8 @@ def delete_document_set(
         db_session=db_session,
         user=user,
         object_is_public=document_set.is_public,
-        object_is_owned_by_user=user and document_set.user_id == user.id,
+        object_is_owned_by_user=user
+        and (document_set.user_id is None or document_set.user_id == user.id),
     )
 
     try:

--- a/backend/tests/unit/onyx/db/test_delete_user.py
+++ b/backend/tests/unit/onyx/db/test_delete_user.py
@@ -1,0 +1,135 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import UUID
+from uuid import uuid4
+
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__User
+from onyx.db.models import Persona
+from onyx.db.models import Persona__User
+from onyx.db.models import SamlAccount
+from onyx.db.models import User__UserGroup
+from onyx.db.users import delete_user_from_db
+
+
+def _mock_user(
+    user_id: UUID | None = None, email: str = "test@example.com"
+) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id or uuid4()
+    user.email = email
+    user.oauth_accounts = []
+    return user
+
+
+def _make_query_chain() -> MagicMock:
+    """Returns a mock that supports .filter(...).delete() and .filter(...).update(...)"""
+    chain = MagicMock()
+    chain.filter.return_value = chain
+    return chain
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_nulls_out_document_set_ownership(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    db_session = MagicMock()
+
+    query_chains: dict[type, MagicMock] = {}
+
+    def query_side_effect(model: type) -> MagicMock:
+        if model not in query_chains:
+            query_chains[model] = _make_query_chain()
+        return query_chains[model]
+
+    db_session.query.side_effect = query_side_effect
+
+    delete_user_from_db(user, db_session)
+
+    # Verify DocumentSet.user_id is nulled out (update, not delete)
+    doc_set_chain = query_chains[DocumentSet]
+    doc_set_chain.filter.assert_called()
+    doc_set_chain.filter.return_value.update.assert_called_once_with(
+        {DocumentSet.user_id: None}
+    )
+
+    # Verify Persona.user_id is nulled out (update, not delete)
+    persona_chain = query_chains[Persona]
+    persona_chain.filter.assert_called()
+    persona_chain.filter.return_value.update.assert_called_once_with(
+        {Persona.user_id: None}
+    )
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_cleans_up_join_tables(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    db_session = MagicMock()
+
+    query_chains: dict[type, MagicMock] = {}
+
+    def query_side_effect(model: type) -> MagicMock:
+        if model not in query_chains:
+            query_chains[model] = _make_query_chain()
+        return query_chains[model]
+
+    db_session.query.side_effect = query_side_effect
+
+    delete_user_from_db(user, db_session)
+
+    # Join tables should be deleted (not updated)
+    for model in [DocumentSet__User, Persona__User, User__UserGroup, SamlAccount]:
+        chain = query_chains[model]
+        chain.filter.return_value.delete.assert_called_once()
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_commits_and_removes_invited(
+    _mock_ee: Any, mock_remove_invited: Any
+) -> None:
+    user = _mock_user(email="deleted@example.com")
+    db_session = MagicMock()
+    db_session.query.return_value = _make_query_chain()
+
+    delete_user_from_db(user, db_session)
+
+    db_session.delete.assert_called_once_with(user)
+    db_session.commit.assert_called_once()
+    mock_remove_invited.assert_called_once_with("deleted@example.com")
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_deletes_oauth_accounts(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    oauth1 = MagicMock()
+    oauth2 = MagicMock()
+    user.oauth_accounts = [oauth1, oauth2]
+    db_session = MagicMock()
+    db_session.query.return_value = _make_query_chain()
+
+    delete_user_from_db(user, db_session)
+
+    db_session.delete.assert_any_call(oauth1)
+    db_session.delete.assert_any_call(oauth2)


### PR DESCRIPTION
## Description

Fixes a `ForeignKeyViolation` error when deleting a user who owns document sets. The `document_set.user_id` FK constraint blocks user deletion because the DB constraint lacks the `ON DELETE CASCADE` that the ORM model declares.

Instead of cascade-deleting (which would destroy document sets used by other users), this PR:
- Nulls out `document_set.user_id` and `persona.user_id` for owned resources before deleting the user, preserving them for other users
- Treats orphaned document sets (`user_id=None`) as curator-manageable so curators can still edit/delete them after the original owner is removed

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user deletion failing when the user owns document sets by clearing ownership instead of deleting data. Orphaned document sets remain editable by curators.

- **Bug Fixes**
  - Set DocumentSet.user_id and Persona.user_id to None before deleting the user to avoid FK violations and preserve shared data.
  - Update document set permission checks to treat ownerless sets as owned by the requester (enables curator edit/delete).
  - Add unit tests for ownership nulling, join-table cleanup, OAuth deletion, and commit behavior.

<sup>Written for commit 34eba6972f90df45eb5c21dc75d85de97087a744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

