### PR TITLE
fix(ui): Inconsistent LLM Provider Logo

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -810,13 +810,12 @@ export function useLlmManager(
   ]);
 
   const updateTemperature = (temperature: number) => {
-    if (isAnthropic(currentLlm.provider, currentLlm.modelName)) {
-      setTemperature(Math.min(temperature, 1.0));
-    } else {
-      setTemperature(temperature);
-    }
+    const clampedTemp = isAnthropic(currentLlm.provider, currentLlm.modelName)
+      ? Math.min(temperature, 1.0)
+      : temperature;
+    setTemperature(clampedTemp);
     if (chatSession) {
-      updateTemperatureOverrideForChatSession(chatSession.id, temperature);
+      updateTemperatureOverrideForChatSession(chatSession.id, clampedTemp);
     }
   };
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There is a bug in which the logo for the LLM provider can potentially be swapped out if the name is the same between the different providers. 

For example: Azure GPT-5 model -> OpenAI GPT-5 model
The UI would jump from the Azure logo to the OpenAI logo when you started a new chat. 

This PR aims to fix this issue.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Reproduced locally and validated that the fix is working.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider logo switching when models share the same name across providers. We now match by provider + model first, falling back to name-only if provider info is missing.

- **Bug Fixes**
  - Prioritize provider-scoped lookup in useLlmManager to ensure the correct logo (e.g., Azure vs OpenAI).
  - Add fallback to search by raw model name when model parsing fails.
  - Temperature and state fixes: remove unintended llmUpdate during init; cap Anthropic temps using session model when currentLlm isn’t ready; fix useEffect deps in source preferences to avoid stale state.

<sup>Written for commit 6643a0468b4bf3cc7952aed0f5f931e2c20f4ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

