### PR TITLE
fix: make it more clear how to add channels to fed slack config form

### DIFF
--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -619,6 +619,9 @@ export function FederatedConnectorForm({
       );
     }
 
+    const channelInputPlaceholder =
+      "Type channel name or regex pattern and press Enter";
+
     return (
       <>
         {Object.entries(formState.configurationSchema).map(
@@ -688,9 +691,9 @@ export function FederatedConnectorForm({
                             }
                           }}
                           placeholder={
-                            fieldSpec.example &&
-                            Array.isArray(fieldSpec.example)
-                              ? `e.g., ${fieldSpec.example.join(", ")}`
+                            fieldKey === "channels" ||
+                            fieldKey === "exclude_channels"
+                              ? channelInputPlaceholder
                               : "Type and press Enter to add an item"
                           }
                           disabled={disableSlackChannelInput(fieldKey)}


### PR DESCRIPTION
## Description

Just changing the placeholder for slack channel configs on the federated connector form. Customers have been confused a number of times so this should hopefulyl clear up that confusion


## How Has This Been Tested?

local testing

<img width="915" height="276" alt="Screenshot 2026-02-06 at 9 28 50 AM" src="https://github.com/user-attachments/assets/6cd6f623-51d5-40e1-93c4-3a156bf644de" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to add Slack channels in the federated connector form by updating the placeholders for the channels and exclude_channels inputs. Users now see “Type channel name or regex pattern and press Enter,” reducing confusion when adding items.

<sup>Written for commit ec4cdab5d05a00b23b9e9f892e14bfbcce607752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

