### PR TITLE
chore(chat): Cleaning Error Codes + Tests (#8186) to release v2.10

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -58,6 +58,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.feedback import create_chat_message_feedback
 from onyx.db.feedback import remove_chat_message_feedback
+from onyx.db.models import ChatSessionSharedStatus
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
@@ -266,7 +267,35 @@ def get_chat_session(
             include_deleted=include_deleted,
         )
     except ValueError:
-        raise ValueError("Chat session does not exist or has been deleted")
+        try:
+            # If we failed to get a chat session, try to retrieve the session with
+            # less restrictive filters in order to identify what exactly mismatched
+            # so we can bubble up an accurate error code andmessage.
+            existing_chat_session = get_chat_session_by_id(
+                chat_session_id=session_id,
+                user_id=None,
+                db_session=db_session,
+                is_shared=False,
+                include_deleted=True,
+            )
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Chat session not found")
+
+        if not include_deleted and existing_chat_session.deleted:
+            raise HTTPException(status_code=404, detail="Chat session has been deleted")
+
+        if is_shared:
+            if existing_chat_session.shared_status != ChatSessionSharedStatus.PUBLIC:
+                raise HTTPException(
+                    status_code=403, detail="Chat session is not shared"
+                )
+        elif user_id is not None and existing_chat_session.user_id not in (
+            user_id,
+            None,
+        ):
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        raise HTTPException(status_code=404, detail="Chat session not found")
 
     # for chat-seeding: if the session is unassigned, assign it now. This is done here
     # to avoid another back and forth between FE -> BE before starting the first

--- a/backend/tests/integration/common_utils/managers/chat.py
+++ b/backend/tests/integration/common_utils/managers/chat.py
@@ -476,8 +476,8 @@ class ChatSessionManager:
                 else GENERAL_HEADERS
             ),
         )
-        # Chat session should return 400 if it doesn't exist
-        return response.status_code == 400
+        # Chat session should return 404 if it doesn't exist or is deleted
+        return response.status_code == 404
 
     @staticmethod
     def verify_soft_deleted(

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -1,0 +1,185 @@
+from uuid import uuid4
+
+import pytest
+import requests
+from requests import HTTPError
+
+from onyx.auth.schemas import UserRole
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.managers.chat import ChatSessionManager
+from tests.integration.common_utils.managers.user import build_email
+from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.reset import reset_all
+from tests.integration.common_utils.test_models import DATestUser
+
+
+@pytest.fixture(scope="module", autouse=True)
+def reset_for_module() -> None:
+    """Reset all data once before running any tests in this module."""
+    reset_all()
+
+
+@pytest.fixture
+def second_user(admin_user: DATestUser) -> DATestUser:
+    # Ensure admin exists so this new user is created with BASIC role.
+    try:
+        return UserManager.create(name="second_basic_user")
+    except HTTPError as e:
+        response = e.response
+        if response is None:
+            raise
+        if response.status_code not in (400, 409):
+            raise
+        try:
+            payload = response.json()
+        except ValueError:
+            raise
+        detail = payload.get("detail")
+        if not _is_user_already_exists_detail(detail):
+            raise
+        print("Second basic user already exists; logging in instead.")
+        return UserManager.login_as_user(
+            DATestUser(
+                id="",
+                email=build_email("second_basic_user"),
+                password=DEFAULT_PASSWORD,
+                headers=GENERAL_HEADERS,
+                role=UserRole.BASIC,
+                is_active=True,
+            )
+        )
+
+
+def _is_user_already_exists_detail(detail: object) -> bool:
+    if isinstance(detail, str):
+        normalized = detail.lower()
+        return (
+            "already exists" in normalized
+            or "register_user_already_exists" in normalized
+        )
+    if isinstance(detail, dict):
+        code = detail.get("code")
+        if isinstance(code, str) and code.lower() == "register_user_already_exists":
+            return True
+        message = detail.get("message")
+        if isinstance(message, str) and "already exists" in message.lower():
+            return True
+    return False
+
+
+def _get_chat_session(
+    chat_session_id: str,
+    user: DATestUser,
+    is_shared: bool | None = None,
+    include_deleted: bool | None = None,
+) -> requests.Response:
+    params: dict[str, str] = {}
+    if is_shared is not None:
+        params["is_shared"] = str(is_shared).lower()
+    if include_deleted is not None:
+        params["include_deleted"] = str(include_deleted).lower()
+
+    return requests.get(
+        f"{API_SERVER_URL}/chat/get-chat-session/{chat_session_id}",
+        params=params,
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _set_sharing_status(
+    chat_session_id: str, sharing_status: str, user: DATestUser
+) -> requests.Response:
+    return requests.patch(
+        f"{API_SERVER_URL}/chat/chat-session/{chat_session_id}",
+        json={"sharing_status": sharing_status},
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def test_private_chat_session_access(
+    basic_user: DATestUser, second_user: DATestUser
+) -> None:
+    """Verify private sessions are only accessible by the owner and never via share link."""
+    # Create a private chat session owned by basic_user.
+    chat_session = ChatSessionManager.create(user_performing_action=basic_user)
+
+    # Owner can access the private session normally.
+    response = _get_chat_session(str(chat_session.id), basic_user)
+    assert response.status_code == 200
+
+    # Share link should be forbidden when the session is private.
+    response = _get_chat_session(str(chat_session.id), basic_user, is_shared=True)
+    assert response.status_code == 403
+
+    # Other users cannot access private sessions directly.
+    response = _get_chat_session(str(chat_session.id), second_user)
+    assert response.status_code == 403
+
+    # Other users also cannot access private sessions via share link.
+    response = _get_chat_session(str(chat_session.id), second_user, is_shared=True)
+    assert response.status_code == 403
+
+
+def test_public_shared_chat_session_access(
+    basic_user: DATestUser, second_user: DATestUser
+) -> None:
+    """Verify shared sessions are accessible only via share link for non-owners."""
+    # Create a private session, then mark it public.
+    chat_session = ChatSessionManager.create(user_performing_action=basic_user)
+
+    response = _set_sharing_status(str(chat_session.id), "public", basic_user)
+    assert response.status_code == 200
+
+    # Owner can access normally.
+    response = _get_chat_session(str(chat_session.id), basic_user)
+    assert response.status_code == 200
+
+    # Owner can also access via share link.
+    response = _get_chat_session(str(chat_session.id), basic_user, is_shared=True)
+    assert response.status_code == 200
+
+    # Non-owner cannot access without share link.
+    response = _get_chat_session(str(chat_session.id), second_user)
+    assert response.status_code == 403
+
+    # Non-owner can access with share link for public sessions.
+    response = _get_chat_session(str(chat_session.id), second_user, is_shared=True)
+    assert response.status_code == 200
+
+
+def test_deleted_chat_session_access(
+    basic_user: DATestUser, second_user: DATestUser
+) -> None:
+    """Verify deleted sessions return 404, with include_deleted gated by access checks."""
+    # Create and soft-delete a session.
+    chat_session = ChatSessionManager.create(user_performing_action=basic_user)
+
+    deletion_success = ChatSessionManager.soft_delete(
+        chat_session=chat_session, user_performing_action=basic_user
+    )
+    assert deletion_success is True
+
+    # Deleted sessions are not accessible normally.
+    response = _get_chat_session(str(chat_session.id), basic_user)
+    assert response.status_code == 404
+
+    # Owner can fetch deleted session only with include_deleted.
+    response = _get_chat_session(str(chat_session.id), basic_user, include_deleted=True)
+    assert response.status_code == 200
+    assert response.json().get("deleted") is True
+
+    # Non-owner should be blocked even with include_deleted.
+    response = _get_chat_session(
+        str(chat_session.id), second_user, include_deleted=True
+    )
+    assert response.status_code == 403
+
+
+def test_chat_session_not_found_returns_404(basic_user: DATestUser) -> None:
+    """Verify unknown IDs return 404."""
+    response = _get_chat_session(str(uuid4()), basic_user)
+    assert response.status_code == 404


### PR DESCRIPTION
Cherry-pick of commit e05a34cad38a90069cccf87183939b4878ff63a7 to release/v2.10 branch.

Original PR: #8186

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up chat session error codes and messages, and added integration tests to enforce access and deletion rules. This makes 404/403 responses consistent and clearer.

- **Bug Fixes**
  - Return 404 for missing sessions and for deleted sessions unless include_deleted=true.
  - Return 403 for private session access by non-owners and when requesting shared access on non-public sessions; also 403 on user mismatch.
  - Added integration tests covering private vs. public sharing, deleted session access, and unknown IDs; updated helper to expect 404 for missing/deleted.

<sup>Written for commit e6e9fd267dc3423ccc4c2b0a859f23996353e04e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

