### PR TITLE
fix(agents): Removing Label Dependency (#8189) to release v2.10

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2932,8 +2932,6 @@ class PersonaLabel(Base):
         "Persona",
         secondary=Persona__PersonaLabel.__table__,
         back_populates="labels",
-        cascade="all, delete-orphan",
-        single_parent=True,
     )
 
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -917,7 +917,9 @@ def upsert_persona(
         existing_persona.icon_name = icon_name
         existing_persona.is_visible = is_visible
         existing_persona.search_start_date = search_start_date
-        existing_persona.labels = labels or []
+        if label_ids is not None:
+            existing_persona.labels.clear()
+            existing_persona.labels = labels or []
         existing_persona.is_default_persona = (
             is_default_persona
             if is_default_persona is not None

--- a/backend/tests/integration/tests/personas/test_persona_label_updates.py
+++ b/backend/tests/integration/tests/personas/test_persona_label_updates.py
@@ -1,0 +1,65 @@
+from uuid import uuid4
+
+import requests
+
+from onyx.server.features.persona.models import PersonaUpsertRequest
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.persona import PersonaLabelManager
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestPersonaLabel
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_update_persona_with_null_label_ids_preserves_labels(
+    reset: None, admin_user: DATestUser
+) -> None:
+    persona_label = PersonaLabelManager.create(
+        label=DATestPersonaLabel(name=f"Test label {uuid4()}"),
+        user_performing_action=admin_user,
+    )
+    assert persona_label.id is not None
+    persona = PersonaManager.create(
+        label_ids=[persona_label.id],
+        user_performing_action=admin_user,
+    )
+
+    updated_description = f"{persona.description}-updated"
+    update_request = PersonaUpsertRequest(
+        name=persona.name,
+        description=updated_description,
+        system_prompt=persona.system_prompt or "",
+        task_prompt=persona.task_prompt or "",
+        datetime_aware=persona.datetime_aware,
+        document_set_ids=persona.document_set_ids,
+        num_chunks=persona.num_chunks,
+        is_public=persona.is_public,
+        recency_bias=persona.recency_bias,
+        llm_filter_extraction=persona.llm_filter_extraction,
+        llm_relevance_filter=persona.llm_relevance_filter,
+        llm_model_provider_override=persona.llm_model_provider_override,
+        llm_model_version_override=persona.llm_model_version_override,
+        tool_ids=persona.tool_ids,
+        users=[],
+        groups=[],
+        label_ids=None,
+    )
+
+    response = requests.patch(
+        f"{API_SERVER_URL}/persona/{persona.id}",
+        json=update_request.model_dump(mode="json", exclude_none=False),
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    response.raise_for_status()
+
+    fetched = requests.get(
+        f"{API_SERVER_URL}/persona/{persona.id}",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    fetched.raise_for_status()
+    fetched_persona = fetched.json()
+
+    assert fetched_persona["description"] == updated_description
+    fetched_label_ids = {label["id"] for label in fetched_persona["labels"]}
+    assert persona_label.id in fetched_label_ids


### PR DESCRIPTION
Cherry-pick of commit a26b4ff8889dd331fd074fff0cf1c904214c9740 to release/v2.10 branch.

Original PR: #8189

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persona updates that unintentionally removed labels when label_ids wasn’t sent. Also removes cascade constraints between personas and labels to prevent accidental label deletions.

- **Bug Fixes**
  - Only update persona labels when label_ids is provided; preserve existing labels when null or omitted.
  - Removed cascade="all, delete-orphan" and single_parent from the Persona–Label relationship to avoid unintended label deletions.

<sup>Written for commit e1b96a7bbc0693db19ae5bc6ba2fe55fadef72dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

