### PR TITLE
fix(opensearch): Allow update to skip if a doc chunk is not found in OpenSearch, or if chunk count is not known

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -5,7 +5,7 @@ from typing import Generic
 from typing import TypeVar
 
 from opensearchpy import OpenSearch
-from opensearchpy.exceptions import TransportError
+from opensearchpy import TransportError
 from opensearchpy.helpers import bulk
 from pydantic import BaseModel
 

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 from datetime import timezone
 
 import pytest
+from opensearchpy import NotFoundError
 
 from onyx.access.models import DocumentAccess
 from onyx.access.utils import prefix_user_email
@@ -450,7 +451,7 @@ class TestOpenSearchClient:
         # Postcondition.
         assert result is True
         # Verify the document is gone.
-        with pytest.raises(Exception, match="404"):
+        with pytest.raises(NotFoundError, match="404"):
             test_client.get_document(document_chunk_id=doc_chunk_id)
 
     def test_delete_nonexistent_document(
@@ -614,7 +615,7 @@ class TestOpenSearchClient:
 
         # Under test and postcondition.
         # Try to update a document that doesn't exist.
-        with pytest.raises(Exception, match="404"):
+        with pytest.raises(NotFoundError, match="404"):
             test_client.update_document(
                 document_chunk_id="test_source__nonexistent__512__0",
                 properties_to_update={"hidden": True},


### PR DESCRIPTION
## Description
We've been seeing the following assuming `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX` is on:
- Document update being triggered but failing since the doc in question is not yet in OpenSearch because it has not been migrated yet. This fails the entire update task and causes it to be re-triggered. There is no knowing when the doc will be migrated so this can happen indefinitely. Let's just no-op the document index update step for now when this happens.
  - When we are fully on OpenSearch, and fix the doc updating/indexing race condition, we will tighten this contract such that it is not an acceptable state for update to be called when an expected document chunk is not in the document index.
- Document update being triggered but failing since the document does not have a chunk count. This can happen either because the document is undergoing an index attempt and its chunk count has not been updated yet (see the aforementioned race condition above) or because it was indexed under an old index regime where its chunk count was never populated. For the former case, in the Vespa codepath essentially does nothing productive: it gets all chunks it currently has and applies the update to those. There might be 0 chunks, or the chunks might all be soon-to-be-overwritten by the concurrent indexing job. For the OpenSearch codepath we'll do something similar and just skip the remaining updates if we find a chunk is missing. For the latter, we will not migrate a document with an unknown chunk count anyway, and the next time it is indexed it will have a chunk count so we don't need to support this case.
  - When we are fully on OpenSearch, and fix the doc updating/indexing race condition, we will tighten this contract such that it is not an acceptable state for update to be called when a document does not have a chunk count.

## How Has This Been Tested?
Relying on CI.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow OpenSearch document updates to no-op when a chunk isn’t found or the document’s chunk count is unknown. This prevents endless retries during migration and makes updates more resilient.

- **Bug Fixes**
  - Catch NotFoundError in update_single; log and skip when a chunk isn’t indexed yet.
  - Add ChunkCountNotFoundError; raised when chunk_count is missing and handled as a no-op in update_single.
  - Standardize OpenSearch errors: import TransportError from opensearchpy and use NotFoundError explicitly; tests updated to expect NotFoundError.
  - Clean up docstrings to reflect raised Exception types.

<sup>Written for commit 852272b230aedf7f94a1eb862c819748d96059e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

