### PR TITLE
fix(settings): default ee_features_enabled to False

### DIFF
--- a/backend/ee/onyx/server/settings/api.py
+++ b/backend/ee/onyx/server/settings/api.py
@@ -64,13 +64,18 @@ def apply_license_status_to_settings(settings: Settings) -> Settings:
     For multi-tenant (cloud), the settings already have the correct status
     from the control plane, so no override is needed.
 
-    If LICENSE_ENFORCEMENT_ENABLED is false, settings are returned unchanged,
-    allowing the product to function normally without license checks.
+    If LICENSE_ENFORCEMENT_ENABLED is false, ee_features_enabled is set to True
+    (since EE code was loaded via ENABLE_PAID_ENTERPRISE_EDITION_FEATURES).
     """
     if not LICENSE_ENFORCEMENT_ENABLED:
+        # License enforcement disabled - EE code is loaded via
+        # ENABLE_PAID_ENTERPRISE_EDITION_FEATURES, so EE features are on
+        settings.ee_features_enabled = True
         return settings
 
     if MULTI_TENANT:
+        # Cloud mode - EE features always available (gating handled by is_tenant_gated)
+        settings.ee_features_enabled = True
         return settings
 
     tenant_id = get_current_tenant_id()

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -59,8 +59,8 @@ class Settings(BaseModel):
 
     # Enterprise features flag - set by license enforcement at runtime
     # When LICENSE_ENFORCEMENT_ENABLED=true, this reflects license status
-    # When LICENSE_ENFORCEMENT_ENABLED=false, defaults to True (legacy behavior)
-    ee_features_enabled: bool = True
+    # When LICENSE_ENFORCEMENT_ENABLED=false, defaults to False
+    ee_features_enabled: bool = False
 
     temperature_override_enabled: bool | None = False
     auto_scroll: bool | None = False

--- a/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
+++ b/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
@@ -24,27 +24,36 @@ class TestApplyLicenseStatusToSettings:
     """Tests for apply_license_status_to_settings function."""
 
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", False)
-    def test_enforcement_disabled_returns_unchanged(
+    def test_enforcement_disabled_enables_ee_features(
         self, base_settings: Settings
     ) -> None:
-        """Critical: When LICENSE_ENFORCEMENT_ENABLED=False, settings remain unchanged.
+        """When LICENSE_ENFORCEMENT_ENABLED=False, EE features are enabled.
 
-        This is the key behavior that allows disabling enforcement for rollback.
+        If we're running the EE apply function, EE code was loaded via
+        ENABLE_PAID_ENTERPRISE_EDITION_FEATURES, so features should be on.
         """
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
+        assert base_settings.ee_features_enabled is False
         result = apply_license_status_to_settings(base_settings)
         assert result.application_status == ApplicationStatus.ACTIVE
+        assert result.ee_features_enabled is True
+
+    @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
+    @patch("ee.onyx.server.settings.api.MULTI_TENANT", True)
+    def test_multi_tenant_enables_ee_features(self, base_settings: Settings) -> None:
+        """Cloud mode always enables EE features."""
+        from ee.onyx.server.settings.api import apply_license_status_to_settings
+
+        result = apply_license_status_to_settings(base_settings)
+        assert result.ee_features_enabled is True
 
     @pytest.mark.parametrize(
-        "license_status,expected_status",
+        "license_status,expected_app_status,expected_ee_enabled",
         [
-            (None, ApplicationStatus.ACTIVE),  # No license = allow community features
-            (
-                ApplicationStatus.GATED_ACCESS,
-                ApplicationStatus.GATED_ACCESS,
-            ),  # Gated status propagated
-            (ApplicationStatus.ACTIVE, ApplicationStatus.ACTIVE),  # Active stays active
+            (None, ApplicationStatus.ACTIVE, False),
+            (ApplicationStatus.GATED_ACCESS, ApplicationStatus.GATED_ACCESS, False),
+            (ApplicationStatus.ACTIVE, ApplicationStatus.ACTIVE, True),
         ],
     )
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
@@ -56,10 +65,11 @@ class TestApplyLicenseStatusToSettings:
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
         license_status: ApplicationStatus | None,
-        expected_status: ApplicationStatus,
+        expected_app_status: ApplicationStatus,
+        expected_ee_enabled: bool,
         base_settings: Settings,
     ) -> None:
-        """Self-hosted: license status is propagated to settings correctly."""
+        """Self-hosted: license status controls both application_status and ee_features_enabled."""
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
         mock_get_tenant.return_value = "test_tenant"
@@ -71,19 +81,20 @@ class TestApplyLicenseStatusToSettings:
             mock_get_metadata.return_value = mock_metadata
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == expected_status
+        assert result.application_status == expected_app_status
+        assert result.ee_features_enabled is expected_ee_enabled
 
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
     @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
     @patch("ee.onyx.server.settings.api.get_current_tenant_id")
     @patch("ee.onyx.server.settings.api.get_cached_license_metadata")
-    def test_redis_error_fails_open(
+    def test_redis_error_disables_ee_features(
         self,
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
         base_settings: Settings,
     ) -> None:
-        """Redis errors should not block users - fail open."""
+        """Redis errors fail closed - disable EE features."""
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
         mock_get_tenant.return_value = "test_tenant"
@@ -91,3 +102,12 @@ class TestApplyLicenseStatusToSettings:
 
         result = apply_license_status_to_settings(base_settings)
         assert result.application_status == ApplicationStatus.ACTIVE
+        assert result.ee_features_enabled is False
+
+
+class TestSettingsDefaultEEDisabled:
+    """Verify the Settings model defaults ee_features_enabled to False."""
+
+    def test_default_ee_features_disabled(self) -> None:
+        settings = Settings()
+        assert settings.ee_features_enabled is False


### PR DESCRIPTION
## Description

The `Settings` model defaulted `ee_features_enabled=True`, which caused EE UI elements (Groups, Standard Answers, Appearance & Theming, etc.) to appear in the admin sidebar even when `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=False` and `LICENSE_ENFORCEMENT_ENABLED=False`.

The root cause: the MIT `apply_license_status_to_settings` is a no-op, so the `True` default flowed unchallenged through to `usePaidEnterpriseFeaturesEnabled()` on the frontend. No combination of env vars could turn off EE in the UI.

Fix:
- Default `ee_features_enabled` to `False` in the `Settings` model
- Explicitly set `ee_features_enabled=True` in the EE `apply_license_status_to_settings` for the `LICENSE_ENFORCEMENT_ENABLED=false` and `MULTI_TENANT` early-return paths

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented EE UI from appearing in MIT installs by defaulting ee_features_enabled to False and only enabling it when EE is loaded or in cloud mode.

- **Bug Fixes**
  - Default ee_features_enabled to False in Settings.
  - In EE apply_license_status_to_settings, set ee_features_enabled to True when LICENSE_ENFORCEMENT_ENABLED is false or MULTI_TENANT is true.
  - Updated tests to assert ee_features_enabled across all paths.

<sup>Written for commit 6273bd05e98540cb802ea98d3c5f6136cc07c21b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

