### PR TITLE
chore(opensearch): Make indexing use the client's new bulk index API

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -324,7 +324,6 @@ class OpenSearchClient:
     @log_function_time(
         print_only=True,
         debug_only=True,
-        include_args=False,
         include_args_subset={
             "documents": len,
             "tenant_state": str,
@@ -355,7 +354,7 @@ class OpenSearchClient:
                 already exists. Defaults to False.
 
         Raises:
-            RuntimeError: There was an error during the bulk index. This
+            Exception: There was an error during the bulk index. This
                 includes the case where a document with the same ID already
                 exists if update_if_exists is False.
         """

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from typing import Any
 
 import httpx
@@ -522,49 +523,76 @@ class OpenSearchDocumentIndex(DocumentIndex):
         chunks: list[DocMetadataAwareIndexChunk],
         indexing_metadata: IndexingMetadata,  # noqa: ARG002
     ) -> list[DocumentInsertionRecord]:
-        logger.debug(
-            f"[OpenSearchDocumentIndex] Indexing {len(chunks)} chunks for index {self._index_name}."
+        """Indexes a list of document chunks into the document index.
+
+        Groups chunks by document ID and for each document, deletes existing
+        chunks and indexes the new chunks in bulk.
+
+        NOTE: It is assumed that chunks for a given document are not spread out
+        over multiple index() calls.
+
+        Args:
+            chunks: Document chunks with all of the information needed for
+                indexing to the document index.
+            indexing_metadata: Information about chunk counts for efficient
+                cleaning / updating.
+
+        Raises:
+            Exception: Failed to index some or all of the chunks for the
+                specified documents.
+
+        Returns:
+            List of document IDs which map to unique documents as well as if the
+                document is newly indexed or had already existed and was just
+                updated.
+        """
+        # Group chunks by document ID.
+        doc_id_to_chunks: dict[str, list[DocMetadataAwareIndexChunk]] = defaultdict(
+            list
         )
-        # Set of doc IDs.
-        unique_docs_to_be_indexed: set[str] = set()
-        document_indexing_results: list[DocumentInsertionRecord] = []
         for chunk in chunks:
-            document_insertion_record: DocumentInsertionRecord | None = None
-            onyx_document: Document = chunk.source_document
-            if onyx_document.id not in unique_docs_to_be_indexed:
-                # If this is the first time we see this doc in this indexing
-                # operation, first delete the doc's chunks from the index. This
-                # is so that there are no dangling chunks in the index, in the
-                # event that the new document's content contains fewer chunks
-                # than the previous content.
-                # TODO(andrei): This can possibly be made more efficient by
-                # checking if the chunk count has actually decreased. This
-                # assumes that overlapping chunks are perfectly overwritten. If
-                # we can't guarantee that then we need the code as-is.
-                unique_docs_to_be_indexed.add(onyx_document.id)
-                num_chunks_deleted = self.delete(
-                    onyx_document.id, onyx_document.chunk_count
-                )
-                # If we see that chunks were deleted we assume the doc already
-                # existed.
-                document_insertion_record = DocumentInsertionRecord(
-                    document_id=onyx_document.id,
-                    already_existed=num_chunks_deleted > 0,
-                )
+            doc_id_to_chunks[chunk.source_document.id].append(chunk)
+        logger.debug(
+            f"[OpenSearchDocumentIndex] Indexing {len(chunks)} chunks from {len(doc_id_to_chunks)} "
+            f"documents for index {self._index_name}."
+        )
 
-            opensearch_document_chunk = _convert_onyx_chunk_to_opensearch_document(
-                chunk
+        document_indexing_results: list[DocumentInsertionRecord] = []
+        # Try to index per-document.
+        for _, chunks in doc_id_to_chunks.items():
+            # Create a batch of OpenSearch-formatted chunks for bulk insertion.
+            # Do this before deleting existing chunks to reduce the amount of
+            # time the document index has no content for a given document, and
+            # to reduce the chance of entering a state where we delete chunks,
+            # then some error happens, and never successfully index new chunks.
+            chunk_batch: list[DocumentChunk] = [
+                _convert_onyx_chunk_to_opensearch_document(chunk) for chunk in chunks
+            ]
+            onyx_document: Document = chunks[0].source_document
+            # First delete the doc's chunks from the index. This is so that
+            # there are no dangling chunks in the index, in the event that the
+            # new document's content contains fewer chunks than the previous
+            # content.
+            # TODO(andrei): This can possibly be made more efficient by checking
+            # if the chunk count has actually decreased. This assumes that
+            # overlapping chunks are perfectly overwritten. If we can't
+            # guarantee that then we need the code as-is.
+            num_chunks_deleted = self.delete(
+                onyx_document.id, onyx_document.chunk_count
             )
-            # TODO(andrei): After our client supports batch indexing, use that
-            # here.
-            self._os_client.index_document(
-                document=opensearch_document_chunk, tenant_state=self._tenant_state
+            # If we see that chunks were deleted we assume the doc already
+            # existed.
+            document_insertion_record = DocumentInsertionRecord(
+                document_id=onyx_document.id,
+                already_existed=num_chunks_deleted > 0,
             )
-
-            if document_insertion_record is not None:
-                # Only add records once per doc. This object is not None only if
-                # we've seen this doc for the first time in this for-loop.
-                document_indexing_results.append(document_insertion_record)
+            # Now index. This will raise if a chunk of the same ID exists, which
+            # we do not expect because we should have deleted all chunks.
+            self._os_client.bulk_index_documents(
+                documents=chunk_batch,
+                tenant_state=self._tenant_state,
+            )
+            document_indexing_results.append(document_insertion_record)
 
         return document_indexing_results
 
@@ -576,15 +604,17 @@ class OpenSearchDocumentIndex(DocumentIndex):
         Does nothing if the specified document ID does not exist.
 
         TODO(andrei): Consider implementing this method to delete on document
-        chunk IDs vs querying for matching document chunks.
+        chunk IDs vs querying for matching document chunks. Unclear if this is
+        any better though.
 
         Args:
-            document_id: The ID of the document to delete.
+            document_id: The unique identifier for the document as represented
+                in Onyx, not necessarily in the document index.
             chunk_count: The number of chunks in OpenSearch for the document.
                 Defaults to None.
 
         Raises:
-            RuntimeError: Failed to delete some or all of the chunks for the
+            Exception: Failed to delete some or all of the chunks for the
                 document.
 
         Returns:


### PR DESCRIPTION
## Description
Now we index in bulk per-document. This should make indexing faster. Has no effect on migration, which was already using this API.

## How Has This Been Tested?
I am going to run the product locally and ensure we can still index fine, have not done this yet though and will not merge until I do.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched OpenSearch document indexing to use the client's bulk_index_documents API, batching chunks per document for faster and more reliable indexing. Migration is unaffected (it already uses this API).

- **Refactors**
  - Group chunks by document ID; build batch, delete old chunks, then bulk index.
  - Return one DocumentInsertionRecord per document based on whether deletes occurred.
  - Minimize empty-index window by preparing batches before delete.
  - Clarified bulk_index_documents docstring to raise Exception.

<sup>Written for commit d82a2fbc50813bea1c2e835e6e291d9e3a610378. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

