### PR TITLE
fix: Modals fix

### DIFF
--- a/web/lib/opal/src/icons/arrow-down-dot.tsx
+++ b/web/lib/opal/src/icons/arrow-down-dot.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgArrowDownDot = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgArrowDownDot = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 9 14"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/arrow-left-dot.tsx
+++ b/web/lib/opal/src/icons/arrow-left-dot.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgArrowLeftDot = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgArrowLeftDot = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 14 9"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/arrow-right-dot.tsx
+++ b/web/lib/opal/src/icons/arrow-right-dot.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgArrowRightDot = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgArrowRightDot = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 14 9"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/arrow-up-dot.tsx
+++ b/web/lib/opal/src/icons/arrow-up-dot.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgArrowUpDot = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgArrowUpDot = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 9 14"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/bracket-curly.tsx
+++ b/web/lib/opal/src/icons/bracket-curly.tsx
@@ -1,7 +1,9 @@
-import type { SVGProps } from "react";
+import type { IconProps } from "@opal/types";
 
-const SvgBracketCurly = (props: SVGProps<SVGSVGElement>) => (
+const SvgBracketCurly = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 15 14"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/claude.tsx
+++ b/web/lib/opal/src/icons/claude.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import type { IconProps } from "@opal/types";
 
-const SvgClaude = (props: IconProps) => {
+const SvgClaude = ({ size, ...props }: IconProps) => {
   const clipId = React.useId();
   return (
     <svg
+      width={size}
+      height={size}
       viewBox="0 0 16 16"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/clipboard.tsx
+++ b/web/lib/opal/src/icons/clipboard.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgClipboard = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgClipboard = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/corner-right-up-dot.tsx
+++ b/web/lib/opal/src/icons/corner-right-up-dot.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgCornerRightUpDot = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgCornerRightUpDot = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 9 14"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/onyx-logo.tsx
+++ b/web/lib/opal/src/icons/onyx-logo.tsx
@@ -1,17 +1,11 @@
 import type { IconProps } from "@opal/types";
 
-const OnyxLogo = ({
-  width = 24,
-  height = 24,
-  className,
-  ...props
-}: IconProps) => (
+const SvgOnyxLogo = ({ size, ...props }: IconProps) => (
   <svg
-    width={width}
-    height={height}
+    width={size}
+    height={size}
     viewBox="0 0 56 56"
     xmlns="http://www.w3.org/2000/svg"
-    className={className}
     stroke="currentColor"
     {...props}
   >
@@ -23,4 +17,4 @@ const OnyxLogo = ({
     />
   </svg>
 );
-export default OnyxLogo;
+export default SvgOnyxLogo;

--- a/web/lib/opal/src/icons/openai.tsx
+++ b/web/lib/opal/src/icons/openai.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import type { IconProps } from "@opal/types";
 
-const SvgOpenAI = (props: IconProps) => {
+const SvgOpenAI = ({ size, ...props }: IconProps) => {
   const clipId = React.useId();
   return (
     <svg
+      width={size}
+      height={size}
       viewBox="0 0 16 16"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/two-line-small.tsx
+++ b/web/lib/opal/src/icons/two-line-small.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgTwoLineSmall = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgTwoLineSmall = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/user-plus.tsx
+++ b/web/lib/opal/src/icons/user-plus.tsx
@@ -1,6 +1,8 @@
 import type { IconProps } from "@opal/types";
 const SvgUserPlus = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/lib/opal/src/icons/wallet.tsx
+++ b/web/lib/opal/src/icons/wallet.tsx
@@ -1,6 +1,8 @@
-import type { SVGProps } from "react";
-const SvgWallet = (props: SVGProps<SVGSVGElement>) => (
+import type { IconProps } from "@opal/types";
+const SvgWallet = ({ size, ...props }: IconProps) => (
   <svg
+    width={size}
+    height={size}
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/web/src/app/admin/configuration/default-assistant/page.tsx
+++ b/web/src/app/admin/configuration/default-assistant/page.tsx
@@ -300,13 +300,7 @@ export default function Page() {
     <>
       <AdminPageTitle
         title="Default Assistant"
-        icon={
-          <SvgOnyxLogo
-            width={32}
-            height={32}
-            className="my-auto stroke-text-04"
-          />
-        }
+        icon={<SvgOnyxLogo size={32} className="my-auto stroke-text-04" />}
       />
       <DefaultAssistantConfig />
     </>

--- a/web/src/app/admin/configuration/web-search/WebProviderSetupModal.tsx
+++ b/web/src/app/admin/configuration/web-search/WebProviderSetupModal.tsx
@@ -68,11 +68,7 @@ export const WebProviderSetupModal = memo(
             <SvgArrowExchange className="size-3 text-text-04" />
           </div>
           <div className="flex items-center justify-center size-7 p-0.5 shrink-0 overflow-clip">
-            <SvgOnyxLogo
-              width={24}
-              height={24}
-              className="text-text-04 shrink-0"
-            />
+            <SvgOnyxLogo size={24} className="text-text-04 shrink-0" />
           </div>
         </div>
       );

--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -1168,7 +1168,7 @@ export default function Page() {
                         alt: `${label} logo`,
                         fallback:
                           provider.provider_type === "onyx_web_crawler" ? (
-                            <SvgOnyxLogo width={16} height={16} />
+                            <SvgOnyxLogo size={16} />
                           ) : undefined,
                         size: 16,
                         isHighlighted: isCurrentCrawler,
@@ -1381,7 +1381,7 @@ export default function Page() {
           } logo`,
           fallback:
             selectedContentProviderType === "onyx_web_crawler" ? (
-              <SvgOnyxLogo width={24} height={24} className="text-text-05" />
+              <SvgOnyxLogo size={24} className="text-text-05" />
             ) : undefined,
           size: 24,
           containerSize: 28,

--- a/web/src/refresh-components/ConnectionProviderIcon.tsx
+++ b/web/src/refresh-components/ConnectionProviderIcon.tsx
@@ -13,7 +13,7 @@ const ConnectionProviderIcon = memo(({ icon }: ConnectionProviderIconProps) => {
         <SvgArrowExchange className="w-3 h-3 stroke-text-04" />
       </div>
       <div className="w-7 h-7 flex items-center justify-center">
-        <SvgOnyxLogo width={24} height={24} className="fill-text-04" />
+        <SvgOnyxLogo size={24} className="fill-text-04" />
       </div>
     </div>
   );

--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -353,7 +353,15 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
             flexDirection="row"
             justifyContent="between"
           >
-            <Icon className="w-[1.5rem] h-[1.5rem] stroke-text-04" />
+            {/*
+              The `h-[1.5rem]` and `w-[1.5rem]` were added as backups here.
+              However, prop-resolution technically resolves to choosing classNames over size props, so technically the `size={24}` is the backup.
+              We specify both to be safe.
+
+              # Note
+              1.5rem === 24px
+            */}
+            <Icon className="stroke-text-04 h-[1.5rem] w-[1.5rem]" size={24} />
             {onClose && (
               <div
                 tabIndex={-1}


### PR DESCRIPTION
## Screenshots

<img width="1270" height="677" alt="image" src="https://github.com/user-attachments/assets/fc1ff5f2-2db6-4a51-93c5-97ee0ebfc2ef" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes modal icon sizing and several UI/UX issues, while tightening access control and improving task lifecycle stability. Also removes desktop global shortcuts and increases connector reliability.

- **Bug Fixes**
  - UI: Modal header enforces icon size; all icons accept a size prop; replaced flaky multi-select with InputComboBox; clearer Slack channel input hints; fixed chat retrieval detection with personas; connector details back navigation.
  - APIs & Access: Project list path normalized to /user/projects (no trailing slash); chat session API returns 404 for missing/deleted sessions with clearer errors; hide non‑public, unrestricted LLM providers from non‑admins.
  - Stability: Added TTLs to Redis fence/taskset keys for document sync, connector prune/delete, document sets, and user groups to prevent memory leaks.
  - Data integrity: Preserve document sets and personas on user deletion by nulling owners; keep persona labels when label_ids is omitted on update.
  - Connectors: Asana IDs trimmed/normalized (handles empty inputs); Salesforce auto‑recovers from SQLite WAL/SHM I/O errors and improves metadata conversion; expanded tests.
  - Desktop: Removed global shortcut support and related ACLs; titlebar/theme now track light/dark mode correctly.
  - Tooling: Fixed MyPy cache key to be branch‑aware, avoiding stale caches.

<sup>Written for commit 6650ae6ca304b92293708f5130d9fcacd94229e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

