### PR TITLE
chore(llm): Introduce Scaffolding for Integration Tests

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -7,6 +7,7 @@ import re
 import time
 import traceback
 from collections.abc import Callable
+from contextvars import Token
 from uuid import UUID
 
 from redis.client import Redis
@@ -43,6 +44,7 @@ from onyx.chat.prompt_utils import calculate_reserved_tokens
 from onyx.chat.save_chat import save_chat_turn
 from onyx.chat.stop_signal_checker import is_connected as check_stop_signal
 from onyx.chat.stop_signal_checker import reset_cancel_status
+from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
@@ -69,6 +71,8 @@ from onyx.llm.factory import get_llm_for_persona
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.request_context import reset_llm_mock_response
+from onyx.llm.request_context import set_llm_mock_response
 from onyx.llm.utils import litellm_exception_to_error_msg
 from onyx.onyxbot.slack.models import SlackContext
 from onyx.redis.redis_pool import get_redis_client
@@ -318,6 +322,7 @@ def handle_stream_message_objects(
 ) -> AnswerStream:
     tenant_id = get_current_tenant_id()
     processing_start_time = time.monotonic()
+    mock_response_token: Token[str | None] | None = None
 
     llm: LLM | None = None
     chat_session: ChatSession | None = None
@@ -328,6 +333,14 @@ def handle_stream_message_objects(
         llm_user_identifier = "anonymous_user"
     else:
         llm_user_identifier = user.email or str(user_id)
+
+    if new_msg_req.mock_llm_response is not None:
+        if not INTEGRATION_TESTS_MODE:
+            raise ValueError(
+                "mock_llm_response can only be used when INTEGRATION_TESTS_MODE=true"
+            )
+        mock_response_token = set_llm_mock_response(new_msg_req.mock_llm_response)
+
     try:
         if not new_msg_req.chat_session_id:
             if not new_msg_req.chat_session_info:
@@ -723,6 +736,9 @@ def handle_stream_message_objects(
 
         db_session.rollback()
     finally:
+        if mock_response_token is not None:
+            reset_llm_mock_response(mock_response_token)
+
         try:
             if redis_client is not None and chat_session is not None:
                 set_processing_status(
@@ -839,6 +855,7 @@ def stream_chat_message_objects(
     translated_new_msg_req = SendMessageRequest(
         message=new_msg_req.message,
         llm_override=new_msg_req.llm_override,
+        mock_llm_response=new_msg_req.mock_llm_response,
         allowed_tool_ids=new_msg_req.allowed_tool_ids,
         forced_tool_id=forced_tool_id,
         file_descriptors=new_msg_req.file_descriptors,

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -21,6 +21,7 @@ from onyx.llm.model_response import ModelResponseStream
 from onyx.llm.model_response import Usage
 from onyx.llm.models import ANTHROPIC_REASONING_EFFORT_BUDGET
 from onyx.llm.models import OPENAI_REASONING_EFFORT
+from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
 from onyx.llm.utils import is_true_openai_model
 from onyx.llm.utils import model_is_reasoning_model
@@ -378,7 +379,7 @@ class LitellmLLM(LLM):
                 passthrough_kwargs["api_key"] = self._api_key or None
 
             response = litellm.completion(
-                mock_response=MOCK_LLM_RESPONSE,
+                mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
                 model=model,
                 base_url=self._api_base or None,
                 api_version=self._api_version or None,

--- a/backend/onyx/llm/request_context.py
+++ b/backend/onyx/llm/request_context.py
@@ -1,0 +1,18 @@
+import contextvars
+
+
+_LLM_MOCK_RESPONSE_CONTEXTVAR: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar("llm_mock_response", default=None)
+)
+
+
+def get_llm_mock_response() -> str | None:
+    return _LLM_MOCK_RESPONSE_CONTEXTVAR.get()
+
+
+def set_llm_mock_response(mock_response: str | None) -> contextvars.Token[str | None]:
+    return _LLM_MOCK_RESPONSE_CONTEXTVAR.set(mock_response)
+
+
+def reset_llm_mock_response(token: contextvars.Token[str | None]) -> None:
+    _LLM_MOCK_RESPONSE_CONTEXTVAR.reset(token)

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -87,6 +87,8 @@ class SendMessageRequest(BaseModel):
     message: str
 
     llm_override: LLMOverride | None = None
+    # Test-only override for deterministic LiteLLM mock responses.
+    mock_llm_response: str | None = None
 
     allowed_tool_ids: list[int] | None = None
     forced_tool_id: int | None = None
@@ -191,6 +193,8 @@ class CreateChatMessageRequest(ChunkContext):
     # allows the caller to override the Persona / Prompt
     # these do not persist in the chat thread details
     llm_override: LLMOverride | None = None
+    # Test-only override for deterministic LiteLLM mock responses.
+    mock_llm_response: str | None = None
     prompt_override: PromptOverride | None = None
 
     # Allows the caller to override the temperature for the chat session

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Annotated
+from typing import Any
 from typing import Literal
 from typing import Union
 
@@ -37,6 +38,7 @@ class StreamingType(Enum):
     REASONING_DELTA = "reasoning_delta"
     REASONING_DONE = "reasoning_done"
     CITATION_INFO = "citation_info"
+    TOOL_CALL_DEBUG = "tool_call_debug"
 
     DEEP_RESEARCH_PLAN_START = "deep_research_plan_start"
     DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta"
@@ -125,6 +127,14 @@ class CitationInfo(BaseObj):
     # The document id of the SearchDoc (same as the field stored in the DB)
     # This is the actual document id from the connector, not the int id
     document_id: str
+
+
+class ToolCallDebug(BaseObj):
+    type: Literal["tool_call_debug"] = StreamingType.TOOL_CALL_DEBUG.value
+
+    tool_call_id: str
+    tool_name: str
+    tool_args: dict[str, Any]
 
 
 ################################################
@@ -318,6 +328,7 @@ PacketObj = Union[
     ReasoningDone,
     # Citation Packets
     CitationInfo,
+    ToolCallDebug,
     # Deep Research Packets
     DeepResearchPlanStart,
     DeepResearchPlanDelta,

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -202,6 +202,12 @@ class ToolResult(BaseModel):
     images: list[GeneratedImage] = Field(default_factory=list)
 
 
+class ToolCallDebug(BaseModel):
+    tool_call_id: str
+    tool_name: str
+    tool_args: dict[str, Any]
+
+
 class ErrorResponse(BaseModel):
     error: str
     stack_trace: str
@@ -212,6 +218,7 @@ class StreamedResponse(BaseModel):
     assistant_message_id: int
     top_documents: list[SearchDoc]
     used_tools: list[ToolResult]
+    tool_call_debug: list[ToolCallDebug] = Field(default_factory=list)
     error: ErrorResponse | None = None
 
     # Track heartbeat packets for image generation and other tools


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Beginning work to introduce scaffolding in order to simplify process to test LLM integrations in different scenarios

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran tests locally.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scaffolding to make LLM integration tests deterministic and easier to debug. Supports per-request mock LLM responses and streams tool call details when INTEGRATION_TESTS_MODE is enabled.

- **New Features**
  - Per-request LiteLLM mock response via contextvar; enforced to test mode only (ValueError otherwise) and wired into litellm.completion.
  - ToolCallDebug streaming packet (tool_call_id, tool_name, tool_args); emitted only in test mode.
  - API updates: mock_llm_response added to SendMessageRequest/CreateChatMessageRequest; test chat manager forwards it; StreamedResponse exposes tool_call_debug.

- **Migration**
  - Set INTEGRATION_TESTS_MODE=true for integration tests.
  - Pass mock_llm_response through ChatManager.send_message(...) to control LLM output.
  - Parse tool_call_debug from streamed responses to verify tool selection and arguments.

<sup>Written for commit 559f8dc01659f916e75be88ff3d35ad0759124f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

