### PR TITLE
fix: Deep Research Agent Cycle Count

### DIFF
--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -2,7 +2,7 @@ from onyx.prompts.deep_research.dr_tool_prompts import GENERATE_REPORT_TOOL_NAME
 from onyx.prompts.deep_research.dr_tool_prompts import THINK_TOOL_NAME
 
 
-MAX_RESEARCH_CYCLES = 3
+MAX_RESEARCH_CYCLES = 8
 
 # ruff: noqa: E501, W605 start
 RESEARCH_AGENT_PROMPT = f"""

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -38,6 +38,7 @@ from onyx.prompts.deep_research.dr_tool_prompts import (
     OPEN_URLS_TOOL_DESCRIPTION_REASONING,
 )
 from onyx.prompts.deep_research.dr_tool_prompts import WEB_SEARCH_TOOL_DESCRIPTION
+from onyx.prompts.deep_research.research_agent import MAX_RESEARCH_CYCLES
 from onyx.prompts.deep_research.research_agent import OPEN_URL_REMINDER_RESEARCH_AGENT
 from onyx.prompts.deep_research.research_agent import RESEARCH_AGENT_PROMPT
 from onyx.prompts.deep_research.research_agent import RESEARCH_AGENT_PROMPT_REASONING
@@ -73,7 +74,6 @@ from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 logger = setup_logger()
 
 
-RESEARCH_CYCLE_CAP = 8
 # 30 minute timeout per research agent
 RESEARCH_AGENT_TIMEOUT_SECONDS = 30 * 60
 RESEARCH_AGENT_TIMEOUT_MESSAGE = "Research Agent timed out after 30 minutes"
@@ -254,7 +254,7 @@ def run_research_agent_call(
 
             citation_mapping: dict[int, str] = {}
             most_recent_reasoning: str | None = None
-            while research_cycle_count <= RESEARCH_CYCLE_CAP:
+            while research_cycle_count <= MAX_RESEARCH_CYCLES:
                 # Check if we've exceeded the time limit - if so, skip LLM and generate report
                 elapsed_seconds = time.monotonic() - start_time
                 if elapsed_seconds > RESEARCH_AGENT_FORCE_REPORT_SECONDS:
@@ -264,7 +264,7 @@ def run_research_agent_call(
                     )
                     break
 
-                if research_cycle_count == RESEARCH_CYCLE_CAP:
+                if research_cycle_count == MAX_RESEARCH_CYCLES:
                     # Auto-generate report on last cycle
                     logger.debug("Auto-generating intermediate report on last cycle.")
                     break


### PR DESCRIPTION
## Description
Was miscounting in the prompt because of a variable which should have been reused but wasn't

## How Has This Been Tested?
N/A high confidence small change

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Deep Research Agent cycle count by using a single constant and aligning the prompt with runtime logic. The agent now consistently caps at 8 cycles and auto-generates the report on the last cycle.

- **Bug Fixes**
  - Set MAX_RESEARCH_CYCLES to 8 in the prompt and reuse it in the tool (removed duplicate RESEARCH_CYCLE_CAP).
  - Updated loop checks to use MAX_RESEARCH_CYCLES to prevent mismatched instructions and miscounts.

<sup>Written for commit 5dfe113c36deb60ef6af1554a48e2243fc7d18af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

