### PR TITLE
chore(devtools): Add comment in AGENTS.md about the limitations of Celery timeouts with threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,10 @@ function.
 If you make any updates to a celery worker and you want to test these changes, you will need
 to ask me to restart the celery worker. There is no auto-restart on code-change mechanism.
 
+**Task Time Limits**:
+Since all tasks are executed in thread pools, the time limit features of Celery are silently 
+disabled and won't work. Timeout logic must be implemented within the task itself.
+
 ### Code Quality
 
 ```bash


### PR DESCRIPTION
## Description
Basically Celery timeouts don't mean anything as long as we use threads for task execution.

## How Has This Been Tested?
It wasn't.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented that Celery task time limits are disabled when using thread pools. Added guidance in AGENTS.md to implement timeout logic within the task itself.

<sup>Written for commit 4b62641aacae4683976c03ddbc6a02120f593022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

