### PR TITLE
fix(profiling): `log_function_time` should use `time.monotonic` not `time.time`

### DIFF
--- a/backend/onyx/utils/timing.py
+++ b/backend/onyx/utils/timing.py
@@ -93,7 +93,7 @@ def log_generator_function_time(
     def decorator(func: FG) -> FG:
         @wraps(func)
         def wrapped_func(*args: Any, **kwargs: Any) -> Any:
-            start_time = time.time()
+            start_time = time.monotonic()
             user = kwargs.get("user")
             gen = func(*args, **kwargs)
             try:
@@ -104,7 +104,7 @@ def log_generator_function_time(
             except StopIteration:
                 pass
             finally:
-                elapsed_time_str = str(time.time() - start_time)
+                elapsed_time_str = f"{time.monotonic() - start_time:.3f}"
                 log_name = func_name or func.__name__
                 logger.info(f"{log_name} took {elapsed_time_str} seconds")
                 if not print_only:


### PR DESCRIPTION
## Description
`time.time` is not guaranteed to be monotonically increasing over time and should not be used to measure elapsed time for things like function calls. `time.monotonic` should be preferred over `time.time` for that use-case.

## How Has This Been Tested?
It wasn't.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use time.monotonic for all function timing (regular and generator) to ensure stable elapsed times even if the system clock changes. Also standardizes timing logs to 3 decimal places.

- **Bug Fixes**
  - Use time.monotonic in log_function_time and log_generator_function_time to avoid negative or skewed durations.
  - Format elapsed time as {:.3f} seconds for consistent logs.

<sup>Written for commit 54345021c791a6958ec5a480a725490404b5756c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

