### PR TITLE
chore(chat frontend): Round up in `formatDurationSeconds` so we don't see "Thought for 0s"

### DIFF
--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -158,7 +158,7 @@ export function getSecondsUntilExpiration(
 }
 
 export function formatDurationSeconds(seconds: number): string {
-  const totalSeconds = Math.round(seconds);
+  const totalSeconds = Math.ceil(seconds);
   if (totalSeconds < 60) {
     return `${totalSeconds}s`;
   }


### PR DESCRIPTION
## Description
This change makes it so that it is not possible to see "Thought for 0s". We will always round up.

This function is used in `web/src/app/app/message/messageComponents/timeline/headers/StreamingHeader.tsx` and `web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx`.

## How Has This Been Tested?
It was not.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Round up chat duration formatting to the next whole second so “Thought for 0s” never appears in the completed and streaming headers.

<sup>Written for commit 44b90076b817b32e54cb167aad1e96b503a946c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

