### PR TITLE
fix(login): window undefined on login

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10491,6 +10491,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Description
This,

```
GET /auth/login?next=%2Fapp%3Ffrom%3Dlogin 500 in 625ms (compile: 381ms, render: 244ms)
⨯ ReferenceError: window is not defined
    at SignInButton (src/app/auth/login/SignInButton.tsx:31:5)
  29 |   const finalAuthorizeUrl = new URL(
  30 |     authorizeUrl,
> 31 |     window.location.origin
     |     ^
  32 |   ).toString();
  33 |
  34 |   if (!button) { {
  digest: '1476751490'
}
```

Is causing headless requests to this endpoint (useful for health checks like [status.onyx.app](https://status.onyx.app)) to return `500`s.

## How Has This Been Tested?

`curl -L -s -o /dev/null -w "%{http_code}" 'http://localhost:3000/auth/login'`

Might be able to either:
1. add a healthcheck to the web container which hits this endpoint
2. add a pre-flight playwright check which hits this endpoint

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a server-side crash on /auth/login by removing a window reference in SignInButton. Adds SSR safety notes to prevent regressions; the page now SSRs and returns 200s for headless and health-check requests.

- **Bug Fixes**
  - Use authorizeUrl directly for Button href to avoid window.location.origin on the server.

<sup>Written for commit 1a7ad91c7b7771da64b7b7173fd494e0747c4c23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



