### PR TITLE
fix(chrome extension): Simplify NRFPage ChatInputBar layout to use normal flex flow

### DIFF
--- a/web/src/app/app/nrf/NRFPage.tsx
+++ b/web/src/app/app/nrf/NRFPage.tsx
@@ -391,47 +391,37 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
               </div>
             )}
 
-            {/* ChatInputBar container - absolutely positioned when in chat, centered when no messages */}
+            {/* ChatInputBar container - in normal flex flow like AppPage */}
             <div
               ref={inputRef}
-              className={cn(
-                "flex justify-center",
-                hasMessages
-                  ? "absolute bottom-6 left-0 right-0 pointer-events-none"
-                  : "w-full"
-              )}
+              className="w-full max-w-[var(--app-page-main-content-width)] flex flex-col px-4"
             >
-              <div
-                className={cn(
-                  "w-full max-w-[var(--app-page-main-content-width)] flex flex-col px-4",
-                  hasMessages && "pointer-events-auto"
-                )}
-              >
-                <ChatInputBar
-                  ref={chatInputBarRef}
-                  deepResearchEnabled={deepResearchEnabled}
-                  toggleDeepResearch={toggleDeepResearch}
-                  toggleDocumentSidebar={() => {}}
-                  filterManager={filterManager}
-                  llmManager={llmManager}
-                  removeDocs={() => {}}
-                  retrievalEnabled={false}
-                  selectedDocuments={[]}
-                  initialMessage={message}
-                  stopGenerating={stopGenerating}
-                  onSubmit={handleChatInputSubmit}
-                  chatState={currentChatState}
-                  currentSessionFileTokenCount={currentSessionFileTokenCount}
-                  availableContextTokens={AVAILABLE_CONTEXT_TOKENS}
-                  selectedAssistant={liveAssistant ?? undefined}
-                  handleFileUpload={handleFileUpload}
-                  disabled={
-                    !llmManager.isLoadingProviders && !llmManager.hasAnyProvider
-                  }
-                />
-                <Spacer rem={0.5} />
-              </div>
+              <ChatInputBar
+                ref={chatInputBarRef}
+                deepResearchEnabled={deepResearchEnabled}
+                toggleDeepResearch={toggleDeepResearch}
+                toggleDocumentSidebar={() => {}}
+                filterManager={filterManager}
+                llmManager={llmManager}
+                removeDocs={() => {}}
+                retrievalEnabled={false}
+                selectedDocuments={[]}
+                initialMessage={message}
+                stopGenerating={stopGenerating}
+                onSubmit={handleChatInputSubmit}
+                chatState={currentChatState}
+                currentSessionFileTokenCount={currentSessionFileTokenCount}
+                availableContextTokens={AVAILABLE_CONTEXT_TOKENS}
+                selectedAssistant={liveAssistant ?? undefined}
+                handleFileUpload={handleFileUpload}
+                disabled={
+                  !llmManager.isLoadingProviders && !llmManager.hasAnyProvider
+                }
+              />
+              <Spacer rem={0.5} />
             </div>
+
+            {/* Spacer to push content up when showing welcome message */}
             {!hasMessages && <div className="flex-1 w-full" />}
           </div>
         )}


### PR DESCRIPTION
## Description

Refactored the ChatInputBar container layout in NRFPage to use normal flexbox flow instead of absolute positioning. This change:

- Removes the conditional absolute positioning logic that was applied when `hasMessages` was true
- Simplifies the DOM structure by eliminating one level of nested divs
- Aligns the layout behavior with AppPage's approach for consistency
- Maintains the same visual spacing with the existing `Spacer` component and flex-1 spacer for welcome message state

The ChatInputBar now flows naturally within the flex container, making the layout more predictable and easier to maintain.

## How Has This Been Tested?

- Verified ChatInputBar displays correctly with and without messages
- Confirmed spacing and alignment match previous behavior
- Tested that the welcome message state still properly positions content with the flex-1 spacer

https://github.com/user-attachments/assets/6cfb783c-0e53-4e18-8fc2-7f4a5bcdaed0



## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01C81TQdHFsmjYkNRiU8ck7R

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the NRFPage ChatInputBar into normal flex flow so it sits below messages and doesn’t overlay the history. Matches AppPage behavior and simplifies the layout.

- **Bug Fixes**
  - Removed absolute positioning that caused the input bar to overlay the ChatScrollContainer.

- **Refactors**
  - Dropped a nested container and used a single flex wrapper with max-width and padding; kept Spacer and the welcome-state flex-1 to preserve spacing.

<sup>Written for commit 3162a94c6fcf67829b4eabe95232acde2c80ec7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

