### PR TITLE
chore: disable hiernodes when opensearch not available

### DIFF
--- a/web/src/lib/hierarchy/svc.ts
+++ b/web/src/lib/hierarchy/svc.ts
@@ -7,6 +7,19 @@ import {
 
 const HIERARCHY_NODES_PREFIX = "/api/hierarchy-nodes";
 
+async function extractErrorDetail(
+  response: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const body = await response.json();
+    if (body.detail) return body.detail;
+  } catch {
+    // JSON parsing failed — fall through to fallback
+  }
+  return fallback;
+}
+
 export async function fetchHierarchyNodes(
   source: ValidSources
 ): Promise<HierarchyNodesResponse> {
@@ -15,7 +28,11 @@ export async function fetchHierarchyNodes(
   );
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch hierarchy nodes: ${response.statusText}`);
+    const detail = await extractErrorDetail(
+      response,
+      `Failed to fetch hierarchy nodes: ${response.statusText}`
+    );
+    throw new Error(detail);
   }
 
   return response.json();
@@ -33,9 +50,11 @@ export async function fetchHierarchyNodeDocuments(
   });
 
   if (!response.ok) {
-    throw new Error(
+    const detail = await extractErrorDetail(
+      response,
       `Failed to fetch hierarchy node documents: ${response.statusText}`
     );
+    throw new Error(detail);
   }
 
   return response.json();


### PR DESCRIPTION
## Description

We shouldn't be showing the UI while opensearch isn't enabled

<img width="807" height="456" alt="Screenshot 2026-02-09 at 12 09 23 PM" src="https://github.com/user-attachments/assets/447e5ff8-6488-47d0-a066-4aad069f49a1" />


## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable hierarchy nodes when OpenSearch is not enabled. The API returns 403 with a clear message, and the frontend surfaces it instead of rendering the feature.

- **Bug Fixes**
  - Backend: Gate hierarchy nodes/documents endpoints with OpenSearch flags; return 403 with "Per-source knowledge selection is coming soon in v3.0! OpenSearch indexing must be enabled to use this feature."
  - Frontend: Parse error JSON and use response.detail in hierarchy services to show the server message.

<sup>Written for commit c6369cde99a3fe4b22586b3da7a7835749c97fee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

