### PR TITLE
fix(openrouter): Fixing Fetch Models button

### DIFF
--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -382,7 +382,8 @@ class OllamaModelDetails(BaseModel):
 # OpenRouter dynamic models fetch
 class OpenRouterModelsRequest(BaseModel):
     api_base: str
-    api_key: str
+    api_key: str | None = None
+    api_key_changed: bool = True
     provider_name: str | None = None  # Optional: to save models to existing provider
 
 

--- a/web/src/app/admin/configuration/llm/forms/OpenRouterForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/OpenRouterForm.tsx
@@ -39,10 +39,12 @@ interface OpenRouterFormValues extends BaseLLMFormValues {
 
 async function fetchOpenRouterModels(params: {
   apiBase: string;
-  apiKey: string;
+  apiKey?: string;
+  apiKeyChanged?: boolean;
   providerName?: string;
 }): Promise<{ models: ModelConfiguration[]; error?: string }> {
-  if (!params.apiBase || !params.apiKey) {
+  const apiKeyChanged = params.apiKeyChanged ?? true;
+  if (!params.apiBase || (apiKeyChanged && !params.apiKey)) {
     return {
       models: [],
       error: "API Base and API Key are required to fetch models",
@@ -58,6 +60,7 @@ async function fetchOpenRouterModels(params: {
       body: JSON.stringify({
         api_base: params.apiBase,
         api_key: params.apiKey,
+        api_key_changed: apiKeyChanged,
         provider_name: params.providerName,
       }),
     });
@@ -186,6 +189,9 @@ export function OpenRouterForm({
                         fetchOpenRouterModels({
                           apiBase: formikProps.values.api_base,
                           apiKey: formikProps.values.api_key,
+                          apiKeyChanged:
+                            formikProps.values.api_key !==
+                            initialValues.api_key,
                           providerName: existingLlmProvider?.name,
                         })
                       }

--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -124,6 +124,7 @@ export interface OllamaFetchParams {
 export interface OpenRouterFetchParams {
   api_base?: string;
   api_key?: string;
+  api_key_changed?: boolean;
   provider_name?: string;
 }
 

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -224,10 +224,11 @@ export const fetchOpenRouterModels = async (
 ): Promise<{ models: ModelConfiguration[]; error?: string }> => {
   const apiBase = params.api_base;
   const apiKey = params.api_key;
+  const apiKeyChanged = params.api_key_changed ?? true;
   if (!apiBase) {
     return { models: [], error: "API Base is required" };
   }
-  if (!apiKey) {
+  if (apiKeyChanged && !apiKey) {
     return { models: [], error: "API Key is required" };
   }
 
@@ -240,6 +241,7 @@ export const fetchOpenRouterModels = async (
       body: JSON.stringify({
         api_base: apiBase,
         api_key: apiKey,
+        api_key_changed: apiKeyChanged,
         provider_name: params.provider_name,
       }),
     });


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The fetch models button for OpenRouter is having issues which this PR addresses

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally in my own setup as well as setting up tests.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenRouter “Fetch Models” button so it works when the API key hasn’t changed. The UI now sends an api_key_changed flag and the backend uses the stored provider key when appropriate.

- **Bug Fixes**
  - Backend: api_key is optional and api_key_changed is supported; when api_key_changed is false and provider_name is set, use the stored provider API key; only return a 400 when a key is truly missing.
  - Frontend: Form and utils send api_key_changed based on whether the user edited the key; skip client-side “API Key required” when unchanged; pass provider name.
  - Tests: Added unit test to verify the stored key is used in the OpenRouter models fetch.

<sup>Written for commit e4ca980fd716d3ba77c58f8fa20a63290641af5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

