### PR TITLE
chore(devtools): upgrade ods: 0.5.0->0.5.1

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -317,7 +317,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-onyx-devtools==0.5.0
+onyx-devtools==0.5.1
     # via onyx
 openai==2.14.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ dev = [
     "matplotlib==3.10.8",
     "mypy-extensions==1.0.0",
     "mypy==1.13.0",
-    "onyx-devtools==0.5.0",
+    "onyx-devtools==0.5.1",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4763,7 +4763,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==2.4.1" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.5.0" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.5.1" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "openapi-generator-cli", marker = "extra == 'dev'", specifier = "==7.17.0" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
@@ -4868,20 +4868,20 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.5.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/72/fcc7f9c9ab3f603e544d7fa3cf77b0dd71d33238d66309d6385436f10fad/onyx_devtools-0.5.0-py3-none-any.whl", hash = "sha256:fe68dce214a0568644cf58b615c6cada3cdf77c7c2ce14c3a23ce76f8180d6fa", size = 2884858, upload-time = "2026-02-05T18:58:36.114Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/08/93ad4c72127fe15511b2361cb7cb4c876a38dcb4b879d9aebad7f9ce8930/onyx_devtools-0.5.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8a5ca43b1b4c6af5e51d0475635ba7a83101ac9e4e53dfe5f24e49e4a3acf98b", size = 2903279, upload-time = "2026-02-05T18:58:36.885Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/40/d32a5fa49fef90672abc9a8bae1f6c93fd7f98798602f32bccc98373bcbf/onyx_devtools-0.5.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4cbb628343a5c7f7fe5efa412593e2808d90197cd1e3bfe4877522515e730c53", size = 2706680, upload-time = "2026-02-05T18:58:32.727Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/98/55cd497a981818189c66bcc06f00708f10c6d4e509de3d4d32214060c208/onyx_devtools-0.5.0-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:f35f83e91b9784704508089cb1e3b19780ad52094f83524db16a7e18bf7cde83", size = 2614836, upload-time = "2026-02-05T18:58:37.638Z" },
-    { url = "https://files.pythonhosted.org/packages/35/83/f609ea5a1d3eefb8a564f4a909ca0f7518bd515b0b45a826e719a339705f/onyx_devtools-0.5.0-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5d375c3051a0cde63260228046588da359e950fa3ef2f060f41e7e4de3079201", size = 2884874, upload-time = "2026-02-05T18:58:37.368Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1b/034c23385528b9fb2605897ed7f3648a1ffd9eeab0a21adb0820ac358e91/onyx_devtools-0.5.0-py3-none-win_amd64.whl", hash = "sha256:1f1182a3431877863b0bc9b730d02523e598e09cd50951deb6c27c2e7a2b4f08", size = 2968041, upload-time = "2026-02-05T18:58:38.055Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b0/7a8a47034fc0662ee7c8a4ff314271324b09bf8f29cdc274a062d75b00ea/onyx_devtools-0.5.0-py3-none-win_arm64.whl", hash = "sha256:e76a789dc4db6a31c46c13f165ebc86e44bc2efcb847e54f9e69e00e1c3ffbff", size = 2678568, upload-time = "2026-02-05T18:58:36.145Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/37/bc043a8d6e3763f032282bb924c7edbed9c868ebab15e38a20e451e83dca/onyx_devtools-0.5.1-py3-none-any.whl", hash = "sha256:eb14f3fd9dcc5219439b5b568fd98d1088927a2d35d706811d4dfdee6ccb63d7", size = 2891955, upload-time = "2026-02-09T22:59:19.53Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/93/c0d623e2bd0780f5b6ccc025698e0eaa5e50939b0a0edaad2ee068b7be83/onyx_devtools-0.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4ac7a500e2a4cbc4f943890d68525f92cd1ea5f9d8eada1c2ed9ff2e81771cd", size = 2909887, upload-time = "2026-02-09T22:59:28.213Z" },
+    { url = "https://files.pythonhosted.org/packages/51/45/94098a852f846c8f2b4226a595e9b95f4ed535a86939dd0601b1ffe8bb73/onyx_devtools-0.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edac64d3ae5691c3aa12363bb2eaee13e6f9e62a3c6385d390a95c29f60fb95e", size = 2713796, upload-time = "2026-02-09T22:59:17.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b8/7ed5486b6302f9d717f6f4f98d4a6162bc63f3eb964feed438eb5875176a/onyx_devtools-0.5.1-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2d713aa258a0799743cf8a37c0a39727deed3d2e7d3033fe08d8920cbeecbb8c", size = 2623042, upload-time = "2026-02-09T22:59:27.833Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/7e/e1a6d0a02ea0dddf48057ae12417cc126902cc2e74078dd33c8ab5e3bb39/onyx_devtools-0.5.1-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:117cc62d3a0637e7eb9a417bbd2dbc045f887da3278708e6d4fcae122c43e4bf", size = 2891968, upload-time = "2026-02-09T22:59:19.941Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/96/fecee71880b65c4ae33c6a3fa7a58d868956d6debfc075cb494d0a142047/onyx_devtools-0.5.1-py3-none-win_amd64.whl", hash = "sha256:e33c8b27cd5568c6925e58c0f8d502d88d96817af879fb78d4b564e7ff2bbc16", size = 2974809, upload-time = "2026-02-09T22:59:23.564Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/37/f59bca099132fae209e4dd2c5158cd1dee729507d4f810e1ea306279e12c/onyx_devtools-0.5.1-py3-none-win_arm64.whl", hash = "sha256:f4987ab6f07797c18067f7a5edccfc12af9d52ae22a6075d0109b924b6791706", size = 2685469, upload-time = "2026-02-09T22:59:27.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Pulls in https://github.com/onyx-dot-app/onyx/pull/8277

## How Has This Been Tested?

```
uv sync --all-extras
ods --version
```

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade onyx-devtools to 0.5.1 to pull in recent fixes and keep dev tooling up to date. Updated pyproject, backend/requirements/dev.txt, and uv.lock accordingly.

<sup>Written for commit d4712573e5b35ae1234751b241aab4b88f2383a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

