### PR TITLE
fix(smtp): Update flow for no SMTP server

### DIFF
--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -373,6 +373,11 @@ class AllUsersResponse(BaseModel):
     slack_users_pages: int
 
 
+class BulkInviteUsersResponse(BaseModel):
+    number_of_invited_users: int
+    email_invite_warning: str | None = None
+
+
 class SlackChannel(BaseModel):
     id: str
     name: str

--- a/backend/tests/unit/onyx/server/manage/test_users.py
+++ b/backend/tests/unit/onyx/server/manage/test_users.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import onyx.server.manage.users as users_api
+
+
+def _setup_bulk_invite_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _validate_email(
+        email: str, check_deliverability: bool = False
+    ) -> SimpleNamespace:
+        _ = check_deliverability
+        return SimpleNamespace(normalized=email.lower())
+
+    def _get_all_users(_db_session: object) -> list[object]:
+        return []
+
+    def _noop(*_call_args: object, **_call_kwargs: object) -> None:
+        return None
+
+    def _ee_noop(*_args: object, **_kwargs: object):
+        return _noop
+
+    monkeypatch.setattr(users_api, "MULTI_TENANT", False, raising=False)
+    monkeypatch.setattr(users_api, "DEV_MODE", False, raising=False)
+    monkeypatch.setattr(users_api, "ENABLE_EMAIL_INVITES", True, raising=False)
+    monkeypatch.setattr(users_api, "get_current_tenant_id", lambda: "tenant-id")
+    monkeypatch.setattr(users_api, "validate_email", _validate_email)
+    monkeypatch.setattr(users_api, "get_all_users", _get_all_users)
+    monkeypatch.setattr(users_api, "get_invited_users", lambda: [])
+    monkeypatch.setattr(users_api, "write_invited_users", lambda emails: len(emails))
+    monkeypatch.setattr(users_api, "fetch_ee_implementation_or_noop", _ee_noop)
+
+
+def test_bulk_invite_users_returns_warning_when_email_send_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _setup_bulk_invite_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        users_api,
+        "send_user_email_invite",
+        MagicMock(side_effect=RuntimeError("SMTP not available")),
+    )
+
+    response = users_api.bulk_invite_users(
+        emails=["NewUser@Example.com"],
+        current_user=SimpleNamespace(email="admin@example.com"),
+        db_session=MagicMock(),
+    )
+
+    assert response.number_of_invited_users == 1
+    assert response.email_invite_warning is not None
+    assert "couldn't confirm" in response.email_invite_warning
+
+
+def test_bulk_invite_users_has_no_warning_when_email_send_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _setup_bulk_invite_dependencies(monkeypatch)
+    send_user_email_invite_mock = MagicMock()
+    monkeypatch.setattr(
+        users_api,
+        "send_user_email_invite",
+        send_user_email_invite_mock,
+    )
+
+    response = users_api.bulk_invite_users(
+        emails=["newuser@example.com"],
+        current_user=SimpleNamespace(email="admin@example.com"),
+        db_session=MagicMock(),
+    )
+
+    send_user_email_invite_mock.assert_called_once()
+    assert response.number_of_invited_users == 1
+    assert response.email_invite_warning is None
+
+
+def test_bulk_invite_users_warns_when_email_invites_are_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _setup_bulk_invite_dependencies(monkeypatch)
+    monkeypatch.setattr(users_api, "ENABLE_EMAIL_INVITES", False, raising=False)
+    send_user_email_invite_mock = MagicMock()
+    monkeypatch.setattr(
+        users_api,
+        "send_user_email_invite",
+        send_user_email_invite_mock,
+    )
+
+    response = users_api.bulk_invite_users(
+        emails=["newuser@example.com"],
+        current_user=SimpleNamespace(email="admin@example.com"),
+        db_session=MagicMock(),
+    )
+
+    send_user_email_invite_mock.assert_not_called()
+    assert response.number_of_invited_users == 1
+    assert response.email_invite_warning is not None
+    assert "email invitations are disabled" in response.email_invite_warning

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -15,6 +15,7 @@ import useSWR, { mutate } from "swr";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import BulkAdd from "@/components/admin/users/BulkAdd";
 import Text from "@/refresh-components/texts/Text";
+import { BulkInviteUsersResponse } from "@/lib/types";
 import { InvitedUserSnapshot } from "@/lib/types";
 import { ConfirmEntityModal } from "@/components/modals/ConfirmEntityModal";
 import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
@@ -300,11 +301,18 @@ const AddUserButton = ({
     invitedUsers &&
     invitedUsers.length === 0;
 
-  const onSuccess = () => {
+  const onSuccess = (response: BulkInviteUsersResponse) => {
     mutate(
       (key) => typeof key === "string" && key.startsWith("/api/manage/users")
     );
     setBulkAddUsersModal(false);
+    if (response.email_invite_warning) {
+      setPopup({
+        message: response.email_invite_warning,
+        type: "warning",
+      });
+      return;
+    }
     setPopup({
       message: "Users invited!",
       type: "success",

--- a/web/src/components/admin/users/buttons/InviteUserButton.tsx
+++ b/web/src/components/admin/users/buttons/InviteUserButton.tsx
@@ -1,4 +1,5 @@
 import {
+  type BulkInviteUsersResponse,
   type InvitedUserSnapshot,
   type AcceptedUserSnapshot,
 } from "@/lib/types";
@@ -33,15 +34,22 @@ export const InviteUserButton = ({
       if (!response.ok) {
         throw new Error(await response.text());
       }
-      return response.json();
+      return (await response.json()) as BulkInviteUsersResponse;
     },
     {
-      onSuccess: () => {
+      onSuccess: (response) => {
         setShowInviteModal(false);
         if (typeof mutate === "function") {
           mutate();
         } else {
           mutate.forEach((fn) => fn());
+        }
+        if (response.email_invite_warning) {
+          setPopup({
+            message: response.email_invite_warning,
+            type: "warning",
+          });
+          return;
         }
         setPopup({
           message: "User invited successfully!",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -123,6 +123,11 @@ export interface InvitedUserSnapshot {
   email: string;
 }
 
+export interface BulkInviteUsersResponse {
+  number_of_invited_users: number;
+  email_invite_warning: string | null;
+}
+
 export interface MinimalUserSnapshot {
   id: string;
   email: string;


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This is focused on making no SMTP server workflows a bit more detailed since it's silently failing right now

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the user invite flow when SMTP/SendGrid isn’t available by returning a clear warning from the backend and surfacing it in the UI instead of silently failing.

- **Bug Fixes**
  - Backend: bulk_invite_users now returns BulkInviteUsersResponse with number_of_invited_users and email_invite_warning; handles partial/all email send failures and disabled invites; adds error logging.
  - Frontend: Admin Users page, BulkAdd, and InviteUserButton read the new response and show a warning popup when emails can’t be sent.
  - Tests: Added unit tests covering failed sends, successful sends, and disabled email invites.

- **Migration**
  - API change: /api/manage/admin/users (PUT) returns JSON { number_of_invited_users, email_invite_warning } instead of an integer. Update any external clients that expect a plain number.

<sup>Written for commit 33c67f978097134c576eb93512bc29b9619e4113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

