### PR TITLE
fix(llm): Fixing seeding logic for LLM Model Flow

### DIFF
--- a/backend/tests/unit/onyx/test_setup_postgres.py
+++ b/backend/tests/unit/onyx/test_setup_postgres.py
@@ -17,6 +17,7 @@ def test_setup_postgres_does_not_seed_dev_provider_when_provider_exists() -> Non
         patch.object(setup_lib, "create_initial_default_connector"),
         patch.object(setup_lib, "associate_default_cc_pair"),
         patch.object(setup_lib, "fetch_default_llm_model", return_value=None),
+        patch.object(setup_lib, "_backfill_llm_model_flow_mappings", return_value=True),
         patch.object(setup_lib, "upsert_llm_provider") as mock_upsert,
         patch.object(setup_lib, "update_default_provider") as mock_update_default,
     ):
@@ -49,3 +50,27 @@ def test_setup_postgres_seeds_dev_provider_on_fresh_install() -> None:
     request = mock_upsert.call_args.kwargs["llm_provider_upsert_request"]
     assert request.name == "DevEnvPresetOpenAI"
     mock_update_default.assert_called_once_with(provider_id=17, db_session=db_session)
+
+
+def test_setup_postgres_attempts_flow_backfill_when_provider_exists_and_no_default() -> (
+    None
+):
+    db_session = MagicMock()
+    db_session.scalar.return_value = 123  # Existing provider id
+
+    with (
+        patch.object(setup_lib, "GEN_AI_API_KEY", "test-api-key"),
+        patch.object(setup_lib, "GEN_AI_MODEL_VERSION", None),
+        patch.object(setup_lib, "create_initial_public_credential"),
+        patch.object(setup_lib, "create_initial_default_connector"),
+        patch.object(setup_lib, "associate_default_cc_pair"),
+        patch.object(setup_lib, "fetch_default_llm_model", side_effect=[None, None]),
+        patch.object(
+            setup_lib, "_backfill_llm_model_flow_mappings", return_value=True
+        ) as mock_backfill,
+        patch.object(setup_lib, "upsert_llm_provider") as mock_upsert,
+    ):
+        setup_lib.setup_postgres(db_session)
+
+    mock_backfill.assert_called_once_with(db_session)
+    mock_upsert.assert_not_called()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There is currently an issue if you upgrade your application code but you don't run a schema migration, you will be caught in a limbo state of not being able to access your previous LLM providers since you will have an overwritten model. 

This PR aims to fix this properly by checking if your LLMProviderModel is empty or not to make sure it's not overwritten with the seeding.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested this locally by going back into my schema migration and then ensuring that the application code is still intact without having ran the schema migrations yet.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLM provider setup to avoid overwriting existing providers. Adds safe backfill for LLM model flow mappings and makes the migration idempotent to prevent the limbo state after upgrades without DB migrations.

- **Bug Fixes**
  - Only seed dev provider on truly fresh installs; skip when any provider exists.
  - Backfill missing flow mappings/defaults at startup using existing provider settings.
  - Make llm_model_flow migration idempotent and recompute defaults from legacy flags; added unit tests for fresh vs. existing/backfill paths.

<sup>Written for commit fdea0cab6e3ca0ac1a94241aa2d411c9275d90ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

