### PR TITLE
chore(tests): use CE backend for model_server tests

### DIFF
--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -1,4 +1,10 @@
 import os
+
+# Set environment variables BEFORE any other imports to ensure they're picked up
+# by module-level code that reads env vars at import time
+# TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
+os.environ["LICENSE_ENFORCEMENT_ENABLED"] = "false"
+
 from collections.abc import AsyncGenerator
 from collections.abc import Generator
 from contextlib import asynccontextmanager
@@ -40,13 +46,11 @@ def mock_current_admin_user() -> MagicMock:
 
 @pytest.fixture(scope="function")
 def client() -> Generator[TestClient, None, None]:
-    # Set environment variables
-    os.environ["ENABLE_PAID_ENTERPRISE_EDITION_FEATURES"] = "True"
-
     # Initialize TestClient with the FastAPI app using a no-op test lifespan
-    app: FastAPI = fetch_versioned_implementation(
+    get_app = fetch_versioned_implementation(
         module="onyx.main", attribute="get_application"
-    )(lifespan_override=test_lifespan)
+    )
+    app: FastAPI = get_app(lifespan_override=test_lifespan)
 
     # Override the database session dependency with a mock
     # (these tests don't actually need DB access)


### PR DESCRIPTION
## Description

Bisected this back to cec37bff6: `feat(ee): Enable license enforcement by default (#8270)`

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/21877696659

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the CE path for model_server tests by disabling license enforcement at import time and removing the EE flag to fix failures. Temporary per Linear ENG-1.

- **Refactors**
  - Set LICENSE_ENFORCEMENT_ENABLED=false before any imports so module-level checks stay off in tests.
  - Initialize the app via fetch_versioned_implementation("onyx.main", "get_application") and call get_app(lifespan_override=test_lifespan); stop setting ENABLE_PAID_ENTERPRISE_EDITION_FEATURES.

<sup>Written for commit 0e77f679578359b436968609e6be40cc9a8144c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







