### PR TITLE
chore(craft): Random craft errors

### DIFF
--- a/web/src/app/admin/settings/SettingsForm.tsx
+++ b/web/src/app/admin/settings/SettingsForm.tsx
@@ -16,6 +16,7 @@ import LLMSelector from "@/components/llm/LLMSelector";
 import { useVisionProviders } from "./hooks/useVisionProviders";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import { SvgAlertTriangle } from "@opal/icons";
+import { useLlmManager } from "@/lib/hooks";
 
 export function Checkbox({
   label,

--- a/web/src/app/craft/hooks/useBuildLlmSelection.ts
+++ b/web/src/app/craft/hooks/useBuildLlmSelection.ts
@@ -1,5 +1,8 @@
 import { useMemo, useState, useCallback } from "react";
-import { LLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
+import {
+  DefaultModel,
+  LLMProviderDescriptor,
+} from "@/app/admin/configuration/llm/interfaces";
 import {
   BuildLlmSelection,
   getBuildLlmSelection,
@@ -16,7 +19,8 @@ import {
  * 2. Smart default - via getDefaultLlmSelection()
  */
 export function useBuildLlmSelection(
-  llmProviders: LLMProviderDescriptor[] | undefined
+  llmProviders: LLMProviderDescriptor[] | undefined,
+  defaultLlmModel?: DefaultModel
 ) {
   const [selection, setSelectionState] = useState<BuildLlmSelection | null>(
     () => getBuildLlmSelection()
@@ -42,7 +46,19 @@ export function useBuildLlmSelection(
     }
 
     // Fall back to smart default
-    return getDefaultLlmSelection(llmProviders);
+    return getDefaultLlmSelection(
+      llmProviders?.map((p) => ({
+        name: p.name,
+        provider: p.provider,
+        default_model_name: (() => {
+          if (p.id === defaultLlmModel?.provider_id) {
+            return defaultLlmModel?.model_name ?? "";
+          }
+          return p.model_configurations[0]?.name ?? "";
+        })(),
+        is_default_provider: p.id === defaultLlmModel?.provider_id,
+      }))
+    );
   }, [selection, llmProviders, isSelectionValid]);
 
   // Update selection and persist to cookie

--- a/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
+++ b/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
@@ -59,6 +59,7 @@ export function BuildOnboardingProvider({
         <BuildOnboardingModal
           mode={controller.mode}
           llmProviders={controller.llmProviders}
+          defaultLlm={controller.defaultText}
           initialValues={controller.initialValues}
           isAdmin={controller.isAdmin}
           hasUserInfo={controller.hasUserInfo}

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -46,6 +46,7 @@ export function useOnboardingModal(): OnboardingModalController {
   const { user, isAdmin, refreshUser } = useUser();
   const {
     llmProviders,
+    defaultText,
     isLoading: isLoadingLlm,
     refetch: refetchLlmProviders,
   } = useLLMProviders();
@@ -168,6 +169,7 @@ export function useOnboardingModal(): OnboardingModalController {
     openLlmSetup,
     close,
     llmProviders,
+    defaultText: defaultText ?? undefined,
     initialValues,
     completeUserInfo,
     completeLlmSetup,

--- a/web/src/app/craft/onboarding/types.ts
+++ b/web/src/app/craft/onboarding/types.ts
@@ -36,6 +36,9 @@ export interface OnboardingModalController {
   llmProviders:
     | import("@/app/admin/configuration/llm/interfaces").LLMProviderDescriptor[]
     | undefined;
+  defaultText:
+    | import("@/app/admin/configuration/llm/interfaces").DefaultModel
+    | undefined;
   initialValues: {
     firstName: string;
     lastName: string;
@@ -54,7 +57,9 @@ export interface OnboardingModalController {
   completeUserInfo: (info: BuildUserInfo) => Promise<void>;
   completeLlmSetup: () => Promise<void>;
   refetchLlmProviders: () => Promise<
-    | import("@/app/admin/configuration/llm/interfaces").LLMProviderDescriptor[]
+    | import("@/app/admin/configuration/llm/interfaces").LLMProviderResponse<
+        import("@/app/admin/configuration/llm/interfaces").LLMProviderDescriptor
+      >
     | undefined
   >;
 }

--- a/web/src/app/craft/v1/configure/page.tsx
+++ b/web/src/app/craft/v1/configure/page.tsx
@@ -78,7 +78,7 @@ interface SelectedConnectorState {
  */
 export default function BuildConfigPage() {
   const { isAdmin, isCurator } = useUser();
-  const { llmProviders } = useLLMProviders();
+  const { llmProviders, defaultText } = useLLMProviders();
   const { openPersonaEditor, openLlmSetup } = useOnboarding();
   const [selectedConnector, setSelectedConnector] =
     useState<SelectedConnectorState | null>(null);
@@ -109,7 +109,7 @@ export default function BuildConfigPage() {
 
   // Build mode LLM selection (cookie-based)
   const { selection: llmSelection, updateSelection: updateLlmSelection } =
-    useBuildLlmSelection(llmProviders);
+    useBuildLlmSelection(llmProviders, defaultText ?? undefined);
 
   // Read demo data from cookie (single source of truth)
   const [demoDataEnabled, setDemoDataEnabledLocal] = useState(() =>

--- a/web/src/components/llm/LLMSelector.tsx
+++ b/web/src/components/llm/LLMSelector.tsx
@@ -2,7 +2,10 @@
 
 import { useMemo } from "react";
 import { parseLlmDescriptor, structureValue } from "@/lib/llm/utils";
-import { LLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
+import {
+  DefaultModel,
+  LLMProviderDescriptor,
+} from "@/app/admin/configuration/llm/interfaces";
 import { getProviderIcon } from "@/app/admin/configuration/llm/utils";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { createIcon } from "@/components/icons/icons";
@@ -139,17 +142,6 @@ export default function LLMSelector({
     });
   }, [llmOptions]);
 
-  const defaultProvider = llmProviders.find(
-    (llmProvider) => llmProvider.is_default_provider
-  );
-
-  const defaultModelName = defaultProvider?.default_model_name;
-  const defaultModelConfig = defaultProvider?.model_configurations.find(
-    (m) => m.name === defaultModelName
-  );
-  const defaultModelDisplayName = defaultModelConfig
-    ? defaultModelConfig.display_name || defaultModelConfig.name
-    : defaultModelName || null;
   const defaultLabel = userSettings ? "System Default" : "User Default";
 
   // Determine if we should show grouped view (only if we have multiple vendors)
@@ -164,16 +156,7 @@ export default function LLMSelector({
 
       <InputSelect.Content>
         {!excludePublicProviders && (
-          <InputSelect.Item
-            value="default"
-            description={
-              userSettings && defaultModelDisplayName
-                ? `(${defaultModelDisplayName})`
-                : undefined
-            }
-          >
-            {defaultLabel}
-          </InputSelect.Item>
+          <InputSelect.Item value="default">{defaultLabel}</InputSelect.Item>
         )}
         {showGrouped
           ? groupedOptions.map((group) => (

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -974,7 +974,8 @@ export default function useChatController({
       const [_, llmModel] = getFinalLLM(
         llmManager.llmProviders || [],
         liveAssistant || null,
-        llmManager.currentLlm
+        llmManager.currentLlm,
+        llmManager.defaultLlmModel
       );
       const llmAcceptsImages = modelSupportsImageInput(
         llmManager.llmProviders || [],

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -474,6 +474,8 @@ export interface LlmDescriptor {
 export interface LlmManager {
   currentLlm: LlmDescriptor;
   updateCurrentLlm: (newOverride: LlmDescriptor) => void;
+  defaultLlmModel?: DefaultModel;
+  updateDefaultLlmModel: (newDefaultLlmModel: DefaultModel) => void;
   temperature: number;
   updateTemperature: (temperature: number) => void;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
@@ -592,6 +594,13 @@ export function useLlmManager(
     provider: "",
     modelName: "",
   });
+
+  const [defaultLlmModel, setDefaultLlmModel] = useState<
+    DefaultModel | undefined
+  >(defaultTextLlmModel);
+  const updateDefaultLlmModel = (newDefaultLlmModel: DefaultModel) => {
+    setDefaultLlmModel(newDefaultLlmModel);
+  };
 
   // Track the previous assistant ID to detect when it changes
   const prevAssistantIdRef = useRef<number | undefined>(undefined);
@@ -802,6 +811,8 @@ export function useLlmManager(
     updateModelOverrideBasedOnChatSession,
     currentLlm,
     updateCurrentLlm,
+    defaultLlmModel,
+    updateDefaultLlmModel,
     temperature,
     updateTemperature,
     imageFilesPresent,

--- a/web/src/lib/llm/utils.ts
+++ b/web/src/lib/llm/utils.ts
@@ -1,5 +1,6 @@
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import {
+  DefaultModel,
   LLMProviderDescriptor,
   ModelConfiguration,
 } from "@/app/admin/configuration/llm/interfaces";
@@ -8,14 +9,15 @@ import { LlmDescriptor } from "@/lib/hooks";
 export function getFinalLLM(
   llmProviders: LLMProviderDescriptor[],
   persona: MinimalPersonaSnapshot | null,
-  currentLlm: LlmDescriptor | null
+  currentLlm: LlmDescriptor | null,
+  defaultLlmModel?: DefaultModel
 ): [string, string] {
   const defaultProvider = llmProviders.find(
-    (llmProvider) => llmProvider.is_default_provider
+    (llmProvider) => llmProvider.id === defaultLlmModel?.provider_id
   );
 
   let provider = defaultProvider?.provider || "";
-  let model = defaultProvider?.default_model_name || "";
+  let model = defaultLlmModel?.model_name || "";
 
   if (persona) {
     // Map "provider override" to actual LLLMProvider


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes default LLM selection across Craft onboarding, build, and chat so we consistently use the server-defined default model and provider. Also simplifies the LLM picker’s default option.

- Bug Fixes
  - Thread the default LLM model from useLLMProviders into onboarding, build selection, and configure page (BuildOnboardingModal, useBuildLlmSelection, BuildConfigPage).
  - Auto-select uses the provided DefaultModel; falls back to a provider’s first configured model when needed.
  - getFinalLLM now resolves default provider/model via DefaultModel instead of is_default_provider.
  - LlmManager now stores and updates defaultLlmModel; useChatController passes it to getFinalLLM.
  - LLMSelector removes extra default-model label text to keep the “Default” option simple.
  - Type tweaks: onboarding refetch returns LLMProviderResponse; controller props updated; minor import cleanup.

<sup>Written for commit 908d3600118b620b45b4c48394e05aac44e348ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

