### PR TITLE
fix(vertex): Updating masking workflow

### DIFF
--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
@@ -24,6 +24,7 @@ from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import UserRole
 from onyx.llm.constants import LlmProviderNames
+from onyx.server.manage.llm.api import _mask_string
 from onyx.server.manage.llm.api import put_llm_provider
 from onyx.server.manage.llm.api import test_llm_configuration as run_llm_config_test
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
@@ -592,6 +593,152 @@ def test_upload_with_custom_config_then_change(
                 f"Expected custom_config {custom_config}, "
                 f"but got {provider.custom_config}"
             )
+    finally:
+        db_session.rollback()
+        _cleanup_provider(db_session, name)
+
+
+def test_preserves_masked_sensitive_custom_config_on_provider_update(
+    db_session: Session,
+) -> None:
+    """Masked sensitive values from the UI should not overwrite stored secrets."""
+    name = f"test-provider-vertex-update-{uuid4().hex[:8]}"
+    provider = LlmProviderNames.VERTEX_AI.value
+    default_model_name = "gemini-2.5-pro"
+    original_custom_config = {
+        "vertex_credentials": '{"type":"service_account","private_key":"REAL_PRIVATE_KEY"}',
+        "vertex_location": "global",
+    }
+
+    try:
+        put_llm_provider(
+            llm_provider_upsert_request=LLMProviderUpsertRequest(
+                name=name,
+                provider=provider,
+                default_model_name=default_model_name,
+                custom_config=original_custom_config,
+                model_configurations=[
+                    ModelConfigurationUpsertRequest(
+                        name=default_model_name, is_visible=True
+                    )
+                ],
+                api_key_changed=False,
+                custom_config_changed=True,
+                is_auto_mode=False,
+            ),
+            is_creation=True,
+            _=_create_mock_admin(),
+            db_session=db_session,
+        )
+
+        with patch("onyx.server.manage.llm.api.MULTI_TENANT", False):
+            put_llm_provider(
+                llm_provider_upsert_request=LLMProviderUpsertRequest(
+                    name=name,
+                    provider=provider,
+                    default_model_name=default_model_name,
+                    custom_config={
+                        "vertex_credentials": _mask_string(
+                            original_custom_config["vertex_credentials"]
+                        ),
+                        "vertex_location": "us-central1",
+                    },
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name=default_model_name, is_visible=True
+                        )
+                    ],
+                    api_key_changed=False,
+                    custom_config_changed=True,
+                    is_auto_mode=False,
+                ),
+                is_creation=False,
+                _=_create_mock_admin(),
+                db_session=db_session,
+            )
+
+        updated_provider = fetch_existing_llm_provider(name=name, db_session=db_session)
+        assert updated_provider is not None
+        assert updated_provider.custom_config is not None
+        assert (
+            updated_provider.custom_config["vertex_credentials"]
+            == original_custom_config["vertex_credentials"]
+        )
+        assert updated_provider.custom_config["vertex_location"] == "us-central1"
+    finally:
+        db_session.rollback()
+        _cleanup_provider(db_session, name)
+
+
+def test_preserves_masked_sensitive_custom_config_on_test_request(
+    db_session: Session,
+) -> None:
+    """LLM test should restore masked sensitive custom config values before invocation."""
+    name = f"test-provider-vertex-test-{uuid4().hex[:8]}"
+    provider = LlmProviderNames.VERTEX_AI.value
+    default_model_name = "gemini-2.5-pro"
+    original_custom_config = {
+        "vertex_credentials": '{"type":"service_account","private_key":"REAL_PRIVATE_KEY"}',
+        "vertex_location": "global",
+    }
+    captured_llms: list[LLM] = []
+
+    def capture_test_llm(llm: LLM) -> str:
+        captured_llms.append(llm)
+        return ""
+
+    try:
+        put_llm_provider(
+            llm_provider_upsert_request=LLMProviderUpsertRequest(
+                name=name,
+                provider=provider,
+                default_model_name=default_model_name,
+                custom_config=original_custom_config,
+                model_configurations=[
+                    ModelConfigurationUpsertRequest(
+                        name=default_model_name, is_visible=True
+                    )
+                ],
+                api_key_changed=False,
+                custom_config_changed=True,
+                is_auto_mode=False,
+            ),
+            is_creation=True,
+            _=_create_mock_admin(),
+            db_session=db_session,
+        )
+
+        with patch("onyx.server.manage.llm.api.test_llm", side_effect=capture_test_llm):
+            run_llm_config_test(
+                LLMTestRequest(
+                    name=name,
+                    provider=provider,
+                    default_model_name=default_model_name,
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name=default_model_name, is_visible=True
+                        )
+                    ],
+                    api_key_changed=False,
+                    custom_config_changed=True,
+                    custom_config={
+                        "vertex_credentials": _mask_string(
+                            original_custom_config["vertex_credentials"]
+                        ),
+                        "vertex_location": "us-central1",
+                    },
+                ),
+                _=_create_mock_admin(),
+                db_session=db_session,
+            )
+
+        assert len(captured_llms) == 1
+        assert captured_llms[0].config.custom_config is not None
+        assert (
+            captured_llms[0].config.custom_config["vertex_credentials"]
+            == original_custom_config["vertex_credentials"]
+        )
+        assert captured_llms[0].config.custom_config["vertex_location"] == "us-central1"
     finally:
         db_session.rollback()
         _cleanup_provider(db_session, name)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The Vertex AI workflow was not working properly since we were not able to use Vertex AI models. 

This was due to the PR that was merged in recently. This PR ensures that Vertex is workflow properly with the masking workflow. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added new tests but also made sure to go through the process of adding a Vertex LLM Provider and then begin a chat with the model.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vertex provider setup and chat by restoring masked secrets in custom_config during updates and tests. Vertex models now work again without losing stored credentials.

- **Bug Fixes**
  - Restore sensitive custom_config values (e.g., vertex_credentials) when the UI sends masked placeholders on provider update and test.
  - Run restoration before SSRF validation and change checks to prevent false diffs and accidental secret overwrites.
  - Add tests covering provider update and test flows to confirm masked values are preserved and non-sensitive fields can still change.

<sup>Written for commit c1212db4a519bb2e6ec3684ea66f7e8d2d7511a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

