### PR TITLE
chore(slack): add logging when bot messages are filtered during indexing

### DIFF
--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1031,7 +1031,8 @@ class SlackConnector(
             range_percent_complete = range_complete / range_total * 100.0
 
             num_filtered = num_bot_filtered_messages + num_other_filtered_messages
-            logger.info(
+            log_func = logger.warning if num_bot_filtered_messages > 0 else logger.info
+            log_func(
                 f"Message processing stats: "
                 f"batch_len={len(message_batch)} "
                 f"batch_yielded={num_threads_processed} "
@@ -1039,13 +1040,6 @@ class SlackConnector(
                 f"(bot={num_bot_filtered_messages} other={num_other_filtered_messages}) "
                 f"total_threads_seen={len(seen_thread_ts)}"
             )
-
-            if num_bot_filtered_messages > 0:
-                logger.warning(
-                    f"Filtered out {num_bot_filtered_messages}/{len(message_batch)} "
-                    f"messages in channel '{channel['name']}' due to bot/app origin. "
-                    f"Bot-generated messages are not indexed."
-                )
 
             logger.info(
                 f"Current channel processing stats: "


### PR DESCRIPTION
## Description

Bot messages in Slack channels were being silently filtered out during indexing with no log output. This made it very difficult to diagnose why channels with bot-generated content (e.g. automated feed channels like "customer-notes-feed") produced zero indexed documents despite the connector showing successful runs.

This adds:
- `bot_filtered=X` count to the existing batch processing stats INFO log
- A WARNING-level log when bot messages are filtered, showing the count and channel name

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear logging when Slack messages are filtered during indexing, with total filtered plus a bot vs other breakdown, consolidated into a single stats line. The line logs at WARNING when any bot messages are filtered, INFO otherwise; the channel-skip threshold now uses all filtered messages, not just bots.

<sup>Written for commit eb24b1ee1315329bda3b485abd807b56cac2c873. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



