### PR TITLE
fix(opal): extract interactive container styles to CSS

### DIFF
--- a/web/lib/opal/src/core/interactive/components.tsx
+++ b/web/lib/opal/src/core/interactive/components.tsx
@@ -419,14 +419,14 @@ function InteractiveContainer({
       ref={ref}
       {...rest}
       className={cn(
-        "flex self-stretch items-center justify-center",
-        border && "border",
+        "interactive-container",
         interactiveContainerRoundingVariants[roundingVariant],
         interactiveContainerPaddingVariants[paddingVariant],
         interactiveContainerHeightVariants[heightVariant],
         interactiveContainerMinWidthVariants[heightVariant],
         slotClassName
       )}
+      data-border={border ? "true" : undefined}
       style={slotStyle}
     />
   );

--- a/web/lib/opal/src/core/interactive/styles.css
+++ b/web/lib/opal/src/core/interactive/styles.css
@@ -12,6 +12,14 @@
   color: var(--interactive-foreground);
 }
 
+.interactive-container {
+  @apply flex self-stretch items-center justify-center;
+}
+
+.interactive-container[data-border="true"] {
+  @apply border;
+}
+
 /* ============================================================================
    Variant + Subvariant combinations (9 + select)
 


### PR DESCRIPTION
## Description

Extract inline Tailwind classes from `InteractiveContainer` into a dedicated CSS class (`.interactive-container`) and move the `border` prop to a `data-border` data attribute, consistent with the existing data-attribute styling pattern used throughout `styles.css`. Also adds `self-stretch` to the container.

## Screenshots

### PATs (in the User Settings)

<img width="729" height="171" alt="image" src="https://github.com/user-attachments/assets/75d37374-f2fb-466a-b939-defdf53a16a8" />

### File Cards (in the main Chat Input Bar)

<img width="280" height="197" alt="image" src="https://github.com/user-attachments/assets/2001052e-5f22-4dfe-9bfd-597373c59945" />

## How Has This Been Tested?

- Verified build passes (`bun run types:check`)
- Visual inspection of interactive components

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted InteractiveContainer inline Tailwind styles into a reusable CSS class and switched border styling to a data attribute. Also restores self-stretch for more consistent layout.

- **Refactors**
  - Added .interactive-container class with flex, center alignment, and self-stretch.
  - Moved border prop to data-border="true" to follow the data-attribute styling pattern.

<sup>Written for commit 340514245d5eea2b521afbe5e8624deab2a7a8d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->