### PR TITLE
fix: make /health check async

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -26,7 +26,7 @@ router = APIRouter()
 
 
 @router.get("/health", tags=PUBLIC_API_TAGS)
-def healthcheck() -> StatusResponse:
+async def healthcheck() -> StatusResponse:
     return StatusResponse(success=True, message="ok")
 
 


### PR DESCRIPTION
## Summary

API server pods crash-loop under moderate concurrent load (~1 crash/hour on some pods). Making `/health` async decouples health probes from thread pool contention, preventing the cascade failure pattern that causes multi-pod outages.

## Problem

**Background:** Uvicorn dispatches `def` (sync) endpoints to a shared anyio thread pool (40 slots). 12 of our 13 most-called endpoints are sync — including `/chat/send-chat-message`, `/settings`, `/me`, `/persona`, `/notifications`, and `/health` itself.

**Under normal production load**, the thread pool runs at moderate-to-high utilization. Each streaming chat request holds an anyio thread for the full duration of tool execution (search: ~6s) because the polling loop in `chat_state.py:228` (`emitter.bus.get(timeout=0.3)` → `continue`) does not yield back to the caller until a packet arrives. Concurrent page loads add bursts of sync endpoint calls on top.

Pod restart data shows ~1 crash/hour under normal traffic — this isn't caused by any single burst of requests:

| Pod | Restarts | Age |
|-----|----------|-----|
| tpvfw | 26 | 27h |
| vg7tr | 14 | 12h |
| knkkq | 9 | 14h |

When the thread pool intermittently hits capacity, the sync `/health` endpoint queues behind user requests and can't respond within the 5s liveness probe timeout. Three consecutive failures (30s) triggers a pod kill (exit code 137).

**The real damage is the cascade.** When 1-2 pods die, traffic redistributes to survivors (~40% more load each), pushing them closer to the same threshold. We observed 4 out of 7 pods crash within 6 seconds of each other at 23:37, triggered by a modest burst of 5 concurrent user requests that tipped already-strained pods over the edge.

## Fix

`def healthcheck()` → `async def healthcheck()`

Async endpoints run directly on the event loop, bypassing the thread pool entirely. Even when all 40 thread pool slots are occupied, the async health check responds in microseconds. This eliminates the intermittent probe failures that seed the cascade.

**Safe because:** the endpoint does zero I/O (returns hardcoded `StatusResponse`), has no `Depends()`, no auth (explicitly public), and all middleware are async-compatible. The model server's `/health` is already async.

## Next steps

- **Investigate chronic thread pool pressure.** The pool runs near capacity under normal load because almost every endpoint is sync. High-value candidates for async conversion: `/me`, `/settings`, `/enterprise-settings` (called on every page load, lightweight DB reads).
- **Consider making the streaming generator async.** The sync generator in `stream_generator()` is wrapped by Starlette's `iterate_in_threadpool`, which holds an anyio thread for the full duration of each `next()` call. An async generator would avoid this entirely and free significant thread pool capacity.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the /health endpoint async to avoid blocking and reduce crash loops during heavy health probe traffic. Response stays the same: success=true, message="ok".

- **Bug Fixes**
  - Converted /health to async def to align with the async router and prevent thread blocking under load.

<sup>Written for commit abda02c372809efa511efa8c4456fd2bf2de9d7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

