### PR TITLE
chore(devtools): deploy preview frontend builds in CI

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,73 @@
+name: Preview Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_CLI: vercel@50.14.1
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - "web/**"
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  Deploy-Preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # ratchet:actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: ./web/package-lock.json
+
+      - name: Pull Vercel Environment Information
+        run: npx --yes ${{ env.VERCEL_CLI }} pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: npx --yes ${{ env.VERCEL_CLI }} build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          DEPLOYMENT_URL=$(npx --yes ${{ env.VERCEL_CLI }} deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Update PR comment with deployment URL
+        if: always() && steps.deploy.outputs.url
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          # Find the PR for this branch
+          PR_NUMBER=$(gh pr list --head "$GITHUB_REF_NAME" --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch $GITHUB_REF_NAME, skipping comment."
+            exit 0
+          fi
+
+          COMMENT_MARKER="<!-- preview-deployment -->"
+          COMMENT_BODY="$COMMENT_MARKER
+          **Preview Deployment**
+
+          | Status | Preview | Commit | Updated |
+          | --- | --- | --- | --- |
+          | ✅ |  $DEPLOYMENT_URL | \`${GITHUB_SHA::7}\` | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |"
+
+          # Find existing comment by marker
+          EXISTING_COMMENT_ID=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id" | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_COMMENT_ID" \
+              --method PATCH --field body="$COMMENT_BODY"
+          else
+            gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+          fi


### PR DESCRIPTION
## Description

Deploys frontend builds to Vercel connected to the https://cloud.onyx.app backend for QA.

It uses a custom GitHub Actions workflow (following [this guide](https://vercel.com/kb/guide/how-can-i-use-github-actions-with-vercel)) to:
1. future-proof the compute cost
2. give us a little more flexibility with the UX (I find the Github deployment status a bit noisy and the native Vercel comments a bit distracting -- I just want [the deployed URL](https://github.com/onyx-dot-app/onyx/pull/8312#issuecomment-3881348109) plainly imo).

In the [Vercel Dashboard](https://vercel.com/danswer/onyx-preview/settings/environment-variables) there are two environment variables set to enable this feature, namely:
- `OVERRIDE_API_PRODUCTION=true` 
- `INTERNAL_URL=https://cloud.onyx.app/api`

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/pull/8312#issuecomment-3881348109

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to build and deploy preview frontend builds to Vercel for every web change, then posts a clean preview URL on the PR. Previews point to the cloud backend (https://cloud.onyx.app) for QA.

- **New Features**
  - Runs on pushes to non-main branches affecting web/**.
  - Uses Vercel CLI to pull env, build, and deploy prebuilt artifacts.
  - Posts/updates a single PR comment with the preview URL, commit, and timestamp.
  - Previews use Vercel env vars: OVERRIDE_API_PRODUCTION=true and INTERNAL_URL=https://cloud.onyx.app/api.

<sup>Written for commit e09a85734c64cb35568c52e7916da8bcb01d51da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

