### PR TITLE
chore(deployment): only try to build desktop if semver-like tag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -91,8 +91,8 @@ jobs:
             BUILD_WEB_CLOUD=true
           else
             BUILD_WEB=true
-            # Skip desktop builds on beta tags and nightly runs
-            if [[ "$IS_BETA" != "true" ]] && [[ "$IS_NIGHTLY" != "true" ]]; then
+            # Only build desktop for semver tags (excluding beta)
+            if [[ "$IS_VERSION_TAG" == "true" ]] && [[ "$IS_BETA" != "true" ]]; then
               BUILD_DESKTOP=true
             fi
           fi


### PR DESCRIPTION
## Description

The desktop builds require semver tags (a detail required by Tauri, not us), so let's not even try to build for non-semver tags since we know it's going to fail (and cause a second ping in #monitor-deployments).

## How Has This Been Tested?

Nah

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update deployment workflow to only build desktop when the tag is semver-like and not a beta. This prevents Tauri build failures and reduces noisy retries in deployments.

<sup>Written for commit 8679423ceba02b86d1bd910a56d5d64b90b8ec88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

