### PR TITLE
chore(craft): bump sandbox limits one last time TM

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -416,7 +416,7 @@ done
             resources=client.V1ResourceRequirements(
                 # Reduced resources since sidecar is mostly idle (sleeping)
                 requests={"cpu": "250m", "memory": "256Mi"},
-                limits={"cpu": "4000m", "memory": "6Gi"},
+                limits={"cpu": "4000m", "memory": "8Gi"},
             ),
         )
 
@@ -451,8 +451,8 @@ done
                 ),
             ],
             resources=client.V1ResourceRequirements(
-                requests={"cpu": "500m", "memory": "1Gi"},
-                limits={"cpu": "2000m", "memory": "6Gi"},
+                requests={"cpu": "1000m", "memory": "2Gi"},
+                limits={"cpu": "4000m", "memory": "8Gi"},
             ),
             # TODO: Re-enable probes when sandbox container runs actual services.
             # Note: Next.js ports are now per-session (dynamic), so container-level


### PR DESCRIPTION

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased Kubernetes sandbox pod resources to support heavier builds and reduce OOMs after the node group upgrade. Sandbox container requests are now 1000m CPU/2Gi memory with limits 4000m CPU/8Gi memory; sidecar memory limit is now 8Gi.

<sup>Written for commit 5b2b78ab2736bce057601f7260e8a456e0a66a37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

