### PR TITLE
fix(ee): copy license public key into Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -134,6 +134,7 @@ COPY --chown=onyx:onyx ./alembic_tenants /app/alembic_tenants
 COPY --chown=onyx:onyx ./alembic.ini /app/alembic.ini
 COPY supervisord.conf /usr/etc/supervisord.conf
 COPY --chown=onyx:onyx ./static /app/static
+COPY --chown=onyx:onyx ./keys /app/keys
 
 # Escape hatch scripts
 COPY --chown=onyx:onyx ./scripts/debugging /app/scripts/debugging


### PR DESCRIPTION
## Description

The `keys/` directory (containing `license_public_key.pem`) was not included in the Dockerfile `COPY` directives, so self-hosted deployments running off prebuilt docker images couldn't verify uploaded licenses — failing with "License public key not found at /app/keys/license_public_key.pem".

Adds `COPY --chown=onyx:onyx ./keys /app/keys` alongside the other application file copies.

## How Has This Been Tested?


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copy the keys directory (including license_public_key.pem) into the backend Docker image so self-hosted EKS deployments can verify uploaded licenses. Uses COPY --chown=onyx:onyx ./keys /app/keys to ensure the key is present with the right ownership.

<sup>Written for commit 72944ea5acba40487c9f77c143a59330cf991688. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

