### PR TITLE
Fix authentication when passing custom MCP Headers in API

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -159,7 +159,8 @@ class MCPTool(Tool[None]):
                 and self.mcp_server.auth_type is not None
             )
             has_auth_config = (
-                self.connection_config is not None and bool(headers)
+                (self.connection_config is not None and bool(headers))
+                or bool(self._additional_headers)
             ) or (is_passthrough_oauth and self._user_oauth_token is not None)
 
             if requires_auth and not has_auth_config:


### PR DESCRIPTION
This fixes https://github.com/onyx-dot-app/onyx/issues/8181

Most of the explanations are in that issue

Related to https://github.com/onyx-dot-app/onyx/pull/7390

## How Has This Been Tested?

Using docker, build locally and tested in production




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes authentication when passing custom MCP headers in the API by treating _additional_headers as valid auth config. This prevents false “missing auth” errors and resolves #8181.

<sup>Written for commit 83e286304eb6aa9b537928b2b8318e5acfdf2501. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

