### PR TITLE
chore: [Running GitHub actions for #8344]

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.26
+version: 0.4.27
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.api.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.api.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.api.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.api.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.api.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.api.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.api.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.api.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.maxReplicas | default 20 }}
   pollingInterval: {{ .Values.celery_worker_docfetching.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_docfetching.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_docfetching.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_docfetching.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_docfetching.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_docprocessing.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_docprocessing.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_docprocessing.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_docprocessing.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_docprocessing.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_heavy.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_heavy.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_heavy.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_heavy.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_heavy.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_light.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_light.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_light.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_light.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_light.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_light.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_light.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_light.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_monitoring.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_monitoring.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_monitoring.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_monitoring.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_monitoring.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_primary.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_primary.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_primary.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_primary.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_primary.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_primary.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_primary.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_primary.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_user_file_processing.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.celery_worker_user_file_processing.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.celery_worker_user_file_processing.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_user_file_processing.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_user_file_processing.autoscaling.fallbackReplicas | default 1 }}

--- a/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
@@ -14,7 +14,9 @@ spec:
   maxReplicaCount: {{ .Values.webserver.autoscaling.maxReplicas }}
   pollingInterval: {{ .Values.webserver.autoscaling.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.webserver.autoscaling.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.webserver.autoscaling.idleReplicaCount | default 1 }}
+  {{- if hasKey .Values.webserver.autoscaling "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.webserver.autoscaling.idleReplicaCount }}
+  {{- end }}
   fallback:
     failureThreshold: {{ .Values.webserver.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.webserver.autoscaling.fallbackReplicas | default 1 }}


### PR DESCRIPTION
This PR runs GitHub Actions CI for #8344.

- [x] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes idleReplicaCount optional in KEDA ScaledObject Helm templates to avoid forcing idle pods when not configured. Improves autoscaling behavior for API, webserver, and all Celery workers.

- **Bug Fixes**
  - Guard idleReplicaCount with hasKey so it renders only when set in values.
  - Removes implicit default of 1 idle replica across affected templates.

- **Dependencies**
  - Bumps onyx chart version to 0.4.27.

<sup>Written for commit 84d35700950fbcf631628b547c8c59a3a5822eb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

