### PR TITLE
refactor(opal): update Container height variants, remove paddingVariant

### DIFF
--- a/web/lib/opal/src/components/buttons/Button/components.tsx
+++ b/web/lib/opal/src/components/buttons/Button/components.tsx
@@ -107,7 +107,6 @@ function Button({
         border={interactiveBaseProps.subvariant === "secondary"}
         heightVariant={isCompact ? "md" : "lg"}
         roundingVariant={isCompact ? "compact" : "default"}
-        paddingVariant={isCompact ? "thin" : "default"}
       >
         <div
           className={cn(

--- a/web/lib/opal/src/core/index.ts
+++ b/web/lib/opal/src/core/index.ts
@@ -5,6 +5,5 @@ export {
   type InteractiveBaseVariantProps,
   type InteractiveContainerProps,
   type InteractiveContainerHeightVariant,
-  type InteractiveContainerPaddingVariant,
   type InteractiveContainerRoundingVariant,
 } from "@opal/core/interactive/components";

--- a/web/lib/opal/src/core/interactive/components.tsx
+++ b/web/lib/opal/src/core/interactive/components.tsx
@@ -58,21 +58,6 @@ const interactiveContainerMinWidthVariants = {
 } as const;
 
 /**
- * Padding presets for `Interactive.Container`.
- *
- * - `"default"` — Default padding of 0.5rem (8px) on all sides
- * - `"thin"` — Reduced padding of 0.25rem (4px), for tighter layouts
- * - `"none"` — No padding, when the child handles its own spacing
- */
-type InteractiveContainerPaddingVariant =
-  keyof typeof interactiveContainerPaddingVariants;
-const interactiveContainerPaddingVariants = {
-  default: "p-2",
-  thin: "p-1",
-  none: "p-0",
-} as const;
-
-/**
  * Border-radius presets for `Interactive.Container`.
  *
  * - `"default"` — Default radius of 0.75rem (12px), matching card rounding
@@ -372,17 +357,6 @@ interface InteractiveContainerProps
   roundingVariant?: InteractiveContainerRoundingVariant;
 
   /**
-   * Padding preset controlling inner spacing.
-   *
-   * - `"default"` — 0.5rem (8px) padding on all sides
-   * - `"thin"` — 0.25rem (4px) padding for tighter layouts
-   * - `"none"` — No padding; child content controls its own spacing
-   *
-   * @default "default"
-   */
-  paddingVariant?: InteractiveContainerPaddingVariant;
-
-  /**
    * Height preset controlling the container's vertical size.
    *
    * - `"lg"` — 2.25rem (36px), typical button/item height
@@ -416,13 +390,9 @@ interface InteractiveContainerProps
  *   </Interactive.Container>
  * </Interactive.Base>
  *
- * // Compact, borderless container with no padding
+ * // Compact, borderless container
  * <Interactive.Base variant="default" subvariant="ghost">
- *   <Interactive.Container
- *     heightVariant="md"
- *     roundingVariant="compact"
- *     paddingVariant="none"
- *   >
+ *   <Interactive.Container heightVariant="md" roundingVariant="compact">
  *     <span>Inline item</span>
  *   </Interactive.Container>
  * </Interactive.Base>
@@ -435,7 +405,6 @@ function InteractiveContainer({
   type,
   border,
   roundingVariant = "default",
-  paddingVariant = "default",
   heightVariant = "lg",
   ...props
 }: InteractiveContainerProps) {
@@ -454,7 +423,6 @@ function InteractiveContainer({
     className: cn(
       "interactive-container",
       interactiveContainerRoundingVariants[roundingVariant],
-      interactiveContainerPaddingVariants[paddingVariant],
       interactiveContainerHeightVariants[heightVariant],
       interactiveContainerMinWidthVariants[heightVariant],
       slotClassName
@@ -520,6 +488,5 @@ export {
   type InteractiveBaseSelectVariantProps,
   type InteractiveContainerProps,
   type InteractiveContainerHeightVariant,
-  type InteractiveContainerPaddingVariant,
   type InteractiveContainerRoundingVariant,
 };

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -1308,10 +1308,7 @@ function AccountsAccessSettings() {
                         subvariant="secondary"
                         static
                       >
-                        <Interactive.Container
-                          paddingVariant="none"
-                          heightVariant="fit"
-                        >
+                        <Interactive.Container heightVariant="fit">
                           <AttachmentItemLayout
                             icon={SvgKey}
                             title={pat.name}

--- a/web/src/sections/cards/DocumentSetCard.tsx
+++ b/web/src/sections/cards/DocumentSetCard.tsx
@@ -39,7 +39,6 @@ export default function DocumentSetCard({
           static={disabled || isSelected === undefined}
         >
           <Interactive.Container
-            paddingVariant="none"
             border
             data-testid={`document-set-card-${documentSet.id}`}
             heightVariant="fit"

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -175,11 +175,7 @@ export function FileCard({
     >
       <div className="max-w-[12rem]">
         <Interactive.Base variant="none" static>
-          <Interactive.Container
-            paddingVariant="none"
-            border
-            heightVariant="fit"
-          >
+          <Interactive.Container border heightVariant="fit">
             <AttachmentItemLayout
               icon={isProcessing ? SimpleLoader : SvgFileText}
               title={file.name}


### PR DESCRIPTION
## Description

Cleans up `Interactive.Container` props:

1. **Updated height variants** from semantic names to t-shirt sizes:
   - `"default"` → `"lg"` (2.25rem / 36px)
   - `"compact"` → `"md"` (1.75rem / 28px)
   - Added `"sm"` (1.5rem / 24px)
   - Added `"xs"` (1.25rem / 20px)
   - `"fit"` kept as-is

2. **Removed `paddingVariant`** — children are always centrally aligned via `items-center justify-center` on the container; padding is no longer controlled here.

## How Has This Been Tested?

- TypeScript type checker passes (`bun run types:check`)
- Pre-commit hooks pass (prettier, type check)

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Interactive.Container sizing: switches to t‑shirt height variants (lg/md/sm/xs) and removes paddingVariant to simplify the API. Call sites updated; content remains centered by default.

- **Refactors**
  - heightVariant: default → lg, compact → md; added sm and xs; fit unchanged
  - Default heightVariant is now lg
  - Removed paddingVariant and its exported type
  - Updated Button and card usages to map compact→md, default→lg, and drop paddingVariant
  - Min-width now scales with the selected height variant

- **Migration**
  - Replace heightVariant values: "default"→"lg", "compact"→"md"
  - Remove paddingVariant from all usages; add padding inside children if needed
  - Remove InteractiveContainerPaddingVariant imports/usages if referenced

<sup>Written for commit 0956c01af566e4c3363352083231e269cd7bf868. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

