### PR TITLE
fix(ollama): Fix Chat

### DIFF
--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -1,0 +1,82 @@
+from litellm.llms.ollama.chat.transformation import OllamaChatCompletionResponseIterator
+from litellm.llms.ollama.chat.transformation import OllamaChatConfig
+
+from onyx.llm.litellm_singleton.monkey_patches import apply_monkey_patches
+
+
+def test_ollama_chunk_parser_preserves_existing_tool_call_id() -> None:
+    apply_monkey_patches()
+
+    iterator = OllamaChatCompletionResponseIterator(
+        streaming_response=iter(()),
+        sync_stream=True,
+    )
+
+    chunk = {
+        "model": "mistral",
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "fae19e3fb",
+                    "function": {
+                        "name": "search",
+                        "arguments": {"query": "test"},
+                    },
+                }
+            ],
+        },
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 1,
+        "eval_count": 1,
+    }
+
+    parsed = iterator.chunk_parser(chunk)
+
+    assert parsed.choices[0].delta.tool_calls is not None
+    assert parsed.choices[0].delta.tool_calls[0]["id"] == "fae19e3fb"
+    assert parsed.choices[0].finish_reason == "tool_calls"
+
+
+def test_ollama_transform_request_preserves_tool_call_linkage_fields() -> None:
+    apply_monkey_patches()
+
+    config = OllamaChatConfig()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "fae19e3fb",
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "arguments": '{"query":"weather"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "fae19e3fb",
+            "content": '{"results": []}',
+        },
+    ]
+
+    request_data = config.transform_request(
+        model="mistral",
+        messages=messages,
+        optional_params={"stream": True},
+        litellm_params={},
+        headers={},
+    )
+
+    transformed_messages = request_data["messages"]
+
+    assert transformed_messages[0]["tool_calls"][0]["id"] == "fae19e3fb"
+    assert transformed_messages[0]["tool_calls"][0]["function"]["name"] == "search"
+    assert transformed_messages[1]["tool_call_id"] == "fae19e3fb"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ollama chat tool-call handling so IDs and linkage are preserved and streaming finishes correctly, preventing unmatched tool results.

- **Bug Fixes**
  - Preserve provider-supplied tool_call IDs in streaming chunks and set finish_reason to "tool_calls" when present.
  - Keep assistant.tool_calls[].id, tool.tool_call_id, and tool_name in request transformation; parse function arguments reliably.
  - Added unit tests for chunk parsing and request transformation.

<sup>Written for commit 62c6fa54a2a128c681b60c808726424305373e42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

