### PR TITLE
chore(devtools): address missed cubic review

### DIFF
--- a/tools/ods/cmd/compose.go
+++ b/tools/ods/cmd/compose.go
@@ -146,10 +146,15 @@ func execDockerCompose(args []string, extraEnv []string) {
 // compose project by running "docker compose -p onyx ps --services".
 // On any error it returns nil (completions will just be empty).
 func runningServiceNames() []string {
+	gitRoot, err := paths.GitRoot()
+	if err != nil {
+		return nil
+	}
+
 	args := []string{"compose", "-p", composeProjectName, "ps", "--services"}
 
 	cmd := exec.Command("docker", args...)
-	cmd.Dir = composeDir()
+	cmd.Dir = filepath.Join(gitRoot, "deployment", "docker_compose")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Description

Addresses: https://github.com/onyx-dot-app/onyx/pull/8351#discussion_r2795859528

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the docker compose working directory for service discovery to use the repo’s deployment/docker_compose path. Prevents empty or incorrect results when running devtools outside the compose directory.

- **Bug Fixes**
  - Use paths.GitRoot() and set cmd.Dir to deployment/docker_compose.
  - Safely return nil if Git root resolution fails.

<sup>Written for commit 6916a9b3facba6ee5302507518c2f9af6c6605db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

