### PR TITLE
chore(devtools): upgrade `ods`: 0.5.1->0.5.2

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -317,7 +317,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-onyx-devtools==0.5.1
+onyx-devtools==0.5.2
     # via onyx
 openai==2.14.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dev = [
     "matplotlib==3.10.8",
     "mypy-extensions==1.0.0",
     "mypy==1.13.0",
-    "onyx-devtools==0.5.1",
+    "onyx-devtools==0.5.2",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4711,7 +4711,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==2.4.1" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.5.1" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.5.2" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "openapi-generator-cli", marker = "extra == 'dev'", specifier = "==7.17.0" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
@@ -4816,20 +4816,20 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/37/bc043a8d6e3763f032282bb924c7edbed9c868ebab15e38a20e451e83dca/onyx_devtools-0.5.1-py3-none-any.whl", hash = "sha256:eb14f3fd9dcc5219439b5b568fd98d1088927a2d35d706811d4dfdee6ccb63d7", size = 2891955, upload-time = "2026-02-09T22:59:19.53Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/93/c0d623e2bd0780f5b6ccc025698e0eaa5e50939b0a0edaad2ee068b7be83/onyx_devtools-0.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4ac7a500e2a4cbc4f943890d68525f92cd1ea5f9d8eada1c2ed9ff2e81771cd", size = 2909887, upload-time = "2026-02-09T22:59:28.213Z" },
-    { url = "https://files.pythonhosted.org/packages/51/45/94098a852f846c8f2b4226a595e9b95f4ed535a86939dd0601b1ffe8bb73/onyx_devtools-0.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edac64d3ae5691c3aa12363bb2eaee13e6f9e62a3c6385d390a95c29f60fb95e", size = 2713796, upload-time = "2026-02-09T22:59:17.919Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b8/7ed5486b6302f9d717f6f4f98d4a6162bc63f3eb964feed438eb5875176a/onyx_devtools-0.5.1-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2d713aa258a0799743cf8a37c0a39727deed3d2e7d3033fe08d8920cbeecbb8c", size = 2623042, upload-time = "2026-02-09T22:59:27.833Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/7e/e1a6d0a02ea0dddf48057ae12417cc126902cc2e74078dd33c8ab5e3bb39/onyx_devtools-0.5.1-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:117cc62d3a0637e7eb9a417bbd2dbc045f887da3278708e6d4fcae122c43e4bf", size = 2891968, upload-time = "2026-02-09T22:59:19.941Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/96/fecee71880b65c4ae33c6a3fa7a58d868956d6debfc075cb494d0a142047/onyx_devtools-0.5.1-py3-none-win_amd64.whl", hash = "sha256:e33c8b27cd5568c6925e58c0f8d502d88d96817af879fb78d4b564e7ff2bbc16", size = 2974809, upload-time = "2026-02-09T22:59:23.564Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/37/f59bca099132fae209e4dd2c5158cd1dee729507d4f810e1ea306279e12c/onyx_devtools-0.5.1-py3-none-win_arm64.whl", hash = "sha256:f4987ab6f07797c18067f7a5edccfc12af9d52ae22a6075d0109b924b6791706", size = 2685469, upload-time = "2026-02-09T22:59:27.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e5/a4d2924f48efb8e8d882fbf4c37ab023d2bd7b946a7e7f641d4e6b736685/onyx_devtools-0.5.2-py3-none-any.whl", hash = "sha256:f8ff0e6cf7a96db8b625c4c3f237ed25df2747f5000a2383a756249c2de60803", size = 2894917, upload-time = "2026-02-11T22:42:02.212Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/12/d857c67e44d64ff995c8876601d87ef5700cf341778b1490490cc78a1b6b/onyx_devtools-0.5.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b6e7e61280aef180a2733f1e9a38aafe41a119f57241cd20be94106c61b53f0e", size = 2913403, upload-time = "2026-02-11T22:42:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/08/5e2bc8186509e96c1845ec437a7c78451e2ea92a19d72be7827bf5822c68/onyx_devtools-0.5.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4ebf9179441af4a3338df803383725680da0777e59f9c22c86afd79716687ea5", size = 2717054, upload-time = "2026-02-11T22:42:07.745Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ef/8748c899ebff8a4440b2bdaee0392fe78c7bb68ee06570030cc92c32ede9/onyx_devtools-0.5.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:5281a3185fc1ed607ddc6f9375ae461d2920c8fd53c5b45ed7275af9766abd86", size = 2625794, upload-time = "2026-02-11T22:42:04.765Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ff/f77170fba079a2ceb4b270021b33c23296bdd8e827fadf075eb031329258/onyx_devtools-0.5.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:c1a3e6004c092accfbe11f1c0d5462e20778c4ca1260b4e2a2e5ea78e6b1c54e", size = 2894936, upload-time = "2026-02-11T22:42:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/77/a74d993d2a4b6d922d7f0dbbb761edc79c6ec8079f5d27005914b99186d4/onyx_devtools-0.5.2-py3-none-win_amd64.whl", hash = "sha256:208be9f35116857b47cb50a8b661f6f751f22f1a967eb78ccb75838118243d71", size = 2977692, upload-time = "2026-02-11T22:42:05.112Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7f/a87c7ec364588fecbde3fc950a6cba6595f0ba9d16d7f93d9ee7bc66b727/onyx_devtools-0.5.2-py3-none-win_arm64.whl", hash = "sha256:c6872d0f42aa5da664a84843a73c024c191f273224fe4d72b62b84ad2f9f52eb", size = 2688448, upload-time = "2026-02-11T22:41:59.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Pulls in https://github.com/onyx-dot-app/onyx/pull/8351

## How Has This Been Tested?

```
$ ods --version
ods version v0.5.2
commit 61502751e8b22fb57d680aaf580d416cb0d2458a
```

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded onyx-devtools (ODS) from 0.5.1 to 0.5.2 to pull in the latest devtools updates. This affects developer tooling only.

- **Dependencies**
  - Bumped onyx-devtools to 0.5.2 in backend/requirements/dev.txt and pyproject.toml; updated uv.lock.

<sup>Written for commit 20d6e89aaa3e858176e7177b99466592bf3112db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

