### PR TITLE
chore(devtools): update `ods compose` defaults

### DIFF
--- a/tools/ods/cmd/compose.go
+++ b/tools/ods/cmd/compose.go
@@ -242,6 +242,9 @@ func runCompose(profile string, opts *ComposeOptions) {
 			eeValue = "false"
 		}
 		setEnvValue("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", eeValue)
+		if !opts.NoEE {
+			setEnvValue("LICENSE_ENFORCEMENT_ENABLED", "false")
+		}
 	}
 
 	args := baseArgs(profile)


### PR DESCRIPTION
## Description

This is also now needed to run the EE edition locally.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update ods compose to set LICENSE_ENFORCEMENT_ENABLED=false when EE features are enabled. This allows running the Enterprise Edition locally without license checks; behavior is unchanged when using --no-ee.

<sup>Written for commit 6b23bdbaaefdbf9e0d5522952cc87fff8d771e14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

