### PR TITLE
fix(deepseek): Getting chat to work

### DIFF
--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -269,3 +269,5 @@ class LlmStepResult(BaseModel):
     reasoning: str | None
     answer: str | None
     tool_calls: list[ToolCallKickoff] | None
+    # Optional raw answer text (before display sanitization), used for fallback tool extraction.
+    raw_answer: str | None = None


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables DeepSeek chat tool calling by parsing XML function_calls and hiding provider XML markup from the user. Adds reliable fallback extraction when native tool calls are missing, including in AUTO mode.

- **New Features**
  - Parse DeepSeek XML function_calls into tool calls, supporting multiple calls and string/JSON parameter parsing.
  - Detect XML markup during streaming, suppress it from user-visible output, and store raw answer for fallback extraction.
  - Trigger fallback tool extraction when XML markup is present but no native tool calls; log whether extraction came from XML or JSON. Added unit tests covering XML parsing and fallback behavior.

<sup>Written for commit 3b4fa7316ce0ca698dc3cbc1dac54aea22e9e28e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

