### PR TITLE
fix(opal): add padding to Interactive.Container and smooth foldable transitions

### DIFF
--- a/web/lib/opal/src/core/interactive/components.tsx
+++ b/web/lib/opal/src/core/interactive/components.tsx
@@ -63,6 +63,13 @@ const interactiveContainerMinWidthVariants = {
   xs: "min-w-[1.25rem]",
   fit: "",
 } as const;
+const interactiveContainerPaddingVariants = {
+  lg: "p-2",
+  md: "p-1",
+  sm: "p-1",
+  xs: "p-0.5",
+  fit: "",
+} as const;
 
 /**
  * Border-radius presets for `Interactive.Container`.
@@ -409,6 +416,7 @@ function InteractiveContainer({
       interactiveContainerRoundingVariants[roundingVariant],
       interactiveContainerHeightVariants[heightVariant],
       interactiveContainerMinWidthVariants[heightVariant],
+      interactiveContainerPaddingVariants[heightVariant],
       slotClassName
     ),
     "data-border": border ? ("true" as const) : undefined,

--- a/web/lib/opal/src/core/interactive/styles.css
+++ b/web/lib/opal/src/core/interactive/styles.css
@@ -16,7 +16,7 @@
 
 /* Utility class — descendants opt in to parent-controlled foreground color */
 .interactive-foreground {
-  @apply transition-colors duration-150 ease-in-out;
+  @apply transition-all duration-150 ease-in-out;
   color: var(--interactive-foreground);
 }
 
@@ -25,7 +25,7 @@
    icon color at rest (e.g. select) set --interactive-foreground-icon; all
    other states leave it unset so icons track the text color automatically. */
 .interactive-foreground-icon {
-  @apply transition-colors duration-150 ease-in-out;
+  @apply transition-all duration-150 ease-in-out;
   color: var(--interactive-foreground-icon, var(--interactive-foreground));
 }
 


### PR DESCRIPTION
## Description

Adds height-variant-tied padding to `Interactive.Container` and fixes the foldable button text jump on collapse/expand.

- **Padding**: Added `interactiveContainerPaddingVariants` map that ties padding to the height variant (`lg: p-2`, `md: p-1`, `sm: p-1`, `xs: p-0.5`, `fit: none`). Previously, containers had no padding, causing content to sit flush against edges when wider than `min-width`.
- **Foldable transition fix**: Changed `transition-colors` to `transition-all` on `.interactive-foreground` and `.interactive-foreground-icon` so that gap and layout changes animate smoothly alongside color transitions, eliminating the text jump during foldable collapse/expand.

## How Has This Been Tested?

Visually verified foldable buttons expand/collapse smoothly without text jump. Verified non-foldable buttons render with correct padding at all height variants.

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds height-based padding to Interactive.Container and smooths foldable button transitions to remove text jump, improving spacing and polish.

- **New Features**
  - Interactive.Container now applies padding per height variant: lg p-2, md p-1, sm p-1, xs p-0.5, fit: none.

- **Bug Fixes**
  - Switched .interactive-foreground and .interactive-foreground-icon to transition-all so spacing/layout changes animate with color, preventing the collapse/expand text jump.

<sup>Written for commit 4ef9eca4f92c809368b42a8d1c03008d9c32681d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

