### PR TITLE
fix: no vector db tests

### DIFF
--- a/backend/tests/integration/tests/no_vectordb/conftest.py
+++ b/backend/tests/integration/tests/no_vectordb/conftest.py
@@ -11,6 +11,9 @@ import requests
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.reset import reset_file_store
+from tests.integration.common_utils.reset import reset_postgres
+from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -37,6 +40,13 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture()
-def llm_provider(admin_user: DATestUser) -> None:
+def reset() -> None:
+    """Reset Postgres and the file store, but skip Vespa (not running)."""
+    reset_postgres()
+    reset_file_store()
+
+
+@pytest.fixture()
+def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
     """Ensure an LLM provider exists for the test session."""
-    LLMProviderManager.create(user_performing_action=admin_user)
+    return LLMProviderManager.create(user_performing_action=admin_user)

--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
@@ -50,6 +50,7 @@ def _wait_for_file_processed(
 
 
 def test_chat_with_small_project_file(
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -105,6 +106,7 @@ def test_chat_with_small_project_file(
 
 
 def test_persona_with_user_files_chat(
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -207,6 +209,7 @@ def _base_persona_body(**overrides: object) -> dict:
 
 
 def test_persona_rejects_document_sets_without_vector_db(
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Creating a persona with document_set_ids should fail with 400."""
@@ -221,6 +224,7 @@ def test_persona_rejects_document_sets_without_vector_db(
 
 
 def test_persona_rejects_document_ids_without_vector_db(
+    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Creating a persona with document_ids should fail with 400."""

--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
@@ -25,7 +25,9 @@ def _headers(user: DATestUser) -> dict[str, str]:
 # ------------------------------------------------------------------
 
 
-def test_admin_search_returns_501(admin_user: DATestUser) -> None:
+def test_admin_search_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.post(
         f"{API_SERVER_URL}/admin/search",
         json={"query": "test", "filters": {}},
@@ -34,7 +36,9 @@ def test_admin_search_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501, f"Expected 501, got {resp.status_code}"
 
 
-def test_document_size_info_returns_501(admin_user: DATestUser) -> None:
+def test_document_size_info_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.get(
         f"{API_SERVER_URL}/document/document-size-info",
         params={"document_id": "fake-doc"},
@@ -43,7 +47,9 @@ def test_document_size_info_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_document_chunk_info_returns_501(admin_user: DATestUser) -> None:
+def test_document_chunk_info_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.get(
         f"{API_SERVER_URL}/document/chunk-info",
         params={"document_id": "fake-doc"},
@@ -52,7 +58,9 @@ def test_document_chunk_info_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_set_new_search_settings_returns_501(admin_user: DATestUser) -> None:
+def test_set_new_search_settings_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.post(
         f"{API_SERVER_URL}/search-settings/set-new-search-settings",
         json={},
@@ -61,7 +69,9 @@ def test_set_new_search_settings_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_cancel_new_embedding_returns_501(admin_user: DATestUser) -> None:
+def test_cancel_new_embedding_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.post(
         f"{API_SERVER_URL}/search-settings/cancel-new-embedding",
         headers=_headers(admin_user),
@@ -69,7 +79,9 @@ def test_cancel_new_embedding_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_connector_router_returns_501(admin_user: DATestUser) -> None:
+def test_connector_router_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     """The entire /manage router is gated — any connector endpoint should 501."""
     resp = requests.get(
         f"{API_SERVER_URL}/manage/connector",
@@ -78,7 +90,9 @@ def test_connector_router_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_ingestion_post_returns_501(admin_user: DATestUser) -> None:
+def test_ingestion_post_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.post(
         f"{API_SERVER_URL}/onyx-api/ingestion",
         json={"document": {}},
@@ -87,7 +101,9 @@ def test_ingestion_post_returns_501(admin_user: DATestUser) -> None:
     assert resp.status_code == 501
 
 
-def test_ingestion_delete_returns_501(admin_user: DATestUser) -> None:
+def test_ingestion_delete_returns_501(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.delete(
         f"{API_SERVER_URL}/onyx-api/ingestion/fake-doc-id",
         headers=_headers(admin_user),
@@ -100,7 +116,9 @@ def test_ingestion_delete_returns_501(admin_user: DATestUser) -> None:
 # ------------------------------------------------------------------
 
 
-def test_settings_endpoint_works(admin_user: DATestUser) -> None:
+def test_settings_endpoint_works(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.get(
         f"{API_SERVER_URL}/settings",
         headers=_headers(admin_user),
@@ -110,7 +128,9 @@ def test_settings_endpoint_works(admin_user: DATestUser) -> None:
     assert data["vector_db_enabled"] is False
 
 
-def test_document_set_list_works(admin_user: DATestUser) -> None:
+def test_document_set_list_works(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.get(
         f"{API_SERVER_URL}/manage/document-set",
         headers=_headers(admin_user),
@@ -118,7 +138,9 @@ def test_document_set_list_works(admin_user: DATestUser) -> None:
     assert resp.status_code == 200
 
 
-def test_persona_list_works(admin_user: DATestUser) -> None:
+def test_persona_list_works(
+    reset: None, admin_user: DATestUser  # noqa: ARG001
+) -> None:
     resp = requests.get(
         f"{API_SERVER_URL}/admin/persona",
         headers=_headers(admin_user),
@@ -126,7 +148,7 @@ def test_persona_list_works(admin_user: DATestUser) -> None:
     assert resp.status_code == 200
 
 
-def test_tool_list_works(admin_user: DATestUser) -> None:
+def test_tool_list_works(reset: None, admin_user: DATestUser) -> None:  # noqa: ARG001
     resp = requests.get(
         f"{API_SERVER_URL}/tool",
         headers=_headers(admin_user),


### PR DESCRIPTION
## Description

tests did not follow our standard practices

## How Has This Been Tested?

now they do

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized and stabilized the “no vector DB” integration tests by adding a per-test reset and fixing the LLM provider fixture to return a provider. This removes flakiness and verifies correct 501/200 behavior, plus 400 on invalid persona creation, when the vector DB is disabled.

- **Refactors**
  - Add reset fixture to clear Postgres and file store (skip Vespa).
  - Return DATestLLMProvider from llm_provider with proper typing.
  - Apply reset across chat and endpoint tests for isolation.
  - Strengthen assertions: 501 for vector-dependent routes; 200 for allowed endpoints (settings, document sets, personas, tools); 400 when persona includes document_set_ids or document_ids.

<sup>Written for commit b2abc988c0ee81ff68ddf3e5e48e66a12461f70b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

