### PR TITLE
fix(billing): exclude inactive users from seat counts and allow users page when gated

### DIFF
--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -281,8 +281,10 @@ function SeatsCard({
   });
 
   const totalSeats = billing?.seats ?? license?.seats ?? 0;
-  const acceptedUsers = usersData?.accepted?.length ?? 0;
-  const slackUsers = usersData?.slack_users?.length ?? 0;
+  const acceptedUsers =
+    usersData?.accepted?.filter((u) => u.is_active).length ?? 0;
+  const slackUsers =
+    usersData?.slack_users?.filter((u) => u.is_active).length ?? 0;
   const usedSeats = acceptedUsers + slackUsers;
   const pendingSeats = usersData?.invited?.length ?? 0;
   const remainingSeats = Math.max(0, totalSeats - usedSeats - pendingSeats);

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -99,9 +99,11 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
   const { user } = useUser();
   const { data: usersData } = useUsers({ includeApiKeys: false });
 
-  // Calculate minimum required seats based on current users
-  const acceptedUsers = usersData?.accepted?.length ?? 0;
-  const slackUsers = usersData?.slack_users?.length ?? 0;
+  // Calculate minimum required seats based on current active users
+  const acceptedUsers =
+    usersData?.accepted?.filter((u) => u.is_active).length ?? 0;
+  const slackUsers =
+    usersData?.slack_users?.filter((u) => u.is_active).length ?? 0;
   const minRequiredSeats = Math.max(1, acceptedUsers + slackUsers);
 
   const [billingPeriod, setBillingPeriod] = useState<PlanType>("annual");

--- a/web/src/components/GatedContentWrapper.tsx
+++ b/web/src/components/GatedContentWrapper.tsx
@@ -3,8 +3,8 @@
 import { usePathname } from "next/navigation";
 import AccessRestrictedPage from "@/components/errorPages/AccessRestrictedPage";
 
-// Paths accessible even when gated - allows users to manage billing/license
-const ALLOWED_GATED_PATHS = ["/admin/billing", "/ee/admin/billing"];
+// Paths accessible even when gated - allows users to manage billing updates and seat counts
+const ALLOWED_GATED_PATHS = ["/admin/billing", "/admin/users"];
 
 /**
  * Check if pathname matches an allowed path exactly or is a subpath.

--- a/web/src/refresh-components/inputs/InputNumber.tsx
+++ b/web/src/refresh-components/inputs/InputNumber.tsx
@@ -167,7 +167,6 @@ export default function InputNumber({
             onClick={handleReset}
             disabled={!canReset || isDisabled}
             prominence="tertiary"
-            size="sm"
           />
         )}
         <div className="flex flex-col">


### PR DESCRIPTION
## Description

Inactive users were being counted toward seat enforcement in the billing UI, inflating the "in use" seat count and forcing admins to purchase more seats than needed. This PR:

- Filters seat counts in `CheckoutView` and `BillingDetailsView` to only include active users (`is_active === true`), matching the backend's `get_used_seats()` behavior
- Allows navigation to `/admin/users` when the app is in gated access mode (expired/missing license), so admins can adjust users before subscribing
- Removes `size="sm"` from InputNumber reset button (prettier/lint fix)

## How Has This Been Tested?
manual testing

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seat counts to include only active users, preventing inflated usage and unnecessary purchases. Also allows access to the Users page when licensing is gated so admins can deactivate users before subscribing.

- **Bug Fixes**
  - Filter accepted and Slack users by is_active in CheckoutView and BillingDetailsView to match backend seat logic.
  - Permit navigation to /admin/users under gated access via GatedContentWrapper.

- **Refactors**
  - Remove size="sm" from InputNumber reset button (lint/prettier cleanup).

<sup>Written for commit 347052262eefe9d125a3c74dc5992ee67cadccc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

