### PR TITLE
fix: remove log error when authtype is not set

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -86,7 +86,7 @@ WEB_DOMAIN = os.environ.get("WEB_DOMAIN") or "http://localhost:3000"
 # Auth Configs
 #####
 # Upgrades users from disabled auth to basic auth and shows warning.
-_auth_type_str = (os.environ.get("AUTH_TYPE") or "").lower()
+_auth_type_str = (os.environ.get("AUTH_TYPE") or "basic").lower()
 if _auth_type_str == "disabled":
     logger.warning(
         "AUTH_TYPE='disabled' is no longer supported. "


### PR DESCRIPTION
## Description
- When no `AUTH_TYPE` is set, we default to an empty string --> causes log.error that empty string is "not a valid authtype" 
- Instead, just default to "basic" when none set

Get's rid of logs like this in tests + in alembic migrations
<img width="960" height="447" alt="image" src="https://github.com/user-attachments/assets/49d1ff92-a651-4c68-b9ff-43936d0569fa" />


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a default of "basic" for AUTH_TYPE when the env var is not set. This prevents noisy error logs and applies a safe default auth mode.

<sup>Written for commit 7ac04698bf90a2fc2e41b23067bec928fc987a9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

