### PR TITLE
fix: flaky no vectordb test

### DIFF
--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
@@ -151,6 +151,8 @@ def test_persona_with_user_files_chat(
     persona = PersonaManager.create(
         name="no-vectordb-persona-test",
         description="Test persona for no-vectordb mode",
+        system_prompt="You are a helpful assistant. Answer questions using the available tools and files.",
+        task_prompt="",
         user_file_ids=[user_file_id],
         tool_ids=[file_reader_tool.id],
         user_performing_action=admin_user,


### PR DESCRIPTION
## Description

attempt to make no-vectordb tests more reliable

## How Has This Been Tested?

did not

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the no-vectordb chat test by setting explicit system_prompt and an empty task_prompt when creating the test persona. This reduces randomness and makes tool/file usage consistent during the test.

<sup>Written for commit 27aae70038e08a676cee60573bde2d349fc409a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

