### PR TITLE
chore: hide file reader

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  FILE_READER_TOOL_ID,
   IMAGE_GENERATION_TOOL_ID,
   PYTHON_TOOL_ID,
   SEARCH_TOOL_ID,
@@ -439,6 +440,14 @@ export default function ActionsPopover({
       hasNoConnectors &&
       !isAdmin &&
       !isCurator
+    ) {
+      return false;
+    }
+
+    // Hide File Reader entirely when it's not available (i.e. DISABLE_VECTOR_DB is off)
+    if (
+      tool.in_code_tool_id === FILE_READER_TOOL_ID &&
+      !availableToolIdSet.has(tool.id)
     ) {
       return false;
     }


### PR DESCRIPTION
## Description

hides the file reader tool when not enabled ( this is a stopgap)

## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the File Reader tool from the Actions popover when it isn’t available (e.g., vector DB disabled) so users don’t see a non-functional option.

<sup>Written for commit 4123ca1c8c41f5a7d06017d3a659e633ca8ce1a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

