### PR TITLE
fix: sharepoint cred refresh

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -165,8 +165,6 @@ def sleep_and_retry(
                 logger.error(
                     f"SharePoint request failed for {method_name}: "
                     f"status={status}, "
-                    f"headers={dict(e.response.headers)}, "
-                    f"url={e.response.url}"
                 )
             raise e
 


### PR DESCRIPTION
## Description

fix sharepoint cred refreshing in a not ideal way, to be made better later

## How Has This Been Tested?

n/a should be safe at least

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint authentication by refreshing tokens on 401 and refining retry/backoff; simplifies error logging to reduce noise.

- **Bug Fixes**
  - On 401, clear office365’s cached access token and retry immediately to get a fresh token.
  - Keep backoff for 429/503 and log sleep duration; simplify final error logs to status only.

<sup>Written for commit b02c8c43da90de85cc792b89340303d8ded2ec99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

