### PR TITLE
chore(playwright): upload baselines with merge_group jobs

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -473,12 +473,16 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
           GH_REF: ${{ github.ref }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             # PRs compare against the base branch (e.g. main, release/2.5)
             echo "rev=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            # Merge queue compares against the target branch (e.g. refs/heads/main -> main)
+            echo "rev=${MERGE_GROUP_BASE_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
           elif [[ "${GH_REF}" == refs/tags/* ]]; then
             # Tag builds compare against the tag name
             echo "rev=${REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -543,7 +547,13 @@ jobs:
           success() && (
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/heads/release/') ||
-            startsWith(github.ref, 'refs/tags/v')
+            startsWith(github.ref, 'refs/tags/v') ||
+            (
+              github.event_name == 'merge_group' && (
+                github.event.merge_group.base_ref == 'refs/heads/main' ||
+                startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
+              )
+            )
           )
         env:
           PROJECT: ${{ matrix.project }}


### PR DESCRIPTION
## Description

Also upload baselines on `merge_group` builds. These are actually how these tests are ran in postsubmit.

https://github.com/onyx-dot-app/onyx/actions/runs/21969533795/job/63467816602 should have updated the baselines but was skipped,
<img width="2880" height="1920" alt="20260212_17h26m43s_grim" src="https://github.com/user-attachments/assets/9d1d8ebb-9745-4778-ae66-6583504e6819" />


## How Has This Been Tested?

Meh

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check
