### PR TITLE
feat(scim): add SCIM bearer token authentication

### DIFF
--- a/backend/ee/onyx/server/scim/auth.py
+++ b/backend/ee/onyx/server/scim/auth.py
@@ -1,0 +1,104 @@
+"""SCIM bearer token authentication.
+
+SCIM endpoints are authenticated via bearer tokens that admins create in the
+Onyx UI. This module provides:
+
+  - ``verify_scim_token``: FastAPI dependency that extracts, hashes, and
+    validates the token from the Authorization header.
+  - ``generate_scim_token``: Creates a new cryptographically random token
+    and returns the raw value, its SHA-256 hash, and a display suffix.
+
+Token format: ``onyx_scim_<random>`` where ``<random>`` is 48 bytes of
+URL-safe base64 from ``secrets.token_urlsafe``.
+
+The hash is stored in the ``scim_token`` table; the raw value is shown to
+the admin exactly once at creation time.
+"""
+
+import hashlib
+import secrets
+
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.scim import ScimDAL
+from onyx.auth.utils import get_hashed_bearer_token_from_request
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import ScimToken
+
+SCIM_TOKEN_PREFIX = "onyx_scim_"
+SCIM_TOKEN_LENGTH = 48
+
+
+def _hash_scim_token(token: str) -> str:
+    """SHA-256 hash a SCIM token. No salt needed — tokens are random."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_scim_token() -> tuple[str, str, str]:
+    """Generate a new SCIM bearer token.
+
+    Returns:
+        A tuple of ``(raw_token, hashed_token, token_display)`` where
+        ``token_display`` is a masked version showing only the last 4 chars.
+    """
+    raw_token = SCIM_TOKEN_PREFIX + secrets.token_urlsafe(SCIM_TOKEN_LENGTH)
+    hashed_token = _hash_scim_token(raw_token)
+    token_display = SCIM_TOKEN_PREFIX + "****" + raw_token[-4:]
+    return raw_token, hashed_token, token_display
+
+
+def _get_hashed_scim_token_from_request(request: Request) -> str | None:
+    """Extract and hash a SCIM token from the request Authorization header."""
+    return get_hashed_bearer_token_from_request(
+        request,
+        valid_prefixes=[SCIM_TOKEN_PREFIX],
+        hash_fn=_hash_scim_token,
+    )
+
+
+def _get_scim_dal(db_session: Session = Depends(get_session)) -> ScimDAL:
+    return ScimDAL(db_session)
+
+
+def verify_scim_token(
+    request: Request,
+    dal: ScimDAL = Depends(_get_scim_dal),
+) -> ScimToken:
+    """FastAPI dependency that authenticates SCIM requests.
+
+    Extracts the bearer token from the Authorization header, hashes it,
+    looks it up in the database, and verifies it is active.
+
+    Note:
+        This dependency does NOT update ``last_used_at`` — the endpoint
+        should do that via ``ScimDAL.update_token_last_used()`` so the
+        timestamp write is part of the endpoint's transaction.
+
+    Raises:
+        HTTPException(401): If the token is missing, invalid, or inactive.
+    """
+    hashed = _get_hashed_scim_token_from_request(request)
+    if not hashed:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid SCIM bearer token",
+        )
+
+    token = dal.get_token_by_hash(hashed)
+
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid SCIM bearer token",
+        )
+
+    if not token.is_active:
+        raise HTTPException(
+            status_code=401,
+            detail="SCIM token has been revoked",
+        )
+
+    return token

--- a/backend/tests/unit/onyx/server/scim/test_auth.py
+++ b/backend/tests/unit/onyx/server/scim/test_auth.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from ee.onyx.server.scim.auth import _hash_scim_token
+from ee.onyx.server.scim.auth import generate_scim_token
+from ee.onyx.server.scim.auth import SCIM_TOKEN_PREFIX
+from ee.onyx.server.scim.auth import verify_scim_token
+
+
+class TestGenerateScimToken:
+    def test_returns_three_strings(self) -> None:
+        raw, hashed, display = generate_scim_token()
+        assert isinstance(raw, str)
+        assert isinstance(hashed, str)
+        assert isinstance(display, str)
+
+    def test_raw_token_has_prefix(self) -> None:
+        raw, _, _ = generate_scim_token()
+        assert raw.startswith(SCIM_TOKEN_PREFIX)
+
+    def test_hash_is_sha256_hex(self) -> None:
+        raw, hashed, _ = generate_scim_token()
+        assert len(hashed) == 64
+        assert hashed == _hash_scim_token(raw)
+
+    def test_display_shows_last_four_chars(self) -> None:
+        raw, _, display = generate_scim_token()
+        assert display.endswith(raw[-4:])
+        assert "****" in display
+
+    def test_tokens_are_unique(self) -> None:
+        tokens = {generate_scim_token()[0] for _ in range(10)}
+        assert len(tokens) == 10
+
+
+class TestHashScimToken:
+    def test_deterministic(self) -> None:
+        assert _hash_scim_token("test") == _hash_scim_token("test")
+
+    def test_different_inputs_different_hashes(self) -> None:
+        assert _hash_scim_token("a") != _hash_scim_token("b")
+
+
+class TestVerifyScimToken:
+    def _make_request(self, auth_header: str | None = None) -> MagicMock:
+        request = MagicMock()
+        headers: dict[str, str] = {}
+        if auth_header is not None:
+            headers["Authorization"] = auth_header
+        request.headers = headers
+        return request
+
+    def _make_dal(self, token: MagicMock | None = None) -> MagicMock:
+        dal = MagicMock()
+        dal.get_token_by_hash.return_value = token
+        return dal
+
+    def test_missing_header_raises_401(self) -> None:
+        request = self._make_request(None)
+        dal = self._make_dal()
+        with pytest.raises(HTTPException) as exc_info:
+            verify_scim_token(request, dal)
+        assert exc_info.value.status_code == 401
+        assert "Missing" in str(exc_info.value.detail)
+
+    def test_wrong_prefix_raises_401(self) -> None:
+        request = self._make_request("Bearer on_some_api_key")
+        dal = self._make_dal()
+        with pytest.raises(HTTPException) as exc_info:
+            verify_scim_token(request, dal)
+        assert exc_info.value.status_code == 401
+
+    def test_token_not_in_db_raises_401(self) -> None:
+        raw, _, _ = generate_scim_token()
+        request = self._make_request(f"Bearer {raw}")
+        dal = self._make_dal(token=None)
+        with pytest.raises(HTTPException) as exc_info:
+            verify_scim_token(request, dal)
+        assert exc_info.value.status_code == 401
+        assert "Invalid" in str(exc_info.value.detail)
+
+    def test_inactive_token_raises_401(self) -> None:
+        raw, _, _ = generate_scim_token()
+        request = self._make_request(f"Bearer {raw}")
+        mock_token = MagicMock()
+        mock_token.is_active = False
+        dal = self._make_dal(token=mock_token)
+        with pytest.raises(HTTPException) as exc_info:
+            verify_scim_token(request, dal)
+        assert exc_info.value.status_code == 401
+        assert "revoked" in str(exc_info.value.detail)
+
+    def test_valid_token_returns_token(self) -> None:
+        raw, _, _ = generate_scim_token()
+        request = self._make_request(f"Bearer {raw}")
+        mock_token = MagicMock()
+        mock_token.is_active = True
+        dal = self._make_dal(token=mock_token)
+        result = verify_scim_token(request, dal)
+        assert result is mock_token
+        dal.get_token_by_hash.assert_called_once()


### PR DESCRIPTION
## Description

Add SCIM bearer token authentication (`auth.py`) — a FastAPI dependency that validates `Authorization: Bearer scim_...` tokens against SHA256 hashes stored in the database. Updates `last_used_at` on successful verification.

Stacked on #8419 (SCIM database models). Only adds `auth.py` and its unit tests.

Linear: https://linear.app/onyx-app/issue/ENG-3642

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SCIM bearer token authentication for FastAPI endpoints using Authorization: Bearer onyx_scim_... with SHA-256 hash lookup and active status checks. Includes a token generator and unit tests; implements ENG-3642.

- **New Features**
  - verify_scim_token: extracts bearer token, hashes, looks up via ScimDAL, checks is_active; returns ScimToken or 401; does not update last_used_at (endpoints should).
  - generate_scim_token: returns raw token (onyx_scim_...), its SHA-256 hash, and a masked display with the last 4 chars.

<sup>Written for commit 3686a53004fd3e269b1a8162e801664d629c1459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

