### PR TITLE
fix(db): null out document set and persona ownership on user deletion (#8219) to release v2.9

### DIFF
--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -15,7 +15,9 @@ from sqlalchemy.sql.elements import KeyedColumnElement
 from onyx.auth.invited_users import remove_user_from_invited_users
 from onyx.auth.schemas import UserRole
 from onyx.db.api_key import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+from onyx.db.models import DocumentSet
 from onyx.db.models import DocumentSet__User
+from onyx.db.models import Persona
 from onyx.db.models import Persona__User
 from onyx.db.models import SamlAccount
 from onyx.db.models import User
@@ -327,6 +329,15 @@ def delete_user_from_db(
     db_session.query(SamlAccount).filter(
         SamlAccount.user_id == user_to_delete.id
     ).delete()
+    # Null out ownership on document sets and personas so they're
+    # preserved for other users instead of being cascade-deleted
+    db_session.query(DocumentSet).filter(
+        DocumentSet.user_id == user_to_delete.id
+    ).update({DocumentSet.user_id: None})
+    db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).update(
+        {Persona.user_id: None}
+    )
+
     db_session.query(DocumentSet__User).filter(
         DocumentSet__User.user_id == user_to_delete.id
     ).delete()

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -84,7 +84,8 @@ def patch_document_set(
         user=user,
         target_group_ids=document_set_update_request.groups,
         object_is_public=document_set_update_request.is_public,
-        object_is_owned_by_user=user and document_set.user_id == user.id,
+        object_is_owned_by_user=user
+        and (document_set.user_id is None or document_set.user_id == user.id),
     )
     try:
         update_document_set(
@@ -125,7 +126,8 @@ def delete_document_set(
         db_session=db_session,
         user=user,
         object_is_public=document_set.is_public,
-        object_is_owned_by_user=user and document_set.user_id == user.id,
+        object_is_owned_by_user=user
+        and (document_set.user_id is None or document_set.user_id == user.id),
     )
 
     try:

--- a/backend/tests/unit/onyx/db/test_delete_user.py
+++ b/backend/tests/unit/onyx/db/test_delete_user.py
@@ -1,0 +1,135 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import UUID
+from uuid import uuid4
+
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__User
+from onyx.db.models import Persona
+from onyx.db.models import Persona__User
+from onyx.db.models import SamlAccount
+from onyx.db.models import User__UserGroup
+from onyx.db.users import delete_user_from_db
+
+
+def _mock_user(
+    user_id: UUID | None = None, email: str = "test@example.com"
+) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id or uuid4()
+    user.email = email
+    user.oauth_accounts = []
+    return user
+
+
+def _make_query_chain() -> MagicMock:
+    """Returns a mock that supports .filter(...).delete() and .filter(...).update(...)"""
+    chain = MagicMock()
+    chain.filter.return_value = chain
+    return chain
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_nulls_out_document_set_ownership(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    db_session = MagicMock()
+
+    query_chains: dict[type, MagicMock] = {}
+
+    def query_side_effect(model: type) -> MagicMock:
+        if model not in query_chains:
+            query_chains[model] = _make_query_chain()
+        return query_chains[model]
+
+    db_session.query.side_effect = query_side_effect
+
+    delete_user_from_db(user, db_session)
+
+    # Verify DocumentSet.user_id is nulled out (update, not delete)
+    doc_set_chain = query_chains[DocumentSet]
+    doc_set_chain.filter.assert_called()
+    doc_set_chain.filter.return_value.update.assert_called_once_with(
+        {DocumentSet.user_id: None}
+    )
+
+    # Verify Persona.user_id is nulled out (update, not delete)
+    persona_chain = query_chains[Persona]
+    persona_chain.filter.assert_called()
+    persona_chain.filter.return_value.update.assert_called_once_with(
+        {Persona.user_id: None}
+    )
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_cleans_up_join_tables(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    db_session = MagicMock()
+
+    query_chains: dict[type, MagicMock] = {}
+
+    def query_side_effect(model: type) -> MagicMock:
+        if model not in query_chains:
+            query_chains[model] = _make_query_chain()
+        return query_chains[model]
+
+    db_session.query.side_effect = query_side_effect
+
+    delete_user_from_db(user, db_session)
+
+    # Join tables should be deleted (not updated)
+    for model in [DocumentSet__User, Persona__User, User__UserGroup, SamlAccount]:
+        chain = query_chains[model]
+        chain.filter.return_value.delete.assert_called_once()
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_commits_and_removes_invited(
+    _mock_ee: Any, mock_remove_invited: Any
+) -> None:
+    user = _mock_user(email="deleted@example.com")
+    db_session = MagicMock()
+    db_session.query.return_value = _make_query_chain()
+
+    delete_user_from_db(user, db_session)
+
+    db_session.delete.assert_called_once_with(user)
+    db_session.commit.assert_called_once()
+    mock_remove_invited.assert_called_once_with("deleted@example.com")
+
+
+@patch("onyx.db.users.remove_user_from_invited_users")
+@patch(
+    "onyx.db.users.fetch_ee_implementation_or_noop",
+    return_value=lambda **_kwargs: None,
+)
+def test_delete_user_deletes_oauth_accounts(
+    _mock_ee: Any, _mock_remove_invited: Any
+) -> None:
+    user = _mock_user()
+    oauth1 = MagicMock()
+    oauth2 = MagicMock()
+    user.oauth_accounts = [oauth1, oauth2]
+    db_session = MagicMock()
+    db_session.query.return_value = _make_query_chain()
+
+    delete_user_from_db(user, db_session)
+
+    db_session.delete.assert_any_call(oauth1)
+    db_session.delete.assert_any_call(oauth2)


### PR DESCRIPTION
Cherry-pick of commit 89dd44bee86fba65307ecd117c48facf05f028e5 to release/v2.9 branch.

Original PR: #8219

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve document sets and personas on user deletion by nulling ownership instead of cascading deletes. Update API checks to handle ownerless document sets and add tests for the deletion flow.

- **Bug Fixes**
  - Set DocumentSet.user_id and Persona.user_id to None when deleting a user to avoid removing shared resources.
  - Adjust patch/delete authorization to handle document sets with no owner.
  - Add unit tests for ownership nulling, join table cleanup, OAuth account deletion, and invited-user removal.

<sup>Written for commit a8872355593ecfe7e811fe2a5e304d165a3cb554. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

