### PR TITLE
feat: allow ipv6 for mcp server host in helm and main python file

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -977,6 +977,7 @@ API_KEY_HASH_ROUNDS = (
 # MCP Server Configs
 #####
 MCP_SERVER_ENABLED = os.environ.get("MCP_SERVER_ENABLED", "").lower() == "true"
+MCP_SERVER_HOST = os.environ.get("MCP_SERVER_HOST", "0.0.0.0")
 MCP_SERVER_PORT = int(os.environ.get("MCP_SERVER_PORT") or 8090)
 
 # CORS origins for MCP clients (comma-separated)

--- a/backend/onyx/mcp_server_main.py
+++ b/backend/onyx/mcp_server_main.py
@@ -3,6 +3,7 @@
 import uvicorn
 
 from onyx.configs.app_configs import MCP_SERVER_ENABLED
+from onyx.configs.app_configs import MCP_SERVER_HOST
 from onyx.configs.app_configs import MCP_SERVER_PORT
 from onyx.utils.logger import setup_logger
 
@@ -15,13 +16,13 @@ def main() -> None:
         logger.info("MCP server is disabled (MCP_SERVER_ENABLED=false)")
         return
 
-    logger.info(f"Starting MCP server on 0.0.0.0:{MCP_SERVER_PORT}")
+    logger.info(f"Starting MCP server on {MCP_SERVER_HOST}:{MCP_SERVER_PORT}")
 
     from onyx.mcp_server.api import mcp_app
 
     uvicorn.run(
         mcp_app,
-        host="0.0.0.0",
+        host=MCP_SERVER_HOST,
         port=MCP_SERVER_PORT,
         log_config=None,
     )

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.27
+version: 0.4.28
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -57,7 +57,12 @@ spec:
             {{- toYaml .Values.mcpServer.securityContext | nindent 12 }}
           image: "{{ .Values.mcpServer.image.repository }}:{{ .Values.mcpServer.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
-          command: ["python", "onyx/mcp_server_main.py"]
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              echo "Starting Onyx MCP Server" &&
+              uvicorn onyx.mcp_server.api:mcp_app --host {{ .Values.global.host }} --port {{ .Values.mcpServer.containerPorts.server }}
           ports:
             - name: mcp-server-port
               containerPort: {{ .Values.mcpServer.containerPorts.server }}


### PR DESCRIPTION
## Description

Allows running MCP server with ipv6 host binding

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IPv6 support for the MCP server by making the host configurable via an env var and Helm. Defaults to 0.0.0.0 for backward compatibility.

- **New Features**
  - Introduced MCP_SERVER_HOST env var; set to "::" to bind on IPv6.
  - Updated server startup to use the configured host in logs and uvicorn.
  - Helm now runs uvicorn with --host from .Values.global.host; chart bumped to 0.4.28.

- **Migration**
  - Docker/Env: set MCP_SERVER_HOST="::" for IPv6.
  - Helm: set global.host: "::" in values to bind on IPv6.

<sup>Written for commit 2962a4d9f962d9d5142ce76f12cc172fbac1dbce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

