### PR TITLE
chore(tests): skip additional web_search test

### DIFF
--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -40,6 +40,7 @@ class TestOnyxWebCrawler:
         assert "This domain is for use in" in content
         assert "documentation" in content or "illustrative" in content
 
+    @pytest.mark.skip(reason="Temporarily disabled")
     def test_fetches_multiple_urls(self, admin_user: DATestUser) -> None:
         """Test that the crawler can fetch multiple URLs in one request."""
         response = requests.post(


### PR DESCRIPTION
## Description

Possibly broken for the same reason as [chore(tests): temporarily disable exa tests](https://github.com/onyx-dot-app/onyx/pull/8431) or depends on the test that was skipped there. At any rate, let's skip for now and investigate async.

Will re-apply this in [revert: "chore(tests): temporarily disable exa tests"](https://github.com/onyx-dot-app/onyx/pull/8437)

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check
