### PR TITLE
chore(playwright): tag appearance_theme tests exclusive

### DIFF
--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../../utils/auth";
 
-test.describe("Appearance Theme Settings", () => {
+test.describe("Appearance Theme Settings @exclusive", () => {
   const TEST_VALUES = {
     applicationName: `TestApp${Date.now()}`,
     greetingMessage: "Welcome to our test application",


### PR DESCRIPTION
## Description

These tests make app-wide changes to many pages and are nearly guaranteed to break full page screenshots, 
<img width="5119" height="2880" alt="20260213_12h05m41s_grim" src="https://github.com/user-attachments/assets/c7742a94-ae7f-4077-bf9d-7064092ac7db" />
so let's just run exclusively.

This kinda helps with sharding too since `admin` project is currently the long pole.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag the Appearance Theme Settings Playwright suite with @exclusive to prevent app-wide theme changes from breaking other tests or full-page screenshots. This also improves test sharding by isolating the long-running admin project.

<sup>Written for commit 4d2570a381ed1b4bd2235127ea12571bc73ef933. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

