### PR TITLE
chore: [Running GitHub actions for #8439]

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -977,6 +977,7 @@ API_KEY_HASH_ROUNDS = (
 # MCP Server Configs
 #####
 MCP_SERVER_ENABLED = os.environ.get("MCP_SERVER_ENABLED", "").lower() == "true"
+MCP_SERVER_HOST = os.environ.get("MCP_SERVER_HOST", "0.0.0.0")
 MCP_SERVER_PORT = int(os.environ.get("MCP_SERVER_PORT") or 8090)
 
 # CORS origins for MCP clients (comma-separated)

--- a/backend/onyx/mcp_server_main.py
+++ b/backend/onyx/mcp_server_main.py
@@ -3,6 +3,7 @@
 import uvicorn
 
 from onyx.configs.app_configs import MCP_SERVER_ENABLED
+from onyx.configs.app_configs import MCP_SERVER_HOST
 from onyx.configs.app_configs import MCP_SERVER_PORT
 from onyx.utils.logger import setup_logger
 
@@ -15,13 +16,13 @@ def main() -> None:
         logger.info("MCP server is disabled (MCP_SERVER_ENABLED=false)")
         return
 
-    logger.info(f"Starting MCP server on 0.0.0.0:{MCP_SERVER_PORT}")
+    logger.info(f"Starting MCP server on {MCP_SERVER_HOST}:{MCP_SERVER_PORT}")
 
     from onyx.mcp_server.api import mcp_app
 
     uvicorn.run(
         mcp_app,
-        host="0.0.0.0",
+        host=MCP_SERVER_HOST,
         port=MCP_SERVER_PORT,
         log_config=None,
     )


### PR DESCRIPTION
This PR runs GitHub Actions CI for #8439.

- [x] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the MCP server host configurable via the MCP_SERVER_HOST environment variable. The server now binds and logs the chosen host instead of hardcoding 0.0.0.0.

- **New Features**
  - Added MCP_SERVER_HOST env var (default: 0.0.0.0).
  - Updated startup to use MCP_SERVER_HOST in uvicorn and logs.

<sup>Written for commit d9749faa5780716bf279c209960fb2f9188e3835. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

