### PR TITLE
chore(playwright): mask non-deterministic email element

### DIFF
--- a/web/tests/e2e/auth/signup.spec.ts
+++ b/web/tests/e2e/auth/signup.spec.ts
@@ -140,8 +140,11 @@ test.describe("Signup flow", () => {
       page.getByText("Unknown error", { exact: true })
     ).toBeVisible();
 
-    // Capture the error state
-    await expectScreenshot(page, { name: "signup-disposable-email-error" });
+    // Capture the error state with hidden email to avoid non-deterministic diffs
+    await expectScreenshot(page, {
+      name: "signup-disposable-email-error",
+      mask: ["[data-testid='email']"],
+    });
 
     // Should stay on the signup page
     await expect(page).toHaveURL(/\/auth\/signup/);


### PR DESCRIPTION
## Description



## How Has This Been Tested?

<img width="1280" height="720" alt="signup-disposable-email-error" src="https://github.com/user-attachments/assets/cdf4debc-537f-4de0-9c5a-103b34dabee3" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mask the email field in the signup screenshot test to avoid non-deterministic diffs and reduce flakiness. Uses Playwright’s mask option to hide [data-testid='email'] in the signup-disposable-email-error snapshot.

<sup>Written for commit 26b5580e58e5543eaba8d5facc1f67dbeac2221e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

