### PR TITLE
fix: don't pass captcha token to db

### DIFF
--- a/backend/onyx/db/auth.py
+++ b/backend/onyx/db/auth.py
@@ -106,7 +106,6 @@ class SQLAlchemyUserAdminDB(SQLAlchemyUserDatabase[UP, ID]):
             create_dict["role"] = UserRole.ADMIN
         else:
             create_dict["role"] = UserRole.BASIC
-
         return await super().create(create_dict)
 
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override UserCreate create_update_dict and create_update_dict_superuser to drop captcha_token so it never reaches the DB layer. Prevents user creation failures and avoids persisting temporary captcha data.

<sup>Written for commit 2e76f36e4382b61f9517573f48bd86968da4c7bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

