### PR TITLE
feat(scim): add SCIM User CRUD endpoints

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -26,12 +26,21 @@ from __future__ import annotations
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy import Select
 from sqlalchemy import select
+from sqlalchemy import SQLColumnExpression
 
+from ee.onyx.server.scim.filtering import ScimFilter
+from ee.onyx.server.scim.filtering import ScimFilterOperator
 from onyx.db.dal import DAL
 from onyx.db.models import ScimGroupMapping
 from onyx.db.models import ScimToken
 from onyx.db.models import ScimUserMapping
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 class ScimDAL(DAL):
@@ -171,15 +180,129 @@ class ScimDAL(DAL):
         return mapping
 
     def delete_user_mapping(self, mapping_id: int) -> None:
-        """Delete a user mapping by ID.
-
-        Raises:
-            ValueError: If the mapping does not exist.
-        """
+        """Delete a user mapping by ID. No-op if already deleted."""
         mapping = self._session.get(ScimUserMapping, mapping_id)
         if not mapping:
-            raise ValueError(f"SCIM user mapping with id {mapping_id} not found")
+            logger.warning("SCIM user mapping %d not found during delete", mapping_id)
+            return
         self._session.delete(mapping)
+
+    # ------------------------------------------------------------------
+    # User query operations
+    # ------------------------------------------------------------------
+
+    def get_user(self, user_id: UUID) -> User | None:
+        """Fetch a user by ID."""
+        return self._session.scalar(
+            select(User).where(User.id == user_id)  # type: ignore[arg-type]
+        )
+
+    def get_user_by_email(self, email: str) -> User | None:
+        """Fetch a user by email (case-insensitive)."""
+        return self._session.scalar(
+            select(User).where(func.lower(User.email) == func.lower(email))
+        )
+
+    def add_user(self, user: User) -> None:
+        """Add a new user to the session and flush to assign an ID."""
+        self._session.add(user)
+        self._session.flush()
+
+    def update_user(
+        self,
+        user: User,
+        *,
+        email: str | None = None,
+        is_active: bool | None = None,
+        personal_name: str | None = None,
+    ) -> None:
+        """Update user attributes. Only sets fields that are provided."""
+        if email is not None:
+            user.email = email
+        if is_active is not None:
+            user.is_active = is_active
+        if personal_name is not None:
+            user.personal_name = personal_name
+
+    def deactivate_user(self, user: User) -> None:
+        """Mark a user as inactive."""
+        user.is_active = False
+
+    def list_users(
+        self,
+        scim_filter: ScimFilter | None,
+        start_index: int = 1,
+        count: int = 100,
+    ) -> tuple[list[tuple[User, str | None]], int]:
+        """Query users with optional SCIM filter and pagination.
+
+        Returns:
+            A tuple of (list of (user, external_id) pairs, total_count).
+
+        Raises:
+            ValueError: If the filter uses an unsupported attribute.
+        """
+        query = select(User).where(
+            User.role.notin_([UserRole.SLACK_USER, UserRole.EXT_PERM_USER])
+        )
+
+        if scim_filter:
+            attr = scim_filter.attribute.lower()
+            if attr == "username":
+                # arg-type: fastapi-users types User.email as str, not a column expression
+                query = _apply_scim_string_op(query, User.email, scim_filter)  # type: ignore[arg-type]
+            elif attr == "active":
+                query = query.where(
+                    User.is_active.is_(scim_filter.value.lower() == "true")  # type: ignore[attr-defined]
+                )
+            elif attr == "externalid":
+                mapping = self.get_user_mapping_by_external_id(scim_filter.value)
+                if not mapping:
+                    return [], 0
+                query = query.where(User.id == mapping.user_id)  # type: ignore[arg-type]
+            else:
+                raise ValueError(
+                    f"Unsupported filter attribute: {scim_filter.attribute}"
+                )
+
+        # Count total matching rows first, then paginate. SCIM uses 1-based
+        # indexing (RFC 7644 §3.4.2), so we convert to a 0-based offset.
+        total = (
+            self._session.scalar(select(func.count()).select_from(query.subquery()))
+            or 0
+        )
+
+        offset = max(start_index - 1, 0)
+        users = list(
+            self._session.scalars(
+                query.order_by(User.id).offset(offset).limit(count)  # type: ignore[arg-type]
+            ).all()
+        )
+
+        # Batch-fetch external IDs to avoid N+1 queries
+        ext_id_map = self._get_user_external_ids([u.id for u in users])
+        return [(u, ext_id_map.get(u.id)) for u in users], total
+
+    def sync_user_external_id(self, user_id: UUID, new_external_id: str | None) -> None:
+        """Create, update, or delete the external ID mapping for a user."""
+        mapping = self.get_user_mapping_by_user_id(user_id)
+        if new_external_id:
+            if mapping:
+                if mapping.external_id != new_external_id:
+                    mapping.external_id = new_external_id
+            else:
+                self.create_user_mapping(external_id=new_external_id, user_id=user_id)
+        elif mapping:
+            self.delete_user_mapping(mapping.id)
+
+    def _get_user_external_ids(self, user_ids: list[UUID]) -> dict[UUID, str]:
+        """Batch-fetch external IDs for a list of user IDs."""
+        if not user_ids:
+            return {}
+        mappings = self._session.scalars(
+            select(ScimUserMapping).where(ScimUserMapping.user_id.in_(user_ids))
+        ).all()
+        return {m.user_id: m.external_id for m in mappings}
 
     # ------------------------------------------------------------------
     # Group mapping operations
@@ -246,12 +369,35 @@ class ScimDAL(DAL):
         return mappings, total
 
     def delete_group_mapping(self, mapping_id: int) -> None:
-        """Delete a group mapping by ID.
-
-        Raises:
-            ValueError: If the mapping does not exist.
-        """
+        """Delete a group mapping by ID. No-op if already deleted."""
         mapping = self._session.get(ScimGroupMapping, mapping_id)
         if not mapping:
-            raise ValueError(f"SCIM group mapping with id {mapping_id} not found")
+            logger.warning("SCIM group mapping %d not found during delete", mapping_id)
+            return
         self._session.delete(mapping)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (used by DAL methods above)
+# ---------------------------------------------------------------------------
+
+
+def _apply_scim_string_op(
+    query: Select[tuple[User]],
+    column: SQLColumnExpression[str],
+    scim_filter: ScimFilter,
+) -> Select[tuple[User]]:
+    """Apply a SCIM string filter operator using SQLAlchemy column operators.
+
+    Handles eq (case-insensitive exact), co (contains), and sw (starts with).
+    SQLAlchemy's operators handle LIKE-pattern escaping internally.
+    """
+    val = scim_filter.value
+    if scim_filter.operator == ScimFilterOperator.EQUAL:
+        return query.where(func.lower(column) == val.lower())
+    elif scim_filter.operator == ScimFilterOperator.CONTAINS:
+        return query.where(column.icontains(val, autoescape=True))
+    elif scim_filter.operator == ScimFilterOperator.STARTS_WITH:
+        return query.where(column.istartswith(val, autoescape=True))
+    else:
+        raise ValueError(f"Unsupported string filter operator: {scim_filter.operator}")

--- a/backend/ee/onyx/server/auth_check.py
+++ b/backend/ee/onyx/server/auth_check.py
@@ -5,7 +5,8 @@ from onyx.server.auth_check import PUBLIC_ENDPOINT_SPECS
 
 
 EE_PUBLIC_ENDPOINT_SPECS = PUBLIC_ENDPOINT_SPECS + [
-    # SCIM 2.0 service discovery — IdPs probe these before auth setup
+    # SCIM 2.0 service discovery — unauthenticated so IdPs can probe
+    # before bearer token configuration is complete
     ("/scim/v2/ServiceProviderConfig", {"GET"}),
     ("/scim/v2/ResourceTypes", {"GET"}),
     ("/scim/v2/Schemas", {"GET"}),

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -11,16 +11,43 @@ require a valid SCIM bearer token.
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from uuid import UUID
 
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Query
+from fastapi import Response
+from fastapi.responses import JSONResponse
+from fastapi_users.password import PasswordHelper
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.scim import ScimDAL
+from ee.onyx.server.scim.auth import verify_scim_token
+from ee.onyx.server.scim.filtering import parse_scim_filter
+from ee.onyx.server.scim.models import ScimEmail
+from ee.onyx.server.scim.models import ScimError
+from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimListResponse
+from ee.onyx.server.scim.models import ScimMeta
+from ee.onyx.server.scim.models import ScimName
+from ee.onyx.server.scim.models import ScimPatchRequest
 from ee.onyx.server.scim.models import ScimResourceType
 from ee.onyx.server.scim.models import ScimSchemaDefinition
 from ee.onyx.server.scim.models import ScimServiceProviderConfig
+from ee.onyx.server.scim.models import ScimUserResource
+from ee.onyx.server.scim.patch import apply_user_patch
+from ee.onyx.server.scim.patch import ScimPatchError
 from ee.onyx.server.scim.schema_definitions import GROUP_RESOURCE_TYPE
 from ee.onyx.server.scim.schema_definitions import GROUP_SCHEMA_DEF
 from ee.onyx.server.scim.schema_definitions import SERVICE_PROVIDER_CONFIG
 from ee.onyx.server.scim.schema_definitions import USER_RESOURCE_TYPE
 from ee.onyx.server.scim.schema_definitions import USER_SCHEMA_DEF
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import ScimToken
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 
 # NOTE: All URL paths in this router (/ServiceProviderConfig, /ResourceTypes,
@@ -28,6 +55,8 @@ from ee.onyx.server.scim.schema_definitions import USER_SCHEMA_DEF
 # IdPs like Okta and Azure AD hardcode these exact paths, so they cannot be
 # changed to kebab-case.
 scim_router = APIRouter(prefix="/scim/v2", tags=["SCIM"])
+
+_pw_helper = PasswordHelper()
 
 
 # ---------------------------------------------------------------------------
@@ -51,3 +80,310 @@ def get_resource_types() -> list[ScimResourceType]:
 def get_schemas() -> list[ScimSchemaDefinition]:
     """Return SCIM schema definitions (RFC 7643 §7)."""
     return [USER_SCHEMA_DEF, GROUP_SCHEMA_DEF]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scim_error_response(status: int, detail: str) -> JSONResponse:
+    """Build a SCIM-compliant error response (RFC 7644 §3.12)."""
+    body = ScimError(status=str(status), detail=detail)
+    return JSONResponse(
+        status_code=status,
+        content=body.model_dump(exclude_none=True),
+    )
+
+
+def _user_to_scim(user: User, external_id: str | None = None) -> ScimUserResource:
+    """Convert an Onyx User to a SCIM User resource representation."""
+    name = None
+    if user.personal_name:
+        parts = user.personal_name.split(" ", 1)
+        name = ScimName(
+            givenName=parts[0],
+            familyName=parts[1] if len(parts) > 1 else None,
+            formatted=user.personal_name,
+        )
+
+    return ScimUserResource(
+        id=str(user.id),
+        externalId=external_id,
+        userName=user.email,
+        name=name,
+        emails=[ScimEmail(value=user.email, type="work", primary=True)],
+        active=user.is_active,
+        meta=ScimMeta(resourceType="User"),
+    )
+
+
+def _check_seat_availability(dal: ScimDAL) -> str | None:
+    """Return an error message if seat limit is reached, else None."""
+    check_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license", "check_seat_availability", None
+    )
+    if check_fn is None:
+        return None
+    result = check_fn(dal.session, seats_needed=1)
+    if not result.available:
+        return result.error_message or "Seat limit reached"
+    return None
+
+
+def _fetch_user_or_404(user_id: str, dal: ScimDAL) -> User | JSONResponse:
+    """Parse *user_id* as UUID, look up the user, or return a 404 error."""
+    try:
+        uid = UUID(user_id)
+    except ValueError:
+        return _scim_error_response(404, f"User {user_id} not found")
+    user = dal.get_user(uid)
+    if not user:
+        return _scim_error_response(404, f"User {user_id} not found")
+    return user
+
+
+def _scim_name_to_str(name: ScimName | None) -> str | None:
+    """Extract a display name string from a SCIM name object.
+
+    Returns None if no name is provided, so the caller can decide
+    whether to update the user's personal_name.
+    """
+    if not name:
+        return None
+    return name.formatted or " ".join(
+        part for part in [name.givenName, name.familyName] if part
+    )
+
+
+# ---------------------------------------------------------------------------
+# User CRUD (RFC 7644 §3)
+# ---------------------------------------------------------------------------
+
+
+@scim_router.get("/Users", response_model=None)
+def list_users(
+    filter: str | None = Query(None),
+    startIndex: int = Query(1, ge=1),
+    count: int = Query(100, ge=0, le=500),
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> ScimListResponse | JSONResponse:
+    """List users with optional SCIM filter and pagination."""
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    try:
+        scim_filter = parse_scim_filter(filter)
+    except ValueError as e:
+        return _scim_error_response(400, str(e))
+
+    try:
+        users_with_ext_ids, total = dal.list_users(scim_filter, startIndex, count)
+    except ValueError as e:
+        return _scim_error_response(400, str(e))
+
+    resources: list[ScimUserResource | ScimGroupResource] = [
+        _user_to_scim(user, ext_id) for user, ext_id in users_with_ext_ids
+    ]
+
+    return ScimListResponse(
+        totalResults=total,
+        startIndex=startIndex,
+        itemsPerPage=count,
+        Resources=resources,
+    )
+
+
+@scim_router.get("/Users/{user_id}", response_model=None)
+def get_user(
+    user_id: str,
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> ScimUserResource | JSONResponse:
+    """Get a single user by ID."""
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    result = _fetch_user_or_404(user_id, dal)
+    if isinstance(result, JSONResponse):
+        return result
+    user = result
+
+    mapping = dal.get_user_mapping_by_user_id(user.id)
+    return _user_to_scim(user, mapping.external_id if mapping else None)
+
+
+@scim_router.post("/Users", status_code=201, response_model=None)
+def create_user(
+    user_resource: ScimUserResource,
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> ScimUserResource | JSONResponse:
+    """Create a new user from a SCIM provisioning request."""
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    email = user_resource.userName.strip().lower()
+
+    # externalId is how the IdP correlates this user on subsequent requests.
+    # Without it, the IdP can't find the user and will try to re-create,
+    # hitting a 409 conflict — so we require it up front.
+    if not user_resource.externalId:
+        return _scim_error_response(400, "externalId is required")
+
+    # Enforce seat limit
+    seat_error = _check_seat_availability(dal)
+    if seat_error:
+        return _scim_error_response(403, seat_error)
+
+    # Check for existing user
+    if dal.get_user_by_email(email):
+        return _scim_error_response(409, f"User with email {email} already exists")
+
+    # Create user with a random password (SCIM users authenticate via IdP)
+    personal_name = _scim_name_to_str(user_resource.name)
+    user = User(
+        email=email,
+        hashed_password=_pw_helper.hash(_pw_helper.generate()),
+        role=UserRole.BASIC,
+        is_active=user_resource.active,
+        is_verified=True,
+        personal_name=personal_name,
+    )
+
+    try:
+        dal.add_user(user)
+    except IntegrityError:
+        dal.rollback()
+        return _scim_error_response(409, f"User with email {email} already exists")
+
+    # Create SCIM mapping (externalId is validated above, always present)
+    external_id = user_resource.externalId
+    dal.create_user_mapping(external_id=external_id, user_id=user.id)
+
+    dal.commit()
+
+    return _user_to_scim(user, external_id)
+
+
+@scim_router.put("/Users/{user_id}", response_model=None)
+def replace_user(
+    user_id: str,
+    user_resource: ScimUserResource,
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> ScimUserResource | JSONResponse:
+    """Replace a user entirely (RFC 7644 §3.5.1)."""
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    result = _fetch_user_or_404(user_id, dal)
+    if isinstance(result, JSONResponse):
+        return result
+    user = result
+
+    # Handle activation (need seat check) / deactivation
+    if user_resource.active and not user.is_active:
+        seat_error = _check_seat_availability(dal)
+        if seat_error:
+            return _scim_error_response(403, seat_error)
+
+    dal.update_user(
+        user,
+        email=user_resource.userName.strip().lower(),
+        is_active=user_resource.active,
+        personal_name=_scim_name_to_str(user_resource.name),
+    )
+
+    new_external_id = user_resource.externalId
+    dal.sync_user_external_id(user.id, new_external_id)
+
+    dal.commit()
+
+    return _user_to_scim(user, new_external_id)
+
+
+@scim_router.patch("/Users/{user_id}", response_model=None)
+def patch_user(
+    user_id: str,
+    patch_request: ScimPatchRequest,
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> ScimUserResource | JSONResponse:
+    """Partially update a user (RFC 7644 §3.5.2).
+
+    This is the primary endpoint for user deprovisioning — Okta sends
+    ``PATCH {"active": false}`` rather than DELETE.
+    """
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    result = _fetch_user_or_404(user_id, dal)
+    if isinstance(result, JSONResponse):
+        return result
+    user = result
+
+    mapping = dal.get_user_mapping_by_user_id(user.id)
+    external_id = mapping.external_id if mapping else None
+
+    current = _user_to_scim(user, external_id)
+
+    try:
+        patched = apply_user_patch(patch_request.Operations, current)
+    except ScimPatchError as e:
+        return _scim_error_response(e.status, e.detail)
+
+    # Apply changes back to the DB model
+    if patched.active != user.is_active:
+        if patched.active:
+            seat_error = _check_seat_availability(dal)
+            if seat_error:
+                return _scim_error_response(403, seat_error)
+
+    dal.update_user(
+        user,
+        email=(
+            patched.userName.strip().lower()
+            if patched.userName.lower() != user.email
+            else None
+        ),
+        is_active=patched.active if patched.active != user.is_active else None,
+        personal_name=_scim_name_to_str(patched.name),
+    )
+
+    dal.sync_user_external_id(user.id, patched.externalId)
+
+    dal.commit()
+
+    return _user_to_scim(user, patched.externalId)
+
+
+@scim_router.delete("/Users/{user_id}", status_code=204, response_model=None)
+def delete_user(
+    user_id: str,
+    _token: ScimToken = Depends(verify_scim_token),
+    db_session: Session = Depends(get_session),
+) -> Response | JSONResponse:
+    """Delete a user (RFC 7644 §3.6).
+
+    Deactivates the user and removes the SCIM mapping. Note that Okta
+    typically uses PATCH active=false instead of DELETE.
+    """
+    dal = ScimDAL(db_session)
+    dal.update_token_last_used(_token.id)
+
+    result = _fetch_user_or_404(user_id, dal)
+    if isinstance(result, JSONResponse):
+        return result
+    user = result
+
+    dal.deactivate_user(user)
+
+    mapping = dal.get_user_mapping_by_user_id(user.id)
+    if mapping:
+        dal.delete_user_mapping(mapping.id)
+
+    dal.commit()
+
+    return Response(status_code=204)

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -102,6 +102,9 @@ def check_router_auth(
     current_cloud_superuser = fetch_ee_implementation_or_noop(
         "onyx.auth.users", "current_cloud_superuser"
     )
+    verify_scim_token = fetch_ee_implementation_or_noop(
+        "onyx.server.scim.auth", "verify_scim_token"
+    )
 
     for route in application.routes:
         # explicitly marked as public
@@ -125,6 +128,7 @@ def check_router_auth(
                     or depends_fn == current_chat_accessible_user
                     or depends_fn == control_plane_dep
                     or depends_fn == current_cloud_superuser
+                    or depends_fn == verify_scim_token
                 ):
                     found_auth = True
                     break

--- a/backend/tests/unit/onyx/server/scim/conftest.py
+++ b/backend/tests/unit/onyx/server/scim/conftest.py
@@ -1,0 +1,98 @@
+"""Shared fixtures for SCIM endpoint unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimName
+from ee.onyx.server.scim.models import ScimUserResource
+from onyx.db.models import ScimToken
+from onyx.db.models import User
+from onyx.db.models import UserGroup
+from onyx.db.models import UserRole
+
+
+@pytest.fixture
+def mock_db_session() -> MagicMock:
+    """A MagicMock standing in for a SQLAlchemy Session."""
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def mock_token() -> MagicMock:
+    """A MagicMock standing in for a verified ScimToken."""
+    token = MagicMock(spec=ScimToken)
+    token.id = 1
+    return token
+
+
+@pytest.fixture
+def mock_dal() -> Generator[MagicMock, None, None]:
+    """Patch ScimDAL construction in api module and yield the mock instance."""
+    with patch("ee.onyx.server.scim.api.ScimDAL") as cls:
+        dal = cls.return_value
+        # User defaults
+        dal.get_user.return_value = None
+        dal.get_user_by_email.return_value = None
+        dal.get_user_mapping_by_user_id.return_value = None
+        dal.get_user_mapping_by_external_id.return_value = None
+        dal.list_users.return_value = ([], 0)
+        # Group defaults
+        dal.get_group_mapping_by_group_id.return_value = None
+        dal.get_group_mapping_by_external_id.return_value = None
+        yield dal
+
+
+def make_scim_user(**kwargs: Any) -> ScimUserResource:
+    """Build a ScimUserResource with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "userName": "test@example.com",
+        "externalId": "ext-default",
+        "active": True,
+        "name": ScimName(givenName="Test", familyName="User"),
+    }
+    defaults.update(kwargs)
+    return ScimUserResource(**defaults)
+
+
+def make_scim_group(**kwargs: Any) -> ScimGroupResource:
+    """Build a ScimGroupResource with sensible defaults."""
+    defaults: dict[str, Any] = {"displayName": "Engineering"}
+    defaults.update(kwargs)
+    return ScimGroupResource(**defaults)
+
+
+def make_db_user(**kwargs: Any) -> MagicMock:
+    """Build a mock User ORM object with configurable attributes."""
+    user = MagicMock(spec=User)
+    user.id = kwargs.get("id", uuid4())
+    user.email = kwargs.get("email", "test@example.com")
+    user.is_active = kwargs.get("is_active", True)
+    user.personal_name = kwargs.get("personal_name", "Test User")
+    user.role = kwargs.get("role", UserRole.BASIC)
+    return user
+
+
+def make_db_group(**kwargs: Any) -> MagicMock:
+    """Build a mock UserGroup ORM object with configurable attributes."""
+    group = MagicMock(spec=UserGroup)
+    group.id = kwargs.get("id", 1)
+    group.name = kwargs.get("name", "Engineering")
+    group.is_up_for_deletion = kwargs.get("is_up_for_deletion", False)
+    group.is_up_to_date = kwargs.get("is_up_to_date", True)
+    return group
+
+
+def assert_scim_error(result: object, expected_status: int) -> None:
+    """Assert *result* is a JSONResponse with the given status code."""
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == expected_status

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -1,0 +1,521 @@
+"""Unit tests for SCIM User CRUD endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import Response
+from sqlalchemy.exc import IntegrityError
+
+from ee.onyx.server.scim.api import create_user
+from ee.onyx.server.scim.api import delete_user
+from ee.onyx.server.scim.api import get_user
+from ee.onyx.server.scim.api import list_users
+from ee.onyx.server.scim.api import patch_user
+from ee.onyx.server.scim.api import replace_user
+from ee.onyx.server.scim.models import ScimListResponse
+from ee.onyx.server.scim.models import ScimName
+from ee.onyx.server.scim.models import ScimPatchOperation
+from ee.onyx.server.scim.models import ScimPatchOperationType
+from ee.onyx.server.scim.models import ScimPatchRequest
+from ee.onyx.server.scim.models import ScimUserResource
+from ee.onyx.server.scim.patch import ScimPatchError
+from tests.unit.onyx.server.scim.conftest import assert_scim_error
+from tests.unit.onyx.server.scim.conftest import make_db_user
+from tests.unit.onyx.server.scim.conftest import make_scim_user
+
+
+class TestListUsers:
+    """Tests for GET /scim/v2/Users."""
+
+    def test_empty_result(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.list_users.return_value = ([], 0)
+
+        result = list_users(
+            filter=None,
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimListResponse)
+        assert result.totalResults == 0
+        assert result.Resources == []
+
+    def test_returns_users_with_scim_shape(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(email="alice@example.com", personal_name="Alice Smith")
+        mock_dal.list_users.return_value = ([(user, "ext-abc")], 1)
+
+        result = list_users(
+            filter=None,
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimListResponse)
+        assert result.totalResults == 1
+        assert len(result.Resources) == 1
+        resource = result.Resources[0]
+        assert isinstance(resource, ScimUserResource)
+        assert resource.userName == "alice@example.com"
+        assert resource.externalId == "ext-abc"
+
+    def test_unsupported_filter_attribute_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.list_users.side_effect = ValueError(
+            "Unsupported filter attribute: emails"
+        )
+
+        result = list_users(
+            filter='emails eq "x@y.com"',
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    def test_invalid_filter_syntax_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        result = list_users(
+            filter="not a valid filter",
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+
+class TestGetUser:
+    """Tests for GET /scim/v2/Users/{user_id}."""
+
+    def test_returns_scim_resource(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(email="alice@example.com")
+        mock_dal.get_user.return_value = user
+
+        result = get_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        assert result.userName == "alice@example.com"
+        assert result.id == str(user.id)
+
+    def test_invalid_uuid_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        result = get_user(
+            user_id="not-a-uuid",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    def test_user_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user.return_value = None
+
+        result = get_user(
+            user_id=str(uuid4()),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+
+class TestCreateUser:
+    """Tests for POST /scim/v2/Users."""
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_success(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user_by_email.return_value = None
+        resource = make_scim_user(userName="new@example.com")
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        assert result.userName == "new@example.com"
+        mock_dal.add_user.assert_called_once()
+        mock_dal.commit.assert_called_once()
+
+    def test_missing_external_id_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        resource = make_scim_user(externalId=None)
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_duplicate_email_returns_409(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user_by_email.return_value = make_db_user()
+        resource = make_scim_user()
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_integrity_error_returns_409(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user_by_email.return_value = None
+        mock_dal.add_user.side_effect = IntegrityError("dup", {}, Exception())
+        resource = make_scim_user()
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.rollback.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_seat_limit_returns_403(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        mock_seats.return_value = "Seat limit reached"
+        resource = make_scim_user()
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_creates_external_id_mapping(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user_by_email.return_value = None
+        resource = make_scim_user(externalId="ext-123")
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        assert result.externalId == "ext-123"
+        mock_dal.create_user_mapping.assert_called_once()
+
+
+class TestReplaceUser:
+    """Tests for PUT /scim/v2/Users/{user_id}."""
+
+    def test_success(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(email="old@example.com")
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(
+            userName="new@example.com",
+            name=ScimName(givenName="New", familyName="Name"),
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        mock_dal.update_user.assert_called_once()
+        mock_dal.commit.assert_called_once()
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user.return_value = None
+
+        result = replace_user(
+            user_id=str(uuid4()),
+            user_resource=make_scim_user(),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_reactivation_checks_seats(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(is_active=False)
+        mock_dal.get_user.return_value = user
+        mock_seats.return_value = "No seats"
+        resource = make_scim_user(active=True)
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_seats.assert_called_once()
+
+    def test_syncs_external_id(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+
+        resource = make_scim_user(externalId=None)
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        mock_dal.sync_user_external_id.assert_called_once_with(user.id, None)
+
+
+class TestPatchUser:
+    """Tests for PATCH /scim/v2/Users/{user_id}."""
+
+    def test_deactivate(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="active",
+                    value=False,
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimUserResource)
+        mock_dal.update_user.assert_called_once()
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user.return_value = None
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="active",
+                    value=False,
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(uuid4()),
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    @patch("ee.onyx.server.scim.api.apply_user_patch")
+    def test_patch_error_returns_error_response(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        mock_apply.side_effect = ScimPatchError("Bad op", 400)
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path="userName",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+
+class TestDeleteUser:
+    """Tests for DELETE /scim/v2/Users/{user_id}."""
+
+    def test_success(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user(is_active=True)
+        mock_dal.get_user.return_value = user
+        mapping = MagicMock()
+        mapping.id = 1
+        mock_dal.get_user_mapping_by_user_id.return_value = mapping
+
+        result = delete_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == 204
+        mock_dal.deactivate_user.assert_called_once_with(user)
+        mock_dal.delete_user_mapping.assert_called_once_with(1)
+        mock_dal.commit.assert_called_once()
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_user.return_value = None
+
+        result = delete_user(
+            user_id=str(uuid4()),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    def test_invalid_uuid_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        result = delete_user(
+            user_id="not-a-uuid",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)


### PR DESCRIPTION
## Description

Closes [ENG-3647](https://linear.app/onyx-app/issue/ENG-3647)

Add SCIM 2.0 User CRUD endpoints (RFC 7644 §3) for identity provider provisioning:

- **GET /scim/v2/Users** — List users with SCIM filter (userName, active, externalId) and pagination
- **GET /scim/v2/Users/{user_id}** — Get a single user by UUID
- **POST /scim/v2/Users** — Create a user with seat limit enforcement and IntegrityError handling for TOCTOU races. Requires `externalId` — without it the IdP can't correlate the user on subsequent requests.
- **PUT /scim/v2/Users/{user_id}** — Full user replacement
- **PATCH /scim/v2/Users/{user_id}** — Partial update (primary deprovisioning path for Okta: `active=false`)
- **DELETE /scim/v2/Users/{user_id}** — Deactivate user and remove SCIM mapping

Also includes service discovery endpoints (ServiceProviderConfig, ResourceTypes, Schemas), router registration in `ee/main.py`, and auth_check entries for SCIM bearer token auth bypass.

Notable improvements to the DAL layer:
- Replaced manual LIKE pattern escaping with SQLAlchemy column operators (`.icontains()`, `.istartswith()` with `autoescape=True`) — eliminates `_escape_like` helper and `Any` types
- Made `delete_user_mapping` and `delete_group_mapping` idempotent (log warning instead of raising on not-found) to handle race conditions gracefully
- Added inline comment explaining SCIM 1-based pagination offset conversion (RFC 7644 §3.4.2)
- Updated unit tests to match idempotent delete behavior

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check