### PR TITLE
feat(scim): add SCIM Group CRUD endpoints

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import func
 from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy import SQLColumnExpression
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from ee.onyx.server.scim.filtering import ScimFilter
 from ee.onyx.server.scim.filtering import ScimFilterOperator
@@ -37,6 +39,8 @@ from onyx.db.models import ScimGroupMapping
 from onyx.db.models import ScimToken
 from onyx.db.models import ScimUserMapping
 from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
 from onyx.db.models import UserRole
 from onyx.utils.logger import setup_logger
 
@@ -250,7 +254,8 @@ class ScimDAL(DAL):
             attr = scim_filter.attribute.lower()
             if attr == "username":
                 # arg-type: fastapi-users types User.email as str, not a column expression
-                query = _apply_scim_string_op(query, User.email, scim_filter)  # type: ignore[arg-type]
+                # assignment: union return type widens but query is still Select[tuple[User]]
+                query = _apply_scim_string_op(query, User.email, scim_filter)  # type: ignore[arg-type, assignment]
             elif attr == "active":
                 query = query.where(
                     User.is_active.is_(scim_filter.value.lower() == "true")  # type: ignore[attr-defined]
@@ -376,6 +381,191 @@ class ScimDAL(DAL):
             return
         self._session.delete(mapping)
 
+    # ------------------------------------------------------------------
+    # Group query operations
+    # ------------------------------------------------------------------
+
+    def get_group(self, group_id: int) -> UserGroup | None:
+        """Fetch a group by ID, returning None if deleted or missing."""
+        group = self._session.get(UserGroup, group_id)
+        if group and group.is_up_for_deletion:
+            return None
+        return group
+
+    def get_group_by_name(self, name: str) -> UserGroup | None:
+        """Fetch a group by exact name."""
+        return self._session.scalar(select(UserGroup).where(UserGroup.name == name))
+
+    def add_group(self, group: UserGroup) -> None:
+        """Add a new group to the session and flush to assign an ID."""
+        self._session.add(group)
+        self._session.flush()
+
+    def update_group(
+        self,
+        group: UserGroup,
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Update group attributes and set the modification timestamp."""
+        if name is not None:
+            group.name = name
+        group.time_last_modified_by_user = func.now()
+
+    def delete_group(self, group: UserGroup) -> None:
+        """Delete a group from the session."""
+        self._session.delete(group)
+
+    def list_groups(
+        self,
+        scim_filter: ScimFilter | None,
+        start_index: int = 1,
+        count: int = 100,
+    ) -> tuple[list[tuple[UserGroup, str | None]], int]:
+        """Query groups with optional SCIM filter and pagination.
+
+        Returns:
+            A tuple of (list of (group, external_id) pairs, total_count).
+
+        Raises:
+            ValueError: If the filter uses an unsupported attribute.
+        """
+        query = select(UserGroup).where(UserGroup.is_up_for_deletion.is_(False))
+
+        if scim_filter:
+            attr = scim_filter.attribute.lower()
+            if attr == "displayname":
+                # assignment: union return type widens but query is still Select[tuple[UserGroup]]
+                query = _apply_scim_string_op(query, UserGroup.name, scim_filter)  # type: ignore[assignment]
+            elif attr == "externalid":
+                mapping = self.get_group_mapping_by_external_id(scim_filter.value)
+                if not mapping:
+                    return [], 0
+                query = query.where(UserGroup.id == mapping.user_group_id)
+            else:
+                raise ValueError(
+                    f"Unsupported filter attribute: {scim_filter.attribute}"
+                )
+
+        total = (
+            self._session.scalar(select(func.count()).select_from(query.subquery()))
+            or 0
+        )
+
+        offset = max(start_index - 1, 0)
+        groups = list(
+            self._session.scalars(
+                query.order_by(UserGroup.id).offset(offset).limit(count)
+            ).all()
+        )
+
+        ext_id_map = self._get_group_external_ids([g.id for g in groups])
+        return [(g, ext_id_map.get(g.id)) for g in groups], total
+
+    def get_group_members(self, group_id: int) -> list[tuple[UUID, str | None]]:
+        """Get group members as (user_id, email) pairs."""
+        rels = self._session.scalars(
+            select(User__UserGroup).where(User__UserGroup.user_group_id == group_id)
+        ).all()
+
+        user_ids = [r.user_id for r in rels if r.user_id]
+        if not user_ids:
+            return []
+
+        users = self._session.scalars(
+            select(User).where(User.id.in_(user_ids))  # type: ignore[attr-defined]
+        ).all()
+        users_by_id = {u.id: u for u in users}
+
+        return [
+            (
+                r.user_id,
+                users_by_id[r.user_id].email if r.user_id in users_by_id else None,
+            )
+            for r in rels
+            if r.user_id
+        ]
+
+    def validate_member_ids(self, uuids: list[UUID]) -> list[UUID]:
+        """Return the subset of UUIDs that don't exist as users.
+
+        Returns an empty list if all IDs are valid.
+        """
+        if not uuids:
+            return []
+        existing_users = self._session.scalars(
+            select(User).where(User.id.in_(uuids))  # type: ignore[attr-defined]
+        ).all()
+        existing_ids = {u.id for u in existing_users}
+        return [uid for uid in uuids if uid not in existing_ids]
+
+    def upsert_group_members(self, group_id: int, user_ids: list[UUID]) -> None:
+        """Add user-group relationships, ignoring duplicates."""
+        if not user_ids:
+            return
+        self._session.execute(
+            pg_insert(User__UserGroup)
+            .values([{"user_id": uid, "user_group_id": group_id} for uid in user_ids])
+            .on_conflict_do_nothing(
+                index_elements=[
+                    User__UserGroup.user_group_id,
+                    User__UserGroup.user_id,
+                ]
+            )
+        )
+
+    def replace_group_members(self, group_id: int, user_ids: list[UUID]) -> None:
+        """Replace all members of a group."""
+        self._session.execute(
+            sa_delete(User__UserGroup).where(User__UserGroup.user_group_id == group_id)
+        )
+        self.upsert_group_members(group_id, user_ids)
+
+    def remove_group_members(self, group_id: int, user_ids: list[UUID]) -> None:
+        """Remove specific members from a group."""
+        if not user_ids:
+            return
+        self._session.execute(
+            sa_delete(User__UserGroup).where(
+                User__UserGroup.user_group_id == group_id,
+                User__UserGroup.user_id.in_(user_ids),
+            )
+        )
+
+    def delete_group_with_members(self, group: UserGroup) -> None:
+        """Remove all member relationships and delete the group."""
+        self._session.execute(
+            sa_delete(User__UserGroup).where(User__UserGroup.user_group_id == group.id)
+        )
+        self._session.delete(group)
+
+    def sync_group_external_id(
+        self, group_id: int, new_external_id: str | None
+    ) -> None:
+        """Create, update, or delete the external ID mapping for a group."""
+        mapping = self.get_group_mapping_by_group_id(group_id)
+        if new_external_id:
+            if mapping:
+                if mapping.external_id != new_external_id:
+                    mapping.external_id = new_external_id
+            else:
+                self.create_group_mapping(
+                    external_id=new_external_id, user_group_id=group_id
+                )
+        elif mapping:
+            self.delete_group_mapping(mapping.id)
+
+    def _get_group_external_ids(self, group_ids: list[int]) -> dict[int, str]:
+        """Batch-fetch external IDs for a list of group IDs."""
+        if not group_ids:
+            return {}
+        mappings = self._session.scalars(
+            select(ScimGroupMapping).where(
+                ScimGroupMapping.user_group_id.in_(group_ids)
+            )
+        ).all()
+        return {m.user_group_id: m.external_id for m in mappings}
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers (used by DAL methods above)
@@ -383,10 +573,10 @@ class ScimDAL(DAL):
 
 
 def _apply_scim_string_op(
-    query: Select[tuple[User]],
+    query: Select[tuple[User]] | Select[tuple[UserGroup]],
     column: SQLColumnExpression[str],
     scim_filter: ScimFilter,
-) -> Select[tuple[User]]:
+) -> Select[tuple[User]] | Select[tuple[UserGroup]]:
     """Apply a SCIM string filter operator using SQLAlchemy column operators.
 
     Handles eq (case-insensitive exact), co (contains), and sw (starts with).

--- a/backend/tests/unit/onyx/server/scim/conftest.py
+++ b/backend/tests/unit/onyx/server/scim/conftest.py
@@ -47,8 +47,12 @@ def mock_dal() -> Generator[MagicMock, None, None]:
         dal.get_user_mapping_by_external_id.return_value = None
         dal.list_users.return_value = ([], 0)
         # Group defaults
+        dal.get_group.return_value = None
+        dal.get_group_by_name.return_value = None
         dal.get_group_mapping_by_group_id.return_value = None
         dal.get_group_mapping_by_external_id.return_value = None
+        dal.get_group_members.return_value = []
+        dal.list_groups.return_value = ([], 0)
         yield dal
 
 

--- a/backend/tests/unit/onyx/server/scim/test_group_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_group_endpoints.py
@@ -1,0 +1,633 @@
+"""Unit tests for SCIM Group CRUD endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import Response
+
+from ee.onyx.server.scim.api import create_group
+from ee.onyx.server.scim.api import delete_group
+from ee.onyx.server.scim.api import get_group
+from ee.onyx.server.scim.api import list_groups
+from ee.onyx.server.scim.api import patch_group
+from ee.onyx.server.scim.api import replace_group
+from ee.onyx.server.scim.models import ScimGroupMember
+from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimListResponse
+from ee.onyx.server.scim.models import ScimPatchOperation
+from ee.onyx.server.scim.models import ScimPatchOperationType
+from ee.onyx.server.scim.models import ScimPatchRequest
+from ee.onyx.server.scim.patch import ScimPatchError
+from tests.unit.onyx.server.scim.conftest import assert_scim_error
+from tests.unit.onyx.server.scim.conftest import make_db_group
+from tests.unit.onyx.server.scim.conftest import make_scim_group
+
+
+class TestListGroups:
+    """Tests for GET /scim/v2/Groups."""
+
+    def test_empty_result(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.list_groups.return_value = ([], 0)
+
+        result = list_groups(
+            filter=None,
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimListResponse)
+        assert result.totalResults == 0
+        assert result.Resources == []
+
+    def test_unsupported_filter_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.list_groups.side_effect = ValueError(
+            "Unsupported filter attribute: userName"
+        )
+
+        result = list_groups(
+            filter='userName eq "x"',
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    def test_returns_groups_with_members(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5, name="Engineering")
+        uid = uuid4()
+        mock_dal.list_groups.return_value = ([(group, "ext-g-1")], 1)
+        mock_dal.get_group_members.return_value = [(uid, "alice@example.com")]
+
+        result = list_groups(
+            filter=None,
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimListResponse)
+        assert result.totalResults == 1
+        resource = result.Resources[0]
+        assert isinstance(resource, ScimGroupResource)
+        assert resource.displayName == "Engineering"
+        assert resource.externalId == "ext-g-1"
+        assert len(resource.members) == 1
+        assert resource.members[0].display == "alice@example.com"
+
+
+class TestGetGroup:
+    """Tests for GET /scim/v2/Groups/{group_id}."""
+
+    def test_returns_scim_resource(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5, name="Engineering")
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        result = get_group(
+            group_id="5",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        assert result.displayName == "Engineering"
+        assert result.id == "5"
+
+    def test_non_integer_id_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        result = get_group(
+            group_id="not-a-number",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group.return_value = None
+
+        result = get_group(
+            group_id="999",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+
+class TestCreateGroup:
+    """Tests for POST /scim/v2/Groups."""
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_success(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group_by_name.return_value = None
+        mock_validate.return_value = ([], None)
+        mock_dal.get_group_members.return_value = []
+
+        resource = make_scim_group(displayName="New Group")
+
+        result = create_group(
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        assert result.displayName == "New Group"
+        mock_dal.add_group.assert_called_once()
+        mock_dal.commit.assert_called_once()
+
+    def test_duplicate_name_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group_by_name.return_value = make_db_group()
+        resource = make_scim_group()
+
+        result = create_group(
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_invalid_member_returns_400(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group_by_name.return_value = None
+        mock_validate.return_value = ([], "Invalid member ID: bad-uuid")
+
+        resource = make_scim_group(members=[ScimGroupMember(value="bad-uuid")])
+
+        result = create_group(
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_nonexistent_member_returns_400(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group_by_name.return_value = None
+        uid = uuid4()
+        mock_validate.return_value = ([], f"Member(s) not found: {uid}")
+
+        resource = make_scim_group(members=[ScimGroupMember(value=str(uid))])
+
+        result = create_group(
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_creates_external_id_mapping(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group_by_name.return_value = None
+        mock_validate.return_value = ([], None)
+        mock_dal.get_group_members.return_value = []
+
+        resource = make_scim_group(externalId="ext-g-123")
+
+        result = create_group(
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        mock_dal.create_group_mapping.assert_called_once()
+
+
+class TestReplaceGroup:
+    """Tests for PUT /scim/v2/Groups/{group_id}."""
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_success(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5, name="Old Name")
+        mock_dal.get_group.return_value = group
+        mock_validate.return_value = ([], None)
+        mock_dal.get_group_members.return_value = []
+
+        resource = make_scim_group(displayName="New Name")
+
+        result = replace_group(
+            group_id="5",
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        mock_dal.update_group.assert_called_once_with(group, name="New Name")
+        mock_dal.replace_group_members.assert_called_once()
+        mock_dal.commit.assert_called_once()
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group.return_value = None
+
+        result = replace_group(
+            group_id="999",
+            group_resource=make_scim_group(),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_invalid_member_returns_400(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_validate.return_value = ([], "Invalid member ID: bad")
+
+        resource = make_scim_group(members=[ScimGroupMember(value="bad")])
+
+        result = replace_group(
+            group_id="5",
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api._validate_and_parse_members")
+    def test_syncs_external_id(
+        self,
+        mock_validate: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_validate.return_value = ([], None)
+        mock_dal.get_group_members.return_value = []
+
+        resource = make_scim_group(externalId="new-ext")
+
+        replace_group(
+            group_id="5",
+            group_resource=resource,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        mock_dal.sync_group_external_id.assert_called_once_with(5, "new-ext")
+
+
+class TestPatchGroup:
+    """Tests for PATCH /scim/v2/Groups/{group_id}."""
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_rename(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5, name="Old Name")
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        patched = ScimGroupResource(id="5", displayName="New Name", members=[])
+        mock_apply.return_value = (patched, [], [])
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="displayName",
+                    value="New Name",
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="5",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        mock_dal.update_group.assert_called_once_with(group, name="New Name")
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group.return_value = None
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="displayName",
+                    value="X",
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="999",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_patch_error_returns_error_response(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        mock_apply.side_effect = ScimPatchError("Unsupported path", 400)
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="badPath",
+                    value="x",
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="5",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_add_members(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+        mock_dal.validate_member_ids.return_value = []
+
+        uid = str(uuid4())
+        patched = ScimGroupResource(
+            id="5",
+            displayName="Engineering",
+            members=[ScimGroupMember(value=uid)],
+        )
+        mock_apply.return_value = (patched, [uid], [])
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.ADD,
+                    path="members",
+                    value=[{"value": uid}],
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="5",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        mock_dal.validate_member_ids.assert_called_once()
+        mock_dal.upsert_group_members.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_add_nonexistent_member_returns_400(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        uid = uuid4()
+        patched = ScimGroupResource(
+            id="5",
+            displayName="Engineering",
+            members=[ScimGroupMember(value=str(uid))],
+        )
+        mock_apply.return_value = (patched, [str(uid)], [])
+        mock_dal.validate_member_ids.return_value = [uid]
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.ADD,
+                    path="members",
+                    value=[{"value": str(uid)}],
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="5",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_remove_members(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        uid = str(uuid4())
+        patched = ScimGroupResource(id="5", displayName="Engineering", members=[])
+        mock_apply.return_value = (patched, [], [uid])
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path=f'members[value eq "{uid}"]',
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="5",
+            patch_request=patch_req,
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimGroupResource)
+        mock_dal.remove_group_members.assert_called_once()
+
+
+class TestDeleteGroup:
+    """Tests for DELETE /scim/v2/Groups/{group_id}."""
+
+    def test_success(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        group = make_db_group(id=5)
+        mock_dal.get_group.return_value = group
+        mapping = MagicMock()
+        mapping.id = 1
+        mock_dal.get_group_mapping_by_group_id.return_value = mapping
+
+        result = delete_group(
+            group_id="5",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == 204
+        mock_dal.delete_group_mapping.assert_called_once_with(1)
+        mock_dal.delete_group_with_members.assert_called_once_with(group)
+        mock_dal.commit.assert_called_once()
+
+    def test_not_found_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        mock_dal.get_group.return_value = None
+
+        result = delete_group(
+            group_id="999",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)
+
+    def test_non_integer_id_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,  # noqa: ARG002
+    ) -> None:
+        result = delete_group(
+            group_id="abc",
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 404)


### PR DESCRIPTION
## Description

Closes [ENG-3648](https://linear.app/onyx-app/issue/ENG-3648)

Add SCIM 2.0 Group CRUD endpoints (RFC 7644 §3) for identity provider group provisioning:

- **GET /scim/v2/Groups** — List groups with SCIM filter (displayName, externalId) and pagination
- **GET /scim/v2/Groups/{group_id}** — Get a single group by ID
- **POST /scim/v2/Groups** — Create group with members (validates member UUIDs exist, uses `pg_insert` with `on_conflict_do_nothing` for idempotent member additions, catches `IntegrityError` for TOCTOU race on duplicate group names)
- **PUT /scim/v2/Groups/{group_id}** — Full group replacement including member reconciliation
- **PATCH /scim/v2/Groups/{group_id}** — Partial update for member add/remove operations (Okta/Azure AD push group changes)
- **DELETE /scim/v2/Groups/{group_id}** — Remove member relationships, SCIM mapping, and delete group

Groups are created directly via ORM with `is_up_to_date=True` since SCIM-provisioned groups have no cc_pair associations that need Vespa sync.

**Stacked on:** #8455 (User CRUD)

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check