### PR TITLE
chore: disable auto craft animation with feature flag

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -46,6 +46,7 @@ import { cn } from "@/lib/utils";
 import {
   DRAG_TYPES,
   DEFAULT_PERSONA_ID,
+  FEATURE_FLAGS,
   LOCAL_STORAGE_KEYS,
 } from "@/sections/sidebar/constants";
 import { showErrorNotification, handleMoveOperation } from "./sidebarUtils";
@@ -223,7 +224,7 @@ const MemoizedAppSidebarInner = memo(
     // Gated by PostHog feature flag: if `craft-animation-disabled` is true (or
     // PostHog is unavailable), skip the auto-show entirely.
     const isCraftAnimationDisabled =
-      posthog?.isFeatureEnabled("craft-animation-disabled") ?? true;
+      posthog?.isFeatureEnabled(FEATURE_FLAGS.CRAFT_ANIMATION_DISABLED) ?? true;
     const hasTenantModal = !!(newTenantInfo || invitationInfo);
     useEffect(() => {
       if (

--- a/web/src/sections/sidebar/constants.ts
+++ b/web/src/sections/sidebar/constants.ts
@@ -9,3 +9,7 @@ export const LOCAL_STORAGE_KEYS = {
 } as const;
 
 export const DEFAULT_PERSONA_ID = 0;
+
+export const FEATURE_FLAGS = {
+  CRAFT_ANIMATION_DISABLED: "craft-animation-disabled",
+} as const;


### PR DESCRIPTION
- only disables the automatic animation
- notification is still generated and users can still click to see the animation

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check
