### PR TITLE
fix: CheckpointedConnector pruning only processes first checkpoint step (mirror of #8464)

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -5,6 +5,7 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 from typing import cast
+from typing import TypeVar
 
 import httpx
 
@@ -16,6 +17,7 @@ from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
 )
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
+from onyx.connectors.interfaces import ConnectorCheckpoint
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SlimConnector
@@ -31,9 +33,11 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 PRUNING_CHECKPOINTED_BATCH_SIZE = 32
 
+CT = TypeVar("CT", bound=ConnectorCheckpoint)
+
 
 def _checkpointed_batched_doc_ids(
-    connector: CheckpointedConnector,
+    connector: CheckpointedConnector[CT],
     start: float,
     end: float,
     batch_size: int,
@@ -50,7 +54,7 @@ def _checkpointed_batched_doc_ids(
         checkpoint_output = connector.load_from_checkpoint(
             start=start, end=end, checkpoint=checkpoint
         )
-        wrapper = CheckpointOutputWrapper()
+        wrapper: CheckpointOutputWrapper[CT] = CheckpointOutputWrapper()
         batch: set[str] = set()
         for document, _hierarchy_node, failure, next_checkpoint in wrapper(
             checkpoint_output


### PR DESCRIPTION
Automated mirror of PR #8464 so private CI can run.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pruning for checkpointed connectors by looping through all checkpoint steps to gather document IDs. Prevents empty first steps (e.g., IMAP) from wiping indexed docs.

- **Bug Fixes**
  - Added _checkpointed_batched_doc_ids that iterates until checkpoint.has_more, batching IDs from documents or failures.
  - Updated extract_ids_from_runnable_connector to use CheckpointOutputWrapper with the new helper; added TypeVar/typing for mypy.

<sup>Written for commit 5b807cd0c65957f613f13c29306780dd5c044e0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



