### PR TITLE
fix: allow public oauth clients via DCR

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -272,7 +272,7 @@ def make_oauth_provider(
     return OAuthClientProvider(
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
-            client_name=mcp_server.name,
+            client_name=f"Onyx - {mcp_server.name}",
             redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
@@ -870,14 +870,15 @@ def _db_mcp_server_to_api_mcp_server(
                         client_info_raw
                     )
                 if client_info:
-                    if not client_info.client_id or not client_info.client_secret:
-                        raise ValueError(
-                            "Stored client info had empty client ID or secret"
-                        )
+                    if not client_info.client_id:
+                        raise ValueError("Stored client info had empty client ID")
                     admin_credentials = {
                         "client_id": mask_string(client_info.client_id),
-                        "client_secret": mask_string(client_info.client_secret),
                     }
+                    if client_info.client_secret:
+                        admin_credentials["client_secret"] = mask_string(
+                            client_info.client_secret
+                        )
                 else:
                     admin_credentials = {}
                     logger.warning(
@@ -910,13 +911,16 @@ def _db_mcp_server_to_api_mcp_server(
             if client_info_raw:
                 client_info = OAuthClientInformationFull.model_validate(client_info_raw)
             if client_info:
-                if not client_info.client_id or not client_info.client_secret:
-                    raise ValueError("Stored client info had empty client ID or secret")
+                if not client_info.client_id:
+                    raise ValueError("Stored client info had empty client ID")
                 if can_view_admin_credentials:
                     admin_credentials = {
                         "client_id": mask_string(client_info.client_id),
-                        "client_secret": mask_string(client_info.client_secret),
                     }
+                    if client_info.client_secret:
+                        admin_credentials["client_secret"] = mask_string(
+                            client_info.client_secret
+                        )
             elif can_view_admin_credentials:
                 admin_credentials = {}
                 logger.warning(f"No client info found for server {db_server.name}")


### PR DESCRIPTION
## Description

Some servers don't allow certain prefixes in the client name... weird but okay. And also if the server uses a public OAuth client for the Dynamic Client Registration flow we won't get a client secret back, just a client id.

## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support public OAuth clients in MCP DCR by making client_secret optional and only showing it when present. Also prefix the registered client name with "Onyx - {server name}" to avoid provider naming restrictions.

- **Bug Fixes**
  - Validate only client_id; include client_secret in admin credentials only if provided.
  - Set client_metadata.client_name to "Onyx - {mcp_server.name}" during registration.

<sup>Written for commit bbf84c1e7347ee957445299f129e349020c52c39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

