### PR TITLE
chore: hiernode passive deletes

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -806,12 +806,13 @@ class HierarchyNode(Base):
         "HierarchyNode", remote_side=[id], back_populates="children"
     )
     children: Mapped[list["HierarchyNode"]] = relationship(
-        "HierarchyNode", back_populates="parent"
+        "HierarchyNode", back_populates="parent", passive_deletes=True
     )
     child_documents: Mapped[list["Document"]] = relationship(
         "Document",
         back_populates="parent_hierarchy_node",
         foreign_keys="Document.parent_hierarchy_node_id",
+        passive_deletes=True,
     )
     # Personas that have this hierarchy node attached for scoped search
     personas: Mapped[list["Persona"]] = relationship(
@@ -936,6 +937,7 @@ class Document(Base):
         "HierarchyNode",
         back_populates="document",
         foreign_keys="HierarchyNode.document_id",
+        passive_deletes=True,
     )
     # Personas that have this document directly attached for scoped search
     attached_personas: Mapped[list["Persona"]] = relationship(


### PR DESCRIPTION
## Description

make cascade deletes go through the db instead of being handled at sqlalchemy level

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the database handle cascade deletes for hierarchy relationships by enabling passive_deletes. This reduces ORM overhead and aligns with our FK on-delete rules.

- **Refactors**
  - Set passive_deletes=True on HierarchyNode.children
  - Set passive_deletes=True on HierarchyNode.child_documents
  - Set passive_deletes=True on Document.hierarchy_nodes

<sup>Written for commit aafe9e0016cb232b94fa202ad8c6f4a2e6971fd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

