### PR TITLE
feat: add search_ui_enabled setting for admin chat preferences

### DIFF
--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -56,6 +56,7 @@ class Settings(BaseModel):
     application_status: ApplicationStatus = ApplicationStatus.ACTIVE
     anonymous_user_enabled: bool | None = None
     deep_research_enabled: bool | None = None
+    search_ui_enabled: bool | None = False
 
     # Enterprise features flag - set by license enforcement at runtime
     # When LICENSE_ENFORCEMENT_ENABLED=true, this reflects license status

--- a/web/src/app/admin/settings/interfaces.ts
+++ b/web/src/app/admin/settings/interfaces.ts
@@ -25,6 +25,7 @@ export interface Settings {
   query_history_type: QueryHistoryType;
 
   deep_research_enabled?: boolean;
+  search_ui_enabled?: boolean;
 
   // Image processing settings
   image_extraction_and_analysis_enabled?: boolean;


### PR DESCRIPTION
## Description

Adds the `search_ui_enabled` field to both the backend `Settings` Pydantic model and the frontend `Settings` TypeScript interface. This is a prerequisite for the new Admin Chat Preferences page, which will allow admins to toggle the search UI mode at the workspace level.

**Changes:**
- `backend/onyx/server/settings/models.py` — Added `search_ui_enabled: bool | None = False` to the `Settings` model
- `web/src/app/admin/settings/interfaces.ts` — Added `search_ui_enabled?: boolean` to the `Settings` interface

No migration needed — settings are stored in a KV store (Redis), not a database table. The new field defaults to `False` and is optional, so existing stored settings will deserialize without issues.

## How Has This Been Tested?

- Verified that the backend `Settings` model accepts and serializes the new field correctly (KV store round-trip)
- Verified TypeScript type check passes (`bun run build` via pre-commit hook)

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new search_ui_enabled setting to backend and frontend Settings to let admins toggle the search UI mode at the workspace level. Defaults to false and is optional, so existing settings keep working.

- **New Features**
  - Backend: Settings model adds search_ui_enabled: bool | None = False
  - Frontend: Settings interface adds search_ui_enabled?: boolean

<sup>Written for commit 5fa2db8e98515808ef30640b7698d3c466092c4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

