### PR TITLE
fix: Enable search UI in Chrome extension side panel

### DIFF
--- a/web/src/app/app/nrf/NRFPage.tsx
+++ b/web/src/app/app/nrf/NRFPage.tsx
@@ -282,6 +282,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   );
 
   // Handle submit from AppInputBar - routes through query controller for search/chat classification
+  const handleChatInputSubmit = useCallback(
     async (submittedMessage: string) => {
       if (!submittedMessage.trim()) return;
       // If we already have messages (chat session started), always use chat mode
@@ -300,6 +301,15 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
       // - Route to chat (calls onChat callback)
       await submitQuery(submittedMessage, onChat);
     },
+    [
+      hasMessages,
+      onSubmit,
+      currentMessageFiles,
+      deepResearchEnabled,
+      resetInputBar,
+      submitQuery,
+      onChat,
+    ]
   );
 
   // Handle resubmit last message on error


### PR DESCRIPTION
The NRFPage (used by Chrome extension side panel) was missing search functionality that exists in AppPage:

1. `retrievalEnabled` was hardcoded to `false` instead of being calculated based on the assistant's capabilities
2. No integration with `useQueryController` for query classification
3. No `SearchUI` component to display search results

Changes:
- Import and use `useQueryController` for search/chat classification
- Calculate `retrievalEnabled` dynamically using `personaIncludesRetrieval`
- Route queries through `submitQuery` for proper classification (EE feature)
- Add `SearchUI` component (EE-gated) to display search results
- Hide welcome message when in search mode

This enables the same search experience in the Chrome extension that exists in the main app, for Enterprise Edition users.

https://claude.ai/code/session_01Es43zZzvuJXn6RPpAAW3Mh

## Description

Note: there will be a SEPARATE PR to fix the header/footer/layout things for the chrome extension, this is just getting feature parity with chrome extension

## How Has This Been Tested?

locally
<img width="1914" height="943" alt="Screenshot 2026-02-16 at 22 07 28" src="https://github.com/user-attachments/assets/dda36ae7-a2d5-414f-943c-f5399a9321c0" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables full search in the Chrome extension side panel for Enterprise Edition, matching the main app. Queries are classified and routed to search or chat, with search results rendered in the panel.

- **Bug Fixes**
  - Wired useQueryController and routed via submitQuery; ongoing chats bypass classification.
  - Computed retrievalEnabled from the assistant with personaIncludesRetrieval and passed to AppInputBar.
  - Added EE-gated SearchUI; shows results when classified as search, hides welcome in search mode, and supports document clicks.

<sup>Written for commit 96a998d302c0cf4dbfbd9637274e9e766bc7f4e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

