### PR TITLE
fix: custom MCP auth Headers in API [mirror of #8345]

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -159,7 +159,8 @@ class MCPTool(Tool[None]):
                 and self.mcp_server.auth_type is not None
             )
             has_auth_config = (
-                self.connection_config is not None and bool(headers)
+                (self.connection_config is not None and bool(headers))
+                or bool(self._additional_headers)
             ) or (is_passthrough_oauth and self._user_oauth_token is not None)
 
             if requires_auth and not has_auth_config:


### PR DESCRIPTION
Automated mirror of PR #8345 so private CI can run.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auth detection in the MCP tool to honor custom auth headers, preventing false “missing auth” errors with header-based auth.

- **Bug Fixes**
  - has_auth_config now treats self._additional_headers as auth, even without connection_config or request headers.

<sup>Written for commit 8174351e202dfcd280760fb992ee32c002303790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



