### PR TITLE
fix: Interactive.Base href rendering and container self-stretch

### DIFF
--- a/web/lib/opal/src/core/interactive/styles.css
+++ b/web/lib/opal/src/core/interactive/styles.css
@@ -8,7 +8,7 @@
 
 /* Interactive — container */
 .interactive-container {
-  @apply flex self-stretch items-center justify-center overflow-clip;
+  @apply flex items-center justify-center overflow-clip;
 }
 .interactive-container[data-border="true"] {
   @apply border;


### PR DESCRIPTION
## Description

Fixes two issues in the opal Interactive component:

1. **Interactive.Base href rendering**: Previously, when `href` was provided, `Interactive.Base` rendered a separate `<a>` wrapper instead of using Slot. This split styling across two elements — backgrounds/colors on the `<a>`, rounding/overflow on the child `Interactive.Container` — causing square corners on hover for link buttons. Now `Interactive.Base` always uses Slot, and `Interactive.Container` renders an `<a>` when `href` is present (same pattern as the existing `<div>` vs `<button>` decision via `type` prop).

2. **Container self-stretch**: Removed `self-stretch` from `.interactive-container` which caused buttons to stretch vertically in row flex layouts, overriding the parent's `align-items`.

## How Has This Been Tested?

- Verified buttons with `href` render with correct rounded corners on hover
- Verified buttons without `href` continue to work as before
- Verified buttons in row layouts no longer stretch vertically
- Build passes with no TypeScript errors

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes link button hover rounding and stops buttons from stretching in row layouts by changing how href is rendered and updating container styles.

- **Bug Fixes**
  - Interactive.Base now always uses Slot and passes href/target/rel; Interactive.Container renders an <a> when href is present, keeping all styling on one element.
  - Removed self-stretch from .interactive-container to respect parent align-items and prevent vertical stretching.

<sup>Written for commit fda079317e240a6abdb01be870e5f030a14e94f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

