### PR TITLE
fix(helm): Log Level Passthrough for Celery

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.28
+version: 0.4.29
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -63,7 +63,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.beat",
               "beat",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_beat.logLevel | quote }},
             ]
           resources:
             {{- toYaml .Values.celery_beat.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -68,7 +68,7 @@ spec:
               "--pool=threads",
               "--concurrency=2",
               "--prefetch-multiplier=1",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_docfetching.logLevel | quote }},
               "--hostname=docfetching@%n",
               "-Q",
               "connector_doc_fetching",

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -68,7 +68,7 @@ spec:
               "--pool=threads",
               "--concurrency=6",
               "--prefetch-multiplier=1",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_docprocessing.logLevel | quote }},
               "--hostname=docprocessing@%n",
               "-Q",
               "docprocessing",

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -65,7 +65,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.heavy",
               "worker",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_heavy.logLevel | quote }},
               "--hostname=heavy@%n",
               "-Q",
               "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox",

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -65,7 +65,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.light",
               "worker",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_light.logLevel | quote }},
               "--hostname=light@%n",
               "-Q",
               "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -65,7 +65,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.monitoring",
               "worker",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_monitoring.logLevel | quote }},
               "--hostname=monitoring@%n",
               "-Q",
               "monitoring",

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -65,7 +65,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.primary",
               "worker",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_primary.logLevel | quote }},
               "--hostname=primary@%n",
               "-Q",
               "celery,periodic_tasks",

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -65,7 +65,7 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.user_file_processing",
               "worker",
-              "--loglevel=INFO",
+              {{ printf "--loglevel=%s" .Values.celery_worker_user_file_processing.logLevel | quote }},
               "--hostname=user-file-processing@%n",
               "-Q",
               "user_file_processing,user_file_project_sync,user_file_delete",
@@ -108,4 +108,3 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
-

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -522,6 +522,7 @@ celery_shared:
 
 celery_beat:
   replicaCount: 1
+  logLevel: INFO
   podAnnotations: {}
   podLabels:
     scope: onyx-backend-celery
@@ -542,6 +543,7 @@ celery_beat:
 
 celery_worker_heavy:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -575,6 +577,7 @@ celery_worker_heavy:
 
 celery_worker_docprocessing:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -608,6 +611,7 @@ celery_worker_docprocessing:
 
 celery_worker_light:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -641,6 +645,7 @@ celery_worker_light:
 
 celery_worker_monitoring:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -674,6 +679,7 @@ celery_worker_monitoring:
 
 celery_worker_primary:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -707,6 +713,7 @@ celery_worker_primary:
 
 celery_worker_user_file_processing:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -851,6 +858,7 @@ mcpServer:
 
 celery_worker_docfetching:
   replicaCount: 1
+  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently you are not able to override the log level of the celery pods so this is to ensure that we are able to update this use case.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Helm Template

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable configurable Celery log levels in the Helm chart by passing logLevel values to all Celery components instead of hard-coding INFO. This lets operators tune verbosity per worker while keeping INFO as the default.

- **New Features**
  - Added logLevel to values for celery_beat and all celery_worker deployments (default: INFO).
  - Templated commands now use --loglevel from values.
  - Bumped chart version to 0.4.29.

<sup>Written for commit f4a14d52d89e1dacba8ffcd119a6f0fa35aa9f77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

