### PR TITLE
fix(vertex): Additional fix for Opus 4.6

### DIFF
--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -25,6 +25,11 @@ from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.utils import get_max_input_tokens
 
+VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
+    "claude-opus-4-5@20251101",
+    "claude-opus-4-6",
+]
+
 
 def _create_delta(
     role: str | None = None,
@@ -420,15 +425,16 @@ def test_multiple_tool_calls_streaming(default_multi_llm: LitellmLLM) -> None:
         )
 
 
-def test_vertex_stream_omits_stream_options() -> None:
+@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)
+def test_vertex_stream_omits_stream_options(model_name: str) -> None:
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
         model_provider=LlmProviderNames.VERTEX_AI,
-        model_name="claude-opus-4-5@20251101",
+        model_name=model_name,
         max_input_tokens=get_max_input_tokens(
             model_provider=LlmProviderNames.VERTEX_AI,
-            model_name="claude-opus-4-5@20251101",
+            model_name=model_name,
         ),
     )
 
@@ -468,15 +474,16 @@ def test_openai_auto_reasoning_effort_maps_to_medium() -> None:
         assert kwargs["reasoning"]["effort"] == "medium"
 
 
-def test_vertex_opus_4_5_omits_reasoning_effort() -> None:
+@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)
+def test_vertex_opus_omits_reasoning_effort(model_name: str) -> None:
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
         model_provider=LlmProviderNames.VERTEX_AI,
-        model_name="claude-opus-4-5@20251101",
+        model_name=model_name,
         max_input_tokens=get_max_input_tokens(
             model_provider=LlmProviderNames.VERTEX_AI,
-            model_name="claude-opus-4-5@20251101",
+            model_name=model_name,
         ),
     )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding in another fix for a customer that has been hitting this. We had this same issue with 4.5

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Updated and rerun tests.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip stream_options and reasoning.effort for Vertex Anthropic Opus 4.5 and 4.6 to prevent API rejections. This fixes streaming and completions for these models on Vertex AI.

- **Bug Fixes**
  - Detect Vertex Anthropic models that reject output_config (Opus 4.5, Opus 4.6) and omit stream_options and reasoning.effort accordingly.
  - Updated unit tests to cover both models with parametrized cases.

<sup>Written for commit 7a7b08103b7ea0dac80b104480c77de131ef7657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

