### PR TITLE
fix(ee): small ux fixes for licensing

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -263,9 +263,15 @@ def refresh_license_cache(
 
     try:
         payload = verify_license_signature(license_record.license_data)
+        # Derive source from payload: manual licenses lack stripe_customer_id
+        source: LicenseSource = (
+            LicenseSource.AUTO_FETCH
+            if payload.stripe_customer_id
+            else LicenseSource.MANUAL_UPLOAD
+        )
         return update_license_cache(
             payload,
-            source=LicenseSource.AUTO_FETCH,
+            source=source,
             tenant_id=tenant_id,
         )
     except ValueError as e:

--- a/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
+++ b/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
@@ -86,12 +86,16 @@ class TestApplyLicenseStatusToSettings:
     @patch("ee.onyx.server.settings.api.ENTERPRISE_EDITION_ENABLED", True)
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
     @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.settings.api.refresh_license_cache", return_value=None)
+    @patch("ee.onyx.server.settings.api.get_session_with_current_tenant")
     @patch("ee.onyx.server.settings.api.get_current_tenant_id")
     @patch("ee.onyx.server.settings.api.get_cached_license_metadata")
     def test_no_license_with_ee_flag_gates_access(
         self,
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
+        _mock_get_session: MagicMock,
+        _mock_refresh: MagicMock,
         base_settings: Settings,
     ) -> None:
         """No license + ENTERPRISE_EDITION_ENABLED=true → GATED_ACCESS."""
@@ -107,12 +111,16 @@ class TestApplyLicenseStatusToSettings:
     @patch("ee.onyx.server.settings.api.ENTERPRISE_EDITION_ENABLED", False)
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
     @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.settings.api.refresh_license_cache", return_value=None)
+    @patch("ee.onyx.server.settings.api.get_session_with_current_tenant")
     @patch("ee.onyx.server.settings.api.get_current_tenant_id")
     @patch("ee.onyx.server.settings.api.get_cached_license_metadata")
     def test_no_license_without_ee_flag_allows_community(
         self,
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
+        _mock_get_session: MagicMock,
+        _mock_refresh: MagicMock,
         base_settings: Settings,
     ) -> None:
         """No license + ENTERPRISE_EDITION_ENABLED=false → community mode (no gating)."""

--- a/web/src/app/admin/billing/PlansView.tsx
+++ b/web/src/app/admin/billing/PlansView.tsx
@@ -161,9 +161,15 @@ function PlanCard({
             >
               {buttonLabel}
             </Button>
-          ) : (
+          ) : onClick ? (
             <Button main primary onClick={onClick} leftIcon={ButtonIcon}>
               {buttonLabel}
+            </Button>
+          ) : (
+            <Button tertiary transient className="pointer-events-none">
+              <Text mainUiAction text03>
+                Included in your plan
+              </Text>
             </Button>
           )}
         </div>
@@ -221,12 +227,14 @@ function PlanCard({
 
 interface PlansViewProps {
   hasSubscription?: boolean;
+  hasLicense?: boolean;
   onCheckout: () => void;
   hideFeatures?: boolean;
 }
 
 export default function PlansView({
   hasSubscription,
+  hasLicense,
   onCheckout,
   hideFeatures,
 }: PlansViewProps) {
@@ -239,10 +247,10 @@ export default function PlansView({
         "per seat/month billed annually\nor $25 per seat if billed monthly",
       buttonLabel: "Get Business Plan",
       buttonVariant: "primary",
-      onClick: onCheckout,
+      onClick: hasLicense ? undefined : onCheckout,
       features: BUSINESS_FEATURES,
       featuresPrefix: "Get more work done with AI for your team.",
-      isCurrentPlan: hasSubscription,
+      isCurrentPlan: !!hasSubscription,
     },
     {
       icon: SvgOrganization,
@@ -254,6 +262,7 @@ export default function PlansView({
       href: SALES_URL,
       features: ENTERPRISE_FEATURES,
       featuresPrefix: "Everything in Business Plan, plus:",
+      isCurrentPlan: !!hasLicense && !hasSubscription,
     },
   ];
 

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -293,6 +293,7 @@ export default function BillingPage() {
       plans: (
         <PlansView
           hasSubscription={!!hasSubscription}
+          hasLicense={!!licenseData?.has_license}
           onCheckout={() => changeView("checkout")}
           hideFeatures={showLicenseActivationInput}
         />


### PR DESCRIPTION
## Description

Three issues fixed for self-hosted enterprise customers with manually uploaded licenses (where `stripe_customer_id` is null):

1. **PlansView showed "Get Business Plan" instead of recognizing the enterprise plan**: When billing information fetch fails (no Stripe customer), `hasActiveSubscription()` returns false, so PlansView didn't recognize the customer's existing plan. Added a `hasLicense` prop to PlansView — Enterprise card now shows "Your Current Plan" and Business card shows "Included in your plan" (with checkout disabled) when a valid license exists.

2. **Brief "Access Restricted" flash after Redis license cache TTL expires**: The `/settings` endpoint used `get_cached_license_metadata()` which only reads from Redis. When the 24h TTL expired, it returned `None` → `GATED_ACCESS`, causing an access-restricted page flash until `/license` re-warmed the cache. Added a DB fallback (via `refresh_license_cache()`) when the cache is empty, matching the pattern already used by `get_license_metadata()`. Wrapped in nested `try/except SQLAlchemyError` to match the middleware pattern.

3. **`refresh_license_cache` overwrote `source` to `AUTO_FETCH` for manual licenses**: After cache TTL expiry, refreshing from DB always set `source=AUTO_FETCH`, which broke air-gap detection for manual license customers. Now derives `source` from the payload's `stripe_customer_id` — present means `AUTO_FETCH`, absent means `MANUAL_UPLOAD`.

## How Has This Been Tested?

<img width="994" height="622" alt="Screenshot 2026-02-17 at 12 39 15 PM" src="https://github.com/user-attachments/assets/70a795e1-6556-445e-af20-b6a184de7fc0" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check