### PR TITLE
chore(playwright): Cleanup for LLM Tests

### DIFF
--- a/web/tests/e2e/utils/chatActions.ts
+++ b/web/tests/e2e/utils/chatActions.ts
@@ -62,6 +62,84 @@ export async function verifyCurrentModel(page: Page, modelName: string) {
   expect(text).toContain(modelName);
 }
 
+export async function selectModelFromInputPopover(
+  page: Page,
+  preferredModels: string[]
+): Promise<string> {
+  const currentModelText =
+    (
+      await page.getByTestId("AppInputBar/llm-popover-trigger").textContent()
+    )?.trim() ?? "";
+
+  await page.getByTestId("AppInputBar/llm-popover-trigger").click();
+  await page.waitForSelector('[role="dialog"]', {
+    state: "visible",
+    timeout: 10000,
+  });
+
+  const dialog = page.locator('[role="dialog"]');
+  const searchInput = dialog.getByPlaceholder("Search models...");
+
+  for (const modelName of preferredModels) {
+    await searchInput.fill(modelName);
+    const modelOptions = dialog.locator("button[data-selected]");
+    const nonSelectedOptions = dialog.locator('button[data-selected="false"]');
+
+    if ((await modelOptions.count()) > 0) {
+      const candidate =
+        (await nonSelectedOptions.count()) > 0
+          ? nonSelectedOptions.first()
+          : modelOptions.first();
+
+      await candidate.click();
+      await page.waitForSelector('[role="dialog"]', { state: "hidden" });
+      const selectedText =
+        (
+          await page
+            .getByTestId("AppInputBar/llm-popover-trigger")
+            .textContent()
+        )?.trim() ?? "";
+      if (!selectedText) {
+        throw new Error(
+          "Failed to read selected model text from input trigger"
+        );
+      }
+      return selectedText;
+    }
+  }
+
+  // Reset search so fallback sees all available models.
+  await searchInput.fill("");
+
+  const nonSelectedOptions = dialog.locator('button[data-selected="false"]');
+  if ((await nonSelectedOptions.count()) > 0) {
+    const fallback = nonSelectedOptions.first();
+    await expect(fallback).toBeVisible();
+    await fallback.click();
+    await page.waitForSelector('[role="dialog"]', { state: "hidden" });
+
+    const selectedText =
+      (
+        await page.getByTestId("AppInputBar/llm-popover-trigger").textContent()
+      )?.trim() ?? "";
+    if (!selectedText) {
+      throw new Error("Failed to read selected model text from input trigger");
+    }
+    return selectedText;
+  }
+
+  await page.keyboard.press("Escape").catch(() => {});
+  await page
+    .waitForSelector('[role="dialog"]', { state: "hidden", timeout: 5000 })
+    .catch(() => {});
+
+  if (currentModelText) {
+    return currentModelText;
+  }
+
+  throw new Error("Unable to select a model from input popover");
+}
+
 export async function switchModel(page: Page, modelName: string) {
   await page.getByTestId("AppInputBar/llm-popover-trigger").click();
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Addressing some followups from @jmelahman that were called out in https://github.com/onyx-dot-app/onyx/pull/8447 to help cleanup some of the new tests that I added. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Running locally

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up Playwright LLM runtime selection tests by extracting shared helpers, simplifying setup, and improving model selection reliability. This reduces duplication and removes fragile env var dependencies.

- **Refactors**
  - Moved selectModelFromInputPopover to utils/chatActions and reused across tests.
  - Added loginWithCleanCookies and used in setup/teardown and admin flows.
  - Replaced provider API key env lookup with a stable placeholder in test provider creation.

- **Bug Fixes**
  - Reset model search before fallback to ensure a model is selected when filters hide options.
  - Hardened popover close and text reads to reduce flakiness.

<sup>Written for commit 4772c0187844374218ce5b63819c7d169f9af682. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

