### PR TITLE
chore: undeprecate doc sets

### DIFF
--- a/backend/onyx/server/features/hierarchy/api.py
+++ b/backend/onyx/server/features/hierarchy/api.py
@@ -30,16 +30,27 @@ OPENSEARCH_NOT_ENABLED_MESSAGE = (
     "OpenSearch indexing must be enabled to use this feature."
 )
 
+MIGRATION_STATUS_MESSAGE = (
+    "Our records indicate that the transition to OpenSearch is still in progress. "
+    "OpenSearch retrieval is necessary to use this feature. "
+    "You can still use Document Sets, though! "
+    "If you would like to manually switch to OpenSearch, "
+    'Go to the "Document Index Migration" section in the Admin panel.'
+)
+
 router = APIRouter(prefix=HIERARCHY_NODES_PREFIX)
 
 
 def _require_opensearch(db_session: Session) -> None:
-    if not ENABLE_OPENSEARCH_INDEXING_FOR_ONYX or not get_opensearch_retrieval_state(
-        db_session
-    ):
+    if not ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
         raise HTTPException(
             status_code=403,
             detail=OPENSEARCH_NOT_ENABLED_MESSAGE,
+        )
+    if not get_opensearch_retrieval_state(db_session):
+        raise HTTPException(
+            status_code=403,
+            detail=MIGRATION_STATUS_MESSAGE,
         )
 
 

--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -98,7 +98,6 @@ function KnowledgeSidebar({
         <>
           <LineItem
             icon={SvgFolder}
-            description="(deprecated)"
             onClick={onNavigateToDocumentSets}
             selected={activeView === "document-sets"}
             emphasized={
@@ -672,7 +671,6 @@ const KnowledgeAddView = memo(function KnowledgeAddView({
         {vectorDbEnabled && (
           <LineItem
             icon={SvgFolder}
-            description="(deprecated)"
             onClick={onNavigateToDocumentSets}
             emphasized={selectedDocumentSetIds.length > 0}
             aria-label="knowledge-add-document-sets"


### PR DESCRIPTION
## Description

We're not deprecating document sets for the foreseeable future, so we're removing the deprecated tag. Also added a more helpful error message when migration status isn't set to done

## How Has This Been Tested?

not much to test, but checked the UI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “(deprecated)” label from Document Sets in the Knowledge UI and kept the feature active. Added a clearer 403 error when OpenSearch migration isn’t complete, including guidance to use Document Sets or switch via Admin > Document Index Migration.

<sup>Written for commit ed3101efe943bf149ebab70466c1007af040dfa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

