### PR TITLE
chore(playwright): skip visual regression report on cancelled

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -594,6 +594,7 @@ jobs:
   visual-regression-comment:
     needs: [playwright-tests]
     if: >-
+      always() &&
       github.event_name == 'pull_request' &&
       needs.playwright-tests.result != 'cancelled'
     runs-on: ubuntu-slim


### PR DESCRIPTION
## Description

When the job is cancelled, the report is half complete, so it looks like a bunch of images were deleted which is confusing. Also, if the report isn't complete, we probably don't want to update the report comment to one with less overall information.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip posting the visual regression report comment when the Playwright tests job is cancelled to avoid partial reports and overwriting a fuller comment.

The visual-regression-comment job now runs only on pull_request events and when needs.playwright-tests.result != 'cancelled'.

<sup>Written for commit e5e6b77ac5e27f16bfe6b987f1969e0e83376a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

