### PR TITLE
chore: increase firecrawl test timeout to 60s for e2e test

### DIFF
--- a/web/tests/e2e/admin/web-search/web_content_providers.spec.ts
+++ b/web/tests/e2e/admin/web-search/web_content_providers.spec.ts
@@ -141,7 +141,7 @@ test.describe("Web Content Provider Configuration", () => {
         await modalDialog
           .getByRole("button", { name: "Connect", exact: true })
           .click();
-        await expect(modalDialog).not.toBeVisible({ timeout: 30000 });
+        await expect(modalDialog).not.toBeVisible({ timeout: 60000 });
         await page.waitForLoadState("networkidle");
       } else if (await setDefaultButton.isVisible()) {
         // If already configured but not active, set as default


### PR DESCRIPTION
## Description

e2e playwirght test for firecrawl setup: 45s --> 60s

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the timeout for the Firecrawl connection modal from 30s to 60s in the admin web search e2e test to reduce flaky failures on slower connections.

<sup>Written for commit 6949ed7d36afc33bf3166b7f5006447bc023f22d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

