### PR TITLE
chore(playwright): screenshots wait for animations

### DIFF
--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -105,6 +105,33 @@ interface ElementScreenshotOptions {
 }
 
 /**
+ * Wait for all running CSS animations and transitions on the page to finish
+ * before proceeding.  This prevents screenshot tests from being non-deterministic
+ * when animated elements (e.g. slide-in cards) are still mid-flight.
+ *
+ * The implementation:
+ *   1. Yields one animation frame so that any pending animations have a chance
+ *      to register with the Web Animations API.
+ *   2. Calls `Promise.allSettled` on every active animation's `.finished`
+ *      promise so we wait for completion (or cancellation) of all of them.
+ */
+export async function waitForAnimations(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    // Allow any freshly-scheduled animations to start
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve())
+    );
+    // Wait for every currently-registered animation to finish (or be cancelled)
+    const animations = document
+      .getAnimations()
+      .filter(
+        (animation) => animation.effect?.getTiming().iterations !== Infinity
+      );
+    await Promise.allSettled(animations.map((animation) => animation.finished));
+  });
+}
+
+/**
  * Take a screenshot and optionally assert it matches the stored baseline.
  *
  * Behavior depends on the `VISUAL_REGRESSION` environment variable:
@@ -133,6 +160,11 @@ export async function expectScreenshot(
     maxDiffPixelRatio,
     threshold,
   } = options;
+
+  // Wait for any in-flight CSS animations / transitions to settle so that
+  // screenshots are deterministic (e.g. slide-in card animations on the
+  // onboarding flow).
+  await waitForAnimations(page);
 
   // Merge default hide selectors with per-call selectors
   const allHideSelectors = [...DEFAULT_HIDE_SELECTORS, ...hide];
@@ -216,6 +248,10 @@ export async function expectElementScreenshot(
   const { name, mask = [], hide = [], maxDiffPixelRatio, threshold } = options;
 
   const page = locator.page();
+
+  // Wait for any in-flight CSS animations / transitions to settle so that
+  // element screenshots are deterministic (same reasoning as expectScreenshot).
+  await waitForAnimations(page);
 
   // Merge default hide selectors with per-call selectors
   const allHideSelectors = [...DEFAULT_HIDE_SELECTORS, ...hide];


### PR DESCRIPTION
## Description

I was going to add this in [chore(playwright): onboarding tests](https://github.com/onyx-dot-app/onyx/pull/8462), but i abandoned that change, but this is still universally useful.

## How Has This Been Tested?

Captured by existing. Should only make screenshots more stable.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Playwright visual regression screenshots deterministic by waiting for CSS animations and transitions to finish before capture. This reduces flakiness in animated flows like onboarding.

- **New Features**
  - Added waitForAnimations(page): yields one frame, filters out infinite iterations, and waits on active animations/transitions via Promise.allSettled on .finished.
  - Integrated into expectScreenshot and expectElementScreenshot before capture.

<sup>Written for commit 0165fd7474b730513c17f7fbb83441ea2c422d60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

