### PR TITLE
chore(gha): update `helm/chart-testing-action` version

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -41,8 +41,7 @@ jobs:
           version: v3.19.0
 
       - name: Set up chart-testing
-        # NOTE: This is Jamison's patch from https://github.com/helm/chart-testing-action/pull/194
-        uses: helm/chart-testing-action@8958a6ac472cbd8ee9a8fbb6f1acbc1b0e966e44 # zizmor: ignore[impostor-commit]
+        uses: helm/chart-testing-action@b5eebdd9998021f29756c53432f48dab66394810
         with:
           uv_version: "0.9.9"
 


### PR DESCRIPTION
## Description

Upstream merged my patch, so we can remove my sussy commit

## How Has This Been Tested?

:eyes: 

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the pr-helm-chart-testing workflow to the official helm/chart-testing-action merged commit, replacing the temporary patched SHA. This removes the impostor-commit ignore and aligns CI with upstream.

<sup>Written for commit 57f55dec96e140cbe80396a8a8cb49b5955ce7b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

