### PR TITLE
feat: sharepoint scalability3

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1148,7 +1148,7 @@ class SharepointConnector(
         site_id = site.id
 
         page_url: str | None = (
-            f"{GRAPH_API_BASE}/sites/{site_id}" f"/pages/microsoft.graph.sitePage"
+            f"{GRAPH_API_BASE}/sites/{site_id}/pages/microsoft.graph.sitePage"
         )
         params: dict[str, str] | None = {"$expand": "canvasLayout"}
         total_yielded = 0

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -5,7 +5,6 @@ from collections.abc import Generator
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timezone
-from types import SimpleNamespace
 from typing import Any
 
 import pytest


### PR DESCRIPTION
## Description

site pages

## How Has This Been Tested?

will rely on CI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamed SharePoint site page fetching to cut memory use and improve scalability. Adds per-item time-window filtering and consolidates Graph API calls.

- **Refactors**
  - _fetch_site_pages now yields lazily and paginates via @odata.nextLink; keeps $expand=canvasLayout.
  - Added _site_page_in_time_window to filter by lastModifiedDateTime before yielding.
  - Switched to _graph_api_get_json and GRAPH_API_BASE; removed custom token/requests and logs yield totals.

- **Migration**
  - _fetch_site_pages now returns a generator. Iterate over it; only materialize with list(...) if needed.

<sup>Written for commit d3e1627c6e00e99bc577f5254bec423c6cd7ce67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

