### PR TITLE
feat(scim): add admin SCIM token management API

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -8,11 +8,11 @@ Usage from FastAPI::
     def get_scim_dal(db_session: Session = Depends(get_session)) -> ScimDAL:
         return ScimDAL(db_session)
 
-    @router.get("/tokens")
-    def list_tokens(dal: ScimDAL = Depends(get_scim_dal)) -> ...:
-        tokens = dal.list_tokens()
+    @router.post("/tokens")
+    def create_token(dal: ScimDAL = Depends(get_scim_dal)) -> ...:
+        token = dal.create_token(name=..., hashed_token=..., ...)
         dal.commit()
-        return tokens
+        return token
 
 Usage from background tasks::
 
@@ -53,7 +53,20 @@ class ScimDAL(DAL):
         token_display: str,
         created_by_id: UUID,
     ) -> ScimToken:
-        """Create a new SCIM bearer token."""
+        """Create a new SCIM bearer token.
+
+        Only one token is active at a time — this method automatically revokes
+        all existing active tokens before creating the new one.
+        """
+        # Revoke any currently active tokens
+        active_tokens = list(
+            self._session.scalars(
+                select(ScimToken).where(ScimToken.is_active.is_(True))
+            ).all()
+        )
+        for t in active_tokens:
+            t.is_active = False
+
         token = ScimToken(
             name=name,
             hashed_token=hashed_token,
@@ -64,18 +77,16 @@ class ScimDAL(DAL):
         self._session.flush()
         return token
 
+    def get_active_token(self) -> ScimToken | None:
+        """Return the single currently active token, or None."""
+        return self._session.scalar(
+            select(ScimToken).where(ScimToken.is_active.is_(True))
+        )
+
     def get_token_by_hash(self, hashed_token: str) -> ScimToken | None:
         """Look up a token by its SHA-256 hash."""
         return self._session.scalar(
             select(ScimToken).where(ScimToken.hashed_token == hashed_token)
-        )
-
-    def list_tokens(self) -> list[ScimToken]:
-        """List all SCIM tokens, ordered by creation date descending."""
-        return list(
-            self._session.scalars(
-                select(ScimToken).order_by(ScimToken.created_at.desc())
-            ).all()
         )
 
     def revoke_token(self, token_id: int) -> None:

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -163,7 +163,8 @@ def get_application() -> FastAPI:
         # Tenant management
         include_router_with_global_prefix_prepended(application, tenants_router)
 
-    # SCIM 2.0 — service discovery endpoints (unauthenticated).
+    # SCIM 2.0 — protocol endpoints (unauthenticated by Onyx session auth;
+    # they use their own SCIM bearer token auth).
     # Not behind APP_API_PREFIX because IdPs expect /scim/v2/... directly.
     application.include_router(scim_router)
 

--- a/backend/tests/unit/onyx/server/scim/test_admin.py
+++ b/backend/tests/unit/onyx/server/scim/test_admin.py
@@ -1,0 +1,132 @@
+"""Tests for SCIM admin token management endpoints."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.scim import ScimDAL
+from ee.onyx.server.enterprise_settings.api import create_scim_token
+from ee.onyx.server.enterprise_settings.api import get_active_scim_token
+from ee.onyx.server.scim.models import ScimTokenCreate
+from onyx.db.models import ScimToken
+from onyx.db.models import User
+
+
+@pytest.fixture
+def mock_db_session() -> MagicMock:
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def scim_dal(mock_db_session: MagicMock) -> ScimDAL:
+    return ScimDAL(mock_db_session)
+
+
+@pytest.fixture
+def admin_user() -> User:
+    user = User(id=uuid4(), email="admin@test.com")
+    user.is_active = True
+    return user
+
+
+def _make_token(token_id: int, name: str, *, is_active: bool = True) -> ScimToken:
+    return ScimToken(
+        id=token_id,
+        name=name,
+        hashed_token="h" * 64,
+        token_display="onyx_scim_****abcd",
+        is_active=is_active,
+        created_by_id=uuid4(),
+        created_at=datetime(2026, 1, 1),
+        last_used_at=None,
+    )
+
+
+class TestGetActiveToken:
+    def test_returns_token_metadata(self, scim_dal: ScimDAL, admin_user: User) -> None:
+        token = _make_token(1, "prod-token")
+        scim_dal._session.scalar.return_value = token  # type: ignore[attr-defined]
+
+        result = get_active_scim_token(_=admin_user, dal=scim_dal)
+
+        assert result.id == 1
+        assert result.name == "prod-token"
+        assert result.is_active is True
+
+    def test_raises_404_when_no_active_token(
+        self, scim_dal: ScimDAL, admin_user: User
+    ) -> None:
+        scim_dal._session.scalar.return_value = None  # type: ignore[attr-defined]
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_active_scim_token(_=admin_user, dal=scim_dal)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestCreateToken:
+    @patch("ee.onyx.server.enterprise_settings.api.generate_scim_token")
+    def test_creates_token_and_revokes_previous(
+        self,
+        mock_generate: MagicMock,
+        scim_dal: ScimDAL,
+        admin_user: User,
+    ) -> None:
+        mock_generate.return_value = ("raw_token_val", "hashed_val", "****abcd")
+
+        # Simulate one existing active token that should get revoked
+        existing = _make_token(1, "old-token", is_active=True)
+        scim_dal._session.scalars.return_value.all.return_value = [existing]  # type: ignore[attr-defined]
+
+        # Simulate DB defaults that would be set on INSERT/flush
+        def fake_add(obj: ScimToken) -> None:
+            obj.id = 2
+            obj.is_active = True
+            obj.created_at = datetime(2026, 2, 1)
+
+        scim_dal._session.add.side_effect = fake_add  # type: ignore[attr-defined]
+
+        body = ScimTokenCreate(name="new-token")
+        result = create_scim_token(body=body, user=admin_user, dal=scim_dal)
+
+        # Previous token was revoked (by create_token's internal revocation)
+        assert existing.is_active is False
+
+        # New token returned with raw value
+        assert result.raw_token == "raw_token_val"
+        assert result.name == "new-token"
+        assert result.is_active is True
+
+        # Session was committed
+        scim_dal._session.commit.assert_called_once()  # type: ignore[attr-defined]
+
+    @patch("ee.onyx.server.enterprise_settings.api.generate_scim_token")
+    def test_creates_first_token_when_none_exist(
+        self,
+        mock_generate: MagicMock,
+        scim_dal: ScimDAL,
+        admin_user: User,
+    ) -> None:
+        mock_generate.return_value = ("raw_token_val", "hashed_val", "****abcd")
+
+        # No existing tokens
+        scim_dal._session.scalars.return_value.all.return_value = []  # type: ignore[attr-defined]
+
+        def fake_add(obj: ScimToken) -> None:
+            obj.id = 1
+            obj.is_active = True
+            obj.created_at = datetime(2026, 2, 1)
+
+        scim_dal._session.add.side_effect = fake_add  # type: ignore[attr-defined]
+
+        body = ScimTokenCreate(name="first-token")
+        result = create_scim_token(body=body, user=admin_user, dal=scim_dal)
+
+        assert result.raw_token == "raw_token_val"
+        assert result.name == "first-token"
+        assert result.is_active is True


### PR DESCRIPTION
## Description

Closes [ENG-3649](https://linear.app/onyx-app/issue/ENG-3649)
Closes [ENG-3650](https://linear.app/onyx-app/issue/ENG-3650)

Add admin endpoints for SCIM bearer token management, registered on the existing `enterprise_settings_admin_router`:

- **GET /admin/enterprise-settings/scim/token** — Return the active token's metadata (name, created date, last used) or 404 if none exists
- **POST /admin/enterprise-settings/scim/token** — Create a new token (auto-revokes all previous tokens; raw value returned once)

Design decisions:
- Only one active token at a time — creating a new token is the rotation mechanism
- No list/revoke/delete endpoints — to disable SCIM, customers revoke provisioning on the IdP side
- Revocation logic is inlined in `ScimDAL.create_token()`
- Uses standard Onyx admin session auth, not SCIM bearer tokens
- Endpoints live on `enterprise_settings_admin_router` alongside other EE admin settings (no separate SCIM admin router)

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check