### PR TITLE
chore(fe): update SourceTag tag size

### DIFF
--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -75,7 +75,6 @@ const SourcesTagWrapper = React.memo(function SourcesTagWrapper({
 
   return (
     <SourceTag
-      data-testid="AgentMessage/sources-tag"
       displayName="Sources"
       sources={sources}
       onSourceClick={handleSourceClick}

--- a/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
@@ -303,9 +303,6 @@ export interface SourceTagProps {
 
   /** Tooltip text shown when query is truncated (defaults to displayName) */
   tooltipText?: string;
-
-  /** Test ID forwarded to the root button element */
-  "data-testid"?: string;
 }
 
 /**
@@ -369,7 +366,6 @@ const SourceTagInner = ({
   isMore,
   toggleSource,
   tooltipText,
-  "data-testid": dataTestId,
 }: SourceTagProps) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
@@ -446,7 +442,6 @@ const SourceTagInner = ({
   const buttonContent = (
     <button
       type="button"
-      data-testid={dataTestId}
       className={cn(
         "group inline-flex items-center transition-all duration-150",
         "appearance-none border-none",

--- a/web/tests/e2e/chat/chat_message_rendering.spec.ts
+++ b/web/tests/e2e/chat/chat_message_rendering.spec.ts
@@ -469,7 +469,6 @@ for (const theme of THEMES) {
         "AgentMessage/copy-button",
         "AgentMessage/like-button",
         "AgentMessage/dislike-button",
-        "AgentMessage/sources-tag",
       ] as const;
 
       async function screenshotToolbarButtonHoverStates(
@@ -486,6 +485,15 @@ for (const theme of THEMES) {
           const buttonSlug = buttonTestId.split("/")[1];
           await expectElementScreenshot(toolbar, {
             name: `${namePrefix}-toolbar-${buttonSlug}-hover-${theme}`,
+          });
+        }
+
+        // Sources tag is located by role+name since SourceTag has no testid.
+        const sourcesButton = toolbar.getByRole("button", { name: "Sources" });
+        if (await sourcesButton.isVisible()) {
+          await sourcesButton.hover();
+          await expectElementScreenshot(toolbar, {
+            name: `${namePrefix}-toolbar-sources-hover-${theme}`,
           });
         }
 


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3668/button-size-mismatch

## How Has This Been Tested?

Included visual regression tests

`chat-web-search-toolbar-llm-popover-hover-light.png` and `chat-web-search-toolbar-sources-hover-light.png` particularly notable

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set SourceTag to a fixed 2.25rem height with a matching min-width and increased padding for consistent alignment. Added a toolbar data-testid and hover-state screenshots for copy/like/dislike buttons, the Sources tag, and the LLMPopover trigger (when present) across web and internal search tests to catch UI regressions.

<sup>Written for commit 0462e0b84b48713833780138cf9a250339aebd47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

