### PR TITLE
chore(llm): Cleaning up Docstring

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -879,7 +879,8 @@ def run_llm_step_pkt_generator(
         tool_definitions: List of tool definitions available to the LLM.
         tool_choice: Tool choice configuration (e.g., "auto", "required", "none").
         llm: Language model interface to use for generation.
-        turn_index: Current turn index in the conversation.
+        placement: Placement info (turn_index, tab_index, sub_turn_index) for
+            positioning packets in the conversation UI.
         state_container: Container for storing chat state (reasoning, answers).
         citation_processor: Optional processor for extracting and formatting citations
             from the response. If provided, processes tokens to identify citations.
@@ -891,7 +892,14 @@ def run_llm_step_pkt_generator(
         custom_token_processor: Optional callable that processes each token delta
             before yielding. Receives (delta, processor_state) and returns
             (modified_delta, new_processor_state). Can return None for delta to skip.
-        sub_turn_index: Optional sub-turn index for nested tool/agent calls.
+        max_tokens: Optional maximum number of tokens for the LLM response.
+        use_existing_tab_index: If True, use the tab_index from placement for all
+            tool calls instead of auto-incrementing.
+        is_deep_research: If True, treat content before tool calls as reasoning
+            when tool_choice is REQUIRED.
+        pre_answer_processing_time: Optional time spent processing before the
+            answer started, recorded in state_container for analytics.
+        timeout_override: Optional timeout override for the LLM call.
 
     Yields:
         Packet: Streaming packets containing:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Updating the docstring for the `run_llm_step_pkt_generator` to be aligned with what's currently being passed in.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran tests but this is a docstring change so it should be simple

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the run_llm_step_pkt_generator docstring to match the current API and behavior. Replaces turn_index with placement and documents new options (max_tokens, use_existing_tab_index, is_deep_research, pre_answer_processing_time, timeout_override), with clearer notes on citation and token processing.

<sup>Written for commit ada40048c5420e73aaf482b3f99e46e0bceb2418. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

