### PR TITLE
chore(fe): update human message size

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -192,10 +192,10 @@ const HumanMessage = React.memo(function HumanMessage({
           />
         ) : typeof content === "string" ? (
           <>
-            <div className="lg:max-w-[37.5rem] flex basis-[100%] md:basis-auto justify-end md:order-1">
+            <div className="md:max-w-[37.5rem] flex basis-[100%] md:basis-auto justify-end md:order-1">
               <div
                 className={
-                  "max-w-[30rem] lg:max-w-[37.5rem] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
+                  "max-w-[30rem] md:max-w-[37.5rem] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
                 }
                 onCopy={(e) => {
                   const selection = window.getSelection();


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3693/chat-user-input-width

## How Has This Been Tested?

Partially captured by visual regression tests (we're missing responsiveness coverage)

<img width="987" height="2085" alt="20260218_13h05m46s_grim" src="https://github.com/user-attachments/assets/28ebbb50-d626-4daf-bf93-cdd0e2e39293" />

<img width="1647" height="2085" alt="20260218_12h58m26s_grim" src="https://github.com/user-attachments/assets/2e2c1378-3304-4bdf-99fe-a91cc0c9baca" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased human message bubble max width from 25rem to 30rem by default, and to 37.5rem on md+ screens, to match the chat input (Linear ENG-3693). Messages wrap less on desktop.

<sup>Written for commit 724ae1d48da06a0dd21ab2c308526dbe946a4f1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



