### PR TITLE
chore(llm): Using bool for has_reasoned

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -919,7 +919,7 @@ def run_llm_step_pkt_generator(
     sub_turn_index = placement.sub_turn_index
 
     llm_msg_history = translate_history_to_llm_format(history, llm.config)
-    has_reasoned = 0
+    has_reasoned = False
 
     if LOG_ONYX_MODEL_INTERACTIONS:
         logger.debug(
@@ -995,7 +995,7 @@ def run_llm_step_pkt_generator(
                     ),
                     obj=ReasoningDone(),
                 )
-                has_reasoned = 1
+                has_reasoned = True
                 turn_index, sub_turn_index = _increment_turns(
                     turn_index, sub_turn_index
                 )
@@ -1155,7 +1155,7 @@ def run_llm_step_pkt_generator(
                         ),
                         obj=ReasoningDone(),
                     )
-                    has_reasoned = 1
+                    has_reasoned = True
                     turn_index, sub_turn_index = _increment_turns(
                         turn_index, sub_turn_index
                     )
@@ -1233,7 +1233,7 @@ def run_llm_step_pkt_generator(
             ),
             obj=ReasoningDone(),
         )
-        has_reasoned = 1
+        has_reasoned = True
         turn_index, sub_turn_index = _increment_turns(turn_index, sub_turn_index)
         reasoning_start = False
 
@@ -1291,7 +1291,7 @@ def run_llm_step_pkt_generator(
             tool_calls=tool_calls if tool_calls else None,
             raw_answer=accumulated_raw_answer if accumulated_raw_answer else None,
         ),
-        bool(has_reasoned),
+        has_reasoned,
     )
 
 
@@ -1346,4 +1346,4 @@ def run_llm_step(
             emitter.emit(packet)
         except StopIteration as e:
             llm_step_result, has_reasoned = e.value
-            return llm_step_result, bool(has_reasoned)
+            return llm_step_result, has_reasoned

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from onyx.chat.llm_step import _extract_tool_call_kickoffs
+from onyx.chat.llm_step import _increment_turns
 from onyx.chat.llm_step import _parse_tool_args_to_dict
 from onyx.chat.llm_step import _sanitize_llm_output
 from onyx.chat.llm_step import _XmlToolCallContentFilter
@@ -363,3 +364,22 @@ class TestXmlToolCallContentFilter:
         assert (
             output == "A <function_calls_v2><invoke>noop</invoke></function_calls_v2> B"
         )
+
+
+class TestIncrementTurns:
+    """Tests for the _increment_turns helper."""
+
+    def test_increments_turn_index_when_no_sub_turn(self) -> None:
+        turn, sub = _increment_turns(0, None)
+        assert turn == 1
+        assert sub is None
+
+    def test_increments_sub_turn_when_present(self) -> None:
+        turn, sub = _increment_turns(3, 0)
+        assert turn == 3
+        assert sub == 1
+
+    def test_increments_sub_turn_from_nonzero(self) -> None:
+        turn, sub = _increment_turns(5, 2)
+        assert turn == 5
+        assert sub == 3


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Historically for whatever reason, we were using ints and then casting back to a bool which is odd. 

Just using Bool out of the box

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Adding tests

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a bool for has_reasoned in the LLM step to replace int flags and remove casts, simplifying reasoning state tracking.

- **Refactors**
  - Initialize has_reasoned as False and set to True on ReasoningDone events.
  - Remove bool() casts when returning from the generator and run_llm_step.
  - Add unit tests for _increment_turns covering turn and sub-turn increments.

<sup>Written for commit df1ca41996c86bc8f480f2ca8b5e117e970ae961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

