### PR TITLE
chore(llm): Extract _close_reasoning

### DIFF
--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -367,7 +367,7 @@ class TestXmlToolCallContentFilter:
 
 
 class TestIncrementTurns:
-    """Tests for the _increment_turns helper."""
+    """Tests for the _increment_turns helper used by _close_reasoning_if_active."""
 
     def test_increments_turn_index_when_no_sub_turn(self) -> None:
         turn, sub = _increment_turns(0, None)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Cleaning up the code to extract _close_reasoning out to simplify and unify the code

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added new tests

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a single _close_reasoning_if_active helper to consistently emit ReasoningDone and update turn indexes across content, tool-call, and stream-end paths. This removes duplicated logic and keeps reasoning closure behavior uniform.

- **Refactors**
  - Introduced _close_reasoning_if_active to emit ReasoningDone and increment turn/sub-turn; updated unit test docstring to reference its use with _increment_turns.
  - Replaced repeated close-reasoning blocks in normal content flow, tool_calls handling, and final reasoning flush with the helper.
  - Moved has_reasoned updates into the helper and removed local handling in _emit_content_chunk.

<sup>Written for commit 1ba59cd7f9ce35b0c09ebde84a5d229edb802214. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

