### PR TITLE
chore(llm): Extract citation flush helper

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -957,7 +957,7 @@ def run_llm_step_pkt_generator(
         first_action_recorded = False
 
         def _emit_citation_results(
-            results: Generator,
+            results: Generator[str | CitationInfo, None, None],
         ) -> Generator[Packet, None, None]:
             """Yield packets for citation processor results (str or CitationInfo)."""
             nonlocal accumulated_answer


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Extracting the citation helper given we do it twice. 

This is to help with testing

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Reran all existing tests

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a helper to emit citation packets to remove duplicated logic in token streaming and final flush. Follow-up commit fixes generator typing, with no behavior changes.

- **Refactors**
  - Added _emit_citation_results to handle str and CitationInfo, update state, and emit packets; corrected generator type annotations.
  - Replaced duplicated loops with yield from in content processing and final flush.

<sup>Written for commit 1b9de42506646b1807129048d076a59041a34f74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

