### PR TITLE
chore(auth): tests cleanup

### DIFF
--- a/backend/tests/integration/common_utils/managers/api_key.py
+++ b/backend/tests/integration/common_utils/managers/api_key.py
@@ -13,9 +13,9 @@ from tests.integration.common_utils.test_models import DATestUser
 class APIKeyManager:
     @staticmethod
     def create(
+        user_performing_action: DATestUser,
         name: str | None = None,
         api_key_role: UserRole = UserRole.ADMIN,
-        user_performing_action: DATestUser | None = None,
     ) -> DATestAPIKey:
         name = f"{name}-api-key" if name else f"test-api-key-{uuid4()}"
         api_key_request = APIKeyArgs(
@@ -25,11 +25,7 @@ class APIKeyManager:
         api_key_response = requests.post(
             f"{API_SERVER_URL}/admin/api-key",
             json=api_key_request.model_dump(),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         api_key_response.raise_for_status()
         api_key = api_key_response.json()
@@ -48,29 +44,21 @@ class APIKeyManager:
     @staticmethod
     def delete(
         api_key: DATestAPIKey,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> None:
         api_key_response = requests.delete(
             f"{API_SERVER_URL}/admin/api-key/{api_key.api_key_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         api_key_response.raise_for_status()
 
     @staticmethod
     def get_all(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[DATestAPIKey]:
         api_key_response = requests.get(
             f"{API_SERVER_URL}/admin/api-key",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         api_key_response.raise_for_status()
         return [DATestAPIKey(**api_key) for api_key in api_key_response.json()]
@@ -78,8 +66,8 @@ class APIKeyManager:
     @staticmethod
     def verify(
         api_key: DATestAPIKey,
+        user_performing_action: DATestUser,
         verify_deleted: bool = False,
-        user_performing_action: DATestUser | None = None,
     ) -> None:
         retrieved_keys = APIKeyManager.get_all(
             user_performing_action=user_performing_action

--- a/backend/tests/integration/common_utils/managers/connector.py
+++ b/backend/tests/integration/common_utils/managers/connector.py
@@ -8,7 +8,6 @@ from onyx.db.enums import AccessType
 from onyx.server.documents.models import ConnectorUpdateRequest
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestConnector
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -16,13 +15,13 @@ from tests.integration.common_utils.test_models import DATestUser
 class ConnectorManager:
     @staticmethod
     def create(
+        user_performing_action: DATestUser,
         name: str | None = None,
         source: DocumentSource = DocumentSource.FILE,
         input_type: InputType = InputType.LOAD_STATE,
         connector_specific_config: dict[str, Any] | None = None,
         access_type: AccessType = AccessType.PUBLIC,
         groups: list[int] | None = None,
-        user_performing_action: DATestUser | None = None,
         refresh_freq: int | None = None,
     ) -> DATestConnector:
         name = f"{name}-connector" if name else f"test-connector-{uuid4()}"
@@ -51,11 +50,7 @@ class ConnectorManager:
         response = requests.post(
             url=f"{API_SERVER_URL}/manage/admin/connector",
             json=connector_update_request.model_dump(),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
 
@@ -73,45 +68,33 @@ class ConnectorManager:
     @staticmethod
     def edit(
         connector: DATestConnector,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> None:
         response = requests.patch(
             url=f"{API_SERVER_URL}/manage/admin/connector/{connector.id}",
             json=connector.model_dump(exclude={"id"}),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
 
     @staticmethod
     def delete(
         connector: DATestConnector,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> None:
         response = requests.delete(
             url=f"{API_SERVER_URL}/manage/admin/connector/{connector.id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
 
     @staticmethod
     def get_all(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[DATestConnector]:
         response = requests.get(
             url=f"{API_SERVER_URL}/manage/connector",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [
@@ -127,15 +110,12 @@ class ConnectorManager:
 
     @staticmethod
     def get(
-        connector_id: int, user_performing_action: DATestUser | None = None
+        connector_id: int,
+        user_performing_action: DATestUser,
     ) -> DATestConnector:
         response = requests.get(
             url=f"{API_SERVER_URL}/manage/connector/{connector_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         conn = response.json()

--- a/backend/tests/integration/common_utils/managers/document_search.py
+++ b/backend/tests/integration/common_utils/managers/document_search.py
@@ -3,7 +3,6 @@ import requests
 from ee.onyx.server.query_and_chat.models import SearchFullResponse
 from ee.onyx.server.query_and_chat.models import SendSearchQueryRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -11,7 +10,7 @@ class DocumentSearchManager:
     @staticmethod
     def search_documents(
         query: str,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[str]:
         """
         Search for documents using the EE search API.
@@ -31,11 +30,7 @@ class DocumentSearchManager:
         result = requests.post(
             url=f"{API_SERVER_URL}/search/send-search-message",
             json=search_request.model_dump(),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         result.raise_for_status()
         result_json = result.json()

--- a/backend/tests/integration/common_utils/managers/document_set.py
+++ b/backend/tests/integration/common_utils/managers/document_set.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 import requests
 
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.constants import MAX_DELAY
 from tests.integration.common_utils.test_models import DATestDocumentSet
 from tests.integration.common_utils.test_models import DATestUser
@@ -15,6 +14,7 @@ from tests.integration.common_utils.test_models import DATestUser
 class DocumentSetManager:
     @staticmethod
     def create(
+        user_performing_action: DATestUser,
         name: str | None = None,
         description: str | None = None,
         cc_pair_ids: list[int] | None = None,
@@ -22,7 +22,6 @@ class DocumentSetManager:
         users: list[str] | None = None,
         groups: list[int] | None = None,
         federated_connectors: list[dict[str, Any]] | None = None,
-        user_performing_action: DATestUser | None = None,
     ) -> DATestDocumentSet:
         if name is None:
             name = f"test_doc_set_{str(uuid4())}"
@@ -40,11 +39,7 @@ class DocumentSetManager:
         response = requests.post(
             f"{API_SERVER_URL}/manage/admin/document-set",
             json=doc_set_creation_request,
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
 
@@ -63,7 +58,7 @@ class DocumentSetManager:
     @staticmethod
     def edit(
         document_set: DATestDocumentSet,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         doc_set_update_request = {
             "id": document_set.id,
@@ -77,11 +72,7 @@ class DocumentSetManager:
         response = requests.patch(
             f"{API_SERVER_URL}/manage/admin/document-set",
             json=doc_set_update_request,
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return True
@@ -89,30 +80,22 @@ class DocumentSetManager:
     @staticmethod
     def delete(
         document_set: DATestDocumentSet,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         response = requests.delete(
             f"{API_SERVER_URL}/manage/admin/document-set/{document_set.id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return True
 
     @staticmethod
     def get_all(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[DATestDocumentSet]:
         response = requests.get(
             f"{API_SERVER_URL}/manage/document-set",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [
@@ -132,8 +115,8 @@ class DocumentSetManager:
 
     @staticmethod
     def wait_for_sync(
+        user_performing_action: DATestUser,
         document_sets_to_check: list[DATestDocumentSet] | None = None,
-        user_performing_action: DATestUser | None = None,
     ) -> None:
         # wait for document sets to be synced
         start = time.time()
@@ -175,8 +158,8 @@ class DocumentSetManager:
     @staticmethod
     def verify(
         document_set: DATestDocumentSet,
+        user_performing_action: DATestUser,
         verify_deleted: bool = False,
-        user_performing_action: DATestUser | None = None,
     ) -> None:
         doc_sets = DocumentSetManager.get_all(user_performing_action)
         for doc_set in doc_sets:

--- a/backend/tests/integration/common_utils/managers/file.py
+++ b/backend/tests/integration/common_utils/managers/file.py
@@ -10,7 +10,6 @@ import requests
 from onyx.file_store.models import FileDescriptor
 from onyx.server.documents.models import FileUploadResponse
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -18,13 +17,9 @@ class FileManager:
     @staticmethod
     def upload_files(
         files: List[Tuple[str, IO]],
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> Tuple[List[FileDescriptor], str]:
-        headers = (
-            user_performing_action.headers
-            if user_performing_action
-            else GENERAL_HEADERS
-        )
+        headers = user_performing_action.headers
         headers.pop("Content-Type", None)
 
         files_param = []
@@ -67,15 +62,11 @@ class FileManager:
     @staticmethod
     def fetch_uploaded_file(
         file_id: str,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bytes:
         response = requests.get(
             f"{API_SERVER_URL}/chat/file/{file_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return response.content

--- a/backend/tests/integration/common_utils/managers/index_attempt.py
+++ b/backend/tests/integration/common_utils/managers/index_attempt.py
@@ -14,7 +14,6 @@ from onyx.db.search_settings import get_current_search_settings
 from onyx.server.documents.models import IndexAttemptSnapshot
 from onyx.server.documents.models import PaginatedReturn
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.constants import MAX_DELAY
 from tests.integration.common_utils.test_models import DATestIndexAttempt
 from tests.integration.common_utils.test_models import DATestUser
@@ -86,9 +85,9 @@ class IndexAttemptManager:
     @staticmethod
     def get_index_attempt_page(
         cc_pair_id: int,
+        user_performing_action: DATestUser,
         page: int = 0,
         page_size: int = 10,
-        user_performing_action: DATestUser | None = None,
     ) -> PaginatedReturn[IndexAttemptSnapshot]:
         query_params: dict[str, str | int] = {
             "page_num": page,
@@ -101,11 +100,7 @@ class IndexAttemptManager:
         )
         response = requests.get(
             url=url,
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         data = response.json()
@@ -117,7 +112,7 @@ class IndexAttemptManager:
     @staticmethod
     def get_latest_index_attempt_for_cc_pair(
         cc_pair_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> IndexAttemptSnapshot | None:
         """Get an IndexAttempt by ID"""
         index_attempts = IndexAttemptManager.get_index_attempt_page(
@@ -134,9 +129,9 @@ class IndexAttemptManager:
     @staticmethod
     def wait_for_index_attempt_start(
         cc_pair_id: int,
+        user_performing_action: DATestUser,
         index_attempts_to_ignore: list[int] | None = None,
         timeout: float = MAX_DELAY,
-        user_performing_action: DATestUser | None = None,
     ) -> IndexAttemptSnapshot:
         """Wait for an IndexAttempt to start"""
         start = datetime.now()
@@ -164,7 +159,7 @@ class IndexAttemptManager:
     def get_index_attempt_by_id(
         index_attempt_id: int,
         cc_pair_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> IndexAttemptSnapshot:
         page_num = 0
         page_size = 10
@@ -190,8 +185,8 @@ class IndexAttemptManager:
     def wait_for_index_attempt_completion(
         index_attempt_id: int,
         cc_pair_id: int,
+        user_performing_action: DATestUser,
         timeout: float = MAX_DELAY,
-        user_performing_action: DATestUser | None = None,
     ) -> None:
         """Wait for an IndexAttempt to complete"""
         start = time.monotonic()
@@ -223,19 +218,15 @@ class IndexAttemptManager:
     @staticmethod
     def get_index_attempt_errors_for_cc_pair(
         cc_pair_id: int,
+        user_performing_action: DATestUser,
         include_resolved: bool = True,
-        user_performing_action: DATestUser | None = None,
     ) -> list[IndexAttemptErrorPydantic]:
         url = f"{API_SERVER_URL}/manage/admin/cc-pair/{cc_pair_id}/errors?page_size=100"
         if include_resolved:
             url += "&include_resolved=true"
         response = requests.get(
             url=url,
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         data = response.json()

--- a/backend/tests/integration/common_utils/managers/persona.py
+++ b/backend/tests/integration/common_utils/managers/persona.py
@@ -7,7 +7,6 @@ from onyx.context.search.enums import RecencyBiasSetting
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import PersonaUpsertRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestPersona
 from tests.integration.common_utils.test_models import DATestPersonaLabel
 from tests.integration.common_utils.test_models import DATestUser
@@ -16,6 +15,7 @@ from tests.integration.common_utils.test_models import DATestUser
 class PersonaManager:
     @staticmethod
     def create(
+        user_performing_action: DATestUser,
         name: str | None = None,
         description: str | None = None,
         system_prompt: str | None = None,
@@ -34,7 +34,6 @@ class PersonaManager:
         groups: list[int] | None = None,
         label_ids: list[int] | None = None,
         user_file_ids: list[str] | None = None,
-        user_performing_action: DATestUser | None = None,
         display_priority: int | None = None,
     ) -> DATestPersona:
         name = name or f"test-persona-{uuid4()}"
@@ -67,11 +66,7 @@ class PersonaManager:
         response = requests.post(
             f"{API_SERVER_URL}/persona",
             json=persona_creation_request.model_dump(mode="json"),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         persona_data = response.json()
@@ -100,6 +95,7 @@ class PersonaManager:
     @staticmethod
     def edit(
         persona: DATestPersona,
+        user_performing_action: DATestUser,
         name: str | None = None,
         description: str | None = None,
         system_prompt: str | None = None,
@@ -117,7 +113,6 @@ class PersonaManager:
         users: list[str] | None = None,
         groups: list[int] | None = None,
         label_ids: list[int] | None = None,
-        user_performing_action: DATestUser | None = None,
     ) -> DATestPersona:
         system_prompt = system_prompt or f"System prompt for {persona.name}"
         task_prompt = task_prompt or f"Task prompt for {persona.name}"
@@ -151,11 +146,7 @@ class PersonaManager:
         response = requests.patch(
             f"{API_SERVER_URL}/persona/{persona.id}",
             json=persona_update_request.model_dump(mode="json"),
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         updated_persona_data = response.json()
@@ -187,15 +178,11 @@ class PersonaManager:
 
     @staticmethod
     def get_all(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[FullPersonaSnapshot]:
         response = requests.get(
             f"{API_SERVER_URL}/admin/persona",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [FullPersonaSnapshot(**persona) for persona in response.json()]
@@ -203,15 +190,11 @@ class PersonaManager:
     @staticmethod
     def get_one(
         persona_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[FullPersonaSnapshot]:
         response = requests.get(
             f"{API_SERVER_URL}/persona/{persona_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [FullPersonaSnapshot(**response.json())]
@@ -219,7 +202,7 @@ class PersonaManager:
     @staticmethod
     def verify(
         persona: DATestPersona,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         all_personas = PersonaManager.get_one(
             persona_id=persona.id,
@@ -388,15 +371,11 @@ class PersonaManager:
     @staticmethod
     def delete(
         persona: DATestPersona,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         response = requests.delete(
             f"{API_SERVER_URL}/persona/{persona.id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         return response.ok
 
@@ -405,18 +384,14 @@ class PersonaLabelManager:
     @staticmethod
     def create(
         label: DATestPersonaLabel,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> DATestPersonaLabel:
         response = requests.post(
             f"{API_SERVER_URL}/persona/labels",
             json={
                 "name": label.name,
             },
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         response_data = response.json()
@@ -425,15 +400,11 @@ class PersonaLabelManager:
 
     @staticmethod
     def get_all(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[DATestPersonaLabel]:
         response = requests.get(
             f"{API_SERVER_URL}/persona/labels",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [DATestPersonaLabel(**label) for label in response.json()]
@@ -441,18 +412,14 @@ class PersonaLabelManager:
     @staticmethod
     def update(
         label: DATestPersonaLabel,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> DATestPersonaLabel:
         response = requests.patch(
             f"{API_SERVER_URL}/admin/persona/label/{label.id}",
             json={
                 "label_name": label.name,
             },
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return label
@@ -460,22 +427,18 @@ class PersonaLabelManager:
     @staticmethod
     def delete(
         label: DATestPersonaLabel,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         response = requests.delete(
             f"{API_SERVER_URL}/admin/persona/label/{label.id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         return response.ok
 
     @staticmethod
     def verify(
         label: DATestPersonaLabel,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         all_labels = PersonaLabelManager.get_all(user_performing_action)
         for fetched_label in all_labels:

--- a/backend/tests/integration/common_utils/managers/project.py
+++ b/backend/tests/integration/common_utils/managers/project.py
@@ -6,7 +6,6 @@ from onyx.server.features.projects.models import CategorizedFilesSnapshot
 from onyx.server.features.projects.models import UserFileSnapshot
 from onyx.server.features.projects.models import UserProjectSnapshot
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -20,7 +19,7 @@ class ProjectManager:
         response = requests.post(
             f"{API_SERVER_URL}/user/projects/create",
             params={"name": name},
-            headers=user_performing_action.headers or GENERAL_HEADERS,
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return UserProjectSnapshot.model_validate(response.json())
@@ -32,7 +31,7 @@ class ProjectManager:
         """Get all projects for a user via API."""
         response = requests.get(
             f"{API_SERVER_URL}/user/projects",
-            headers=user_performing_action.headers or GENERAL_HEADERS,
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [UserProjectSnapshot.model_validate(obj) for obj in response.json()]
@@ -45,7 +44,7 @@ class ProjectManager:
         """Delete a project via API."""
         response = requests.delete(
             f"{API_SERVER_URL}/user/projects/{project_id}",
-            headers=user_performing_action.headers or GENERAL_HEADERS,
+            headers=user_performing_action.headers,
         )
         return response.status_code == 204
 
@@ -57,7 +56,7 @@ class ProjectManager:
         """Verify that a project has been deleted by ensuring it's not in list."""
         response = requests.get(
             f"{API_SERVER_URL}/user/projects",
-            headers=user_performing_action.headers or GENERAL_HEADERS,
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         projects = [UserProjectSnapshot.model_validate(obj) for obj in response.json()]
@@ -66,16 +65,12 @@ class ProjectManager:
     @staticmethod
     def verify_files_unlinked(
         project_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         """Verify that all files have been unlinked from the project via API."""
         response = requests.get(
             f"{API_SERVER_URL}/user/projects/files/{project_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         if response.status_code == 404:
             return True
@@ -87,16 +82,12 @@ class ProjectManager:
     @staticmethod
     def verify_chat_sessions_unlinked(
         project_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> bool:
         """Verify that all chat sessions have been unlinked from the project via API."""
         response = requests.get(
             f"{API_SERVER_URL}/user/projects/{project_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         if response.status_code == 404:
             return True
@@ -144,16 +135,12 @@ class ProjectManager:
     @staticmethod
     def get_project_files(
         project_id: int,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> List[UserFileSnapshot]:
         """Get all files associated with a project via API."""
         response = requests.get(
             f"{API_SERVER_URL}/user/projects/files/{project_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         if response.status_code == 404:
             return []
@@ -170,7 +157,7 @@ class ProjectManager:
         response = requests.post(
             f"{API_SERVER_URL}/user/projects/{project_id}/instructions",
             json={"instructions": instructions},
-            headers=user_performing_action.headers or GENERAL_HEADERS,
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return (response.json() or {}).get("instructions") or ""

--- a/backend/tests/integration/common_utils/managers/query_history.py
+++ b/backend/tests/integration/common_utils/managers/query_history.py
@@ -10,19 +10,18 @@ from ee.onyx.server.query_history.models import ChatSessionSnapshot
 from onyx.configs.constants import QAFeedbackType
 from onyx.server.documents.models import PaginatedReturn
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestUser
 
 
 class QueryHistoryManager:
     @staticmethod
     def get_query_history_page(
+        user_performing_action: DATestUser,
         page_num: int = 0,
         page_size: int = 10,
         feedback_type: QAFeedbackType | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
-        user_performing_action: DATestUser | None = None,
     ) -> PaginatedReturn[ChatSessionMinimal]:
         query_params: dict[str, str | int] = {
             "page_num": page_num,
@@ -37,11 +36,7 @@ class QueryHistoryManager:
 
         response = requests.get(
             url=f"{API_SERVER_URL}/admin/chat-session-history?{urlencode(query_params, doseq=True)}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         data = response.json()
@@ -53,24 +48,20 @@ class QueryHistoryManager:
     @staticmethod
     def get_chat_session_admin(
         chat_session_id: UUID | str,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> ChatSessionSnapshot:
         response = requests.get(
             url=f"{API_SERVER_URL}/admin/chat-session-history/{chat_session_id}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return ChatSessionSnapshot(**response.json())
 
     @staticmethod
     def get_query_history_as_csv(
+        user_performing_action: DATestUser,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
-        user_performing_action: DATestUser | None = None,
     ) -> tuple[CaseInsensitiveDict[str], str]:
         query_params: dict[str, str | int] = {}
         if start_time:
@@ -80,11 +71,7 @@ class QueryHistoryManager:
 
         response = requests.get(
             url=f"{API_SERVER_URL}/admin/query-history-csv?{urlencode(query_params, doseq=True)}",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return response.headers, response.content.decode()

--- a/backend/tests/integration/common_utils/managers/settings.py
+++ b/backend/tests/integration/common_utils/managers/settings.py
@@ -5,7 +5,6 @@ from typing import Optional
 import requests
 
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -13,13 +12,9 @@ from tests.integration.common_utils.test_models import DATestUser
 class SettingsManager:
     @staticmethod
     def get_settings(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> tuple[Dict[str, Any], str]:
-        headers = (
-            user_performing_action.headers
-            if user_performing_action
-            else GENERAL_HEADERS
-        )
+        headers = user_performing_action.headers
         headers.pop("Content-Type", None)
 
         response = requests.get(
@@ -38,13 +33,9 @@ class SettingsManager:
     @staticmethod
     def update_settings(
         settings: DATestSettings,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> tuple[Dict[str, Any], str]:
-        headers = (
-            user_performing_action.headers
-            if user_performing_action
-            else GENERAL_HEADERS
-        )
+        headers = user_performing_action.headers
         headers.pop("Content-Type", None)
 
         payload = settings.model_dump()
@@ -65,7 +56,7 @@ class SettingsManager:
     @staticmethod
     def get_setting(
         key: str,
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> Optional[Any]:
         settings, error = SettingsManager.get_settings(user_performing_action)
         if error:

--- a/backend/tests/integration/common_utils/managers/tenant.py
+++ b/backend/tests/integration/common_utils/managers/tenant.py
@@ -8,7 +8,6 @@ from onyx.server.manage.models import AllUsersResponse
 from onyx.server.models import FullUserSnapshot
 from onyx.server.models import InvitedUserSnapshot
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -26,15 +25,11 @@ def generate_auth_token() -> str:
 class TenantManager:
     @staticmethod
     def get_all_users(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> AllUsersResponse:
         response = requests.get(
             url=f"{API_SERVER_URL}/manage/users",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
 
@@ -50,7 +45,8 @@ class TenantManager:
 
     @staticmethod
     def verify_user_in_tenant(
-        user: DATestUser, user_performing_action: DATestUser | None = None
+        user: DATestUser,
+        user_performing_action: DATestUser,
     ) -> None:
         all_users = TenantManager.get_all_users(user_performing_action)
         for accepted_user in all_users.accepted:

--- a/backend/tests/integration/common_utils/managers/tool.py
+++ b/backend/tests/integration/common_utils/managers/tool.py
@@ -1,7 +1,6 @@
 import requests
 
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.test_models import DATestTool
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -9,15 +8,11 @@ from tests.integration.common_utils.test_models import DATestUser
 class ToolManager:
     @staticmethod
     def list_tools(
-        user_performing_action: DATestUser | None = None,
+        user_performing_action: DATestUser,
     ) -> list[DATestTool]:
         response = requests.get(
             url=f"{API_SERVER_URL}/tool",
-            headers=(
-                user_performing_action.headers
-                if user_performing_action
-                else GENERAL_HEADERS
-            ),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return [

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -88,11 +88,8 @@ def reset() -> None:
 
 
 @pytest.fixture
-def new_admin_user(reset: None) -> DATestUser | None:  # noqa: ARG001
-    try:
-        return UserManager.create(name=ADMIN_USER_NAME)
-    except Exception:
-        return None
+def new_admin_user(reset: None) -> DATestUser:  # noqa: ARG001
+    return UserManager.create(name=ADMIN_USER_NAME)
 
 
 @pytest.fixture
@@ -182,18 +179,18 @@ def reset_multitenant() -> None:
 
 
 @pytest.fixture
-def llm_provider(admin_user: DATestUser | None) -> DATestLLMProvider:
+def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
     return LLMProviderManager.create(user_performing_action=admin_user)
 
 
 @pytest.fixture
 def image_generation_config(
-    admin_user: DATestUser | None,
+    admin_user: DATestUser,
 ) -> DATestImageGenerationConfig:
     """Create a default image generation config for tests."""
     return ImageGenerationConfigManager.create(
-        is_default=True,
         user_performing_action=admin_user,
+        is_default=True,
     )
 
 

--- a/backend/tests/integration/tests/index_attempt/test_index_attempt_pagination.py
+++ b/backend/tests/integration/tests/index_attempt/test_index_attempt_pagination.py
@@ -11,8 +11,8 @@ from tests.integration.common_utils.test_models import DATestUser
 def _verify_index_attempt_pagination(
     cc_pair_id: int,
     index_attempt_ids: list[int],
+    user_performing_action: DATestUser,
     page_size: int = 5,
-    user_performing_action: DATestUser | None = None,
 ) -> None:
     retrieved_attempts: list[int] = []
     last_time_started = None  # Track the last time_started seen

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -207,7 +207,9 @@ def test_mcp_search_respects_acl_filters(
         cc_pair_ids=[restricted_cc_pair.id],
         user_performing_action=admin_user,
     )
-    UserGroupManager.wait_for_sync([user_group], user_performing_action=admin_user)
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user, user_groups_to_check=[user_group]
+    )
 
     restricted_doc_content = "MCP restricted knowledge base document"
     _seed_document_and_wait_for_indexing(

--- a/backend/tests/integration/tests/query_history/test_query_history_pagination.py
+++ b/backend/tests/integration/tests/query_history/test_query_history_pagination.py
@@ -14,11 +14,11 @@ from tests.integration.tests.query_history.utils import (
 
 def _verify_query_history_pagination(
     chat_sessions: list[DAQueryHistoryEntry],
+    user_performing_action: DATestUser,
     page_size: int = 5,
     feedback_type: QAFeedbackType | None = None,
     start_time: datetime | None = None,
     end_time: datetime | None = None,
-    user_performing_action: DATestUser | None = None,
 ) -> None:
     retrieved_sessions: list[str] = []
 

--- a/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
+++ b/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
@@ -59,7 +58,7 @@ def test_add_users_to_group_invalid_user(reset: None) -> None:  # noqa: ARG001
     response = requests.post(
         f"{API_SERVER_URL}/manage/admin/user-group/{user_group.id}/add-users",
         json={"user_ids": [invalid_user_id]},
-        headers=admin_user.headers if admin_user else GENERAL_HEADERS,
+        headers=admin_user.headers,
     )
 
     assert response.status_code == 404

--- a/backend/tests/integration/tests/users/test_user_pagination.py
+++ b/backend/tests/integration/tests/users/test_user_pagination.py
@@ -9,11 +9,11 @@ from tests.integration.common_utils.test_models import DATestUser
 # to verify that the pagination and filtering works as expected.
 def _verify_user_pagination(
     users: list[DATestUser],
+    user_performing_action: DATestUser,
     page_size: int = 5,
     search_query: str | None = None,
     role_filter: list[UserRole] | None = None,
     is_active_filter: bool | None = None,
-    user_performing_action: DATestUser | None = None,
 ) -> None:
     retrieved_users: list[FullUserSnapshot] = []
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized auth handling in integration tests by requiring an explicit user on all manager calls and removing GENERAL_HEADERS fallbacks. Added anonymous user coverage to verify access when the setting is enabled/disabled.

- **Refactors**
  - Made user_performing_action a required argument across test managers (API keys, connectors, credentials, CC pairs, chat, document sets, files, image generation, index attempts, LLM providers, personas, projects, query history, settings, tenant, tools, user groups).
  - Removed implicit GENERAL_HEADERS usage; all requests now use the provided user’s headers or API key.
  - Tightened helper signatures (e.g., DocumentManager requires api_key and doc_creating_user; ingestion helpers require api_key).
  - Improved permission verification for documents (always checks creator ACL).
  - Updated fixtures to always return a DATestUser (e.g., new_admin_user).

- **New Features**
  - Added UserManager.get_anonymous_user helper.
  - Added tests confirming anonymous user access to personas when enabled and denial when disabled.

<sup>Written for commit 7f6379281cfddf418cf8a584807c13f562ceaa7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

