### PR TITLE
chore(auth): deployment cleanup

### DIFF
--- a/contributing_guides/dev_setup.md
+++ b/contributing_guides/dev_setup.md
@@ -158,14 +158,14 @@ python ./scripts/dev_run_background_jobs.py
 To run the backend API server, navigate back to `onyx/backend` and run:
 
 ```bash
-AUTH_TYPE=disabled uvicorn onyx.main:app --reload --port 8080
+AUTH_TYPE=basic uvicorn onyx.main:app --reload --port 8080
 ```
 
 _For Windows (for compatibility with both PowerShell and Command Prompt):_
 
 ```bash
 powershell -Command "
-    $env:AUTH_TYPE='disabled'
+    $env:AUTH_TYPE='basic'
     uvicorn onyx.main:app --reload --port 8080
 "
 ```

--- a/deployment/aws_ecs_fargate/cloudformation/onyx_cluster_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/onyx_cluster_template.yaml
@@ -126,7 +126,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/postgres/user/password-*
+                Resource:
+                  - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/postgres/user/password-*
+                  - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/onyx/user-auth-secret-*
 
 Outputs:
   OutputEcsCluster:

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_api_server_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_api_server_service_template.yaml
@@ -167,10 +167,12 @@ Resources:
                 - ImportedNamespace: !ImportValue
                     Fn::Sub: "${Environment}-onyx-cluster-OnyxNamespaceName"
             - Name: AUTH_TYPE
-              Value: disabled
+              Value: basic
           Secrets:
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/postgres/user/password
+            - Name: USER_AUTH_SECRET
+              ValueFrom: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/onyx/user-auth-secret
           VolumesFrom: []
           SystemControls: []
 

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_background_server_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_background_server_service_template.yaml
@@ -166,9 +166,11 @@ Resources:
                 - ImportedNamespace: !ImportValue
                     Fn::Sub: "${Environment}-onyx-cluster-OnyxNamespaceName"
             - Name: AUTH_TYPE
-              Value: disabled
+              Value: basic
           Secrets:
             - Name: POSTGRES_PASSWORD
               ValueFrom: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/postgres/user/password
+            - Name: USER_AUTH_SECRET
+              ValueFrom: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Environment}/onyx/user-auth-secret
           VolumesFrom: []
           SystemControls: []

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -21,7 +21,7 @@ services:
     env_file:
       - .env_eval
     environment:
-      - AUTH_TYPE=disabled
+      - AUTH_TYPE=basic
       - POSTGRES_HOST=relational_db
       - VESPA_HOST=index
       - REDIS_HOST=cache
@@ -59,7 +59,7 @@ services:
       - .env_eval
     environment:
       - USE_LIGHTWEIGHT_BACKGROUND_WORKER=${USE_LIGHTWEIGHT_BACKGROUND_WORKER:-true}
-      - AUTH_TYPE=disabled
+      - AUTH_TYPE=basic
       - POSTGRES_HOST=relational_db
       - VESPA_HOST=index
       - REDIS_HOST=cache

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -20,8 +20,11 @@ IMAGE_TAG=latest
 
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
-AUTH_TYPE=disabled
+AUTH_TYPE=basic
 # SESSION_EXPIRE_TIME_SECONDS=
+### Required for basic auth - used for signing password reset and verification tokens
+### Generate a secure value with: openssl rand -hex 32
+USER_AUTH_SECRET=OnyxDevSecret1!
 ### Recommend to set this for security
 # ENCRYPTION_KEY_SECRET=
 ### Optional

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -654,16 +654,9 @@ else
     sed -i.bak "s/^IMAGE_TAG=.*/IMAGE_TAG=$VERSION/" "$ENV_FILE"
     print_success "IMAGE_TAG set to $VERSION"
 
-    # Configure authentication settings based on selection
-    if [ "$AUTH_SCHEMA" = "disabled" ]; then
-        # Disable authentication in .env file
-        sed -i.bak 's/^AUTH_TYPE=.*/AUTH_TYPE=disabled/' "$ENV_FILE" 2>/dev/null || true
-        print_success "Authentication disabled in configuration"
-    else
-        # Enable basic authentication
-        sed -i.bak 's/^AUTH_TYPE=.*/AUTH_TYPE=basic/' "$ENV_FILE" 2>/dev/null || true
-        print_success "Basic authentication enabled in configuration"
-    fi
+    # Configure basic authentication (default)
+    sed -i.bak 's/^AUTH_TYPE=.*/AUTH_TYPE=basic/' "$ENV_FILE" 2>/dev/null || true
+    print_success "Basic authentication enabled in configuration"
 
     # Configure Craft based on flag or if using a craft-* image tag
     # By default, env.template has Craft commented out (disabled)

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -522,7 +522,6 @@ celery_shared:
 
 celery_beat:
   replicaCount: 1
-  logLevel: INFO
   podAnnotations: {}
   podLabels:
     scope: onyx-backend-celery
@@ -543,7 +542,6 @@ celery_beat:
 
 celery_worker_heavy:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -577,7 +575,6 @@ celery_worker_heavy:
 
 celery_worker_docprocessing:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -611,7 +608,6 @@ celery_worker_docprocessing:
 
 celery_worker_light:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -645,7 +641,6 @@ celery_worker_light:
 
 celery_worker_monitoring:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -679,7 +674,6 @@ celery_worker_monitoring:
 
 celery_worker_primary:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -713,7 +707,6 @@ celery_worker_primary:
 
 celery_worker_user_file_processing:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -858,7 +851,6 @@ mcpServer:
 
 celery_worker_docfetching:
   replicaCount: 1
-  logLevel: INFO
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -1175,10 +1167,25 @@ auth:
     values:
       opensearch_admin_username: "admin"
       opensearch_admin_password: "OnyxDev1!"
+  userauth:
+    # -- Required when AUTH_TYPE is "basic". Used for signing password reset
+    # tokens, email verification tokens, and JWT tokens.
+    enabled: true
+    # -- Overwrite the default secret name, ignored if existingSecret is defined
+    secretName: 'onyx-userauth'
+    # -- Use a secret specified elsewhere
+    existingSecret: ""
+    # -- This defines the env var to secret map
+    secretKeys:
+      USER_AUTH_SECRET: user_auth_secret
+    # -- Secret value. CHANGE THIS FOR PRODUCTION.
+    # Generate a secure value with: openssl rand -hex 32
+    values:
+      user_auth_secret: "OnyxDevSecret1!"
 
 configMap:
   # Change this for production uses unless Onyx is only accessible behind VPN
-  AUTH_TYPE: "disabled"
+  AUTH_TYPE: "basic"
   # 1 Day Default
   SESSION_EXPIRE_TIME_SECONDS: "86400"
   # Can be something like onyx.app, as an extra double-check


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted all deployments to basic auth and added secret management for USER_AUTH_SECRET across Docker Compose, Helm, and AWS ECS. This secures login, password reset, and email verification flows and removes the “disabled” auth mode from deployment configs.

- **Migration**
  - Set AUTH_TYPE=basic in all environments.
  - Provide USER_AUTH_SECRET:
    - Docker Compose: add to .env (generate with: openssl rand -hex 32).
    - Helm: set auth.userauth.values.user_auth_secret or reference an existing secret.
    - AWS ECS: create Secrets Manager entry at ${Environment}/onyx/user-auth-secret and grant access (policy updated).
  - Re-run deployment scripts; install.sh now enables basic auth by default.

<sup>Written for commit 4a04ce4de57e4b3ddf5322b8b36899f7c3ecfdbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

