### PR TITLE
chore(fe): whitelabeling header nits

### DIFF
--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -112,6 +112,10 @@ function Header() {
 
   const customHeaderContent =
     settings?.enterpriseSettings?.custom_header_content;
+  // Some pages don't want the custom header content, namely every page except Chat, Search, and
+  // NewSession. The header provides features such as the open sidebar button on mobile which pages
+  // without this content still use.
+  const pageWithHeaderContent = appFocus.isChat() || appFocus.isNewSession();
 
   const effectiveMode: AppMode = appFocus.isNewSession() ? appMode : "chat";
 
@@ -358,7 +362,7 @@ function Header() {
         */}
         <div className="flex-1 flex flex-col items-center overflow-hidden">
           <Text text03 className="text-center w-full">
-            {customHeaderContent}
+            {pageWithHeaderContent && customHeaderContent}
           </Text>
         </div>
 

--- a/web/src/layouts/settings-layouts.tsx
+++ b/web/src/layouts/settings-layouts.tsx
@@ -216,7 +216,7 @@ function SettingsHeader({
       ref={headerRef}
       className={cn(
         "sticky top-0 z-settings-header w-full bg-background-tint-01",
-        backButton ? "pt-4" : "pt-10"
+        backButton ? "md:pt-4" : "md:pt-10"
       )}
     >
       {backButton && (


### PR DESCRIPTION
## Description

Removes the custom header content from Agents and User Settings pages and fixes associated responsive whitespace.

The Header provides the open sidebar button on mobile which is why we disable the header **content** specifically rather than the entire header (i.e. like `isSharedChat` is doing elsewhere in this file).

Also confirmed offline with Duo this intentionally includes the `/project` page despite it having a ChatInputBar with the idea they'll be navigated to the chat page after starting a session and that's sufficient.

Resolves 1/2 from https://linear.app/onyx-app/issue/ENG-3609/whitelabeling-headerfooter-issues

## How Has This Been Tested?

**before**

<img width="1587" height="2085" alt="20260218_14h55m22s_grim" src="https://github.com/user-attachments/assets/4d53040d-5b64-4d3d-93f1-79b6ca5289a4" />

**after**

<img width="1587" height="2085" alt="20260218_14h52m39s_grim" src="https://github.com/user-attachments/assets/c4651060-e155-4960-9857-6bdecc315ed3" />

**before**

<img width="1587" height="2085" alt="20260218_14h55m14s_grim" src="https://github.com/user-attachments/assets/9378be7e-0a5e-4ae7-9da6-bc4706bb1ab9" />

**after**

<img width="1587" height="2085" alt="20260218_14h52m52s_grim" src="https://github.com/user-attachments/assets/c3898275-1a7a-43e8-84f8-4b4bf2f055fc" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits whitelabel custom header content to Chat and Welcome pages and fixes mobile spacing in Settings. The header stays mounted so the mobile sidebar button still works. Partially addresses Linear ENG-3609.

- **Bug Fixes**
  - Only render custom header content on Chat and New Session pages.
  - Always mount Header; move visibility check into content to preserve the mobile sidebar toggle.
  - Make SettingsHeader padding md-only (md:pt-4/md:pt-10) to remove extra whitespace on small screens.

<sup>Written for commit 8e0f1bbadedaa954b3c027be899236f1e370d108. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



