### PR TITLE
chore(fe): Button handles empty string as text, use in header

### DIFF
--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -377,7 +377,7 @@ function Header() {
                 onClick={() => setShowShareModal(true)}
                 aria-label="share-chat-button"
               >
-                Share Chat
+                {isMobile ? "" : "Share Chat"}
               </Button>
               <SimplePopover
                 trigger={

--- a/web/src/refresh-components/buttons/Button.tsx
+++ b/web/src/refresh-components/buttons/Button.tsx
@@ -131,18 +131,24 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <LeftIcon className={cn("w-[1rem] h-[1rem]", iconClass)} />
           </div>
         )}
-        <div className={cn("leading-none", sizeClasses.content[iconPlacement])}>
-          {typeof children === "string" ? (
-            <Text
-              {...textSizeProps}
-              className={cn("whitespace-nowrap", textClass)}
-            >
-              {children}
-            </Text>
-          ) : (
-            children
-          )}
-        </div>
+        {/* Buttons may conditionally pass text as children (e.g. responsive
+            breakpoints), so skip content padding when children is empty. */}
+        {children !== "" && (
+          <div
+            className={cn("leading-none", sizeClasses.content[iconPlacement])}
+          >
+            {typeof children === "string" ? (
+              <Text
+                {...textSizeProps}
+                className={cn("whitespace-nowrap", textClass)}
+              >
+                {children}
+              </Text>
+            ) : (
+              children
+            )}
+          </div>
+        )}
         {RightIcon && (
           <div className="w-[1rem] h-[1rem]">
             <RightIcon className={cn("w-[1rem] h-[1rem]", iconClass)} />


### PR DESCRIPTION
## Description

I think this is the most elegant way to handle this button in responive regimes where there is not room for text.

Related to https://linear.app/onyx-app/issue/ENG-3609/whitelabeling-headerfooter-issues

## How Has This Been Tested?

**before**
<img width="1647" height="2085" alt="20260218_15h50m24s_grim" src="https://github.com/user-attachments/assets/00c1b066-e02b-4b38-92fd-7fd11a2f2f4b" />

**after**
<img width="1647" height="2085" alt="20260218_15h50m12s_grim" src="https://github.com/user-attachments/assets/0b451667-e8fc-44b7-a950-9dc315839548" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Button now treats an empty string child as no content and skips content padding. Used in the header to hide the "Share Chat" label on mobile, improving responsive spacing and aligning with ENG-3609 (whitelabeling header/footer issues).

<sup>Written for commit 0f6ccf75ce845485b3744a821193636c6126927c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

