### PR TITLE
fix: define fallback only on custom metrics

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.29
+version: 0.4.30
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.api.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.api.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.api.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.api.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.api.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.api.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_docfetching.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_docfetching.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_docfetching.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_docfetching.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_docfetching.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_docprocessing.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_docprocessing.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_docprocessing.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_docprocessing.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_docprocessing.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_heavy.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_heavy.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_heavy.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_heavy.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_heavy.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_light.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_light.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_light.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_light.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_light.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_light.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_monitoring.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_monitoring.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_monitoring.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_monitoring.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_monitoring.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_primary.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_primary.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_primary.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_primary.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_primary.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_primary.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.celery_worker_user_file_processing.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.celery_worker_user_file_processing.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.celery_worker_user_file_processing.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.celery_worker_user_file_processing.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.celery_worker_user_file_processing.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
@@ -17,9 +17,11 @@ spec:
   {{- if hasKey .Values.webserver.autoscaling "idleReplicaCount" }}
   idleReplicaCount: {{ .Values.webserver.autoscaling.idleReplicaCount }}
   {{- end }}
+  {{- if .Values.webserver.autoscaling.customTriggers }}
   fallback:
     failureThreshold: {{ .Values.webserver.autoscaling.failureThreshold | default 3 }}
     replicas: {{ .Values.webserver.autoscaling.fallbackReplicas | default 1 }}
+  {{- end }}
   triggers:
     {{- if .Values.webserver.autoscaling.targetCPUUtilizationPercentage }}
     - type: cpu

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -185,6 +185,7 @@ inferenceCapability:
   #     maxSurge: 0
   #     maxUnavailable: 1
 
+
 indexCapability:
   service:
     portName: modelserver


### PR DESCRIPTION
## Description

Fallback behavior is only needed when an external metric provider is defined in an additional custom metric. In our cluster, we even have an admission webhook denying creation of scaledObjects where fallback is defined for scaled objects only using cpu / memory triggers.

## How Has This Been Tested?

Confirmed via local render

## Additional Options

- [ ] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit KEDA fallback replicas to only apply when custom metric triggers are configured. Prevents unexpected fallback scaling on CPU-based autoscaling.

- **Bug Fixes**
  - Gate fallback under .autoscaling.customTriggers across all ScaledObject templates (api, webserver, all celery workers).
  - Bump chart version to 0.4.30.

<sup>Written for commit 1eeaefa21e3dc0a5fae34ed70072ee1710cc78d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

