### PR TITLE
fix: model config not populating flow during sync (#8542) to release v2.12

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -722,13 +722,15 @@ def sync_auto_mode_models(
                 changes += 1
         else:
             # Add new model - all models from GitHub config are visible
-            new_model = ModelConfiguration(
+            insert_new_model_configuration__no_commit(
+                db_session=db_session,
                 llm_provider_id=provider.id,
-                name=model_config.name,
-                display_name=model_config.display_name,
+                model_name=model_config.name,
+                supported_flows=[LLMModelFlowType.CHAT],
                 is_visible=True,
+                max_input_tokens=None,
+                display_name=model_config.display_name,
             )
-            db_session.add(new_model)
             changes += 1
 
     # In Auto mode, default model is always set from GitHub config

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -14,9 +14,12 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_existing_llm_provider
+from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import sync_auto_mode_models
 from onyx.db.llm import update_default_provider
 from onyx.db.models import UserRole
 from onyx.llm.constants import LlmProviderNames
@@ -606,3 +609,95 @@ class TestAutoModeSyncFeature:
             db_session.rollback()
             _cleanup_provider(db_session, provider_1_name)
             _cleanup_provider(db_session, provider_2_name)
+
+
+class TestAutoModeMissingFlows:
+    """Regression test: sync_auto_mode_models must create LLMModelFlow rows
+    for every ModelConfiguration it inserts, otherwise the provider vanishes
+    from listing queries that join through LLMModelFlow."""
+
+    def test_sync_auto_mode_creates_flow_rows(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """
+        Steps:
+        1. Create a provider with no model configs (empty shell).
+        2. Call sync_auto_mode_models to add models from a mock config.
+        3. Assert every new ModelConfiguration has at least one LLMModelFlow.
+        4. Assert fetch_existing_llm_providers (which joins through
+           LLMModelFlow) returns the provider.
+        """
+        mock_recommendations = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+
+        try:
+            # Step 1: Create provider with no model configs
+            put_llm_provider(
+                llm_provider_upsert_request=LLMProviderUpsertRequest(
+                    name=provider_name,
+                    provider=LlmProviderNames.OPENAI,
+                    api_key="sk-test-key-00000000000000000000000000000000000",
+                    api_key_changed=True,
+                    is_auto_mode=True,
+                    default_model_name="gpt-4o",
+                    model_configurations=[],
+                ),
+                is_creation=True,
+                _=_create_mock_admin(),
+                db_session=db_session,
+            )
+
+            # Step 2: Run sync_auto_mode_models (simulating the periodic sync)
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=mock_recommendations,
+            )
+
+            # Step 3: Every ModelConfiguration must have at least one LLMModelFlow
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+
+            synced_model_names = {mc.name for mc in provider.model_configurations}
+            assert "gpt-4o" in synced_model_names
+            assert "gpt-4o-mini" in synced_model_names
+
+            for mc in provider.model_configurations:
+                assert len(mc.llm_model_flows) > 0, (
+                    f"ModelConfiguration '{mc.name}' (id={mc.id}) has no "
+                    f"LLMModelFlow rows — it will be invisible to listing queries"
+                )
+
+                flow_types = {f.llm_model_flow_type for f in mc.llm_model_flows}
+                assert (
+                    LLMModelFlowType.CHAT in flow_types
+                ), f"ModelConfiguration '{mc.name}' is missing a CHAT flow"
+
+            # Step 4: The provider must appear in fetch_existing_llm_providers
+            listed_providers = fetch_existing_llm_providers(
+                db_session=db_session,
+                flow_types=[LLMModelFlowType.CHAT],
+            )
+            listed_provider_names = {p.name for p in listed_providers}
+            assert provider_name in listed_provider_names, (
+                f"Provider '{provider_name}' not returned by "
+                f"fetch_existing_llm_providers — models are missing flow rows"
+            )
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)


### PR DESCRIPTION
Cherry-pick of commit 53f9f042a1770d1707d50a3b6aed75e5939299ed to release/v2.12 branch.

Original PR: #8542

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Auto mode sync so newly added models create their flow rows (CHAT) and show up in provider listings. Prevents providers from disappearing after sync due to missing LLMModelFlow entries.

- **Bug Fixes**
  - Use insert_new_model_configuration__no_commit with supported_flows=[CHAT] when adding models in sync_auto_mode_models to ensure LLMModelFlow rows are created.
  - Add regression test verifying each inserted model has a CHAT flow and that fetch_existing_llm_providers returns the provider when filtering by CHAT.

<sup>Written for commit 6788371027b602a4a8536ea98e5fdb2b9b0a4910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

