### PR TITLE
fix(slack): Cleaning up URL Links

### DIFF
--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -1,14 +1,68 @@
+import re
 from typing import Any
 
 from mistune import create_markdown
 from mistune import HTMLRenderer
+
+_CITATION_LINK_PATTERN = re.compile(r"\[\[\d+\]\]\(")
+
+
+def _extract_link_destination(message: str, start_idx: int) -> tuple[str, int | None]:
+    """Extract markdown link destination, allowing nested parentheses in the URL."""
+    depth = 0
+    i = start_idx
+
+    while i < len(message):
+        curr = message[i]
+        if curr == "\\":
+            i += 2
+            continue
+
+        if curr == "(":
+            depth += 1
+        elif curr == ")":
+            if depth == 0:
+                return message[start_idx:i], i
+            depth -= 1
+        i += 1
+
+    return message[start_idx:], None
+
+
+def _normalize_citation_link_destinations(message: str) -> str:
+    """Wrap citation URLs in angle brackets so markdown parsers handle parentheses safely."""
+    if "[[" not in message:
+        return message
+
+    normalized_parts: list[str] = []
+    cursor = 0
+
+    while match := _CITATION_LINK_PATTERN.search(message, cursor):
+        normalized_parts.append(message[cursor : match.end()])
+        destination_start = match.end()
+        destination, end_idx = _extract_link_destination(message, destination_start)
+        if end_idx is None:
+            normalized_parts.append(message[destination_start:])
+            return "".join(normalized_parts)
+
+        already_wrapped = destination.startswith("<") and destination.endswith(">")
+        if destination and not already_wrapped:
+            destination = f"<{destination}>"
+
+        normalized_parts.append(destination)
+        normalized_parts.append(")")
+        cursor = end_idx + 1
+
+    normalized_parts.append(message[cursor:])
+    return "".join(normalized_parts)
 
 
 def format_slack_message(message: str | None) -> str:
     if message is None:
         return ""
     md = create_markdown(renderer=SlackRenderer(), plugins=["strikethrough"])
-    result = md(message)
+    normalized_message = _normalize_citation_link_destinations(message)
+    result = md(normalized_message)
     # With HTMLRenderer, result is always str (not AST list)
     assert isinstance(result, str)
     return result

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -1,0 +1,52 @@
+from onyx.onyxbot.slack.formatting import _normalize_citation_link_destinations
+from onyx.onyxbot.slack.formatting import format_slack_message
+from onyx.onyxbot.slack.utils import remove_slack_text_interactions
+from onyx.utils.text_processing import decode_escapes
+
+
+def test_normalize_citation_link_wraps_url_with_parentheses() -> None:
+    message = (
+        "See [[1]](https://example.com/Access%20ID%20Card(s)%20Guide.pdf) for details."
+    )
+
+    normalized = _normalize_citation_link_destinations(message)
+
+    assert (
+        "See [[1]](<https://example.com/Access%20ID%20Card(s)%20Guide.pdf>) for details."
+        == normalized
+    )
+
+
+def test_normalize_citation_link_keeps_existing_angle_brackets() -> None:
+    message = "[[1]](<https://example.com/Access%20ID%20Card(s)%20Guide.pdf>)"
+
+    normalized = _normalize_citation_link_destinations(message)
+
+    assert message == normalized
+
+
+def test_normalize_citation_link_handles_multiple_links() -> None:
+    message = (
+        "[[1]](https://example.com/(USA)%20Guide.pdf) "
+        "[[2]](https://example.com/Plan(s)%20Overview.pdf)"
+    )
+
+    normalized = _normalize_citation_link_destinations(message)
+
+    assert "[[1]](<https://example.com/(USA)%20Guide.pdf>)" in normalized
+    assert "[[2]](<https://example.com/Plan(s)%20Overview.pdf>)" in normalized
+
+
+def test_format_slack_message_keeps_parenthesized_citation_links_intact() -> None:
+    message = (
+        "Download [[1]](https://example.com/(USA)%20Access%20ID%20Card(s)%20Guide.pdf)"
+    )
+
+    formatted = format_slack_message(message)
+    rendered = decode_escapes(remove_slack_text_interactions(formatted))
+
+    assert (
+        "<https://example.com/(USA)%20Access%20ID%20Card(s)%20Guide.pdf|[1]>"
+        in rendered
+    )
+    assert "|[1]>%20Access%20ID%20Card" not in rendered


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing slack bot responses when citing sources with escaped characters to clean up the formatting.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally with a local Slack Bot setup to ensure docs with weird formatting were properly rendered. 

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Slack citation links by wrapping URLs with parentheses in angle brackets so they render correctly and don’t split the link text.

- **Bug Fixes**
  - Normalize citation link destinations for patterns like [[n]](url) before rendering.
  - Support nested parentheses and escaped characters in URLs.
  - Update format_slack_message to run normalization first.
  - Add unit tests covering multiple links, existing angle brackets, and rendering output.

<sup>Written for commit 386072374f9aec309872e7b885de66c5668246d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

