### PR TITLE
chore(fe): fix drop-down overflow in API Key modal

### DIFF
--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -1,13 +1,17 @@
 import { Form, Formik } from "formik";
 import { toast } from "@/hooks/useToast";
-import { SelectorFormField, TextFormField } from "@/components/Field";
 import { createApiKey, updateApiKey } from "./lib";
 import Modal from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { FormikField } from "@/refresh-components/form/FormikField";
+import { FormField } from "@/refresh-components/form/FormField";
 import { USER_ROLE_LABELS, UserRole } from "@/lib/types";
 import { APIKey } from "./types";
 import { SvgKey } from "@opal/icons";
+
 export interface OnyxApiKeyFormProps {
   onClose: () => void;
   onCreateApiKey: (apiKey: APIKey) => void;
@@ -29,89 +33,118 @@ export default function OnyxApiKeyForm({
           title={isUpdate ? "Update API Key" : "Create a new API Key"}
           onClose={onClose}
         />
-        <Modal.Body>
-          <Formik
-            initialValues={{
-              name: apiKey?.api_key_name || "",
-              role: apiKey?.api_key_role || UserRole.BASIC.toString(),
-            }}
-            onSubmit={async (values, formikHelpers) => {
-              formikHelpers.setSubmitting(true);
+        <Formik
+          initialValues={{
+            name: apiKey?.api_key_name || "",
+            role: apiKey?.api_key_role || UserRole.BASIC.toString(),
+          }}
+          onSubmit={async (values, formikHelpers) => {
+            formikHelpers.setSubmitting(true);
 
-              // Prepare the payload with the UserRole
-              const payload = {
-                ...values,
-                role: values.role as UserRole, // Assign the role directly as a UserRole type
-              };
+            // Prepare the payload with the UserRole
+            const payload = {
+              ...values,
+              role: values.role as UserRole, // Assign the role directly as a UserRole type
+            };
 
-              let response;
-              if (isUpdate) {
-                response = await updateApiKey(apiKey.api_key_id, payload);
-              } else {
-                response = await createApiKey(payload);
+            let response;
+            if (isUpdate) {
+              response = await updateApiKey(apiKey.api_key_id, payload);
+            } else {
+              response = await createApiKey(payload);
+            }
+            formikHelpers.setSubmitting(false);
+            if (response.ok) {
+              toast.success(
+                isUpdate
+                  ? "Successfully updated API key!"
+                  : "Successfully created API key!"
+              );
+              if (!isUpdate) {
+                onCreateApiKey(await response.json());
               }
-              formikHelpers.setSubmitting(false);
-              if (response.ok) {
-                toast.success(
-                  isUpdate
-                    ? "Successfully updated API key!"
-                    : "Successfully created API key!"
-                );
-                if (!isUpdate) {
-                  onCreateApiKey(await response.json());
-                }
-                onClose();
-              } else {
-                const responseJson = await response.json();
-                const errorMsg = responseJson.detail || responseJson.message;
-                toast.error(
-                  isUpdate
-                    ? `Error updating API key - ${errorMsg}`
-                    : `Error creating API key - ${errorMsg}`
-                );
-              }
-            }}
-          >
-            {({ isSubmitting }) => (
-              <Form className="w-full overflow-visible">
+              onClose();
+            } else {
+              const responseJson = await response.json();
+              const errorMsg = responseJson.detail || responseJson.message;
+              toast.error(
+                isUpdate
+                  ? `Error updating API key - ${errorMsg}`
+                  : `Error creating API key - ${errorMsg}`
+              );
+            }
+          }}
+        >
+          {({ isSubmitting }) => (
+            <Form className="w-full overflow-visible">
+              <Modal.Body>
                 <Text as="p">
                   Choose a memorable name for your API key. This is optional and
                   can be added or changed later!
                 </Text>
 
-                <TextFormField name="name" label="Name (optional):" />
-
-                <SelectorFormField
-                  // defaultValue is managed by Formik
-                  label="Role:"
-                  subtext="Select the role for this API key.
-                           Limited has access to simple public API's.
-                           Basic has access to regular user API's.
-                           Admin has access to admin level APIs."
-                  name="role"
-                  options={[
-                    {
-                      name: USER_ROLE_LABELS[UserRole.LIMITED],
-                      value: UserRole.LIMITED.toString(),
-                    },
-                    {
-                      name: USER_ROLE_LABELS[UserRole.BASIC],
-                      value: UserRole.BASIC.toString(),
-                    },
-                    {
-                      name: USER_ROLE_LABELS[UserRole.ADMIN],
-                      value: UserRole.ADMIN.toString(),
-                    },
-                  ]}
+                <FormikField<string>
+                  name="name"
+                  render={(field, helper, _meta, state) => (
+                    <FormField name="name" state={state} className="w-full">
+                      <FormField.Label>Name (optional):</FormField.Label>
+                      <FormField.Control>
+                        <InputTypeIn
+                          {...field}
+                          placeholder=""
+                          onClear={() => helper.setValue("")}
+                          showClearButton={false}
+                        />
+                      </FormField.Control>
+                    </FormField>
+                  )}
                 />
 
+                <FormikField<string>
+                  name="role"
+                  render={(field, helper, _meta, state) => (
+                    <FormField name="role" state={state} className="w-full">
+                      <FormField.Label>Role:</FormField.Label>
+                      <FormField.Control>
+                        <InputComboBox
+                          value={field.value}
+                          onValueChange={(value) => helper.setValue(value)}
+                          options={[
+                            {
+                              label: USER_ROLE_LABELS[UserRole.LIMITED],
+                              value: UserRole.LIMITED.toString(),
+                            },
+                            {
+                              label: USER_ROLE_LABELS[UserRole.BASIC],
+                              value: UserRole.BASIC.toString(),
+                            },
+                            {
+                              label: USER_ROLE_LABELS[UserRole.ADMIN],
+                              value: UserRole.ADMIN.toString(),
+                            },
+                          ]}
+                          placeholder="Select a role"
+                          strict
+                        />
+                      </FormField.Control>
+                      <FormField.Description>
+                        Select the role for this API key. Limited has access to
+                        simple public APIs. Basic has access to regular user
+                        APIs. Admin has access to admin level APIs.
+                      </FormField.Description>
+                    </FormField>
+                  )}
+                />
+              </Modal.Body>
+
+              <Modal.Footer>
                 <Button type="submit" disabled={isSubmitting}>
                   {isUpdate ? "Update" : "Create"}
                 </Button>
-              </Form>
-            )}
-          </Formik>
-        </Modal.Body>
+              </Modal.Footer>
+            </Form>
+          )}
+        </Formik>
       </Modal.Content>
     </Modal>
   );


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3419/api-key-creation-modal-popover-bugged

## How Has This Been Tested?

<img width="2880" height="1920" alt="20260218_19h05m20s_grim" src="https://github.com/user-attachments/assets/cb6824ec-8dba-4d5e-8f27-e536a8af2182" />
<img width="2880" height="1920" alt="20260218_19h05m16s_grim" src="https://github.com/user-attachments/assets/49c95292-dfd9-4133-9b5c-cfe4701d88a2" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the role dropdown clipping in the API Key create/edit modal so the popover opens correctly. Addresses Linear ENG-3419 and adds tests to prevent regressions.

- **Bug Fixes**
  - Switched the role selector to InputComboBox within Formik/FormField, moved Modal.Body/Footer inside the Form, and set the Form to overflow-visible to prevent popover clipping.
  - Added Playwright E2E and visual regression tests (light/dark) for modal open, dropdown open/selection, creation flow, and edit flow.

- **Refactors**
  - Replaced legacy TextFormField/SelectorFormField with InputTypeIn and FormikField/FormField for consistent layout and behavior.

<sup>Written for commit ccbaf7ebb0aa41fb1ef95252c52766bb1010412f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



