### PR TITLE
fix: update SourceTag component to use variant prop for sizing

### DIFF
--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -166,7 +166,7 @@ export const MemoizedLink = memo(
 
       return (
         <SourceTag
-          inlineCitation
+          variant="inlineCitation"
           displayName={displayName}
           sources={[sourceInfo]}
           onSourceClick={handleSourceClick}

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -75,6 +75,7 @@ const SourcesTagWrapper = React.memo(function SourcesTagWrapper({
 
   return (
     <SourceTag
+      variant="button"
       displayName="Sources"
       sources={sources}
       onSourceClick={handleSourceClick}

--- a/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
@@ -32,6 +32,9 @@ const sizeClasses = {
     container: "rounded-04 p-0.5 gap-0.5",
   },
   tag: {
+    container: "rounded-08 p-1 gap-1",
+  },
+  button: {
     container: "rounded-08 h-[2.25rem] min-w-[2.25rem] p-2 gap-1",
   },
 } as const;
@@ -271,8 +274,8 @@ const QueryText = ({
  * Props for the SourceTag component.
  */
 export interface SourceTagProps {
-  /** Use inline citation size (smaller, for use within text) */
-  inlineCitation?: boolean;
+  /** Sizing variant: "inlineCitation" for compact in-text use, "button" for interactive contexts, "tag" (default) for standard display */
+  variant?: "inlineCitation" | "tag" | "button";
 
   /** Display name shown on the tag (e.g., "Google Drive", "Business Insider") */
   displayName: string;
@@ -314,7 +317,7 @@ export interface SourceTagProps {
  * - Shows stacked source icons + display name
  * - Hovering opens a details card with source navigation
  *
- * **Inline Citation** (`inlineCitation`):
+ * **Inline Citation** (`variant="inlineCitation"`):
  * - Compact size for use within text content
  * - Shows "+N" count for multiple sources
  *
@@ -341,7 +344,7 @@ export interface SourceTagProps {
  *
  * // Inline citation within text
  * <SourceTag
- *   inlineCitation
+ *   variant="inlineCitation"
  *   displayName="Source 1"
  *   sources={multipleSources}
  * />
@@ -355,7 +358,7 @@ export interface SourceTagProps {
  * ```
  */
 const SourceTagInner = ({
-  inlineCitation,
+  variant = "tag",
   displayName,
   displayUrl,
   sources,
@@ -367,6 +370,8 @@ const SourceTagInner = ({
   toggleSource,
   tooltipText,
 }: SourceTagProps) => {
+  const inlineCitation = variant === "inlineCitation";
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -383,7 +388,7 @@ const SourceTagInner = ({
 
   const extraCount = sources.length - 1;
 
-  const size = inlineCitation ? "inlineCitation" : "tag";
+  const size = variant;
   const styles = sizeClasses[size];
 
   // Shared text styling props


### PR DESCRIPTION
## Description
fix source tag height issues

## How Has This Been Tested?
https://github.com/user-attachments/assets/844a82f6-513d-41af-91a9-441f7f37e70a

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched SourceTag sizing to a variant prop ("inlineCitation" | "tag" | "button") to standardize styles and fix inconsistent heights. Updated message link and toolbar to use the correct variants.

- **Refactors**
  - Replaced inlineCitation boolean with variant prop (default "tag").
  - Mapped sizeClasses to variants and derived styles from variant.
  - Updated MemoizedLink to use variant="inlineCitation".
  - Updated SourcesTagWrapper to use variant="button".

- **Bug Fixes**
  - Fixed SourceTag height and spacing across inline citations and toolbar buttons.

<sup>Written for commit 8184d7bbcf93c3c569ca4be5654ffb34186bb781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

