### PR TITLE
chore(fe): remove close button from image gen tooltip

### DIFF
--- a/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
+++ b/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
@@ -147,6 +147,7 @@ export default function ImageGenerationContent() {
             info
             static
             large
+            close={false}
             text="Connect an image generation model to use in chat."
             className="w-full"
           />


### PR DESCRIPTION
## Description

This message has no `onClose` (`Message` should probably throw a type-error in this case), so this button does nothing. Moreover, I don't think we want to fill `onClose` as this should persist until the user/team configures a image gen provider.

## How Has This Been Tested?

**before**
<img width="1276" height="1820" alt="20260219_09h56m36s_grim" src="https://github.com/user-attachments/assets/831cef2a-455e-491b-a402-d622edd92afb" />

**after**
<img width="1276" height="1820" alt="20260219_09h56m08s_grim" src="https://github.com/user-attachments/assets/94de1d05-6a03-4a66-abe9-d9755a25edb1" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the close button from the image generation setup tooltip. The message is static and has no onClose handler, so this removes a dead button and keeps the notice visible until a provider is configured.

<sup>Written for commit 4d7d67dd5c973e31355a95bc63525c64a5fed591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

