### PR TITLE
fix(celery): Index Attempt Cleanup DB Fix

### DIFF
--- a/backend/alembic/versions/2ad17bf3c8e1_add_index_on_index_attempt_errors_fk.py
+++ b/backend/alembic/versions/2ad17bf3c8e1_add_index_on_index_attempt_errors_fk.py
@@ -1,0 +1,34 @@
+"""add index on index_attempt_errors.index_attempt_id
+
+Revision ID: 2ad17bf3c8e1
+Revises: 631fd2504136
+Create Date: 2026-02-19 00:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "2ad17bf3c8e1"
+down_revision = "631fd2504136"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ix_index_attempt_errors_index_attempt_id"
+TABLE_NAME = "index_attempt_errors"
+
+
+def upgrade() -> None:
+    # Run concurrently so large tables do not block writes during deployment.
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
+            f"ON {TABLE_NAME} (index_attempt_id)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/backend/onyx/background/indexing/index_attempt_utils.py
+++ b/backend/onyx/background/indexing/index_attempt_utils.py
@@ -5,16 +5,25 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.constants import NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS
 from onyx.db.engine.time_utils import get_db_current_time
+from onyx.db.enums import IndexingStatus
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptError
 
 
 # Always retain at least this many attempts per connector/search settings pair
 NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP = 10
+TERMINAL_INDEX_ATTEMPT_STATUSES = (
+    IndexingStatus.SUCCESS,
+    IndexingStatus.COMPLETED_WITH_ERRORS,
+    IndexingStatus.CANCELED,
+    IndexingStatus.FAILED,
+)
 
 
 def get_old_index_attempts(
-    db_session: Session, days_to_keep: int = NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS
+    db_session: Session,
+    days_to_keep: int = NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS,
+    limit: int | None = None,
 ) -> list[IndexAttempt]:
     """
     Get index attempts older than the specified number of days while retaining
@@ -37,7 +46,7 @@ def get_old_index_attempts(
         )
     ).subquery()
 
-    return (
+    query = (
         db_session.query(IndexAttempt)
         .join(
             ranked_attempts,
@@ -46,18 +55,32 @@ def get_old_index_attempts(
         .filter(
             ranked_attempts.c.time_created < cutoff_date,
             ranked_attempts.c.attempt_rank > NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP,
+            IndexAttempt.status.in_(TERMINAL_INDEX_ATTEMPT_STATUSES),
         )
-        .all()
+        .order_by(ranked_attempts.c.time_created.asc())
     )
+
+    if limit is not None:
+        query = query.limit(limit)
+
+    return query.all()
 
 
 def cleanup_index_attempts(db_session: Session, index_attempt_ids: list[int]) -> None:
     """Clean up multiple index attempts"""
-    db_session.query(IndexAttemptError).filter(
-        IndexAttemptError.index_attempt_id.in_(index_attempt_ids)
-    ).delete(synchronize_session=False)
+    if not index_attempt_ids:
+        return
 
-    db_session.query(IndexAttempt).filter(
-        IndexAttempt.id.in_(index_attempt_ids)
-    ).delete(synchronize_session=False)
-    db_session.commit()
+    # Keep each transaction smaller to reduce lock duration and WAL bursts.
+    sub_batch_size = 100
+    for i in range(0, len(index_attempt_ids), sub_batch_size):
+        sub_batch = index_attempt_ids[i : i + sub_batch_size]
+
+        db_session.query(IndexAttemptError).filter(
+            IndexAttemptError.index_attempt_id.in_(sub_batch)
+        ).delete(synchronize_session=False)
+
+        db_session.query(IndexAttempt).filter(IndexAttempt.id.in_(sub_batch)).delete(
+            synchronize_session=False
+        )
+        db_session.commit()

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -414,6 +414,7 @@ class OnyxRedisLocks:
     CHECK_INDEXING_BEAT_LOCK = "da_lock:check_indexing_beat"
     CHECK_CHECKPOINT_CLEANUP_BEAT_LOCK = "da_lock:check_checkpoint_cleanup_beat"
     CHECK_INDEX_ATTEMPT_CLEANUP_BEAT_LOCK = "da_lock:check_index_attempt_cleanup_beat"
+    INDEX_ATTEMPT_CLEANUP_TASK_LOCK = "da_lock:index_attempt_cleanup_task"
     CHECK_CONNECTOR_DOC_PERMISSIONS_SYNC_BEAT_LOCK = (
         "da_lock:check_connector_doc_permissions_sync_beat"
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2303,6 +2303,7 @@ class IndexAttemptError(Base):
     index_attempt_id: Mapped[int] = mapped_column(
         ForeignKey("index_attempt.id"),
         nullable=False,
+        index=True,
     )
     connector_credential_pair_id: Mapped[int] = mapped_column(
         ForeignKey("connector_credential_pair.id"),


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes index attempt cleanup to reduce DB contention and prevent overlapping runs. Adds an index on index_attempt_errors.index_attempt_id, serializes the cleanup task, and processes smaller batches safely.

- **Bug Fixes**
  - Queue a single cleanup task per check with up to 100 attempts; removed internal batching.
  - Add a Redis lock (30 min) to prevent concurrent cleanup executions per tenant.
  - Only clean up terminal-status attempts and keep the 10 most recent per connector/search settings; delete oldest first.
  - Delete IDs in 100-item sub-batches with commits to reduce lock duration and WAL bursts.

- **Migration**
  - Run the DB migration to add an index on index_attempt_errors.index_attempt_id (created concurrently to avoid write blocking).

<sup>Written for commit 7af23e8020f733fe05d8431cd1e0a5ecf4bcf596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

