### PR TITLE
feat: Modal Header no icon

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -390,6 +390,7 @@ ModalContent.displayName = DialogPrimitive.Content.displayName;
  *
  * When `icon` is omitted the header renders a minimal variant: just the
  * title + description with the close button inline to the right of the title.
+ * This is JUST to be used for preview windows
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Description
Currently the Modal Header requires an icon. This enables the Modal Header to accept no header

## How Has This Been Tested?
Example without icon:
<img width="921" height="74" alt="Screenshot 2026-02-19 at 12 09 10 PM" src="https://github.com/user-attachments/assets/aa5e707f-376e-457f-be25-1ce95d8b2f42" />



## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modal Header now supports no icon: the icon prop is optional and renders a minimal title/description header with the close button inline; with an icon, the close button sits next to it. Also removes an accidentally committed file.

<sup>Written for commit cd8de8ea1f007bb592288902cb4bb89311830ce9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

