### PR TITLE
fix(manage-users): exclude slack users from /users list

### DIFF
--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -600,7 +600,7 @@ def get_valid_domains(
 
 @router.get("/users", tags=PUBLIC_API_TAGS)
 def list_all_users_basic_info(
-    include_api_keys: bool = True,
+    include_api_keys: bool = False,
     _: User = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> list[MinimalUserSnapshot]:

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -51,7 +51,7 @@ interface ShareAgentFormContentProps {
 function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
   const { values, setFieldValue, handleSubmit, dirty } =
     useFormikContext<ShareAgentFormValues>();
-  const { data: usersData } = useShareableUsers({ includeApiKeys: false });
+  const { data: usersData } = useShareableUsers({ includeApiKeys: true });
   const { data: groupsData } = useShareableGroups();
   const { user: currentUser } = useUser();
   const { agent: fullAgent } = useAgent(agentId ?? null);


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Slack-provisioned users from the /users endpoint so sharing lists only show real user accounts. The share modal now explicitly includes API key accounts without changing the API default.

- **Bug Fixes**
  - Exclude users with role SLACK_USER from /users.
  - ShareAgentModal calls useShareableUsers({ includeApiKeys: true }) to show API key accounts while keeping the API default unchanged.

<sup>Written for commit 9ebfa62f0e9d25293f92efce5c08e9356bc01983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

