### PR TITLE
chore(app packaging): Ensure `curl` is included in the app image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,13 +28,15 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 # Install system dependencies
 # cmake needed for psycopg (postgres)
 # libpq-dev needed for psycopg (postgres)
-# curl included just for users' convenience
 # zip for Vespa step futher down
 # ca-certificates for HTTPS
+# NOTE: Packages installed here are liable to be removed by `apt-get remove -y
+# --allow-remove-essential` below, even though they were manually installed
+# here. For useful packages like curl, prefer installing them below after the
+# remove step.
 RUN apt-get update && \
     apt-get install -y \
         cmake \
-        curl \
         zip \
         ca-certificates \
         libgnutls30 \
@@ -85,6 +87,7 @@ RUN uv pip install --system --no-cache-dir --upgrade \
     # xserver-common and xvfb included by playwright installation but not needed after
     # perl-base is part of the base Python Debian image but not needed for Onyx functionality
     # perl-base could only be removed with --allow-remove-essential
+    # NOTE: This removes packages that may have been manually installed above (such as curl).
     apt-get update && \
     apt-get remove -y --allow-remove-essential \
         perl-base \
@@ -98,6 +101,8 @@ RUN uv pip install --system --no-cache-dir --upgrade \
     # Install here to avoid some packages being cleaned up above
     apt-get install -y \
         libxmlsec1-openssl \
+        # curl is included for debugging convenience.
+        curl \
         # Install postgresql-client for easy manual tests
         postgresql-client && \
     apt-get autoremove -y && \


### PR DESCRIPTION
## Description
We were nuking `curl` in the `apt-get remove -y --allow-remove-essential ...` step of the Dockerfile.

## How Has This Been Tested?
I did not test that this Dockerfile results in an image with `curl`, but I manually verified that running `apt-get update && \
    apt-get remove -y --allow-remove-essential \
        perl-base \
        xserver-common \
        xvfb \
        cmake \
        libldap-2.5-0 \
        libxmlsec1-dev \
        pkg-config \
        gcc`
removes `curl` from the system even though I manually installed it.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure curl is included in the backend Docker image by installing it after the cleanup step. This fixes missing curl in built images and helps with debugging.

- **Bug Fixes**
  - Install curl in the final apt-get install block after the remove --allow-remove-essential step.
  - Add Dockerfile notes warning that the remove step can delete manually installed packages.

<sup>Written for commit 069f6f25fa81acdd801b1167f359d9c3d65b6e26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

