### PR TITLE
fix(bedrock): Fixing toolConfig call (#8342) to release v2.12

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -28,6 +28,7 @@ from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.db.models import Persona
+from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.interfaces import ToolChoiceOptions
@@ -57,6 +58,28 @@ from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
+
+
+def _should_keep_bedrock_tool_definitions(
+    llm: object, simple_chat_history: list[ChatMessageSimple]
+) -> bool:
+    """Bedrock requires tool config when history includes toolUse/toolResult blocks."""
+    model_provider = getattr(getattr(llm, "config", None), "model_provider", None)
+    if model_provider not in {
+        LlmProviderNames.BEDROCK,
+        LlmProviderNames.BEDROCK_CONVERSE,
+    }:
+        return False
+
+    return any(
+        (
+            msg.message_type == MessageType.ASSISTANT
+            and msg.tool_calls
+            and len(msg.tool_calls) > 0
+        )
+        or msg.message_type == MessageType.TOOL_CALL_RESPONSE
+        for msg in simple_chat_history
+    )
 
 
 def _try_fallback_tool_extraction(
@@ -454,7 +477,12 @@ def run_llm_loop(
             elif out_of_cycles or ran_image_gen:
                 # Last cycle, no tools allowed, just answer!
                 tool_choice = ToolChoiceOptions.NONE
-                final_tools = []
+                # Bedrock requires tool config in requests that include toolUse/toolResult history.
+                final_tools = (
+                    tools
+                    if _should_keep_bedrock_tool_definitions(llm, simple_chat_history)
+                    else []
+                )
             else:
                 tool_choice = ToolChoiceOptions.AUTO
                 final_tools = tools


### PR DESCRIPTION
Cherry-pick of commit f10b994a276ea84f5c345f9a62d215816ff71560 to release/v2.12 branch.

Original PR: #8342

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bedrock tool config handling in the chat loop. We now keep tool definitions when history includes toolUse/toolResult, preventing Bedrock errors in final answer requests.

- **Bug Fixes**
  - Added a guard to detect Bedrock providers and tool history (_should_keep_bedrock_tool_definitions).
  - When tool_choice is NONE in the last cycle, keep tools for Bedrock if history has tool calls/responses; otherwise omit.
  - Added unit tests for Bedrock with/without tool history and for non-Bedrock providers.

<sup>Written for commit f9548ee1c797bb7bc267bbb28f2a2663b690ec0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

