### PR TITLE
fix(helm): route /openapi.json to api_server in nginx config

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.30
+version: 0.4.31
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -57,7 +57,7 @@ data:
         }
         {{- end }}
 
-        location ~ ^/api(.*)$ {
+        location ~ ^/(api|openapi\.json)(/.*)?$ {
             rewrite ^/api(/.*)$ $1 break;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Description

The Helm chart's nginx `location` block only matched `/api/*` paths, so `/openapi.json` requests fell through to the Next.js webserver. The webserver's build-time rewrite to `localhost:8080` is unreachable from the K8s pod, resulting in a 500 error when loading Swagger UI at `/api/docs`.

This aligns the Helm nginx config with the docker-compose config, which already handles `/openapi.json` correctly via `^/(api|openapi\.json)(/.*)?$`.

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route /openapi.json to api_server in the Helm Nginx config to fix 500s when loading Swagger UI at /api/docs. Aligns the Helm Nginx location regex with docker-compose (^/(api|openapi\.json)(/.*)?$) and bumps the chart version to 0.4.31.

<sup>Written for commit e4e6e48ef6258070f57a5424873f93cec072078c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

