### PR TITLE
fix(timeline): reduce agent message re-renders with referential stability in usePacedTurnGroups

### DIFF
--- a/web/src/refresh-components/onboarding/steps/NameStep.tsx
+++ b/web/src/refresh-components/onboarding/steps/NameStep.tsx
@@ -58,7 +58,7 @@ const NameStep = React.memo(
           value={userName || ""}
           onChange={(e) => updateName(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="w-[26%] min-w-40"
+          className="max-w-60"
         />
       </div>
     ) : (


### PR DESCRIPTION
## Description
reduce agent message re-renders with referential stability in usePacedTurnGroups

## How Has This Been Tested?
Tested abve

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces timeline re-renders by preserving referential stability in usePacedTurnGroups and fixes pacing when switching from message streaming back to tools. This makes agent message updates smoother and reduces flicker.

- **Bug Fixes**
  - Preserve array/object references for completed turn groups when content hasn’t changed to prevent downstream re-renders.
  - Reset tool pacing when finalAnswerComing flips true → false and a new tool step arrives (tool-after-message transition).
  - Add targeted tests for referential stability, streaming updates, transition handling, and timer cleanup.
  - Tweak NameStep input width to max-w-60.

<sup>Written for commit 9dc0b851f39d8e3ba5dea7be3075f50db74ee6dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

