### PR TITLE
chore(helm): remove broken code-interpreter dependency

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -91,7 +91,6 @@ jobs:
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
           helm repo add minio https://charts.min.io/
-          helm repo add code-interpreter https://onyx-dot-app.github.io/code-interpreter/
           helm repo update
 
       - name: Install Redis operator

--- a/ct.yaml
+++ b/ct.yaml
@@ -12,8 +12,7 @@ chart-repos:
   - postgresql=https://cloudnative-pg.github.io/charts
   - redis=https://ot-container-kit.github.io/helm-charts
   - minio=https://charts.min.io/
-  - code-interpreter=https://onyx-dot-app.github.io/code-interpreter/
-  
+
 # have seen postgres take 10 min to pull ... so 15 min seems like a good timeout?
 helm-extra-args: --debug --timeout 900s
 

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -17,8 +17,5 @@ dependencies:
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-- name: code-interpreter
-  repository: https://onyx-dot-app.github.io/code-interpreter/
-  version: 0.2.0
-digest: sha256:65e3aad0189907ff35e1532374ca0b4a5c32c7356c8af55f646a6e3c59e574cd
-generated: "2026-01-21T11:06:55.190114-08:00"
+digest: sha256:e3e3df4464d00165d63e5aa150b768c0957e5eab2b310414ce5d7381d00dbd2e
+generated: "2026-02-19T20:17:06.462195-08:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.31
+version: 0.4.32
 appVersion: latest
 annotations:
   category: Productivity
@@ -44,7 +44,3 @@ dependencies:
     version: 5.4.0
     repository: https://charts.min.io/
     condition: minio.enabled
-  - name: code-interpreter
-    version: 0.2.0
-    repository: https://onyx-dot-app.github.io/code-interpreter/
-    condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description

The `code-interpreter` Helm chart repo at `https://onyx-dot-app.github.io/code-interpreter/` returns 404, causing `ct lint` to fail in CI for any PR that touches the Helm chart.

This removes the `code-interpreter` reference from:
- `Chart.yaml` dependencies
- `Chart.lock`
- `ct.yaml` chart-repos
- CI workflow `helm repo add` step

The `values.yaml` and `configmap.yaml` references are gated behind `codeInterpreter.enabled` (disabled by default) and remain untouched — they'll work if someone brings their own chart repo.

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken code-interpreter Helm chart dependency to stop ct lint failures in CI.

- **Dependencies**
  - Removed code-interpreter from Chart.yaml and Chart.lock.
  - Dropped its repo from ct.yaml and the pr-helm-chart-testing workflow.
  - Bumped chart version to 0.4.32.
  - Kept values.yaml and configmap.yaml references gated behind codeInterpreter.enabled (off by default).

<sup>Written for commit 48e7428069f4d5fc6d9386f847bc843731e95bdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



