### PR TITLE
chore(fe): rm settings page top padding

### DIFF
--- a/web/src/layouts/settings-layouts.tsx
+++ b/web/src/layouts/settings-layouts.tsx
@@ -220,7 +220,7 @@ function SettingsHeader({
       className={cn(
         "w-full bg-background-tint-01",
         isSticky && "sticky top-0 z-settings-header",
-        backButton ? "md:pt-4" : "md:pt-10"
+        backButton && "md:pt-4"
       )}
     >
       {backButton && (


### PR DESCRIPTION
## Description

It looks like these pages didn't previously have a header and compensated with this `pt-10`, but they have headers now, so remove the duplicated whitespace from padding.

## How Has This Been Tested?

Screenshot report looks as expected

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed extra top padding in the Settings header when no back button is present, eliminating unnecessary whitespace at the top. The header now only applies md:pt-4 when a back button is shown.

<sup>Written for commit 5148914e8ade60b224779aa9215d7be06381f158. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

