### PR TITLE
fix: update SourceTag component to use variant prop for sizing (#8582) to release v2.12

### DIFF
--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -165,7 +165,7 @@ export const MemoizedLink = memo(
 
       return (
         <SourceTag
-          inlineCitation
+          variant="inlineCitation"
           displayName={displayName}
           sources={[sourceInfo]}
           onSourceClick={handleSourceClick}

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -77,6 +77,7 @@ const SourcesTagWrapper = React.memo(function SourcesTagWrapper({
 
   return (
     <SourceTag
+      variant="button"
       displayName="Sources"
       sources={sources}
       onSourceClick={handleSourceClick}

--- a/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
@@ -34,6 +34,9 @@ const sizeClasses = {
   tag: {
     container: "rounded-08 p-1 gap-1",
   },
+  button: {
+    container: "rounded-08 h-[2.25rem] min-w-[2.25rem] p-2 gap-1",
+  },
 } as const;
 
 /**
@@ -271,8 +274,8 @@ const QueryText = ({
  * Props for the SourceTag component.
  */
 export interface SourceTagProps {
-  /** Use inline citation size (smaller, for use within text) */
-  inlineCitation?: boolean;
+  /** Sizing variant: "inlineCitation" for compact in-text use, "button" for interactive contexts, "tag" (default) for standard display */
+  variant?: "inlineCitation" | "tag" | "button";
 
   /** Display name shown on the tag (e.g., "Google Drive", "Business Insider") */
   displayName: string;
@@ -314,7 +317,7 @@ export interface SourceTagProps {
  * - Shows stacked source icons + display name
  * - Hovering opens a details card with source navigation
  *
- * **Inline Citation** (`inlineCitation`):
+ * **Inline Citation** (`variant="inlineCitation"`):
  * - Compact size for use within text content
  * - Shows "+N" count for multiple sources
  *
@@ -341,7 +344,7 @@ export interface SourceTagProps {
  *
  * // Inline citation within text
  * <SourceTag
- *   inlineCitation
+ *   variant="inlineCitation"
  *   displayName="Source 1"
  *   sources={multipleSources}
  * />
@@ -355,7 +358,7 @@ export interface SourceTagProps {
  * ```
  */
 const SourceTagInner = ({
-  inlineCitation,
+  variant = "tag",
   displayName,
   displayUrl,
   sources,
@@ -367,6 +370,8 @@ const SourceTagInner = ({
   toggleSource,
   tooltipText,
 }: SourceTagProps) => {
+  const inlineCitation = variant === "inlineCitation";
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -383,7 +388,7 @@ const SourceTagInner = ({
 
   const extraCount = sources.length - 1;
 
-  const size = inlineCitation ? "inlineCitation" : "tag";
+  const size = variant;
   const styles = sizeClasses[size];
 
   // Shared text styling props


### PR DESCRIPTION
Cherry-pick of commit 0891737dfdf19ef7ec20af9c1cf64b807f371e91 to release/v2.12 branch.

Original PR: #8582

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches SourceTag sizing to a variant prop and adds a new button variant to fix inconsistent sizing and improve clarity. Updates MemoizedTextComponents and MessageToolbar to use the new API.

- **Refactors**
  - Replace inlineCitation with variant ("inlineCitation" | "tag" | "button"; default "tag").
  - Add button sizing styles and route sizing through variant.
  - Update usages: MemoizedLink uses variant="inlineCitation"; MessageToolbar uses variant="button".

- **Migration**
  - Replace inlineCitation with variant="inlineCitation" in any remaining usages.

<sup>Written for commit 68d28a1fc855851c82de466595341ef16db65850. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

