### PR TITLE
fix(fe): popover width can fit trigger element

### DIFF
--- a/web/src/components/Dropdown.tsx
+++ b/web/src/components/Dropdown.tsx
@@ -186,7 +186,12 @@ export const DefaultDropdown = forwardRef<HTMLDivElement, DefaultDropdownProps>(
             <FiChevronDown className="my-auto ml-auto" />
           </div>
         </Popover.Trigger>
-        <Popover.Content align="start" side={side} sideOffset={5}>
+        <Popover.Content
+          align="start"
+          side={side}
+          sideOffset={5}
+          width="trigger"
+        >
           <div
             ref={ref}
             className={`

--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -107,12 +107,13 @@ const PopoverClose = PopoverPrimitive.Close;
  * </Popover.Content>
  * ```
  */
-type PopoverWidths = "fit" | "md" | "lg" | "xl";
+type PopoverWidths = "fit" | "md" | "lg" | "xl" | "trigger";
 const widthClasses: Record<PopoverWidths, string> = {
   fit: "w-fit",
   md: "w-[12rem]",
   lg: "w-[15rem]",
   xl: "w-[18rem]",
+  trigger: "w-[var(--radix-popover-trigger-width)]",
 };
 interface PopoverContentProps
   extends WithoutStyles<


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3670/connector-dropdown

## How Has This Been Tested?

<img width="2880" height="1920" alt="20260219_22h44m17s_grim" src="https://github.com/user-attachments/assets/e0584e73-1d1a-4f05-9c48-02021ac23000" />
<img width="1256" height="1820" alt="20260219_22h44m11s_grim" src="https://github.com/user-attachments/assets/acfa4316-0130-4d06-9420-5b70e425f2ec" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the connector dropdown popover match the trigger width to prevent truncation and misalignment. Adds a “trigger” width to Popover and applies it in the dropdown (Linear ENG-3670).

- **Bug Fixes**
  - Added “trigger” width to Popover to use the trigger’s computed width.
  - Updated DefaultDropdown to set Popover.Content width="trigger".

<sup>Written for commit 861e1d6c042d0fd41661528f84a0038f990910b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

