### PR TITLE
chore(helm): update code-interpreter chart repo URL to python-sandbox

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -33,7 +33,7 @@ jobs:
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
           helm repo add minio https://charts.min.io/
-          helm repo add code-interpreter https://onyx-dot-app.github.io/code-interpreter/
+          helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/
           helm repo update
 
       - name: Build chart dependencies

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -91,7 +91,7 @@ jobs:
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
           helm repo add minio https://charts.min.io/
-          helm repo add code-interpreter https://onyx-dot-app.github.io/code-interpreter/
+          helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/
           helm repo update
 
       - name: Install Redis operator

--- a/ct.yaml
+++ b/ct.yaml
@@ -12,7 +12,7 @@ chart-repos:
   - postgresql=https://cloudnative-pg.github.io/charts
   - redis=https://ot-container-kit.github.io/helm-charts
   - minio=https://charts.min.io/
-  - code-interpreter=https://onyx-dot-app.github.io/code-interpreter/
+  - code-interpreter=https://onyx-dot-app.github.io/python-sandbox/
   
 # have seen postgres take 10 min to pull ... so 15 min seems like a good timeout?
 helm-extra-args: --debug --timeout 900s

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -18,7 +18,7 @@ dependencies:
   repository: https://charts.min.io/
   version: 5.4.0
 - name: code-interpreter
-  repository: https://onyx-dot-app.github.io/code-interpreter/
-  version: 0.2.0
-digest: sha256:65e3aad0189907ff35e1532374ca0b4a5c32c7356c8af55f646a6e3c59e574cd
-generated: "2026-01-21T11:06:55.190114-08:00"
+  repository: https://onyx-dot-app.github.io/python-sandbox/
+  version: 0.2.1
+digest: sha256:aedc211d9732c934be8b79735b62f8caa9bcd235e03fd0dd10b49e0a13ed15b7
+generated: "2026-02-20T11:19:47.957449-08:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.31
+version: 0.4.32
 appVersion: latest
 annotations:
   category: Productivity
@@ -45,6 +45,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.2.0
-    repository: https://onyx-dot-app.github.io/code-interpreter/
+    version: 0.2.1
+    repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description

The `code-interpreter` GitHub repo was renamed to [`python-sandbox`](https://github.com/onyx-dot-app/python-sandbox). Update the Helm chart repo URL from `onyx-dot-app.github.io/code-interpreter/` to `onyx-dot-app.github.io/python-sandbox/` in:

- `Chart.yaml` + `Chart.lock` (regenerated)
- `ct.yaml`
- CI workflows (`pr-helm-chart-testing.yml`, `helm-chart-releases.yml`)

Also bumps chart version to `0.4.32`.

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check