### PR TITLE
chore(fe): whitelabel logo layout followup

### DIFF
--- a/web/src/sections/sidebar/SidebarWrapper.tsx
+++ b/web/src/sections/sidebar/SidebarWrapper.tsx
@@ -34,9 +34,11 @@ function LogoSection({ folded, onFoldClick }: LogoSectionProps) {
     <div
       className={cn(
         /* px-2.5 => 2 for the standard sidebar padding + 0.5 for internal padding specific to this component. */
-        "flex px-2.5 py-2 min-h-[3.25rem]",
+        "flex px-2.5 py-2",
         folded ? "justify-center" : "justify-between",
-        applicationName ? "min-h-[3.75rem]" : "min-h-[3.25rem]"
+        applicationName
+          ? "h-[3.75rem] min-h-[3.75rem]"
+          : "h-[3.25rem] min-h-[3.25rem]"
       )}
     >
       {folded === undefined ? (


### PR DESCRIPTION
## Description

Small nit follow up to https://github.com/onyx-dot-app/onyx/pull/8577

The sidebar height with a custom application name is inconsistent between folded and not because the wrapped `Powered by Onyx` text slightly overflows the container, exceeding the `min-h`.

<img width="2880" height="1920" alt="20260219_23h23m55s_grim" src="https://github.com/user-attachments/assets/8df806ec-0446-40ff-b47e-228752253c95" />
<img width="2880" height="1920" alt="20260219_23h23m47s_grim" src="https://github.com/user-attachments/assets/981a49e3-f526-4941-84eb-41a5fee01b05" />

## How Has This Been Tested?

<img width="2880" height="1920" alt="20260219_23h24m39s_grim" src="https://github.com/user-attachments/assets/86246e01-f795-47cc-be77-8f0ccfaef221" />
<img width="2880" height="1920" alt="20260219_23h24m32s_grim" src="https://github.com/user-attachments/assets/50cdbd30-07b5-467d-8e1b-2aeda6a5239e" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inconsistent sidebar header height when a custom application name is used. Set a fixed height (and min-height) instead of only min-height to prevent overflow from the “Powered by Onyx” wrap, keeping folded and expanded states consistent.

<sup>Written for commit 7bb482cf89c06267154031922c558ed4b5a75e82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

