### PR TITLE
fix(fe): Truncated tooltip is disabled when not needed to be shown

### DIFF
--- a/web/src/refresh-components/texts/Truncated.tsx
+++ b/web/src/refresh-components/texts/Truncated.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useLayoutEffect } from "react";
+import React, { useState, useRef, useCallback, useLayoutEffect } from "react";
 import { TextProps } from "@/refresh-components/texts/Text";
 import {
   Tooltip,
@@ -73,6 +73,18 @@ export default function Truncated({
 
   const showTooltip = !disable && isTruncated;
 
+  // Radix's composeEventHandlers skips its internal handler when
+  // event.defaultPrevented is true. When there is nothing to show we
+  // block onPointerMove so the inner Tooltip never starts its open-delay
+  // timer and therefore never dispatches the global "tooltip.open" custom
+  // event that would close any *outer* tooltip wrapping this component.
+  const blockPointerWhenInert = useCallback(
+    (e: React.PointerEvent) => {
+      if (!showTooltip) e.preventDefault();
+    },
+    [showTooltip]
+  );
+
   return (
     <>
       <TooltipProvider>
@@ -82,7 +94,7 @@ export default function Truncated({
             className="flex-grow overflow-hidden text-left w-full"
           >
             <TooltipTrigger asChild>
-              <div>{text}</div>
+              <div onPointerMove={blockPointerWhenInert}>{text}</div>
             </TooltipTrigger>
           </div>
 


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3603/action-descriptions-blink-and-disappear

TL;DR: the `Truncated` component uses a Tooltip which is semantically different than that expected by Radix. Radix has a 1 tooltip at a time philosophy with the intention they provide supplemental context to the component at hand. `Truncated` on the other had uses this to optionally display clipped text -- this is likely better implemented as a CSS tooltip or HTML `title`.

When there are nested Tooltips, race-conditions inside of Radix cause tooltips to open and close each other unexpectedly (since they're assuming 1 tooltip is visible/present at a time).

See Claude's assessment:

<img width="884" height="872" alt="image" src="https://github.com/user-attachments/assets/272eaa10-b577-4dcf-bf13-9a251b370990" />

## How Has This Been Tested?

I tried writing a playwright test and I couldn't get it to fail with previous behavior, but can try as time allows.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ActionsPopover description flicker (Linear ENG-3603). Prevents tooltip/focus-driven closes and stops Truncated from starting Radix’s open-delay when no tooltip is needed to avoid the first-hover re-render.

- **Bug Fixes**
  - Cancel focus-outside by default, ignore tooltip-origin pointer events, and block inert pointer-move in Truncated to prevent Radix’s global tooltip.open from closing the popover.

- **Refactors**
  - Memoized the tool toggle handler; added mount/unmount, outside interaction, and close traces for easier debugging.

<sup>Written for commit badaad3c2c41df420aae69161d0fc406b88bd1d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

