### PR TITLE
fix: /llm/provider route returns all providers (#8545) to release v2.12

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -428,7 +428,7 @@ def fetch_existing_models(
 
 def fetch_existing_llm_providers(
     db_session: Session,
-    flow_types: list[LLMModelFlowType],
+    flow_type_filter: list[LLMModelFlowType],
     only_public: bool = False,
     exclude_image_generation_providers: bool = True,
 ) -> list[LLMProviderModel]:
@@ -436,30 +436,27 @@ def fetch_existing_llm_providers(
 
     Args:
         db_session: Database session
-        flow_types: List of flow types to filter by
+        flow_type_filter: List of flow types to filter by, empty list for no filter
         only_public: If True, only return public providers
         exclude_image_generation_providers: If True, exclude providers that are
             used for image generation configs
     """
-    providers_with_flows = (
-        select(ModelConfiguration.llm_provider_id)
-        .join(LLMModelFlow)
-        .where(LLMModelFlow.llm_model_flow_type.in_(flow_types))
-        .distinct()
-    )
+    stmt = select(LLMProviderModel)
+
+    if flow_type_filter:
+        providers_with_flows = (
+            select(ModelConfiguration.llm_provider_id)
+            .join(LLMModelFlow)
+            .where(LLMModelFlow.llm_model_flow_type.in_(flow_type_filter))
+            .distinct()
+        )
+        stmt = stmt.where(LLMProviderModel.id.in_(providers_with_flows))
 
     if exclude_image_generation_providers:
-        stmt = select(LLMProviderModel).where(
-            LLMProviderModel.id.in_(providers_with_flows)
-        )
-    else:
         image_gen_provider_ids = select(ModelConfiguration.llm_provider_id).join(
             ImageGenerationConfig
         )
-        stmt = select(LLMProviderModel).where(
-            LLMProviderModel.id.in_(providers_with_flows)
-            | LLMProviderModel.id.in_(image_gen_provider_ids)
-        )
+        stmt = stmt.where(~LLMProviderModel.id.in_(image_gen_provider_ids))
 
     stmt = stmt.options(
         selectinload(LLMProviderModel.model_configurations),

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -255,7 +255,7 @@ def list_llm_providers(
     llm_provider_list: list[LLMProviderView] = []
     for llm_provider_model in fetch_existing_llm_providers(
         db_session=db_session,
-        flow_types=[LLMModelFlowType.CHAT, LLMModelFlowType.VISION],
+        flow_type_filter=[],
         exclude_image_generation_providers=not include_image_gen,
     ):
         from_model_start = datetime.now(timezone.utc)
@@ -503,9 +503,7 @@ def list_llm_provider_basics(
     start_time = datetime.now(timezone.utc)
     logger.debug("Starting to fetch user-accessible LLM providers")
 
-    all_providers = fetch_existing_llm_providers(
-        db_session, [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
-    )
+    all_providers = fetch_existing_llm_providers(db_session, [])
     user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider.py
@@ -553,7 +553,7 @@ class TestDefaultProviderEndpoint:
 
         try:
             existing_providers = fetch_existing_llm_providers(
-                db_session, flow_types=[LLMModelFlowType.CHAT]
+                db_session, flow_type_filter=[LLMModelFlowType.CHAT]
             )
             provider_names_to_restore: list[str] = []
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -690,7 +690,7 @@ class TestAutoModeMissingFlows:
             # Step 4: The provider must appear in fetch_existing_llm_providers
             listed_providers = fetch_existing_llm_providers(
                 db_session=db_session,
-                flow_types=[LLMModelFlowType.CHAT],
+                flow_type_filter=[LLMModelFlowType.CHAT],
             )
             listed_provider_names = {p.name for p in listed_providers}
             assert provider_name in listed_provider_names, (


### PR DESCRIPTION
Cherry-pick of commit 27c254ecf942db433f87c59688cbe9725aa59a11 to release/v2.12 branch.

Original PR: #8545

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /llm/provider so it returns all LLM providers by default, excluding image-generation providers unless requested. Also updates the DB query to only apply flow-type filtering when a filter is provided.

- **Bug Fixes**
  - API now calls fetch_existing_llm_providers with flow_type_filter=[]; include_image_gen toggles image-gen inclusion.
  - DB: apply flow filter only when non-empty; exclude image-gen providers via NOT IN; renamed param to flow_type_filter.
  - Tests updated to use flow_type_filter.

<sup>Written for commit 4ddc381f351d970ec80e7d94753c345af0b16eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

