### PR TITLE
feat(scim): add scim_username column to ScimUserMapping

### DIFF
--- a/backend/alembic/versions/0bb4558f35df_add_scim_username_to_scim_user_mapping.py
+++ b/backend/alembic/versions/0bb4558f35df_add_scim_username_to_scim_user_mapping.py
@@ -1,0 +1,28 @@
+"""add scim_username to scim_user_mapping
+
+Revision ID: 0bb4558f35df
+Revises: 631fd2504136
+Create Date: 2026-02-20 10:45:30.340188
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0bb4558f35df"
+down_revision = "631fd2504136"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("scim_username", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scim_user_mapping", "scim_username")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4940,6 +4940,7 @@ class ScimUserMapping(Base):
     user_id: Mapped[UUID] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), unique=True, nullable=False
     )
+    scim_username: Mapped[str | None] = mapped_column(String, nullable=True)
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False


### PR DESCRIPTION
## Description

Adds a nullable `scim_username` column to `ScimUserMapping` to preserve the original-case `userName` sent by identity providers. 

`User.email` is force-lowercased by a model-level `@validates` decorator and a PostgreSQL CHECK constraint (`ensure_lowercase_email`), so SCIM responses currently return lowercase `userName`/`emails` even when the IdP sent mixed case. Okta's CRUD test validates exact case preservation, causing test failures.

This column lets the SCIM layer store and return the original case without touching the core `User` model or auth flows.

## How Has This Been Tested?

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check