### PR TITLE
feat(web): Initial Framework for Brave Web Search 1/3 (#8594)

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/clients/brave_client.py
+++ b/backend/onyx/tools/tool_implementations/web_search/clients/brave_client.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from fastapi import HTTPException
+
+from onyx.tools.tool_implementations.web_search.models import (
+    WebSearchProvider,
+)
+from onyx.tools.tool_implementations.web_search.models import WebSearchResult
+from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
+
+logger = setup_logger()
+
+BRAVE_WEB_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
+BRAVE_MAX_RESULTS_PER_REQUEST = 20
+
+
+class BraveClient(WebSearchProvider):
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        num_results: int = 10,
+        timeout_seconds: int = 10,
+    ) -> None:
+        self._headers = {
+            "Accept": "application/json",
+            "X-Subscription-Token": api_key,
+        }
+        logger.debug(f"Count of results passed to BraveClient: {num_results}")
+        self._num_results = max(1, min(num_results, BRAVE_MAX_RESULTS_PER_REQUEST))
+        self._timeout_seconds = timeout_seconds
+
+    @retry_builder(tries=3, delay=1, backoff=2)
+    def search(self, query: str) -> list[WebSearchResult]:
+        params = {
+            "q": query,
+            "count": str(self._num_results),
+        }
+
+        response = requests.get(
+            BRAVE_WEB_SEARCH_URL,
+            headers=self._headers,
+            params=params,
+            timeout=self._timeout_seconds,
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise ValueError(_build_error_message(response)) from exc
+
+        data = response.json()
+        web_results = (data.get("web") or {}).get("results") or []
+
+        results: list[WebSearchResult] = []
+        for result in web_results:
+            link = (result.get("url") or "").strip()
+            if not link:
+                continue
+
+            title = (result.get("title") or "").strip()
+            description = (result.get("description") or "").strip()
+
+            results.append(
+                WebSearchResult(
+                    title=title,
+                    link=link,
+                    snippet=description,
+                    author=None,
+                    published_date=None,
+                )
+            )
+
+        return results
+
+    def test_connection(self) -> dict[str, str]:
+        try:
+            test_results = self.search("test")
+            if not test_results or not any(result.link for result in test_results):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Brave API key validation failed: search returned no results.",
+                )
+        except HTTPException:
+            raise
+        except (ValueError, requests.RequestException) as e:
+            error_msg = str(e)
+            lower = error_msg.lower()
+            if (
+                "status 401" in lower
+                or "status 403" in lower
+                or "api key" in lower
+                or "auth" in lower
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid Brave API key: {error_msg}",
+                ) from e
+            if "status 429" in lower or "rate limit" in lower:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Brave API rate limit exceeded: {error_msg}",
+                ) from e
+            raise HTTPException(
+                status_code=400,
+                detail=f"Brave API key validation failed: {error_msg}",
+            ) from e
+
+        logger.info("Web search provider test succeeded for Brave.")
+        return {"status": "ok"}
+
+
+def _build_error_message(response: requests.Response) -> str:
+    return (
+        "Brave search failed "
+        f"(status {response.status_code}): {_extract_error_detail(response)}"
+    )
+
+
+def _extract_error_detail(response: requests.Response) -> str:
+    try:
+        payload: Any = response.json()
+    except Exception:
+        text = response.text.strip()
+        return text[:200] if text else "No error details"
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            detail = error.get("detail") or error.get("message")
+            if isinstance(detail, str):
+                return detail
+        if isinstance(error, str):
+            return error
+
+        message = payload.get("message")
+        if isinstance(message, str):
+            return message
+
+    return str(payload)[:200]

--- a/backend/onyx/tools/tool_implementations/web_search/providers.py
+++ b/backend/onyx/tools/tool_implementations/web_search/providers.py
@@ -13,6 +13,9 @@ from onyx.tools.tool_implementations.open_url.onyx_web_crawler import (
     DEFAULT_MAX_PDF_SIZE_BYTES,
 )
 from onyx.tools.tool_implementations.open_url.onyx_web_crawler import OnyxWebCrawler
+from onyx.tools.tool_implementations.web_search.clients.brave_client import (
+    BraveClient,
+)
 from onyx.tools.tool_implementations.web_search.clients.exa_client import (
     ExaClient,
 )
@@ -45,6 +48,12 @@ def build_search_provider_from_config(
 
     if provider_type == WebSearchProviderType.EXA:
         return ExaClient(api_key=api_key, num_results=num_results)
+    if provider_type == WebSearchProviderType.BRAVE:
+        return BraveClient(
+            api_key=api_key,
+            num_results=num_results,
+            timeout_seconds=int(config.get("timeout_seconds") or 10),
+        )
     if provider_type == WebSearchProviderType.SERPER:
         return SerperClient(api_key=api_key, num_results=num_results)
     if provider_type == WebSearchProviderType.GOOGLE_PSE:

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -26,6 +26,7 @@ class WebSearchProviderType(str, Enum):
     SERPER = "serper"
     EXA = "exa"
     SEARXNG = "searxng"
+    BRAVE = "brave"
 
 
 class WebContentProviderType(str, Enum):

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_brave_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_brave_client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+import onyx.tools.tool_implementations.web_search.clients.brave_client as brave_module
+from onyx.tools.tool_implementations.web_search.clients.brave_client import (
+    BraveClient,
+)
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            http_error = requests.HTTPError(f"{self.status_code} Client Error")
+            http_error.response = cast(requests.Response, self)
+            raise http_error
+
+    def json(self) -> dict[str, Any]:
+        if self._payload is None:
+            raise ValueError("No JSON payload")
+        return self._payload
+
+
+def test_search_maps_brave_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = BraveClient(api_key="test-key", num_results=5)
+
+    def _mock_get(*args: Any, **kwargs: Any) -> DummyResponse:  # noqa: ARG001
+        return DummyResponse(
+            status_code=200,
+            payload={
+                "web": {
+                    "results": [
+                        {
+                            "title": "Result 1",
+                            "url": "https://example.com/one",
+                            "description": "Snippet 1",
+                        },
+                        {
+                            "title": "Result without URL",
+                            "description": "Should be skipped",
+                        },
+                    ]
+                }
+            },
+        )
+
+    monkeypatch.setattr(brave_module.requests, "get", _mock_get)
+
+    results = client.search("onyx")
+
+    assert len(results) == 1
+    assert results[0].title == "Result 1"
+    assert results[0].link == "https://example.com/one"
+    assert results[0].snippet == "Snippet 1"
+
+
+def test_search_caps_count_to_brave_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = BraveClient(api_key="test-key", num_results=100)
+    captured_count: str | None = None
+
+    def _mock_get(*args: Any, **kwargs: Any) -> DummyResponse:  # noqa: ARG001
+        nonlocal captured_count
+        captured_count = kwargs["params"]["count"]
+        return DummyResponse(status_code=200, payload={"web": {"results": []}})
+
+    monkeypatch.setattr(brave_module.requests, "get", _mock_get)
+
+    client.search("onyx")
+
+    assert captured_count == "20"
+
+
+def test_search_raises_descriptive_error_on_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = BraveClient(api_key="test-key", num_results=5)
+
+    def _mock_get(*args: Any, **kwargs: Any) -> DummyResponse:  # noqa: ARG001
+        return DummyResponse(
+            status_code=401,
+            payload={"error": {"message": "Unauthorized"}},
+        )
+
+    monkeypatch.setattr(brave_module.requests, "get", _mock_get)
+
+    with pytest.raises(ValueError, match="status 401"):
+        client.search("onyx")
+
+
+def test_test_connection_maps_invalid_key_errors() -> None:
+    client = BraveClient(api_key="test-key")
+
+    def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
+        raise ValueError("Brave search failed (status 401): Unauthorized")
+
+    client.search = _mock_search  # type: ignore[method-assign]
+
+    with pytest.raises(HTTPException, match="Invalid Brave API key"):
+        client.test_connection()
+
+
+def test_test_connection_maps_rate_limit_errors() -> None:
+    client = BraveClient(api_key="test-key")
+
+    def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
+        raise ValueError("Brave search failed (status 429): Too many requests")
+
+    client.search = _mock_search  # type: ignore[method-assign]
+
+    with pytest.raises(HTTPException, match="rate limit exceeded"):
+        client.test_connection()
+
+
+def test_test_connection_propagates_unexpected_errors() -> None:
+    client = BraveClient(api_key="test-key")
+
+    def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
+        raise RuntimeError("unexpected parsing bug")
+
+    client.search = _mock_search  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="unexpected parsing bug"):
+        client.test_connection()

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_providers.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_providers.py
@@ -1,0 +1,88 @@
+import pytest
+
+from onyx.tools.tool_implementations.web_search.providers import (
+    build_search_provider_from_config,
+)
+from onyx.tools.tool_implementations.web_search.providers import (
+    provider_requires_api_key,
+)
+from shared_configs.enums import WebSearchProviderType
+
+
+def test_provider_requires_api_key() -> None:
+    """Test that provider_requires_api_key correctly identifies which providers need API keys."""
+    assert provider_requires_api_key(WebSearchProviderType.EXA) is True
+    assert provider_requires_api_key(WebSearchProviderType.BRAVE) is True
+    assert provider_requires_api_key(WebSearchProviderType.SERPER) is True
+    assert provider_requires_api_key(WebSearchProviderType.GOOGLE_PSE) is True
+    assert provider_requires_api_key(WebSearchProviderType.SEARXNG) is False
+
+
+def test_build_searxng_provider_without_api_key() -> None:
+    """Test that SearXNG provider can be built without an API key."""
+    provider = build_search_provider_from_config(
+        provider_type=WebSearchProviderType.SEARXNG,
+        api_key=None,
+        config={"searxng_base_url": "http://localhost:8080"},
+    )
+    assert provider is not None
+
+
+def test_build_searxng_provider_requires_base_url() -> None:
+    """Test that SearXNG provider requires a base URL."""
+    with pytest.raises(ValueError, match="Please provide a URL"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.SEARXNG,
+            api_key=None,
+            config={},
+        )
+
+
+def test_build_exa_provider_requires_api_key() -> None:
+    """Test that Exa provider requires an API key."""
+    with pytest.raises(ValueError, match="API key is required"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.EXA,
+            api_key=None,
+            config={},
+        )
+
+
+def test_build_brave_provider_requires_api_key() -> None:
+    """Test that Brave provider requires an API key."""
+    with pytest.raises(ValueError, match="API key is required"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.BRAVE,
+            api_key=None,
+            config={},
+        )
+
+
+def test_build_serper_provider_requires_api_key() -> None:
+    """Test that Serper provider requires an API key."""
+    with pytest.raises(ValueError, match="API key is required"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.SERPER,
+            api_key=None,
+            config={},
+        )
+
+
+def test_build_google_pse_provider_requires_api_key() -> None:
+    """Test that Google PSE provider requires an API key."""
+    with pytest.raises(ValueError, match="API key is required"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.GOOGLE_PSE,
+            api_key=None,
+            config={"search_engine_id": "test-cx"},
+        )
+
+
+def test_build_google_pse_provider_requires_search_engine_id() -> None:
+    """Test that Google PSE provider requires a search engine ID."""
+    with pytest.raises(ValueError, match="search engine id"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.GOOGLE_PSE,
+            api_key="test-api-key",
+            config={},
+        )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Brave as a new web search provider with a dedicated client, provider wiring, and unit tests. Enables result mapping, API key validation, and clear error handling.

- **New Features**
  - New BraveClient that queries Brave Web Search (max 20 results, configurable timeout).
  - Provider builder now supports provider_type="brave".
  - Added BRAVE to WebSearchProviderType enum.
  - Robust test_connection with specific 401/403/429 handling.
  - Unit tests for client behavior and provider config validation.

- **Migration**
  - Set provider_type to "brave" and supply a Brave API key.
  - Optional: set timeout_seconds in provider config (defaults to 10).

<sup>Written for commit 284467ef26dc2dba159f2648fe8cb6a01846a080. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

