### PR TITLE
fix: search tool enabled when nothing selected

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -33,7 +33,6 @@ export interface ActionItemProps {
   onForceToggle: () => void;
   onSourceManagementOpen?: () => void;
   hasNoConnectors?: boolean;
-  hasNoKnowledgeSources?: boolean;
   toolAuthStatus?: ToolAuthStatus;
   onOAuthAuthenticate?: () => void;
   onClose?: () => void;
@@ -56,7 +55,6 @@ export default function ActionLineItem({
   onForceToggle,
   onSourceManagementOpen,
   hasNoConnectors = false,
-  hasNoKnowledgeSources = false,
   toolAuthStatus,
   onOAuthAuthenticate,
   onClose,
@@ -78,11 +76,6 @@ export default function ActionLineItem({
     tool?.in_code_tool_id === SEARCH_TOOL_ID &&
     hasNoConnectors;
 
-  const isSearchToolWithNoKnowledgeSources =
-    !currentProjectId &&
-    tool?.in_code_tool_id === SEARCH_TOOL_ID &&
-    hasNoKnowledgeSources;
-
   const isSearchToolAndNotInProject =
     tool?.in_code_tool_id === SEARCH_TOOL_ID && !currentProjectId;
 
@@ -95,22 +88,14 @@ export default function ActionLineItem({
     sourceCounts.enabled > 0 &&
     sourceCounts.enabled < sourceCounts.total;
 
-  const tooltipText = isSearchToolWithNoKnowledgeSources
-    ? "No knowledge sources are available. Contact your admin to add a knowledge source to this agent."
-    : isUnavailable
-      ? unavailableReason
-      : tool?.description;
+  const tooltipText = isUnavailable ? unavailableReason : tool?.description;
 
   return (
     <SimpleTooltip tooltip={tooltipText} className="max-w-[30rem]">
       <div data-testid={`tool-option-${toolName}`}>
         <LineItem
           onClick={() => {
-            if (
-              isSearchToolWithNoConnectors ||
-              isSearchToolWithNoKnowledgeSources
-            )
-              return;
+            if (isSearchToolWithNoConnectors) return;
             if (isUnavailable) {
               if (isForced) onForceToggle();
               return;
@@ -123,10 +108,7 @@ export default function ActionLineItem({
           }}
           selected={isForced}
           strikethrough={
-            disabled ||
-            isSearchToolWithNoConnectors ||
-            isSearchToolWithNoKnowledgeSources ||
-            isUnavailable
+            disabled || isSearchToolWithNoConnectors || isUnavailable
           }
           icon={Icon}
           rightChildren={
@@ -201,31 +183,28 @@ export default function ActionLineItem({
                 </span>
               )}
 
-              {isSearchToolAndNotInProject &&
-                !isSearchToolWithNoKnowledgeSources && (
-                  <IconButton
-                    icon={
-                      isSearchToolWithNoConnectors
-                        ? SvgSettings
-                        : SvgChevronRight
-                    }
-                    onClick={noProp(() => {
-                      if (isSearchToolWithNoConnectors)
-                        router.push("/admin/add-connector");
-                      else onSourceManagementOpen?.();
-                    })}
-                    internal
-                    className={cn(
-                      isSearchToolWithNoConnectors &&
-                        "invisible group-hover/LineItem:visible"
-                    )}
-                    tooltip={
-                      isSearchToolWithNoConnectors
-                        ? "Add Connectors"
-                        : "Configure Connectors"
-                    }
-                  />
-                )}
+              {isSearchToolAndNotInProject && (
+                <IconButton
+                  icon={
+                    isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
+                  }
+                  onClick={noProp(() => {
+                    if (isSearchToolWithNoConnectors)
+                      router.push("/admin/add-connector");
+                    else onSourceManagementOpen?.();
+                  })}
+                  internal
+                  className={cn(
+                    isSearchToolWithNoConnectors &&
+                      "invisible group-hover/LineItem:visible"
+                  )}
+                  tooltip={
+                    isSearchToolWithNoConnectors
+                      ? "Add Connectors"
+                      : "Configure Connectors"
+                  }
+                />
+              )}
             </Section>
           }
         >

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -210,22 +210,15 @@ export default function ActionsPopover({
       sourceSet.add(normalized);
     });
 
+    // No specific sources selected means everything is searchable
+    if (sourceSet.size === 0) return null;
+
     return sourceSet;
   }, [
     isDefaultAgent,
     selectedAssistant.document_sets,
     selectedAssistant.knowledge_sources,
   ]);
-
-  // Check if non-default agent has no knowledge sources (Internal Search should be disabled)
-  // Knowledge sources include document sets and hierarchy nodes (folders, spaces, channels)
-  // Check if non-default agent has no knowledge sources (Internal Search should be disabled)
-  // Knowledge sources include document sets, hierarchy nodes, and attached documents
-  const hasNoKnowledgeSources =
-    !isDefaultAgent &&
-    selectedAssistant.document_sets.length === 0 &&
-    (selectedAssistant.hierarchy_node_count ?? 0) === 0 &&
-    (selectedAssistant.attached_document_count ?? 0) === 0;
 
   // Store MCP server auth/loading state (tools are part of selectedAssistant.tools)
   const [mcpServerData, setMcpServerData] = useState<{
@@ -905,7 +898,6 @@ export default function ActionsPopover({
                   setSecondaryView({ type: "sources" })
                 }
                 hasNoConnectors={hasNoConnectors}
-                hasNoKnowledgeSources={hasNoKnowledgeSources}
                 toolAuthStatus={getToolAuthStatus(tool)}
                 onOAuthAuthenticate={() => authenticateTool(tool)}
                 onClose={() => setOpen(false)}


### PR DESCRIPTION
## Description

There was a UI bug where the search tool would show up as disabled when the user created an assistant with "knowledge enabled" but nothing specific selected. The intended behavior (which was still the case on the backend) was that everything was searchable, but in the UI the search tool was coming up as disabled.

## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a UI bug where the search tool appeared disabled when an assistant had knowledge enabled but no specific sources selected. Now “no selection” means “search all knowledge,” matching backend behavior.

- **Bug Fixes**
  - Treat empty knowledge selection as “search all knowledge” in ActionsPopover.
  - Remove no-knowledge checks and tooltip; search stays enabled unless connectors are missing or the tool is unavailable.

<sup>Written for commit 89318e6bb6b87b7619820f6bbe8e885479fa8ca9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

