### PR TITLE
feat(web): Logical Hardening for Brave Web Search 2/3 #8595

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/clients/brave_client.py
+++ b/backend/onyx/tools/tool_implementations/web_search/clients/brave_client.py
@@ -16,6 +16,12 @@ logger = setup_logger()
 
 BRAVE_WEB_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 BRAVE_MAX_RESULTS_PER_REQUEST = 20
+BRAVE_SAFESEARCH_OPTIONS = {"off", "moderate", "strict"}
+BRAVE_FRESHNESS_OPTIONS = {"pd", "pw", "pm", "py"}
+
+
+class RetryableBraveSearchError(Exception):
+    """Error type used to trigger retry for transient Brave search failures."""
 
 
 class BraveClient(WebSearchProvider):
@@ -25,7 +31,15 @@ class BraveClient(WebSearchProvider):
         *,
         num_results: int = 10,
         timeout_seconds: int = 10,
+        country: str | None = None,
+        search_lang: str | None = None,
+        ui_lang: str | None = None,
+        safesearch: str | None = None,
+        freshness: str | None = None,
     ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("Brave provider config 'timeout_seconds' must be > 0.")
+
         self._headers = {
             "Accept": "application/json",
             "X-Subscription-Token": api_key,
@@ -33,37 +47,82 @@ class BraveClient(WebSearchProvider):
         logger.debug(f"Count of results passed to BraveClient: {num_results}")
         self._num_results = max(1, min(num_results, BRAVE_MAX_RESULTS_PER_REQUEST))
         self._timeout_seconds = timeout_seconds
+        self._country = _normalize_country(country)
+        self._search_lang = _normalize_language_code(
+            search_lang, field_name="search_lang"
+        )
+        self._ui_lang = _normalize_language_code(ui_lang, field_name="ui_lang")
+        self._safesearch = _normalize_option(
+            safesearch,
+            field_name="safesearch",
+            allowed_values=BRAVE_SAFESEARCH_OPTIONS,
+        )
+        self._freshness = _normalize_option(
+            freshness,
+            field_name="freshness",
+            allowed_values=BRAVE_FRESHNESS_OPTIONS,
+        )
 
-    @retry_builder(tries=3, delay=1, backoff=2)
-    def search(self, query: str) -> list[WebSearchResult]:
+    def _build_search_params(self, query: str) -> dict[str, str]:
         params = {
             "q": query,
             "count": str(self._num_results),
         }
+        if self._country:
+            params["country"] = self._country
+        if self._search_lang:
+            params["search_lang"] = self._search_lang
+        if self._ui_lang:
+            params["ui_lang"] = self._ui_lang
+        if self._safesearch:
+            params["safesearch"] = self._safesearch
+        if self._freshness:
+            params["freshness"] = self._freshness
+        return params
 
-        response = requests.get(
-            BRAVE_WEB_SEARCH_URL,
-            headers=self._headers,
-            params=params,
-            timeout=self._timeout_seconds,
-        )
+    @retry_builder(
+        tries=3,
+        delay=1,
+        backoff=2,
+        exceptions=(RetryableBraveSearchError,),
+    )
+    def _search_with_retries(self, query: str) -> list[WebSearchResult]:
+        params = self._build_search_params(query)
+
+        try:
+            response = requests.get(
+                BRAVE_WEB_SEARCH_URL,
+                headers=self._headers,
+                params=params,
+                timeout=self._timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise RetryableBraveSearchError(
+                f"Brave search request failed: {exc}"
+            ) from exc
 
         try:
             response.raise_for_status()
         except requests.HTTPError as exc:
-            raise ValueError(_build_error_message(response)) from exc
+            error_msg = _build_error_message(response)
+            if _is_retryable_status(response.status_code):
+                raise RetryableBraveSearchError(error_msg) from exc
+            raise ValueError(error_msg) from exc
 
         data = response.json()
         web_results = (data.get("web") or {}).get("results") or []
 
         results: list[WebSearchResult] = []
         for result in web_results:
-            link = (result.get("url") or "").strip()
+            if not isinstance(result, dict):
+                continue
+
+            link = _clean_string(result.get("url"))
             if not link:
                 continue
 
-            title = (result.get("title") or "").strip()
-            description = (result.get("description") or "").strip()
+            title = _clean_string(result.get("title"))
+            description = _clean_string(result.get("description"))
 
             results.append(
                 WebSearchResult(
@@ -76,6 +135,12 @@ class BraveClient(WebSearchProvider):
             )
 
         return results
+
+    def search(self, query: str) -> list[WebSearchResult]:
+        try:
+            return self._search_with_retries(query)
+        except RetryableBraveSearchError as exc:
+            raise ValueError(str(exc)) from exc
 
     def test_connection(self) -> dict[str, str]:
         try:
@@ -142,3 +207,54 @@ def _extract_error_detail(response: requests.Response) -> str:
             return message
 
     return str(payload)[:200]
+
+
+def _is_retryable_status(status_code: int) -> bool:
+    return status_code == 429 or status_code >= 500
+
+
+def _clean_string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalize_country(country: str | None) -> str | None:
+    if country is None:
+        return None
+    normalized = country.strip().upper()
+    if not normalized:
+        return None
+    if len(normalized) != 2 or not normalized.isalpha():
+        raise ValueError(
+            "Brave provider config 'country' must be a 2-letter ISO country code."
+        )
+    return normalized
+
+
+def _normalize_language_code(value: str | None, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if len(normalized) > 20:
+        raise ValueError(f"Brave provider config '{field_name}' is too long.")
+    return normalized
+
+
+def _normalize_option(
+    value: str | None,
+    *,
+    field_name: str,
+    allowed_values: set[str],
+) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise ValueError(
+            f"Brave provider config '{field_name}' must be one of: {allowed}."
+        )
+    return normalized

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_providers.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_providers.py
@@ -1,5 +1,8 @@
 import pytest
 
+from onyx.tools.tool_implementations.web_search.clients.brave_client import (
+    BraveClient,
+)
 from onyx.tools.tool_implementations.web_search.providers import (
     build_search_provider_from_config,
 )
@@ -55,6 +58,37 @@ def test_build_brave_provider_requires_api_key() -> None:
             provider_type=WebSearchProviderType.BRAVE,
             api_key=None,
             config={},
+        )
+
+
+def test_build_brave_provider_with_optional_config() -> None:
+    provider = build_search_provider_from_config(
+        provider_type=WebSearchProviderType.BRAVE,
+        api_key="test-api-key",
+        config={
+            "country": "us",
+            "search_lang": "en",
+            "ui_lang": "en-US",
+            "safesearch": "strict",
+            "freshness": "pm",
+            "timeout_seconds": "12",
+        },
+    )
+    assert isinstance(provider, BraveClient)
+    assert provider._country == "US"  # noqa: SLF001
+    assert provider._search_lang == "en"  # noqa: SLF001
+    assert provider._ui_lang == "en-US"  # noqa: SLF001
+    assert provider._safesearch == "strict"  # noqa: SLF001
+    assert provider._freshness == "pm"  # noqa: SLF001
+    assert provider._timeout_seconds == 12  # noqa: SLF001
+
+
+def test_build_brave_provider_rejects_invalid_timeout() -> None:
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        build_search_provider_from_config(
+            provider_type=WebSearchProviderType.BRAVE,
+            api_key="test-api-key",
+            config={"timeout_seconds": "not-an-int"},
         )
 
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds input validation, optional Brave query params, and targeted retry logic to harden Brave Web Search. Reduces transient failures and supports region/language controls.

- **New Features**
  - Optional params: country (ISO-2), search_lang, ui_lang, safesearch (off/moderate/strict), freshness (pd/pw/pm/py).
  - Validates config: timeout_seconds > 0; strict checks for country, language, and option values.
  - Retries only on 429 and 5xx via RetryableBraveSearchError; non-retryable HTTP errors fail fast with clear messages.
  - Sanitizes response fields and skips malformed results to prevent errors.
  - Provider builder parses timeout_seconds as a positive int and passes new config options.
  - Unit tests added for optional params, retry behavior, invalid config handling, and timeout parsing.

<sup>Written for commit 68fccedbeed3ba170ad882618d37bcf2a95eaa6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

