### PR TITLE
fix: search tool enabled when nothing selected to release v2.12

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -32,7 +32,6 @@ export interface ActionItemProps {
   onForceToggle: () => void;
   onSourceManagementOpen?: () => void;
   hasNoConnectors?: boolean;
-  hasNoKnowledgeSources?: boolean;
   toolAuthStatus?: ToolAuthStatus;
   onOAuthAuthenticate?: () => void;
   onClose?: () => void;
@@ -55,7 +54,6 @@ export default function ActionLineItem({
   onForceToggle,
   onSourceManagementOpen,
   hasNoConnectors = false,
-  hasNoKnowledgeSources = false,
   toolAuthStatus,
   onOAuthAuthenticate,
   onClose,
@@ -77,11 +75,6 @@ export default function ActionLineItem({
     tool?.in_code_tool_id === SEARCH_TOOL_ID &&
     hasNoConnectors;
 
-  const isSearchToolWithNoKnowledgeSources =
-    !currentProjectId &&
-    tool?.in_code_tool_id === SEARCH_TOOL_ID &&
-    hasNoKnowledgeSources;
-
   const isSearchToolAndNotInProject =
     tool?.in_code_tool_id === SEARCH_TOOL_ID && !currentProjectId;
 
@@ -94,22 +87,14 @@ export default function ActionLineItem({
     sourceCounts.enabled > 0 &&
     sourceCounts.enabled < sourceCounts.total;
 
-  const tooltipText = isSearchToolWithNoKnowledgeSources
-    ? "No knowledge sources are available. Contact your admin to add a knowledge source to this agent."
-    : isUnavailable
-      ? unavailableReason
-      : tool?.description;
+  const tooltipText = isUnavailable ? unavailableReason : tool?.description;
 
   return (
     <SimpleTooltip tooltip={tooltipText} className="max-w-[30rem]">
       <div data-testid={`tool-option-${toolName}`}>
         <LineItem
           onClick={() => {
-            if (
-              isSearchToolWithNoConnectors ||
-              isSearchToolWithNoKnowledgeSources
-            )
-              return;
+            if (isSearchToolWithNoConnectors) return;
             if (isUnavailable) {
               if (isForced) onForceToggle();
               return;
@@ -122,10 +107,7 @@ export default function ActionLineItem({
           }}
           selected={isForced}
           strikethrough={
-            disabled ||
-            isSearchToolWithNoConnectors ||
-            isSearchToolWithNoKnowledgeSources ||
-            isUnavailable
+            disabled || isSearchToolWithNoConnectors || isUnavailable
           }
           icon={Icon}
           rightChildren={
@@ -198,31 +180,28 @@ export default function ActionLineItem({
                 </span>
               )}
 
-              {isSearchToolAndNotInProject &&
-                !isSearchToolWithNoKnowledgeSources && (
-                  <IconButton
-                    icon={
-                      isSearchToolWithNoConnectors
-                        ? SvgSettings
-                        : SvgChevronRight
-                    }
-                    onClick={noProp(() => {
-                      if (isSearchToolWithNoConnectors)
-                        router.push("/admin/add-connector");
-                      else onSourceManagementOpen?.();
-                    })}
-                    internal
-                    className={cn(
-                      isSearchToolWithNoConnectors &&
-                        "invisible group-hover/LineItem:visible"
-                    )}
-                    tooltip={
-                      isSearchToolWithNoConnectors
-                        ? "Add Connectors"
-                        : "Configure Connectors"
-                    }
-                  />
-                )}
+              {isSearchToolAndNotInProject && (
+                <IconButton
+                  icon={
+                    isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
+                  }
+                  onClick={noProp(() => {
+                    if (isSearchToolWithNoConnectors)
+                      router.push("/admin/add-connector");
+                    else onSourceManagementOpen?.();
+                  })}
+                  internal
+                  className={cn(
+                    isSearchToolWithNoConnectors &&
+                      "invisible group-hover/LineItem:visible"
+                  )}
+                  tooltip={
+                    isSearchToolWithNoConnectors
+                      ? "Add Connectors"
+                      : "Configure Connectors"
+                  }
+                />
+              )}
             </Section>
           }
         >

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -209,22 +209,15 @@ export default function ActionsPopover({
       sourceSet.add(normalized);
     });
 
+    // No specific sources selected means everything is searchable
+    if (sourceSet.size === 0) return null;
+
     return sourceSet;
   }, [
     isDefaultAgent,
     selectedAssistant.document_sets,
     selectedAssistant.knowledge_sources,
   ]);
-
-  // Check if non-default agent has no knowledge sources (Internal Search should be disabled)
-  // Knowledge sources include document sets and hierarchy nodes (folders, spaces, channels)
-  // Check if non-default agent has no knowledge sources (Internal Search should be disabled)
-  // Knowledge sources include document sets, hierarchy nodes, and attached documents
-  const hasNoKnowledgeSources =
-    !isDefaultAgent &&
-    selectedAssistant.document_sets.length === 0 &&
-    (selectedAssistant.hierarchy_node_count ?? 0) === 0 &&
-    (selectedAssistant.attached_document_count ?? 0) === 0;
 
   // Store MCP server auth/loading state (tools are part of selectedAssistant.tools)
   const [mcpServerData, setMcpServerData] = useState<{
@@ -894,7 +887,6 @@ export default function ActionsPopover({
                   setSecondaryView({ type: "sources" })
                 }
                 hasNoConnectors={hasNoConnectors}
-                hasNoKnowledgeSources={hasNoKnowledgeSources}
                 toolAuthStatus={getToolAuthStatus(tool)}
                 onOAuthAuthenticate={() => authenticateTool(tool)}
                 onClose={() => setOpen(false)}


### PR DESCRIPTION
Cherry-pick of commit 89318e6bb6b87b7619820f6bbe8e885479fa8ca9 to release/v2.12 branch.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Internal Search when no specific sources are selected, so users can search all available content by default. The search tool now only disables when there are no connectors or the tool is unavailable.

- **Bug Fixes**
  - Treat empty source selection as “search everything” in ActionsPopover.
  - Remove “no knowledge sources” checks and related tooltip/strikethrough blocking in ActionLineItem.
  - Keep connector configuration button; routes to Add Connector or Sources as expected.

<sup>Written for commit 9d83088228925bffed2a664fcea88905ea95e011. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

