### PR TITLE
chore(deps): @radix-ui/react-tooltip: v1.1.3->v1.2.8

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-slider": "^1.2.2",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.1",
-        "@radix-ui/react-tooltip": "^1.1.3",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/nextjs": "^10.27.0",
         "@sentry/tracing": "^7.120.3",
         "@stripe/stripe-js": "^4.6.0",
@@ -3788,6 +3788,8 @@
     },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -51,7 +51,7 @@
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.1",
-    "@radix-ui/react-tooltip": "^1.1.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/nextjs": "^10.27.0",
     "@sentry/tracing": "^7.120.3",
     "@stripe/stripe-js": "^4.6.0",


### PR DESCRIPTION
## Description

Grasping at straws a bit trying to resolve, https://linear.app/onyx-app/issue/ENG-3603/action-descriptions-blink-and-disappear. Non-zero chance it's a bug upstream, so let's upgrade.

## How Has This Been Tested?



## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded @radix-ui/react-tooltip to v1.2.8 to address tooltip flicker causing action descriptions to blink and disappear. Connects to Linear ENG-3603.

- **Dependencies**
  - @radix-ui/react-tooltip: 1.1.3 → 1.2.8

<sup>Written for commit 00be72acf2b30e775f3a92acb8e5aa99f6cd81b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

