### PR TITLE
chore(fe): fix drop-down overflow in API Key modal (#8574) to release v2.12

### DIFF
--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -1,13 +1,17 @@
 import { Form, Formik } from "formik";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
-import { SelectorFormField, TextFormField } from "@/components/Field";
 import { createApiKey, updateApiKey } from "./lib";
 import Modal from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { FormikField } from "@/refresh-components/form/FormikField";
+import { FormField } from "@/refresh-components/form/FormField";
 import { USER_ROLE_LABELS, UserRole } from "@/lib/types";
 import { APIKey } from "./types";
 import { SvgKey } from "@opal/icons";
+
 export interface OnyxApiKeyFormProps {
   onClose: () => void;
   setPopup: (popupSpec: PopupSpec | null) => void;
@@ -31,91 +35,120 @@ export default function OnyxApiKeyForm({
           title={isUpdate ? "Update API Key" : "Create a new API Key"}
           onClose={onClose}
         />
-        <Modal.Body>
-          <Formik
-            initialValues={{
-              name: apiKey?.api_key_name || "",
-              role: apiKey?.api_key_role || UserRole.BASIC.toString(),
-            }}
-            onSubmit={async (values, formikHelpers) => {
-              formikHelpers.setSubmitting(true);
+        <Formik
+          initialValues={{
+            name: apiKey?.api_key_name || "",
+            role: apiKey?.api_key_role || UserRole.BASIC.toString(),
+          }}
+          onSubmit={async (values, formikHelpers) => {
+            formikHelpers.setSubmitting(true);
 
-              // Prepare the payload with the UserRole
-              const payload = {
-                ...values,
-                role: values.role as UserRole, // Assign the role directly as a UserRole type
-              };
+            // Prepare the payload with the UserRole
+            const payload = {
+              ...values,
+              role: values.role as UserRole, // Assign the role directly as a UserRole type
+            };
 
-              let response;
-              if (isUpdate) {
-                response = await updateApiKey(apiKey.api_key_id, payload);
-              } else {
-                response = await createApiKey(payload);
+            let response;
+            if (isUpdate) {
+              response = await updateApiKey(apiKey.api_key_id, payload);
+            } else {
+              response = await createApiKey(payload);
+            }
+            formikHelpers.setSubmitting(false);
+            if (response.ok) {
+              setPopup({
+                message: isUpdate
+                  ? "Successfully updated API key!"
+                  : "Successfully created API key!",
+                type: "success",
+              });
+              if (!isUpdate) {
+                onCreateApiKey(await response.json());
               }
-              formikHelpers.setSubmitting(false);
-              if (response.ok) {
-                setPopup({
-                  message: isUpdate
-                    ? "Successfully updated API key!"
-                    : "Successfully created API key!",
-                  type: "success",
-                });
-                if (!isUpdate) {
-                  onCreateApiKey(await response.json());
-                }
-                onClose();
-              } else {
-                const responseJson = await response.json();
-                const errorMsg = responseJson.detail || responseJson.message;
-                setPopup({
-                  message: isUpdate
-                    ? `Error updating API key - ${errorMsg}`
-                    : `Error creating API key - ${errorMsg}`,
-                  type: "error",
-                });
-              }
-            }}
-          >
-            {({ isSubmitting }) => (
-              <Form className="w-full overflow-visible">
+              onClose();
+            } else {
+              const responseJson = await response.json();
+              const errorMsg = responseJson.detail || responseJson.message;
+              setPopup({
+                message: isUpdate
+                  ? `Error updating API key - ${errorMsg}`
+                  : `Error creating API key - ${errorMsg}`,
+                type: "error",
+              });
+            }
+          }}
+        >
+          {({ isSubmitting }) => (
+            <Form className="w-full overflow-visible">
+              <Modal.Body>
                 <Text as="p">
                   Choose a memorable name for your API key. This is optional and
                   can be added or changed later!
                 </Text>
 
-                <TextFormField name="name" label="Name (optional):" />
-
-                <SelectorFormField
-                  // defaultValue is managed by Formik
-                  label="Role:"
-                  subtext="Select the role for this API key.
-                           Limited has access to simple public API's.
-                           Basic has access to regular user API's.
-                           Admin has access to admin level APIs."
-                  name="role"
-                  options={[
-                    {
-                      name: USER_ROLE_LABELS[UserRole.LIMITED],
-                      value: UserRole.LIMITED.toString(),
-                    },
-                    {
-                      name: USER_ROLE_LABELS[UserRole.BASIC],
-                      value: UserRole.BASIC.toString(),
-                    },
-                    {
-                      name: USER_ROLE_LABELS[UserRole.ADMIN],
-                      value: UserRole.ADMIN.toString(),
-                    },
-                  ]}
+                <FormikField<string>
+                  name="name"
+                  render={(field, helper, _meta, state) => (
+                    <FormField name="name" state={state} className="w-full">
+                      <FormField.Label>Name (optional):</FormField.Label>
+                      <FormField.Control>
+                        <InputTypeIn
+                          {...field}
+                          placeholder=""
+                          onClear={() => helper.setValue("")}
+                          showClearButton={false}
+                        />
+                      </FormField.Control>
+                    </FormField>
+                  )}
                 />
 
+                <FormikField<string>
+                  name="role"
+                  render={(field, helper, _meta, state) => (
+                    <FormField name="role" state={state} className="w-full">
+                      <FormField.Label>Role:</FormField.Label>
+                      <FormField.Control>
+                        <InputComboBox
+                          value={field.value}
+                          onValueChange={(value) => helper.setValue(value)}
+                          options={[
+                            {
+                              label: USER_ROLE_LABELS[UserRole.LIMITED],
+                              value: UserRole.LIMITED.toString(),
+                            },
+                            {
+                              label: USER_ROLE_LABELS[UserRole.BASIC],
+                              value: UserRole.BASIC.toString(),
+                            },
+                            {
+                              label: USER_ROLE_LABELS[UserRole.ADMIN],
+                              value: UserRole.ADMIN.toString(),
+                            },
+                          ]}
+                          placeholder="Select a role"
+                          strict
+                        />
+                      </FormField.Control>
+                      <FormField.Description>
+                        Select the role for this API key. Limited has access to
+                        simple public APIs. Basic has access to regular user
+                        APIs. Admin has access to admin level APIs.
+                      </FormField.Description>
+                    </FormField>
+                  )}
+                />
+              </Modal.Body>
+
+              <Modal.Footer>
                 <Button type="submit" disabled={isSubmitting}>
                   {isUpdate ? "Update" : "Create"}
                 </Button>
-              </Form>
-            )}
-          </Formik>
-        </Modal.Body>
+              </Modal.Footer>
+            </Form>
+          )}
+        </Formik>
       </Modal.Content>
     </Modal>
   );


### PR DESCRIPTION
Cherry-pick of commit 59e1ad51ba6c6ad95c171870bac732a6bf75631f to release/v2.12 branch.

Original PR: #8574

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the role dropdown being cut off in the API Key modal so the menu opens fully. Updates the form to use refresh input components and a safer modal layout with no behavior changes.

- **Bug Fixes**
  - Replaced the role selector with InputComboBox via FormikField/FormField and added a short role description.
  - Set the form container to overflow-visible and moved actions to Modal.Footer so the dropdown isn’t clipped.

<sup>Written for commit 58810687af5d849c42617622ea958a269bed203b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

