### PR TITLE
chore(devtools): AGENTS.md warns against enqueueing tasks without an expiration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ The deployment mode affects:
 - Put tasks under `background/celery/tasks/` or `ee/background/celery/tasks`
 - Never enqueue a task without an expiration. Always supply `expires=` when
   sending tasks, either from the beat schedule or directly from another task. It
-  should never be acceptible to submit code which enqueues tasks without an
+  should never be acceptable to submit code which enqueues tasks without an
   expiration, as doing so can lead to unbounded task queue growth.
 
 **Defining APIs**:


### PR DESCRIPTION
## Description
Doing this is bad and leads to unbounded queue growth.

## How Has This Been Tested?
Twas not.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a rule in AGENTS.md: never enqueue Celery tasks without an expiration. Require expires= on all task submissions (beat schedules and chained tasks) to prevent unbounded queue growth.

<sup>Written for commit 79c738b62bb20135ebd84c4bcc84852019c6705a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

