### PR TITLE
chore(fe): fix Pinned icon hover background when card is hovered

### DIFF
--- a/web/src/sections/cards/AgentCard.tsx
+++ b/web/src/sections/cards/AgentCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import Button from "@/refresh-components/buttons/Button";
@@ -46,7 +46,6 @@ export default function AgentCard({ agent }: AgentCardProps) {
   const { user } = useUser();
   const isPaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
   const isOwnedByUser = checkUserOwnsAssistant(user, agent);
-  const [hovered, setHovered] = React.useState(false);
   const shareAgentModal = useCreateModal();
   const agentViewerModal = useCreateModal();
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
@@ -100,8 +99,6 @@ export default function AgentCard({ agent }: AgentCardProps) {
       <Interactive.Base
         onClick={() => agentViewerModal.toggle(true)}
         group="group/AgentCard"
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
         variant="none"
       >
         <Card padding={0} gap={0} height="full">
@@ -148,7 +145,6 @@ export default function AgentCard({ agent }: AgentCardProps) {
                     tertiary
                     onClick={noProp(() => togglePinnedAgent(agent, !pinned))}
                     tooltip={pinned ? "Unpin from Sidebar" : "Pin to Sidebar"}
-                    transient={hovered && pinned}
                     className={cn(
                       !pinned && "hidden group-hover/AgentCard:flex"
                     )}


### PR DESCRIPTION
## Description

Updates the Pinned icon in the AgentCard to only show hover state when the icon is hovered -- not when the card is hovered.

## How Has This Been Tested?
Pinned, no hover
<img width="2880" height="1920" alt="20260220_17h58m09s_grim" src="https://github.com/user-attachments/assets/e82f4e33-74a5-4df3-8a11-99bd31ce1b4e" />
Pinned, card hover
<img width="2880" height="1920" alt="20260220_17h57m57s_grim" src="https://github.com/user-attachments/assets/16f031de-0367-489b-a777-59a191264f89" />
Pinned, icon hover
<img width="2880" height="1920" alt="20260220_17h58m00s_grim" src="https://github.com/user-attachments/assets/decee6ae-9d6e-470b-84f0-a6c2f602a440" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pinned icon hover background in AgentCard so the hover state triggers only when the icon is hovered, not when the card is hovered. Removes the card-level hover state and the button’s transient prop to prevent unintended hover styling.

<sup>Written for commit 1e394a28da1e7f7e07875bdc29093ac1d2029060. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

