### PR TITLE
fix: limit connectors section to 3 items in Chat Preferences

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -25,6 +25,7 @@ import {
   SvgFold,
   SvgExternalLink,
 } from "@opal/icons";
+import { Content } from "@opal/layouts";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import useCCPairs from "@/hooks/useCCPairs";
 import { getSourceMetadata } from "@/lib/sources";
@@ -471,19 +472,18 @@ function ChatPreferencesForm() {
                       <EmptyMessage title="No connectors set up" />
                     ) : (
                       <>
-                        {uniqueSources.map((source) => {
+                        {uniqueSources.slice(0, 3).map((source) => {
                           const meta = getSourceMetadata(source);
                           return (
                             <Card
                               key={source}
                               padding={0.75}
-                              className="!w-[10rem]"
+                              className="w-[10rem]"
                             >
-                              <LineItemLayout
+                              <Content
                                 icon={meta.icon}
                                 title={meta.displayName}
-                                variant="secondary"
-                                center
+                                sizePreset="main-ui"
                               />
                             </Card>
                           );


### PR DESCRIPTION
## Description

Limits the connectors section in the Chat Preferences admin page to show at most 3 connector sources. The "Manage All" button links to the full connectors page for viewing the rest.

Also swaps `LineItemLayout` for the `Content` layout component and removes the `!important` width override.

## Screenshots

### Before

<img width="826" height="298" alt="image" src="https://github.com/user-attachments/assets/b14d20a9-9f7f-4517-a059-124d16a3bced" />

### After

<img width="847" height="298" alt="image" src="https://github.com/user-attachments/assets/7f34bba6-36d8-452b-9e62-8dfedbd26da0" />

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the connectors section in Chat Preferences to show up to 3 sources, with a “Manage All” button linking to the full connectors page. Also swaps LineItemLayout for the Content component and removes the !important width override for cleaner, consistent styling.

<sup>Written for commit e1e740ed34f38ac1843ed0bb0f948c2c6c303aca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->