### PR TITLE
fix(popover): prevent viewport overflow with dynamic max-height and collision padding

### DIFF
--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -135,8 +135,10 @@ function PopoverContent({
         ref={ref}
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={8}
         className={cn(
           "bg-background-neutral-00 p-1 z-popover rounded-12 overflow-hidden border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "max-h-[var(--radix-popover-content-available-height)]",
           widthClasses[width]
         )}
         {...props}


### PR DESCRIPTION
## Description
  - Add `max-h-[var(--radix-popover-content-available-height)]` so the popover shrinks to fit within the viewport when near edges
  - Add `collisionPadding={8}` to maintain an 8px gap from viewport edges, which Radix factors into the available height
  automatically
ticket: https://linear.app/onyx-app/issue/ENG-3499/model-selector-going-off-screen-on-small-monitors

## How Has This Been Tested?
Before:
<img width="1050" height="754" alt="Screenshot 2026-02-23 at 7 13 21 PM" src="https://github.com/user-attachments/assets/8d032098-7c3a-4d6e-8a18-1a2402da1834" />

After:
<img width="1049" height="752" alt="Screenshot 2026-02-23 at 7 14 52 PM" src="https://github.com/user-attachments/assets/ea86e784-7510-44fa-a888-20a2d8076418" />


## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented popovers from overflowing the viewport by setting a dynamic max height and adding an 8px collision padding, keeping content within screen edges. Addresses Linear ENG-3499 (model selector going off-screen on small monitors).

<sup>Written for commit ff8c0060a53c796eac23a82d11309922ea8a6d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

