### PR TITLE
fix(fe): modal aligning with detached element after navigation

### DIFF
--- a/web/src/hooks/useContainerCenter.ts
+++ b/web/src/hooks/useContainerCenter.ts
@@ -55,8 +55,7 @@ export default function useContainerCenter(): ContainerCenter {
     }
 
     const update = () => {
-      const el = document.querySelector<HTMLElement>(SELECTOR);
-      const m = el ? measure(el) : null;
+      const m = measure(container);
       setCenter(m ?? NULL_CENTER);
     };
 


### PR DESCRIPTION
## Description

`@container` is now on attached to the `AppLayout.Root` rather than the Chat page's main container meaning a page navigation renders a new element for `@container`. This breaks the centered modals as they refer to the now detached element to align with resulting in `center.x` to resolve to `0` from then on.

Instead, detect if a navigation has occurred when re-rendering to update the new element reference.

Closes https://linear.app/onyx-app/issue/ENG-3735/search-chat-modal-positionin

## How Has This Been Tested?

Went to /app/agents, clicked to start a new session, opened search modal and confirmed it was center alighed relative to the chat container instead of viewport.

Playwright regression test is probably possible, but not sure it'd be a meaningful test

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes centered modals aligning to a detached element after route changes by re-selecting the main container on navigation. Modals now stay centered relative to the chat container across page transitions.

- **Bug Fixes**
  - Re-subscribe on pathname changes to use the new AppLayout.Root element and re-measure the center.
  - Ignore detached or zero-size elements; set center to null when no container is found.
  - Keep lazy init with a NULL_CENTER default and use ResizeObserver for layout changes.

<sup>Written for commit 1efaa30bead492756a845ff8288d879e00e0e61b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

