### PR TITLE
fix(db): Multitenant Schema migration update

### DIFF
--- a/backend/alembic/run_multitenant_migrations.py
+++ b/backend/alembic/run_multitenant_migrations.py
@@ -21,14 +21,14 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, NamedTuple
+from typing import NamedTuple
 
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import text
 
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
+from onyx.db.engine.tenant_utils import get_schemas_needing_migration
 from shared_configs.configs import TENANT_ID_PREFIX
 
 
@@ -102,90 +102,6 @@ def get_head_revision() -> str | None:
     alembic_cfg = Config("alembic.ini")
     script = ScriptDirectory.from_config(alembic_cfg)
     return script.get_current_head()
-
-
-def get_schemas_needing_migration(
-    tenant_schemas: List[str], head_rev: str
-) -> List[str]:
-    """Return only schemas whose current alembic version is not at head.
-
-    Uses a server-side PL/pgSQL loop to collect each schema's alembic version
-    into a temp table one at a time. This avoids building a massive UNION ALL
-    query (which locks the DB and times out at 17k+ schemas) and instead
-    acquires locks sequentially, one schema per iteration.
-    """
-    if not tenant_schemas:
-        return []
-
-    engine = SqlEngine.get_engine()
-
-    with engine.connect() as conn:
-        # Populate a temp input table with exactly the schemas we care about.
-        # The DO block reads from this table so it only iterates the requested
-        # schemas instead of every tenant_% schema in the database.
-        conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
-        conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
-        conn.execute(text("CREATE TEMP TABLE _tenant_schemas_input (schema_name text)"))
-        conn.execute(
-            text(
-                "INSERT INTO _tenant_schemas_input (schema_name) "
-                "SELECT unnest(CAST(:schemas AS text[]))"
-            ),
-            {"schemas": tenant_schemas},
-        )
-        conn.execute(
-            text(
-                "CREATE TEMP TABLE _alembic_version_snapshot "
-                "(schema_name text, version_num text)"
-            )
-        )
-
-        conn.execute(
-            text(
-                """
-                DO $$
-                DECLARE
-                    s        text;
-                    schemas  text[];
-                BEGIN
-                    SELECT array_agg(schema_name) INTO schemas
-                    FROM _tenant_schemas_input;
-
-                    IF schemas IS NULL THEN
-                        RAISE NOTICE 'No tenant schemas found.';
-                        RETURN;
-                    END IF;
-
-                    FOREACH s IN ARRAY schemas LOOP
-                        BEGIN
-                            EXECUTE format(
-                                'INSERT INTO _alembic_version_snapshot
-                                 SELECT %L, version_num FROM %I.alembic_version',
-                                s, s
-                            );
-                        EXCEPTION
-                            WHEN undefined_table THEN NULL;
-                            WHEN invalid_schema_name THEN NULL;
-                        END;
-                    END LOOP;
-                END;
-                $$
-                """
-            )
-        )
-
-        rows = conn.execute(
-            text("SELECT schema_name, version_num FROM _alembic_version_snapshot")
-        )
-        version_by_schema = {row[0]: row[1] for row in rows}
-
-        conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
-        conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
-
-    # Schemas missing from the snapshot have no alembic_version table yet and
-    # also need migration. version_by_schema.get(s) returns None for those,
-    # and None != head_rev, so they are included automatically.
-    return [s for s in tenant_schemas if version_by_schema.get(s) != head_rev]
 
 
 def run_migrations_parallel(

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,9 +1,100 @@
 from sqlalchemy import text
 
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import SqlEngine
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import TENANT_ID_PREFIX
+
+
+def get_schemas_needing_migration(
+    tenant_schemas: list[str], head_rev: str
+) -> list[str]:
+    """Return only schemas whose current alembic version is not at head.
+
+    Uses a server-side PL/pgSQL loop to collect each schema's alembic version
+    into a temp table one at a time. This avoids building a massive UNION ALL
+    query (which locks the DB and times out at 17k+ schemas) and instead
+    acquires locks sequentially, one schema per iteration.
+    """
+    if not tenant_schemas:
+        return []
+
+    engine = SqlEngine.get_engine()
+
+    with engine.connect() as conn:
+        # Populate a temp input table with exactly the schemas we care about.
+        # The DO block reads from this table so it only iterates the requested
+        # schemas instead of every tenant_% schema in the database.
+        conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
+        conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
+        conn.execute(text("CREATE TEMP TABLE _tenant_schemas_input (schema_name text)"))
+        conn.execute(
+            text(
+                "INSERT INTO _tenant_schemas_input (schema_name) "
+                "SELECT unnest(CAST(:schemas AS text[]))"
+            ),
+            {"schemas": tenant_schemas},
+        )
+        conn.execute(
+            text(
+                "CREATE TEMP TABLE _alembic_version_snapshot "
+                "(schema_name text, version_num text)"
+            )
+        )
+
+        conn.execute(
+            text(
+                """
+                DO $$
+                DECLARE
+                    s        text;
+                    schemas  text[];
+                BEGIN
+                    SELECT array_agg(schema_name) INTO schemas
+                    FROM _tenant_schemas_input;
+
+                    IF schemas IS NULL THEN
+                        RAISE NOTICE 'No tenant schemas found.';
+                        RETURN;
+                    END IF;
+
+                    FOREACH s IN ARRAY schemas LOOP
+                        BEGIN
+                            EXECUTE format(
+                                'INSERT INTO _alembic_version_snapshot
+                                 SELECT %L, version_num FROM %I.alembic_version',
+                                s, s
+                            );
+                        EXCEPTION
+                            -- undefined_table: schema exists but has no alembic_version
+                            --   table yet (new tenant, not yet migrated).
+                            -- invalid_schema_name: tenant is registered but its
+                            --   PostgreSQL schema does not exist yet (e.g. provisioning
+                            --   incomplete). Both cases mean no version is available and
+                            --   the schema will be included in the migration list.
+                            WHEN undefined_table THEN NULL;
+                            WHEN invalid_schema_name THEN NULL;
+                        END;
+                    END LOOP;
+                END;
+                $$
+                """
+            )
+        )
+
+        rows = conn.execute(
+            text("SELECT schema_name, version_num FROM _alembic_version_snapshot")
+        )
+        version_by_schema = {row[0]: row[1] for row in rows}
+
+        conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
+        conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
+
+    # Schemas missing from the snapshot have no alembic_version table yet and
+    # also need migration. version_by_schema.get(s) returns None for those,
+    # and None != head_rev, so they are included automatically.
+    return [s for s in tenant_schemas if version_by_schema.get(s) != head_rev]
 
 
 def get_all_tenant_ids() -> list[str]:

--- a/backend/tests/integration/multitenant_tests/test_get_schemas_needing_migration.py
+++ b/backend/tests/integration/multitenant_tests/test_get_schemas_needing_migration.py
@@ -1,0 +1,167 @@
+"""
+Integration tests for onyx.db.engine.tenant_utils.get_schemas_needing_migration.
+
+These tests require a live database and exercise the function directly,
+independent of the alembic migration runner script.
+
+Usage:
+    pytest tests/integration/multitenant_tests/test_get_schemas_needing_migration.py -v
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.engine.tenant_utils import get_schemas_needing_migration
+
+_BACKEND_DIR = __file__[: __file__.index("/tests/")]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def engine() -> Engine:
+    return SqlEngine.get_engine()
+
+
+@pytest.fixture
+def current_head_rev() -> str:
+    result = subprocess.run(
+        ["alembic", "heads", "--resolve-dependencies"],
+        cwd=_BACKEND_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"alembic heads failed (exit {result.returncode}):\n{result.stdout}"
+    rev = result.stdout.strip().split()[0]
+    assert len(rev) > 0
+    return rev
+
+
+@pytest.fixture
+def tenant_schema_at_head(
+    engine: Engine, current_head_rev: str
+) -> Generator[str, None, None]:
+    """Tenant schema with alembic_version already at head — should be excluded."""
+    schema = f"tenant_test_{uuid.uuid4().hex[:12]}"
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+        conn.execute(
+            text(
+                f'CREATE TABLE "{schema}".alembic_version '
+                f"(version_num VARCHAR(32) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(f'INSERT INTO "{schema}".alembic_version (version_num) VALUES (:rev)'),
+            {"rev": current_head_rev},
+        )
+        conn.commit()
+
+    yield schema
+
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+@pytest.fixture
+def tenant_schema_empty(engine: Engine) -> Generator[str, None, None]:
+    """Tenant schema with no tables — should be included (needs migration)."""
+    schema = f"tenant_test_{uuid.uuid4().hex[:12]}"
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+        conn.commit()
+
+    yield schema
+
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+@pytest.fixture
+def tenant_schema_stale_rev(engine: Engine) -> Generator[str, None, None]:
+    """Tenant schema with a non-head revision — should be included (needs migration)."""
+    schema = f"tenant_test_{uuid.uuid4().hex[:12]}"
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+        conn.execute(
+            text(
+                f'CREATE TABLE "{schema}".alembic_version '
+                f"(version_num VARCHAR(32) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                f'INSERT INTO "{schema}".alembic_version (version_num) '
+                f"VALUES ('stalerev000000000000')"
+            )
+        )
+        conn.commit()
+
+    yield schema
+
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_classifies_all_cases(
+    current_head_rev: str,
+    tenant_schema_at_head: str,
+    tenant_schema_empty: str,
+    tenant_schema_stale_rev: str,
+) -> None:
+    """Correctly classifies all three schema states:
+    - at head      → excluded
+    - no table     → included (needs migration)
+    - stale rev    → included (needs migration)
+    """
+    all_schemas = [tenant_schema_at_head, tenant_schema_empty, tenant_schema_stale_rev]
+    result = get_schemas_needing_migration(all_schemas, current_head_rev)
+
+    assert tenant_schema_at_head not in result
+    assert tenant_schema_empty in result
+    assert tenant_schema_stale_rev in result
+
+
+def test_idempotent(
+    current_head_rev: str,
+    tenant_schema_at_head: str,
+    tenant_schema_empty: str,
+) -> None:
+    """Calling the function twice returns the same result.
+
+    Verifies that the DROP TABLE IF EXISTS guards correctly clean up temp
+    tables so a second call succeeds even if the first left state behind.
+    """
+    schemas = [tenant_schema_at_head, tenant_schema_empty]
+
+    first = get_schemas_needing_migration(schemas, current_head_rev)
+    second = get_schemas_needing_migration(schemas, current_head_rev)
+
+    assert first == second
+
+
+def test_empty_input(current_head_rev: str) -> None:
+    """An empty input list returns immediately without touching the DB."""
+    assert get_schemas_needing_migration([], current_head_rev) == []


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The previous approach that we had would cause the database to lock since we were holding a lock on the entire set of schemas causing us to destroy the DB. This new approach creates a temp table that is used to maintain a running list instead of doing the entire query at once. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran the live command on the DB and tested that it finished in a reasonable amount of time. Also added a new set of tests as well.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents DB locks during multitenant migration checks by replacing the giant UNION with a server-side loop and temp tables that snapshot alembic versions per schema. Iterates only the requested schemas, keeps locks short, scales to large schema counts, and is safe to run repeatedly.

- **Bug Fixes**
  - Move schema check logic into tenant_utils; runner now imports get_schemas_needing_migration.
  - Use a PL/pgSQL DO block with temp input/snapshot tables to iterate schemas server-side.
  - Quote identifiers on the server; include schemas with missing tables or invalid names as needing migration.
  - Add integration tests for classification (head/empty/stale), idempotency, and empty input.

<sup>Written for commit 372dc9ece5ed92139c01c44cae68f667feb909bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

