### PR TITLE
chore(fe): add hover style to AgentCard

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -159,6 +159,15 @@
       0px 0px 12px 1px var(--shadow-03);
   }
 
+  /* RADIAL GRADIENTS */
+  .radial-00 {
+    background: radial-gradient(
+      236.31% 141.42% at 0% 0%,
+      var(--background-tint-00) 0%,
+      var(--background-tint-01) 100%
+    );
+  }
+
   /* DEBUGGING UTILITIES
   If you ever want to highlight a component for debugging purposes, just type in `className="dbg-red ..."`, and a red box should appear around it.
   This helps with placing things properly on the screen and seeing how they look during active development.

--- a/web/src/sections/cards/AgentCard.tsx
+++ b/web/src/sections/cards/AgentCard.tsx
@@ -101,7 +101,12 @@ export default function AgentCard({ agent }: AgentCardProps) {
         group="group/AgentCard"
         variant="none"
       >
-        <Card padding={0} gap={0} height="full">
+        <Card
+          padding={0}
+          gap={0}
+          height="full"
+          className="radial-00 hover:shadow-00"
+        >
           <div className="flex self-stretch h-[6rem]">
             <CardItemLayout
               icon={(props) => <AgentAvatar agent={agent} {...props} />}


### PR DESCRIPTION
## Description

Adds a slight radial-gradient and on hover, a box-shadow to the AgentCard. Closes https://linear.app/onyx-app/issue/ENG-3601/hover-states-on-agent-card

## How Has This Been Tested?

**before**
<img width="1662" height="2085" alt="20260223_13h58m20s_grim" src="https://github.com/user-attachments/assets/a160fed6-4878-4a6c-bee0-2d9a64a9fd11" />

**after**

<img width="1662" height="2085" alt="20260223_13h55m29s_grim" src="https://github.com/user-attachments/assets/f27ec8d8-9eb2-48d3-a3f7-5abc0a07a265" />
w/ hover
<img width="1662" height="2085" alt="20260223_13h55m38s_grim" src="https://github.com/user-attachments/assets/0f08954e-31b6-4ffa-92c9-abb8f29a6ea8" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subtle hover state to AgentCard with a radial gradient background and soft shadow to improve affordance, meeting Linear ENG-3601.

<sup>Written for commit bd6aadf03ac10b364d77e1eb4603a329b1aaa6d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

