### PR TITLE
feat(scim): Entra ID  SCIM compatibility

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -26,14 +26,14 @@ from sqlalchemy.orm import Session
 from ee.onyx.db.scim import ScimDAL
 from ee.onyx.server.scim.auth import verify_scim_token
 from ee.onyx.server.scim.filtering import parse_scim_filter
+from ee.onyx.server.scim.models import SCIM_LIST_RESPONSE_SCHEMA
 from ee.onyx.server.scim.models import ScimError
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
 from ee.onyx.server.scim.models import ScimListResponse
+from ee.onyx.server.scim.models import ScimMappingFields
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimPatchRequest
-from ee.onyx.server.scim.models import ScimResourceType
-from ee.onyx.server.scim.models import ScimSchemaDefinition
 from ee.onyx.server.scim.models import ScimServiceProviderConfig
 from ee.onyx.server.scim.models import ScimUserResource
 from ee.onyx.server.scim.patch import apply_group_patch
@@ -41,6 +41,8 @@ from ee.onyx.server.scim.patch import apply_user_patch
 from ee.onyx.server.scim.patch import ScimPatchError
 from ee.onyx.server.scim.providers.base import get_default_provider
 from ee.onyx.server.scim.providers.base import ScimProvider
+from ee.onyx.server.scim.providers.base import serialize_emails
+from ee.onyx.server.scim.schema_definitions import ENTERPRISE_USER_SCHEMA_DEF
 from ee.onyx.server.scim.schema_definitions import GROUP_RESOURCE_TYPE
 from ee.onyx.server.scim.schema_definitions import GROUP_SCHEMA_DEF
 from ee.onyx.server.scim.schema_definitions import SERVICE_PROVIDER_CONFIG
@@ -48,15 +50,28 @@ from ee.onyx.server.scim.schema_definitions import USER_RESOURCE_TYPE
 from ee.onyx.server.scim.schema_definitions import USER_SCHEMA_DEF
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import ScimToken
+from onyx.db.models import ScimUserMapping
 from onyx.db.models import User
 from onyx.db.models import UserGroup
 from onyx.db.models import UserRole
+from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+
+logger = setup_logger()
+
+
+class ScimJSONResponse(JSONResponse):
+    """JSONResponse with Content-Type: application/scim+json (RFC 7644 §3.1)."""
+
+    media_type = "application/scim+json"
+
 
 # NOTE: All URL paths in this router (/ServiceProviderConfig, /ResourceTypes,
 # /Schemas, /Users, /Groups) are mandated by the SCIM spec (RFC 7643/7644).
 # IdPs like Okta and Azure AD hardcode these exact paths, so they cannot be
 # changed to kebab-case.
+
+
 scim_router = APIRouter(prefix="/scim/v2", tags=["SCIM"])
 
 _pw_helper = PasswordHelper()
@@ -86,15 +101,39 @@ def get_service_provider_config() -> ScimServiceProviderConfig:
 
 
 @scim_router.get("/ResourceTypes")
-def get_resource_types() -> list[ScimResourceType]:
-    """List available SCIM resource types (RFC 7643 §6)."""
-    return [USER_RESOURCE_TYPE, GROUP_RESOURCE_TYPE]
+def get_resource_types() -> ScimJSONResponse:
+    """List available SCIM resource types (RFC 7643 §6).
+
+    Wrapped in a ListResponse envelope (RFC 7644 §3.4.2) because IdPs
+    like Entra ID expect a JSON object, not a bare array.
+    """
+    resources = [USER_RESOURCE_TYPE, GROUP_RESOURCE_TYPE]
+    return ScimJSONResponse(
+        content={
+            "schemas": [SCIM_LIST_RESPONSE_SCHEMA],
+            "totalResults": len(resources),
+            "Resources": [
+                r.model_dump(exclude_none=True, by_alias=True) for r in resources
+            ],
+        }
+    )
 
 
 @scim_router.get("/Schemas")
-def get_schemas() -> list[ScimSchemaDefinition]:
-    """Return SCIM schema definitions (RFC 7643 §7)."""
-    return [USER_SCHEMA_DEF, GROUP_SCHEMA_DEF]
+def get_schemas() -> ScimJSONResponse:
+    """Return SCIM schema definitions (RFC 7643 §7).
+
+    Wrapped in a ListResponse envelope (RFC 7644 §3.4.2) because IdPs
+    like Entra ID expect a JSON object, not a bare array.
+    """
+    schemas = [USER_SCHEMA_DEF, GROUP_SCHEMA_DEF, ENTERPRISE_USER_SCHEMA_DEF]
+    return ScimJSONResponse(
+        content={
+            "schemas": [SCIM_LIST_RESPONSE_SCHEMA],
+            "totalResults": len(schemas),
+            "Resources": [s.model_dump(exclude_none=True) for s in schemas],
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -102,13 +141,43 @@ def get_schemas() -> list[ScimSchemaDefinition]:
 # ---------------------------------------------------------------------------
 
 
-def _scim_error_response(status: int, detail: str) -> JSONResponse:
+def _scim_error_response(status: int, detail: str) -> ScimJSONResponse:
     """Build a SCIM-compliant error response (RFC 7644 §3.12)."""
+    logger.warning("SCIM error response: status=%s detail=%s", status, detail)
     body = ScimError(status=str(status), detail=detail)
-    return JSONResponse(
+    return ScimJSONResponse(
         status_code=status,
         content=body.model_dump(exclude_none=True),
     )
+
+
+def _parse_excluded_attributes(raw: str | None) -> set[str]:
+    """Parse the ``excludedAttributes`` query parameter (RFC 7644 §3.4.2.5).
+
+    Returns a set of lowercased attribute names to omit from responses.
+    """
+    if not raw:
+        return set()
+    return {attr.strip().lower() for attr in raw.split(",") if attr.strip()}
+
+
+def _apply_exclusions(
+    resource: ScimUserResource | ScimGroupResource,
+    excluded: set[str],
+) -> dict:
+    """Serialize a SCIM resource, omitting attributes the IdP excluded.
+
+    RFC 7644 §3.4.2.5 lets the IdP pass ``?excludedAttributes=groups,emails``
+    to reduce response payload size. We strip those fields after serialization
+    so the rest of the pipeline doesn't need to know about them.
+    """
+    data = resource.model_dump(exclude_none=True, by_alias=True)
+    for attr in excluded:
+        # Match case-insensitively against the camelCase field names
+        keys_to_remove = [k for k in data if k.lower() == attr]
+        for k in keys_to_remove:
+            del data[k]
+    return data
 
 
 def _check_seat_availability(dal: ScimDAL) -> str | None:
@@ -124,7 +193,7 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     return None
 
 
-def _fetch_user_or_404(user_id: str, dal: ScimDAL) -> User | JSONResponse:
+def _fetch_user_or_404(user_id: str, dal: ScimDAL) -> User | ScimJSONResponse:
     """Parse *user_id* as UUID, look up the user, or return a 404 error."""
     try:
         uid = UUID(user_id)
@@ -144,10 +213,63 @@ def _scim_name_to_str(name: ScimName | None) -> str | None:
     """
     if not name:
         return None
-    # Build from givenName/familyName first — IdPs like Okta may send a stale
-    # ``formatted`` value while updating the individual name components.
+    # If the client explicitly provides ``formatted``, prefer it — the client
+    # knows what display string it wants. Otherwise build from components.
+    if name.formatted:
+        return name.formatted
     parts = " ".join(part for part in [name.givenName, name.familyName] if part)
-    return parts or name.formatted
+    return parts or None
+
+
+def _scim_resource_response(
+    resource: ScimUserResource | ScimGroupResource | ScimListResponse,
+    status_code: int = 200,
+) -> ScimJSONResponse:
+    """Serialize a SCIM resource as ``application/scim+json``."""
+    content = resource.model_dump(exclude_none=True, by_alias=True)
+    return ScimJSONResponse(
+        status_code=status_code,
+        content=content,
+    )
+
+
+def _extract_enterprise_fields(
+    resource: ScimUserResource,
+) -> tuple[str | None, str | None]:
+    """Extract department and manager from enterprise extension."""
+    ext = resource.enterprise_extension
+    if not ext:
+        return None, None
+    department = ext.department
+    manager = ext.manager.value if ext.manager else None
+    return department, manager
+
+
+def _mapping_to_fields(
+    mapping: ScimUserMapping | None,
+) -> ScimMappingFields | None:
+    """Extract round-trip fields from a SCIM user mapping."""
+    if not mapping:
+        return None
+    return ScimMappingFields(
+        department=mapping.department,
+        manager=mapping.manager,
+        given_name=mapping.given_name,
+        family_name=mapping.family_name,
+        scim_emails_json=mapping.scim_emails_json,
+    )
+
+
+def _fields_from_resource(resource: ScimUserResource) -> ScimMappingFields:
+    """Build mapping fields from an incoming SCIM user resource."""
+    department, manager = _extract_enterprise_fields(resource)
+    return ScimMappingFields(
+        department=department,
+        manager=manager,
+        given_name=resource.name.givenName if resource.name else None,
+        family_name=resource.name.familyName if resource.name else None,
+        scim_emails_json=serialize_emails(resource.emails),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -158,12 +280,13 @@ def _scim_name_to_str(name: ScimName | None) -> str | None:
 @scim_router.get("/Users", response_model=None)
 def list_users(
     filter: str | None = Query(None),
+    excludedAttributes: str | None = None,
     startIndex: int = Query(1, ge=1),
     count: int = Query(100, ge=0, le=500),
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimListResponse | JSONResponse:
+) -> ScimListResponse | ScimJSONResponse:
     """List users with optional SCIM filter and pagination."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
@@ -185,41 +308,65 @@ def list_users(
             mapping.external_id if mapping else None,
             groups=user_groups_map.get(user.id, []),
             scim_username=mapping.scim_username if mapping else None,
+            fields=_mapping_to_fields(mapping),
         )
         for user, mapping in users_with_mappings
     ]
 
-    return ScimListResponse(
+    # RFC 7644 §3.4.2.5 — IdP may request certain attributes be omitted
+    excluded = _parse_excluded_attributes(excludedAttributes)
+    if excluded:
+        response = ScimListResponse(
+            totalResults=total,
+            startIndex=startIndex,
+            itemsPerPage=count,
+        )
+        data = response.model_dump(exclude_none=True)
+        data["Resources"] = [_apply_exclusions(r, excluded) for r in resources]
+        return ScimJSONResponse(content=data)
+
+    list_resp = ScimListResponse(
         totalResults=total,
         startIndex=startIndex,
         itemsPerPage=count,
         Resources=resources,
     )
+    return _scim_resource_response(list_resp)
 
 
 @scim_router.get("/Users/{user_id}", response_model=None)
 def get_user(
     user_id: str,
+    excludedAttributes: str | None = None,
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimUserResource | JSONResponse:
+) -> ScimUserResource | ScimJSONResponse:
     """Get a single user by ID."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_user_or_404(user_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     user = result
 
     mapping = dal.get_user_mapping_by_user_id(user.id)
-    return provider.build_user_resource(
+
+    resource = provider.build_user_resource(
         user,
         mapping.external_id if mapping else None,
         groups=dal.get_user_groups(user.id),
         scim_username=mapping.scim_username if mapping else None,
+        fields=_mapping_to_fields(mapping),
     )
+
+    # RFC 7644 §3.4.2.5 — IdP may request certain attributes be omitted
+    excluded = _parse_excluded_attributes(excludedAttributes)
+    if excluded:
+        return ScimJSONResponse(content=_apply_exclusions(resource, excluded))
+
+    return _scim_resource_response(resource)
 
 
 @scim_router.post("/Users", status_code=201, response_model=None)
@@ -228,7 +375,7 @@ def create_user(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimUserResource | JSONResponse:
+) -> ScimUserResource | ScimJSONResponse:
     """Create a new user from a SCIM provisioning request."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
@@ -270,13 +417,25 @@ def create_user(
     # Create SCIM mapping (externalId is validated above, always present)
     external_id = user_resource.externalId
     scim_username = user_resource.userName.strip()
+    fields = _fields_from_resource(user_resource)
     dal.create_user_mapping(
-        external_id=external_id, user_id=user.id, scim_username=scim_username
+        external_id=external_id,
+        user_id=user.id,
+        scim_username=scim_username,
+        fields=fields,
     )
 
     dal.commit()
 
-    return provider.build_user_resource(user, external_id, scim_username=scim_username)
+    return _scim_resource_response(
+        provider.build_user_resource(
+            user,
+            external_id,
+            scim_username=scim_username,
+            fields=fields,
+        ),
+        status_code=201,
+    )
 
 
 @scim_router.put("/Users/{user_id}", response_model=None)
@@ -286,13 +445,13 @@ def replace_user(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimUserResource | JSONResponse:
+) -> ScimUserResource | ScimJSONResponse:
     """Replace a user entirely (RFC 7644 §3.5.1)."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_user_or_404(user_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     user = result
 
@@ -313,15 +472,24 @@ def replace_user(
 
     new_external_id = user_resource.externalId
     scim_username = user_resource.userName.strip()
-    dal.sync_user_external_id(user.id, new_external_id, scim_username=scim_username)
+    fields = _fields_from_resource(user_resource)
+    dal.sync_user_external_id(
+        user.id,
+        new_external_id,
+        scim_username=scim_username,
+        fields=fields,
+    )
 
     dal.commit()
 
-    return provider.build_user_resource(
-        user,
-        new_external_id,
-        groups=dal.get_user_groups(user.id),
-        scim_username=scim_username,
+    return _scim_resource_response(
+        provider.build_user_resource(
+            user,
+            new_external_id,
+            groups=dal.get_user_groups(user.id),
+            scim_username=scim_username,
+            fields=fields,
+        )
     )
 
 
@@ -332,7 +500,7 @@ def patch_user(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimUserResource | JSONResponse:
+) -> ScimUserResource | ScimJSONResponse:
     """Partially update a user (RFC 7644 §3.5.2).
 
     This is the primary endpoint for user deprovisioning — Okta sends
@@ -342,23 +510,25 @@ def patch_user(
     dal.update_token_last_used(_token.id)
 
     result = _fetch_user_or_404(user_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     user = result
 
     mapping = dal.get_user_mapping_by_user_id(user.id)
     external_id = mapping.external_id if mapping else None
     current_scim_username = mapping.scim_username if mapping else None
+    current_fields = _mapping_to_fields(mapping)
 
     current = provider.build_user_resource(
         user,
         external_id,
         groups=dal.get_user_groups(user.id),
         scim_username=current_scim_username,
+        fields=current_fields,
     )
 
     try:
-        patched = apply_user_patch(
+        patched, ent_data = apply_user_patch(
             patch_request.Operations, current, provider.ignored_patch_paths
         )
     except ScimPatchError as e:
@@ -393,17 +563,35 @@ def patch_user(
         personal_name=personal_name,
     )
 
+    # Build updated fields by merging PATCH enterprise data with current values
+    cf = current_fields or ScimMappingFields()
+    fields = ScimMappingFields(
+        department=ent_data.get("department", cf.department),
+        manager=ent_data.get("manager", cf.manager),
+        given_name=patched.name.givenName if patched.name else cf.given_name,
+        family_name=patched.name.familyName if patched.name else cf.family_name,
+        scim_emails_json=(
+            serialize_emails(patched.emails) if patched.emails else cf.scim_emails_json
+        ),
+    )
+
     dal.sync_user_external_id(
-        user.id, patched.externalId, scim_username=new_scim_username
+        user.id,
+        patched.externalId,
+        scim_username=new_scim_username,
+        fields=fields,
     )
 
     dal.commit()
 
-    return provider.build_user_resource(
-        user,
-        patched.externalId,
-        groups=dal.get_user_groups(user.id),
-        scim_username=new_scim_username,
+    return _scim_resource_response(
+        provider.build_user_resource(
+            user,
+            patched.externalId,
+            groups=dal.get_user_groups(user.id),
+            scim_username=new_scim_username,
+            fields=fields,
+        )
     )
 
 
@@ -412,25 +600,29 @@ def delete_user(
     user_id: str,
     _token: ScimToken = Depends(verify_scim_token),
     db_session: Session = Depends(get_session),
-) -> Response | JSONResponse:
+) -> Response | ScimJSONResponse:
     """Delete a user (RFC 7644 §3.6).
 
     Deactivates the user and removes the SCIM mapping. Note that Okta
     typically uses PATCH active=false instead of DELETE.
+    A second DELETE returns 404 per RFC 7644 §3.6.
     """
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_user_or_404(user_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     user = result
 
-    dal.deactivate_user(user)
-
+    # If no SCIM mapping exists, the user was already deleted from
+    # SCIM's perspective — return 404 per RFC 7644 §3.6.
     mapping = dal.get_user_mapping_by_user_id(user.id)
-    if mapping:
-        dal.delete_user_mapping(mapping.id)
+    if not mapping:
+        return _scim_error_response(404, f"User {user_id} not found")
+
+    dal.deactivate_user(user)
+    dal.delete_user_mapping(mapping.id)
 
     dal.commit()
 
@@ -442,7 +634,7 @@ def delete_user(
 # ---------------------------------------------------------------------------
 
 
-def _fetch_group_or_404(group_id: str, dal: ScimDAL) -> UserGroup | JSONResponse:
+def _fetch_group_or_404(group_id: str, dal: ScimDAL) -> UserGroup | ScimJSONResponse:
     """Parse *group_id* as int, look up the group, or return a 404 error."""
     try:
         gid = int(group_id)
@@ -497,12 +689,13 @@ def _validate_and_parse_members(
 @scim_router.get("/Groups", response_model=None)
 def list_groups(
     filter: str | None = Query(None),
+    excludedAttributes: str | None = None,
     startIndex: int = Query(1, ge=1),
     count: int = Query(100, ge=0, le=500),
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimListResponse | JSONResponse:
+) -> ScimListResponse | ScimJSONResponse:
     """List groups with optional SCIM filter and pagination."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
@@ -522,36 +715,58 @@ def list_groups(
         for group, ext_id in groups_with_ext_ids
     ]
 
-    return ScimListResponse(
-        totalResults=total,
-        startIndex=startIndex,
-        itemsPerPage=count,
-        Resources=resources,
+    # RFC 7644 §3.4.2.5 — IdP may request certain attributes be omitted
+    excluded = _parse_excluded_attributes(excludedAttributes)
+    if excluded:
+        response = ScimListResponse(
+            totalResults=total,
+            startIndex=startIndex,
+            itemsPerPage=count,
+        )
+        data = response.model_dump(exclude_none=True)
+        data["Resources"] = [_apply_exclusions(r, excluded) for r in resources]
+        return ScimJSONResponse(content=data)
+
+    return _scim_resource_response(
+        ScimListResponse(
+            totalResults=total,
+            startIndex=startIndex,
+            itemsPerPage=count,
+            Resources=resources,
+        )
     )
 
 
 @scim_router.get("/Groups/{group_id}", response_model=None)
 def get_group(
     group_id: str,
+    excludedAttributes: str | None = None,
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimGroupResource | JSONResponse:
+) -> ScimGroupResource | ScimJSONResponse:
     """Get a single group by ID."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_group_or_404(group_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     group = result
 
     mapping = dal.get_group_mapping_by_group_id(group.id)
     members = dal.get_group_members(group.id)
 
-    return provider.build_group_resource(
+    resource = provider.build_group_resource(
         group, members, mapping.external_id if mapping else None
     )
+
+    # RFC 7644 §3.4.2.5 — IdP may request certain attributes be omitted
+    excluded = _parse_excluded_attributes(excludedAttributes)
+    if excluded:
+        return ScimJSONResponse(content=_apply_exclusions(resource, excluded))
+
+    return _scim_resource_response(resource)
 
 
 @scim_router.post("/Groups", status_code=201, response_model=None)
@@ -560,7 +775,7 @@ def create_group(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimGroupResource | JSONResponse:
+) -> ScimGroupResource | ScimJSONResponse:
     """Create a new group from a SCIM provisioning request."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
@@ -596,7 +811,10 @@ def create_group(
     dal.commit()
 
     members = dal.get_group_members(db_group.id)
-    return provider.build_group_resource(db_group, members, external_id)
+    return _scim_resource_response(
+        provider.build_group_resource(db_group, members, external_id),
+        status_code=201,
+    )
 
 
 @scim_router.put("/Groups/{group_id}", response_model=None)
@@ -606,13 +824,13 @@ def replace_group(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimGroupResource | JSONResponse:
+) -> ScimGroupResource | ScimJSONResponse:
     """Replace a group entirely (RFC 7644 §3.5.1)."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_group_or_404(group_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     group = result
 
@@ -627,7 +845,9 @@ def replace_group(
     dal.commit()
 
     members = dal.get_group_members(group.id)
-    return provider.build_group_resource(group, members, group_resource.externalId)
+    return _scim_resource_response(
+        provider.build_group_resource(group, members, group_resource.externalId)
+    )
 
 
 @scim_router.patch("/Groups/{group_id}", response_model=None)
@@ -637,7 +857,7 @@ def patch_group(
     _token: ScimToken = Depends(verify_scim_token),
     provider: ScimProvider = Depends(_get_provider),
     db_session: Session = Depends(get_session),
-) -> ScimGroupResource | JSONResponse:
+) -> ScimGroupResource | ScimJSONResponse:
     """Partially update a group (RFC 7644 §3.5.2).
 
     Handles member add/remove operations from Okta and Azure AD.
@@ -646,7 +866,7 @@ def patch_group(
     dal.update_token_last_used(_token.id)
 
     result = _fetch_group_or_404(group_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     group = result
 
@@ -685,7 +905,9 @@ def patch_group(
     dal.commit()
 
     members = dal.get_group_members(group.id)
-    return provider.build_group_resource(group, members, patched.externalId)
+    return _scim_resource_response(
+        provider.build_group_resource(group, members, patched.externalId)
+    )
 
 
 @scim_router.delete("/Groups/{group_id}", status_code=204, response_model=None)
@@ -693,13 +915,13 @@ def delete_group(
     group_id: str,
     _token: ScimToken = Depends(verify_scim_token),
     db_session: Session = Depends(get_session),
-) -> Response | JSONResponse:
+) -> Response | ScimJSONResponse:
     """Delete a group (RFC 7644 §3.6)."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
     result = _fetch_group_or_404(group_id, dal)
-    if isinstance(result, JSONResponse):
+    if isinstance(result, ScimJSONResponse):
         return result
     group = result
 

--- a/backend/ee/onyx/server/scim/patch.py
+++ b/backend/ee/onyx/server/scim/patch.py
@@ -15,7 +15,10 @@ responsible for persisting changes.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from dataclasses import field
 
+from ee.onyx.server.scim.models import SCIM_ENTERPRISE_USER_SCHEMA
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
 from ee.onyx.server.scim.models import ScimPatchOperation
@@ -23,6 +26,51 @@ from ee.onyx.server.scim.models import ScimPatchOperationType
 from ee.onyx.server.scim.models import ScimPatchResourceValue
 from ee.onyx.server.scim.models import ScimPatchValue
 from ee.onyx.server.scim.models import ScimUserResource
+
+# Lowercased enterprise extension URN for case-insensitive matching
+_ENTERPRISE_URN_LOWER = SCIM_ENTERPRISE_USER_SCHEMA.lower()
+
+# Pattern for email filter paths: emails[primary eq true].value
+_EMAIL_FILTER_RE = re.compile(
+    r"^emails\[primary\s+eq\s+true\]\.value$",
+    re.IGNORECASE,
+)
+
+# Pattern for member removal path: members[value eq "user-id"]
+_MEMBER_FILTER_RE = re.compile(
+    r'^members\[value\s+eq\s+"([^"]+)"\]$',
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Dispatch tables for user PATCH paths
+#
+# Maps lowercased SCIM path → (camelCase key, target dict name).
+# "data" writes to the top-level resource dict, "name" writes to the
+# name sub-object dict. This replaces the elif chains for simple fields.
+# ---------------------------------------------------------------------------
+
+_USER_REPLACE_PATHS: dict[str, tuple[str, str]] = {
+    "active": ("active", "data"),
+    "username": ("userName", "data"),
+    "externalid": ("externalId", "data"),
+    "name.givenname": ("givenName", "name"),
+    "name.familyname": ("familyName", "name"),
+    "name.formatted": ("formatted", "name"),
+}
+
+_USER_REMOVE_PATHS: dict[str, tuple[str, str]] = {
+    "externalid": ("externalId", "data"),
+    "name.givenname": ("givenName", "name"),
+    "name.familyname": ("familyName", "name"),
+    "name.formatted": ("formatted", "name"),
+    "displayname": ("displayName", "data"),
+}
+
+_GROUP_REPLACE_PATHS: dict[str, tuple[str, str]] = {
+    "displayname": ("displayName", "data"),
+    "externalid": ("externalId", "data"),
+}
 
 
 class ScimPatchError(Exception):
@@ -34,18 +82,25 @@ class ScimPatchError(Exception):
         super().__init__(detail)
 
 
-# Pattern for member removal path: members[value eq "user-id"]
-_MEMBER_FILTER_RE = re.compile(
-    r'^members\[value\s+eq\s+"([^"]+)"\]$',
-    re.IGNORECASE,
-)
+@dataclass
+class _UserPatchCtx:
+    """Bundles the mutable state for user PATCH operations."""
+
+    data: dict
+    name_data: dict
+    ent_data: dict[str, str | None] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# User PATCH
+# ---------------------------------------------------------------------------
 
 
 def apply_user_patch(
     operations: list[ScimPatchOperation],
     current: ScimUserResource,
     ignored_paths: frozenset[str] = frozenset(),
-) -> ScimUserResource:
+) -> tuple[ScimUserResource, dict[str, str | None]]:
     """Apply SCIM PATCH operations to a user resource.
 
     Args:
@@ -53,77 +108,181 @@ def apply_user_patch(
         current: The current user resource state.
         ignored_paths: SCIM attribute paths to silently skip (from provider).
 
-    Returns a new ``ScimUserResource`` with the modifications applied.
-    The original object is not mutated.
+    Returns:
+        A tuple of (modified user resource, enterprise extension data dict).
+        The enterprise dict has keys ``"department"`` and ``"manager"``
+        with values set only when a PATCH operation touched them.
 
     Raises:
         ScimPatchError: If an operation targets an unsupported path.
     """
     data = current.model_dump()
-    name_data = data.get("name") or {}
+    ctx = _UserPatchCtx(data=data, name_data=data.get("name") or {})
 
     for op in operations:
-        if op.op == ScimPatchOperationType.REPLACE:
-            _apply_user_replace(op, data, name_data, ignored_paths)
-        elif op.op == ScimPatchOperationType.ADD:
-            _apply_user_replace(op, data, name_data, ignored_paths)
+        if op.op in (ScimPatchOperationType.REPLACE, ScimPatchOperationType.ADD):
+            _apply_user_replace(op, ctx, ignored_paths)
+        elif op.op == ScimPatchOperationType.REMOVE:
+            _apply_user_remove(op, ctx, ignored_paths)
         else:
             raise ScimPatchError(
                 f"Unsupported operation '{op.op.value}' on User resource"
             )
 
-    data["name"] = name_data
-    return ScimUserResource.model_validate(data)
+    ctx.data["name"] = ctx.name_data
+    return ScimUserResource.model_validate(ctx.data), ctx.ent_data
 
 
 def _apply_user_replace(
     op: ScimPatchOperation,
-    data: dict,
-    name_data: dict,
+    ctx: _UserPatchCtx,
     ignored_paths: frozenset[str],
 ) -> None:
     """Apply a replace/add operation to user data."""
     path = (op.path or "").lower()
 
     if not path:
-        # No path — value is a resource dict of top-level attributes to set
+        # No path — value is a resource dict of top-level attributes to set.
         if isinstance(op.value, ScimPatchResourceValue):
             for key, val in op.value.model_dump(exclude_unset=True).items():
-                _set_user_field(key.lower(), val, data, name_data, ignored_paths)
+                _set_user_field(key.lower(), val, ctx, ignored_paths, strict=False)
         else:
             raise ScimPatchError("Replace without path requires a dict value")
         return
 
-    _set_user_field(path, op.value, data, name_data, ignored_paths)
+    _set_user_field(path, op.value, ctx, ignored_paths)
+
+
+def _apply_user_remove(
+    op: ScimPatchOperation,
+    ctx: _UserPatchCtx,
+    ignored_paths: frozenset[str],
+) -> None:
+    """Apply a remove operation to user data — clears the target field."""
+    path = (op.path or "").lower()
+    if not path:
+        raise ScimPatchError("Remove operation requires a path")
+
+    if path in ignored_paths:
+        return
+
+    entry = _USER_REMOVE_PATHS.get(path)
+    if entry:
+        key, target = entry
+        target_dict = ctx.data if target == "data" else ctx.name_data
+        target_dict[key] = None
+        return
+
+    raise ScimPatchError(f"Unsupported remove path '{path}' for User PATCH")
 
 
 def _set_user_field(
     path: str,
     value: ScimPatchValue,
-    data: dict,
-    name_data: dict,
+    ctx: _UserPatchCtx,
     ignored_paths: frozenset[str],
+    *,
+    strict: bool = True,
 ) -> None:
-    """Set a single field on user data by SCIM path."""
+    """Set a single field on user data by SCIM path.
+
+    Args:
+        strict: When ``False`` (path-less replace), unknown attributes are
+            silently skipped.  When ``True`` (explicit path), they raise.
+    """
     if path in ignored_paths:
         return
-    elif path == "active":
-        data["active"] = value
-    elif path == "username":
-        data["userName"] = value
-    elif path == "externalid":
-        data["externalId"] = value
-    elif path == "name.givenname":
-        name_data["givenName"] = value
-    elif path == "name.familyname":
-        name_data["familyName"] = value
-    elif path == "name.formatted":
-        name_data["formatted"] = value
-    elif path == "displayname":
-        data["displayName"] = value
-        name_data["formatted"] = value
+
+    # Simple field writes handled by the dispatch table
+    entry = _USER_REPLACE_PATHS.get(path)
+    if entry:
+        key, target = entry
+        target_dict = ctx.data if target == "data" else ctx.name_data
+        target_dict[key] = value
+        return
+
+    # displayName sets both the top-level field and the name.formatted sub-field
+    if path == "displayname":
+        ctx.data["displayName"] = value
+        ctx.name_data["formatted"] = value
+    elif path == "name":
+        if isinstance(value, dict):
+            for k, v in value.items():
+                ctx.name_data[k] = v
+    elif path == "emails":
+        if isinstance(value, list):
+            ctx.data["emails"] = value
+    elif _EMAIL_FILTER_RE.match(path):
+        _update_primary_email(ctx.data, value)
+    elif path.startswith(_ENTERPRISE_URN_LOWER):
+        _set_enterprise_field(path, value, ctx.ent_data)
+    elif not strict:
+        return
     else:
         raise ScimPatchError(f"Unsupported path '{path}' for User PATCH")
+
+
+def _update_primary_email(data: dict, value: ScimPatchValue) -> None:
+    """Update the primary email entry via emails[primary eq true].value."""
+    emails: list[dict] = data.get("emails") or []
+    for email_entry in emails:
+        if email_entry.get("primary"):
+            email_entry["value"] = value
+            break
+    else:
+        emails.append({"value": value, "type": "work", "primary": True})
+    data["emails"] = emails
+
+
+def _to_dict(value: ScimPatchValue) -> dict | None:
+    """Coerce a SCIM patch value to a plain dict if possible.
+
+    Pydantic may parse raw dicts as ``ScimPatchResourceValue`` (which uses
+    ``extra="allow"``), so we also dump those back to a dict.
+    """
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, ScimPatchResourceValue):
+        return value.model_dump(exclude_unset=True)
+    return None
+
+
+def _set_enterprise_field(
+    path: str,
+    value: ScimPatchValue,
+    ent_data: dict[str, str | None],
+) -> None:
+    """Handle enterprise extension URN paths or value dicts."""
+    # Full URN as key with dict value (path-less PATCH)
+    # e.g. key="urn:...:user", value={"department": "Eng", "manager": {...}}
+    if path == _ENTERPRISE_URN_LOWER:
+        d = _to_dict(value)
+        if d is not None:
+            if "department" in d:
+                ent_data["department"] = d["department"]
+            if "manager" in d:
+                mgr = d["manager"]
+                if isinstance(mgr, dict):
+                    ent_data["manager"] = mgr.get("value")
+        return
+
+    # Dotted URN path, e.g. "urn:...:user:department"
+    suffix = path[len(_ENTERPRISE_URN_LOWER) :].lstrip(":").lower()
+    if suffix == "department":
+        ent_data["department"] = str(value) if value is not None else None
+    elif suffix == "manager":
+        d = _to_dict(value)
+        if d is not None:
+            ent_data["manager"] = d.get("value")
+        elif isinstance(value, str):
+            ent_data["manager"] = value
+    else:
+        raise ScimPatchError(f"Unsupported enterprise extension attribute '{suffix}'")
+
+
+# ---------------------------------------------------------------------------
+# Group PATCH
+# ---------------------------------------------------------------------------
 
 
 def apply_group_patch(
@@ -235,12 +394,14 @@ def _set_group_field(
     """Set a single field on group data by SCIM path."""
     if path in ignored_paths:
         return
-    elif path == "displayname":
-        data["displayName"] = value
-    elif path == "externalid":
-        data["externalId"] = value
-    else:
-        raise ScimPatchError(f"Unsupported path '{path}' for Group PATCH")
+
+    entry = _GROUP_REPLACE_PATHS.get(path)
+    if entry:
+        key, _ = entry
+        data[key] = value
+        return
+
+    raise ScimPatchError(f"Unsupported path '{path}' for Group PATCH")
 
 
 def _apply_group_add(

--- a/backend/ee/onyx/server/scim/providers/base.py
+++ b/backend/ee/onyx/server/scim/providers/base.py
@@ -2,19 +2,37 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from abc import ABC
 from abc import abstractmethod
 from uuid import UUID
 
+from ee.onyx.server.scim.models import SCIM_ENTERPRISE_USER_SCHEMA
+from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
 from ee.onyx.server.scim.models import ScimEmail
+from ee.onyx.server.scim.models import ScimEnterpriseExtension
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimManagerRef
+from ee.onyx.server.scim.models import ScimMappingFields
 from ee.onyx.server.scim.models import ScimMeta
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimUserGroupRef
 from ee.onyx.server.scim.models import ScimUserResource
 from onyx.db.models import User
 from onyx.db.models import UserGroup
+
+
+logger = logging.getLogger(__name__)
+
+COMMON_IGNORED_PATCH_PATHS: frozenset[str] = frozenset(
+    {
+        "id",
+        "schemas",
+        "meta",
+    }
+)
 
 
 class ScimProvider(ABC):
@@ -41,12 +59,22 @@ class ScimProvider(ABC):
         """
         ...
 
+    @property
+    def user_schemas(self) -> list[str]:
+        """Schema URIs to include in User resource responses.
+
+        Override in subclasses to advertise additional schemas (e.g. the
+        enterprise extension for Entra ID).
+        """
+        return [SCIM_USER_SCHEMA]
+
     def build_user_resource(
         self,
         user: User,
         external_id: str | None = None,
         groups: list[tuple[int, str]] | None = None,
         scim_username: str | None = None,
+        fields: ScimMappingFields | None = None,
     ) -> ScimUserResource:
         """Build a SCIM User response from an Onyx User.
 
@@ -58,27 +86,48 @@ class ScimProvider(ABC):
                 for newly-created users.
             scim_username: The original-case userName from the IdP. Falls
                 back to ``user.email`` (lowercase) when not available.
+            fields: Stored mapping fields that the IdP expects round-tripped.
         """
+        f = fields or ScimMappingFields()
         group_refs = [
             ScimUserGroupRef(value=str(gid), display=gname)
             for gid, gname in (groups or [])
         ]
 
-        # Use original-case userName if stored, otherwise fall back to the
-        # lowercased email from the User model.
         username = scim_username or user.email
 
-        return ScimUserResource(
+        # Build enterprise extension when at least one value is present.
+        # Dynamically add the enterprise URN to schemas per RFC 7643 §3.0.
+        enterprise_ext: ScimEnterpriseExtension | None = None
+        schemas = list(self.user_schemas)
+        if f.department is not None or f.manager is not None:
+            manager_ref = (
+                ScimManagerRef(value=f.manager) if f.manager is not None else None
+            )
+            enterprise_ext = ScimEnterpriseExtension(
+                department=f.department,
+                manager=manager_ref,
+            )
+            if SCIM_ENTERPRISE_USER_SCHEMA not in schemas:
+                schemas.append(SCIM_ENTERPRISE_USER_SCHEMA)
+
+        name = self.build_scim_name(user, f)
+        emails = _deserialize_emails(f.scim_emails_json, username)
+
+        resource = ScimUserResource(
+            schemas=schemas,
             id=str(user.id),
             externalId=external_id,
             userName=username,
-            name=self._build_scim_name(user),
+            name=name,
             displayName=user.personal_name,
-            emails=[ScimEmail(value=username, type="work", primary=True)],
+            emails=emails,
             active=user.is_active,
             groups=group_refs,
             meta=ScimMeta(resourceType="User"),
         )
+        resource.enterprise_extension = enterprise_ext
+        return resource
 
     def build_group_resource(
         self,
@@ -98,9 +147,24 @@ class ScimProvider(ABC):
             meta=ScimMeta(resourceType="Group"),
         )
 
-    @staticmethod
-    def _build_scim_name(user: User) -> ScimName | None:
-        """Extract SCIM name components from a user's personal name."""
+    def build_scim_name(
+        self,
+        user: User,
+        fields: ScimMappingFields,
+    ) -> ScimName | None:
+        """Build SCIM name components for the response.
+
+        Round-trips stored ``given_name``/``family_name`` when available (so
+        the IdP gets back what it sent). Falls back to splitting
+        ``personal_name`` for users provisioned before we stored components.
+        Providers may override for custom behavior.
+        """
+        if fields.given_name is not None or fields.family_name is not None:
+            return ScimName(
+                givenName=fields.given_name,
+                familyName=fields.family_name,
+                formatted=user.personal_name,
+            )
         if not user.personal_name:
             return None
         parts = user.personal_name.split(" ", 1)
@@ -109,6 +173,27 @@ class ScimProvider(ABC):
             familyName=parts[1] if len(parts) > 1 else None,
             formatted=user.personal_name,
         )
+
+
+def _deserialize_emails(stored_json: str | None, username: str) -> list[ScimEmail]:
+    """Deserialize stored email entries or build a default work email."""
+    if stored_json:
+        try:
+            entries = json.loads(stored_json)
+            if isinstance(entries, list) and entries:
+                return [ScimEmail(**e) for e in entries]
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Corrupt scim_emails_json, falling back to default: %s", stored_json
+            )
+    return [ScimEmail(value=username, type="work", primary=True)]
+
+
+def serialize_emails(emails: list[ScimEmail]) -> str | None:
+    """Serialize SCIM email entries to JSON for storage."""
+    if not emails:
+        return None
+    return json.dumps([e.model_dump(exclude_none=True) for e in emails])
 
 
 def get_default_provider() -> ScimProvider:

--- a/backend/ee/onyx/server/scim/providers/entra.py
+++ b/backend/ee/onyx/server/scim/providers/entra.py
@@ -1,0 +1,36 @@
+"""Entra ID (Azure AD) SCIM provider."""
+
+from __future__ import annotations
+
+from ee.onyx.server.scim.models import SCIM_ENTERPRISE_USER_SCHEMA
+from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
+from ee.onyx.server.scim.providers.base import COMMON_IGNORED_PATCH_PATHS
+from ee.onyx.server.scim.providers.base import ScimProvider
+
+_ENTRA_IGNORED_PATCH_PATHS = COMMON_IGNORED_PATCH_PATHS
+
+
+class EntraProvider(ScimProvider):
+    """Entra ID (Azure AD) SCIM provider.
+
+    Entra behavioral notes:
+      - Sends capitalized PATCH ops (``"Add"``, ``"Replace"``, ``"Remove"``)
+        — handled by ``ScimPatchOperation.normalize_op`` validator.
+      - Sends the enterprise extension URN as a key in path-less PATCH value
+        dicts — handled by ``_set_enterprise_field`` in ``patch.py`` to
+        store department/manager values.
+      - Expects the enterprise extension schema in ``schemas`` arrays and
+        ``/Schemas`` + ``/ResourceTypes`` discovery endpoints.
+    """
+
+    @property
+    def name(self) -> str:
+        return "entra"
+
+    @property
+    def ignored_patch_paths(self) -> frozenset[str]:
+        return _ENTRA_IGNORED_PATCH_PATHS
+
+    @property
+    def user_schemas(self) -> list[str]:
+        return [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA]

--- a/backend/ee/onyx/server/scim/providers/okta.py
+++ b/backend/ee/onyx/server/scim/providers/okta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ee.onyx.server.scim.providers.base import COMMON_IGNORED_PATCH_PATHS
 from ee.onyx.server.scim.providers.base import ScimProvider
 
 
@@ -22,4 +23,4 @@ class OktaProvider(ScimProvider):
 
     @property
     def ignored_patch_paths(self) -> frozenset[str]:
-        return frozenset({"id", "schemas", "meta"})
+        return COMMON_IGNORED_PATCH_PATHS

--- a/backend/ee/onyx/server/scim/schema_definitions.py
+++ b/backend/ee/onyx/server/scim/schema_definitions.py
@@ -4,6 +4,7 @@ Pre-built at import time — these never change at runtime. Separated from
 api.py to keep the endpoint module focused on request handling.
 """
 
+from ee.onyx.server.scim.models import SCIM_ENTERPRISE_USER_SCHEMA
 from ee.onyx.server.scim.models import SCIM_GROUP_SCHEMA
 from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
 from ee.onyx.server.scim.models import ScimResourceType
@@ -20,6 +21,9 @@ USER_RESOURCE_TYPE = ScimResourceType.model_validate(
         "endpoint": "/scim/v2/Users",
         "description": "SCIM User resource",
         "schema": SCIM_USER_SCHEMA,
+        "schemaExtensions": [
+            {"schema": SCIM_ENTERPRISE_USER_SCHEMA, "required": False}
+        ],
     }
 )
 
@@ -100,6 +104,31 @@ USER_SCHEMA_DEF = ScimSchemaDefinition(
             type="string",
             description="Identifier from the provisioning client (IdP).",
             caseExact=True,
+        ),
+    ],
+)
+
+ENTERPRISE_USER_SCHEMA_DEF = ScimSchemaDefinition(
+    id=SCIM_ENTERPRISE_USER_SCHEMA,
+    name="EnterpriseUser",
+    description="Enterprise User extension (RFC 7643 §4.3)",
+    attributes=[
+        ScimSchemaAttribute(
+            name="department",
+            type="string",
+            description="Department.",
+        ),
+        ScimSchemaAttribute(
+            name="manager",
+            type="complex",
+            description="The user's manager.",
+            subAttributes=[
+                ScimSchemaAttribute(
+                    name="value",
+                    type="string",
+                    description="Manager user ID.",
+                ),
+            ],
         ),
     ],
 )

--- a/backend/tests/unit/onyx/db/test_scim_dal.py
+++ b/backend/tests/unit/onyx/db/test_scim_dal.py
@@ -98,6 +98,11 @@ class TestScimDALUserMappings:
             "external_id": "ext-1",
             "user_id": user_id,
             "scim_username": None,
+            "department": None,
+            "manager": None,
+            "given_name": None,
+            "family_name": None,
+            "scim_emails_json": None,
         }
 
     def test_delete_user_mapping(

--- a/backend/tests/unit/onyx/server/scim/test_entra.py
+++ b/backend/tests/unit/onyx/server/scim/test_entra.py
@@ -1,0 +1,983 @@
+"""Comprehensive Entra ID (Azure AD) SCIM compatibility tests.
+
+Covers the full Entra provisioning lifecycle: service discovery, user CRUD
+with enterprise extension schema, group CRUD with excludedAttributes, and
+all Entra-specific behavioral quirks (PascalCase ops, enterprise URN in
+PATCH value dicts).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Response
+
+from ee.onyx.server.scim.api import create_user
+from ee.onyx.server.scim.api import delete_user
+from ee.onyx.server.scim.api import get_group
+from ee.onyx.server.scim.api import get_resource_types
+from ee.onyx.server.scim.api import get_schemas
+from ee.onyx.server.scim.api import get_service_provider_config
+from ee.onyx.server.scim.api import get_user
+from ee.onyx.server.scim.api import list_groups
+from ee.onyx.server.scim.api import list_users
+from ee.onyx.server.scim.api import patch_group
+from ee.onyx.server.scim.api import patch_user
+from ee.onyx.server.scim.api import replace_user
+from ee.onyx.server.scim.api import ScimJSONResponse
+from ee.onyx.server.scim.models import SCIM_ENTERPRISE_USER_SCHEMA
+from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
+from ee.onyx.server.scim.models import ScimEnterpriseExtension
+from ee.onyx.server.scim.models import ScimGroupMember
+from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimManagerRef
+from ee.onyx.server.scim.models import ScimMappingFields
+from ee.onyx.server.scim.models import ScimName
+from ee.onyx.server.scim.models import ScimPatchOperation
+from ee.onyx.server.scim.models import ScimPatchOperationType
+from ee.onyx.server.scim.models import ScimPatchRequest
+from ee.onyx.server.scim.models import ScimPatchResourceValue
+from ee.onyx.server.scim.models import ScimUserResource
+from ee.onyx.server.scim.providers.base import ScimProvider
+from ee.onyx.server.scim.providers.entra import EntraProvider
+from tests.unit.onyx.server.scim.conftest import make_db_group
+from tests.unit.onyx.server.scim.conftest import make_db_user
+from tests.unit.onyx.server.scim.conftest import make_scim_user
+from tests.unit.onyx.server.scim.conftest import make_user_mapping
+from tests.unit.onyx.server.scim.conftest import parse_scim_group
+from tests.unit.onyx.server.scim.conftest import parse_scim_list
+from tests.unit.onyx.server.scim.conftest import parse_scim_user
+
+
+@pytest.fixture
+def entra_provider() -> ScimProvider:
+    """An EntraProvider instance for Entra-specific endpoint tests."""
+    return EntraProvider()
+
+
+# ---------------------------------------------------------------------------
+# Service Discovery
+# ---------------------------------------------------------------------------
+
+
+class TestEntraServiceDiscovery:
+    """Entra expects enterprise extension in discovery endpoints."""
+
+    def test_service_provider_config_advertises_patch(self) -> None:
+        config = get_service_provider_config()
+        assert config.patch.supported is True
+
+    def test_resource_types_include_enterprise_extension(self) -> None:
+        result = get_resource_types()
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert "Resources" in parsed
+        user_type = next(rt for rt in parsed["Resources"] if rt["id"] == "User")
+        extension_schemas = [ext["schema"] for ext in user_type["schemaExtensions"]]
+        assert SCIM_ENTERPRISE_USER_SCHEMA in extension_schemas
+
+    def test_schemas_include_enterprise_user(self) -> None:
+        result = get_schemas()
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        schema_ids = [s["id"] for s in parsed["Resources"]]
+        assert SCIM_ENTERPRISE_USER_SCHEMA in schema_ids
+
+    def test_enterprise_schema_has_expected_attributes(self) -> None:
+        result = get_schemas()
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        enterprise = next(
+            s for s in parsed["Resources"] if s["id"] == SCIM_ENTERPRISE_USER_SCHEMA
+        )
+        attr_names = {a["name"] for a in enterprise["attributes"]}
+        assert "department" in attr_names
+        assert "manager" in attr_names
+
+    def test_service_discovery_content_type(self) -> None:
+        """SCIM responses must use application/scim+json content type."""
+        result = get_resource_types()
+        assert isinstance(result, ScimJSONResponse)
+        assert result.media_type == "application/scim+json"
+
+
+# ---------------------------------------------------------------------------
+# User Lifecycle (Entra-specific)
+# ---------------------------------------------------------------------------
+
+
+class TestEntraUserLifecycle:
+    """Test user CRUD through Entra's lens: enterprise schemas, PascalCase ops."""
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_create_user_includes_enterprise_schema(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        mock_dal.get_user_by_email.return_value = None
+        resource = make_scim_user(userName="alice@contoso.com")
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result, status=201)
+        assert SCIM_ENTERPRISE_USER_SCHEMA in resource.schemas
+        assert SCIM_USER_SCHEMA in resource.schemas
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_create_user_with_enterprise_extension(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Enterprise extension department/manager should round-trip on create."""
+        mock_dal.get_user_by_email.return_value = None
+        resource = make_scim_user(
+            userName="alice@contoso.com",
+            enterprise_extension=ScimEnterpriseExtension(
+                department="Engineering",
+                manager=ScimManagerRef(value="mgr-uuid-123"),
+            ),
+        )
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result, status=201)
+        assert resource.enterprise_extension is not None
+        assert resource.enterprise_extension.department == "Engineering"
+        assert resource.enterprise_extension.manager is not None
+        assert resource.enterprise_extension.manager.value == "mgr-uuid-123"
+
+        # Verify DAL received the enterprise fields
+        mock_dal.create_user_mapping.assert_called_once()
+        call_kwargs = mock_dal.create_user_mapping.call_args[1]
+        assert call_kwargs["fields"] == ScimMappingFields(
+            department="Engineering",
+            manager="mgr-uuid-123",
+            given_name="Test",
+            family_name="User",
+        )
+
+    def test_get_user_includes_enterprise_schema(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="alice@contoso.com")
+        mock_dal.get_user.return_value = user
+
+        result = get_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert SCIM_ENTERPRISE_USER_SCHEMA in resource.schemas
+
+    def test_get_user_returns_enterprise_extension_data(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """GET should return stored enterprise extension data."""
+        user = make_db_user(email="alice@contoso.com")
+        mock_dal.get_user.return_value = user
+        mapping = make_user_mapping(user_id=user.id)
+        mapping.department = "Sales"
+        mapping.manager = "mgr-456"
+        mock_dal.get_user_mapping_by_user_id.return_value = mapping
+
+        result = get_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.enterprise_extension is not None
+        assert resource.enterprise_extension.department == "Sales"
+        assert resource.enterprise_extension.manager is not None
+        assert resource.enterprise_extension.manager.value == "mgr-456"
+
+    def test_list_users_includes_enterprise_schema(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="alice@contoso.com")
+        mapping = make_user_mapping(external_id="entra-ext-1", user_id=user.id)
+        mock_dal.list_users.return_value = ([(user, mapping)], 1)
+
+        result = list_users(
+            filter=None,
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parsed = parse_scim_list(result)
+        resource = parsed.Resources[0]
+        assert isinstance(resource, ScimUserResource)
+        assert SCIM_ENTERPRISE_USER_SCHEMA in resource.schemas
+
+    def test_patch_user_deactivate_with_pascal_case_replace(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ``"Replace"`` (PascalCase) instead of ``"replace"``."""
+        user = make_db_user(is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op="Replace",  # type: ignore[arg-type]
+                    path="active",
+                    value=False,
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        # Mock doesn't propagate the change, so verify via the DAL call
+        mock_dal.update_user.assert_called_once()
+        call_kwargs = mock_dal.update_user.call_args
+        assert call_kwargs[1]["is_active"] is False
+
+    def test_patch_user_add_external_id_with_pascal_case(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ``"Add"`` (PascalCase) instead of ``"add"``."""
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op="Add",  # type: ignore[arg-type]
+                    path="externalId",
+                    value="entra-ext-999",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        # Verify the patched externalId was synced to the DAL
+        mock_dal.sync_user_external_id.assert_called_once()
+        call_args = mock_dal.sync_user_external_id.call_args
+        assert call_args[0][1] == "entra-ext-999"
+
+    def test_patch_user_enterprise_extension_in_value_dict(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends enterprise extension URN as key in path-less PATCH value
+        dicts — enterprise data should be stored, not ignored."""
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+
+        value = ScimPatchResourceValue(active=False)
+        assert value.__pydantic_extra__ is not None
+        value.__pydantic_extra__[
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ] = {"department": "Engineering"}
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path=None,
+                    value=value,
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        # Verify active=False was applied
+        mock_dal.update_user.assert_called_once()
+        call_kwargs = mock_dal.update_user.call_args
+        assert call_kwargs[1]["is_active"] is False
+        # Verify enterprise data was passed to DAL
+        mock_dal.sync_user_external_id.assert_called_once()
+        sync_kwargs = mock_dal.sync_user_external_id.call_args[1]
+        assert sync_kwargs["fields"] == ScimMappingFields(
+            department="Engineering",
+            given_name="Test",
+            family_name="User",
+            scim_emails_json='[{"value": "test@example.com", "type": "work", "primary": true}]',
+        )
+
+    def test_patch_user_remove_external_id(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """PATCH remove op should clear the target field."""
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        mapping = make_user_mapping(user_id=user.id)
+        mapping.external_id = "ext-to-remove"
+        mock_dal.get_user_mapping_by_user_id.return_value = mapping
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path="externalId",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        # externalId should be cleared (None)
+        mock_dal.sync_user_external_id.assert_called_once()
+        call_args = mock_dal.sync_user_external_id.call_args
+        assert call_args[0][1] is None
+
+    def test_patch_user_emails_primary_eq_true_value(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """PATCH with path emails[primary eq true].value should update
+        the primary email entry, not userName."""
+        user = make_db_user(email="old@contoso.com")
+        mock_dal.get_user.return_value = user
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="emails[primary eq true].value",
+                    value="new@contoso.com",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        # userName should remain unchanged — emails and userName are separate
+        assert resource.userName == "old@contoso.com"
+        # Primary email should be updated
+        primary_emails = [e for e in resource.emails if e.primary]
+        assert len(primary_emails) == 1
+        assert primary_emails[0].value == "new@contoso.com"
+
+    def test_patch_user_enterprise_urn_department_path(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """PATCH with dotted enterprise URN path should store department."""
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+                    value="Marketing",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.sync_user_external_id.assert_called_once()
+        sync_kwargs = mock_dal.sync_user_external_id.call_args[1]
+        assert sync_kwargs["fields"] == ScimMappingFields(
+            department="Marketing",
+            given_name="Test",
+            family_name="User",
+            scim_emails_json='[{"value": "test@example.com", "type": "work", "primary": true}]',
+        )
+
+    def test_replace_user_includes_enterprise_schema(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@contoso.com")
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(
+            userName="new@contoso.com",
+            name=ScimName(givenName="New", familyName="Name"),
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert SCIM_ENTERPRISE_USER_SCHEMA in resource.schemas
+
+    def test_replace_user_with_enterprise_extension(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """PUT with enterprise extension should store the fields."""
+        user = make_db_user(email="alice@contoso.com")
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(
+            userName="alice@contoso.com",
+            enterprise_extension=ScimEnterpriseExtension(
+                department="HR",
+                manager=ScimManagerRef(value="boss-id"),
+            ),
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.sync_user_external_id.assert_called_once()
+        sync_kwargs = mock_dal.sync_user_external_id.call_args[1]
+        assert sync_kwargs["fields"] == ScimMappingFields(
+            department="HR",
+            manager="boss-id",
+            given_name="Test",
+            family_name="User",
+        )
+
+    def test_delete_user_returns_204(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_mapping_by_user_id.return_value = MagicMock(id=1)
+
+        result = delete_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == 204
+
+    def test_double_delete_returns_404(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        """Second DELETE should return 404 — the SCIM mapping is gone."""
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        # No mapping — user was already deleted from SCIM's perspective
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+
+        result = delete_user(
+            user_id=str(user.id),
+            _token=mock_token,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        assert result.status_code == 404
+
+    def test_name_formatted_preserved_on_create(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """When name.formatted is provided, it should be used as personal_name."""
+        mock_dal.get_user_by_email.return_value = None
+        resource = make_scim_user(
+            userName="alice@contoso.com",
+            name=ScimName(
+                givenName="Alice",
+                familyName="Smith",
+                formatted="Dr. Alice Smith",
+            ),
+        )
+
+        with patch(
+            "ee.onyx.server.scim.api._check_seat_availability", return_value=None
+        ):
+            result = create_user(
+                user_resource=resource,
+                _token=mock_token,
+                provider=entra_provider,
+                db_session=mock_db_session,
+            )
+
+        parse_scim_user(result, status=201)
+        # The User constructor should have received the formatted name
+        mock_dal.add_user.assert_called_once()
+        created_user = mock_dal.add_user.call_args[0][0]
+        assert created_user.personal_name == "Dr. Alice Smith"
+
+
+# ---------------------------------------------------------------------------
+# Group Lifecycle (Entra-specific)
+# ---------------------------------------------------------------------------
+
+
+class TestEntraGroupLifecycle:
+    """Test group CRUD with Entra-specific behaviors."""
+
+    def test_get_group_standard_response(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        group = make_db_group(id=10, name="Contoso Engineering")
+        mock_dal.get_group.return_value = group
+        uid = uuid4()
+        mock_dal.get_group_members.return_value = [(uid, "alice@contoso.com")]
+
+        result = get_group(
+            group_id="10",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_group(result)
+        assert resource.displayName == "Contoso Engineering"
+        assert len(resource.members) == 1
+
+    def test_list_groups_with_excluded_attributes_members(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ?excludedAttributes=members on group list queries."""
+        group = make_db_group(id=10, name="Engineering")
+        uid = uuid4()
+        mock_dal.list_groups.return_value = ([(group, "ext-g-1")], 1)
+        mock_dal.get_group_members.return_value = [(uid, "alice@contoso.com")]
+
+        result = list_groups(
+            filter=None,
+            excludedAttributes="members",
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert parsed["totalResults"] == 1
+        resource = parsed["Resources"][0]
+        assert "members" not in resource
+        assert resource["displayName"] == "Engineering"
+
+    def test_get_group_with_excluded_attributes_members(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ?excludedAttributes=members on single group GET."""
+        group = make_db_group(id=10, name="Engineering")
+        uid = uuid4()
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = [(uid, "alice@contoso.com")]
+
+        result = get_group(
+            group_id="10",
+            excludedAttributes="members",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert "members" not in parsed
+        assert parsed["displayName"] == "Engineering"
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_patch_group_add_members_with_pascal_case(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ``"Add"`` (PascalCase) for group member additions."""
+        group = make_db_group(id=10)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+        mock_dal.validate_member_ids.return_value = []
+
+        uid = str(uuid4())
+        patched = ScimGroupResource(
+            id="10",
+            displayName="Engineering",
+            members=[ScimGroupMember(value=uid)],
+        )
+        mock_apply.return_value = (patched, [uid], [])
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op="Add",  # type: ignore[arg-type]
+                    path="members",
+                    value=[ScimGroupMember(value=uid)],
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="10",
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_group(result)
+        mock_dal.upsert_group_members.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api.apply_group_patch")
+    def test_patch_group_remove_member_with_pascal_case(
+        self,
+        mock_apply: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra sends ``"Remove"`` (PascalCase) for group member removals."""
+        group = make_db_group(id=10)
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        uid = str(uuid4())
+        patched = ScimGroupResource(id="10", displayName="Engineering", members=[])
+        mock_apply.return_value = (patched, [], [uid])
+
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op="Remove",  # type: ignore[arg-type]
+                    path=f'members[value eq "{uid}"]',
+                )
+            ]
+        )
+
+        result = patch_group(
+            group_id="10",
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_group(result)
+        mock_dal.remove_group_members.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# excludedAttributes (RFC 7644 §3.4.2.5)
+# ---------------------------------------------------------------------------
+
+
+class TestExcludedAttributes:
+    """Test excludedAttributes query parameter on GET endpoints."""
+
+    def test_list_groups_excludes_members(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        group = make_db_group(id=1, name="Team")
+        uid = uuid4()
+        mock_dal.list_groups.return_value = ([(group, None)], 1)
+        mock_dal.get_group_members.return_value = [(uid, "user@example.com")]
+
+        result = list_groups(
+            filter=None,
+            excludedAttributes="members",
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        resource = parsed["Resources"][0]
+        assert "members" not in resource
+        assert "displayName" in resource
+
+    def test_get_group_excludes_members(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        group = make_db_group(id=1, name="Team")
+        uid = uuid4()
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = [(uid, "user@example.com")]
+
+        result = get_group(
+            group_id="1",
+            excludedAttributes="members",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert "members" not in parsed
+        assert "displayName" in parsed
+
+    def test_list_users_excludes_groups(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        user = make_db_user()
+        mapping = make_user_mapping(user_id=user.id)
+        mock_dal.list_users.return_value = ([(user, mapping)], 1)
+        mock_dal.get_users_groups_batch.return_value = {user.id: [(1, "Engineering")]}
+
+        result = list_users(
+            filter=None,
+            excludedAttributes="groups",
+            startIndex=1,
+            count=100,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        resource = parsed["Resources"][0]
+        assert "groups" not in resource
+        assert "userName" in resource
+
+    def test_get_user_excludes_groups(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        user = make_db_user()
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_groups.return_value = [(1, "Engineering")]
+
+        result = get_user(
+            user_id=str(user.id),
+            excludedAttributes="groups",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert "groups" not in parsed
+        assert "userName" in parsed
+
+    def test_multiple_excluded_attributes(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        group = make_db_group(id=1, name="Team")
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = []
+
+        result = get_group(
+            group_id="1",
+            excludedAttributes="members,externalId",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        assert isinstance(result, ScimJSONResponse)
+        parsed = json.loads(result.body)
+        assert "members" not in parsed
+        assert "externalId" not in parsed
+        assert "displayName" in parsed
+
+    def test_no_excluded_attributes_returns_full_response(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        group = make_db_group(id=1, name="Team")
+        uid = uuid4()
+        mock_dal.get_group.return_value = group
+        mock_dal.get_group_members.return_value = [(uid, "user@example.com")]
+
+        result = get_group(
+            group_id="1",
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_group(result)
+        assert len(resource.members) == 1
+
+
+# ---------------------------------------------------------------------------
+# Entra Connection Probe
+# ---------------------------------------------------------------------------
+
+
+class TestEntraConnectionProbe:
+    """Entra sends a probe request during initial SCIM setup."""
+
+    def test_filter_for_nonexistent_user_returns_empty_list(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        entra_provider: ScimProvider,
+    ) -> None:
+        """Entra probes with: GET /Users?filter=userName eq "non-existent"&count=1"""
+        mock_dal.list_users.return_value = ([], 0)
+
+        result = list_users(
+            filter='userName eq "non-existent@contoso.com"',
+            startIndex=1,
+            count=1,
+            _token=mock_token,
+            provider=entra_provider,
+            db_session=mock_db_session,
+        )
+
+        parsed = parse_scim_list(result)
+        assert parsed.totalResults == 0
+        assert parsed.Resources == []

--- a/backend/tests/unit/onyx/server/scim/test_patch.py
+++ b/backend/tests/unit/onyx/server/scim/test_patch.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ee.onyx.server.scim.models import ScimEmail
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
 from ee.onyx.server.scim.models import ScimMeta
@@ -12,9 +13,11 @@ from ee.onyx.server.scim.models import ScimUserResource
 from ee.onyx.server.scim.patch import apply_group_patch
 from ee.onyx.server.scim.patch import apply_user_patch
 from ee.onyx.server.scim.patch import ScimPatchError
+from ee.onyx.server.scim.providers.entra import EntraProvider
 from ee.onyx.server.scim.providers.okta import OktaProvider
 
 _OKTA_IGNORED = OktaProvider().ignored_patch_paths
+_ENTRA_IGNORED = EntraProvider().ignored_patch_paths
 
 
 def _make_user(**kwargs: object) -> ScimUserResource:
@@ -56,36 +59,36 @@ class TestApplyUserPatch:
 
     def test_deactivate_user(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_replace_op("active", False)], user)
+        result, _ = apply_user_patch([_replace_op("active", False)], user)
         assert result.active is False
         assert result.userName == "test@example.com"
 
     def test_activate_user(self) -> None:
         user = _make_user(active=False)
-        result = apply_user_patch([_replace_op("active", True)], user)
+        result, _ = apply_user_patch([_replace_op("active", True)], user)
         assert result.active is True
 
     def test_replace_given_name(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_replace_op("name.givenName", "NewFirst")], user)
+        result, _ = apply_user_patch([_replace_op("name.givenName", "NewFirst")], user)
         assert result.name is not None
         assert result.name.givenName == "NewFirst"
         assert result.name.familyName == "User"
 
     def test_replace_family_name(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_replace_op("name.familyName", "NewLast")], user)
+        result, _ = apply_user_patch([_replace_op("name.familyName", "NewLast")], user)
         assert result.name is not None
         assert result.name.familyName == "NewLast"
 
     def test_replace_username(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_replace_op("userName", "new@example.com")], user)
+        result, _ = apply_user_patch([_replace_op("userName", "new@example.com")], user)
         assert result.userName == "new@example.com"
 
     def test_replace_without_path_uses_dict(self) -> None:
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [
                 _replace_op(
                     None,
@@ -99,7 +102,7 @@ class TestApplyUserPatch:
 
     def test_multiple_operations(self) -> None:
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [
                 _replace_op("active", False),
                 _replace_op("name.givenName", "Updated"),
@@ -112,7 +115,7 @@ class TestApplyUserPatch:
 
     def test_case_insensitive_path(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_replace_op("Active", False)], user)
+        result, _ = apply_user_patch([_replace_op("Active", False)], user)
         assert result.active is False
 
     def test_original_not_mutated(self) -> None:
@@ -125,15 +128,22 @@ class TestApplyUserPatch:
         with pytest.raises(ScimPatchError, match="Unsupported path"):
             apply_user_patch([_replace_op("unknownField", "value")], user)
 
-    def test_remove_op_on_user_raises(self) -> None:
+    def test_remove_op_clears_field(self) -> None:
+        """Remove op should clear the target field (not raise)."""
+        user = _make_user(externalId="ext-123")
+        result, _ = apply_user_patch([_remove_op("externalId")], user)
+        assert result.externalId is None
+
+    def test_remove_unsupported_path_raises(self) -> None:
+        """Remove op on unsupported path (e.g. 'active') should raise."""
         user = _make_user()
-        with pytest.raises(ScimPatchError, match="Unsupported operation"):
+        with pytest.raises(ScimPatchError, match="Unsupported remove path"):
             apply_user_patch([_remove_op("active")], user)
 
     def test_replace_without_path_ignores_id(self) -> None:
         """Okta sends 'id' alongside actual changes — it should be silently ignored."""
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [_replace_op(None, ScimPatchResourceValue(active=False, id="some-uuid"))],
             user,
             ignored_paths=_OKTA_IGNORED,
@@ -143,7 +153,7 @@ class TestApplyUserPatch:
     def test_replace_without_path_ignores_schemas(self) -> None:
         """The 'schemas' key in a value dict should be silently ignored."""
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [
                 _replace_op(
                     None,
@@ -161,7 +171,7 @@ class TestApplyUserPatch:
     def test_okta_deactivation_payload(self) -> None:
         """Exact Okta deactivation payload: path-less replace with id + active."""
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [
                 _replace_op(
                     None,
@@ -176,7 +186,7 @@ class TestApplyUserPatch:
 
     def test_replace_displayname(self) -> None:
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [_replace_op("displayName", "New Display Name")], user
         )
         assert result.displayName == "New Display Name"
@@ -187,7 +197,7 @@ class TestApplyUserPatch:
         """Okta sends id/schemas/meta alongside actual changes — complex types
         (lists, nested dicts) must not cause Pydantic validation errors."""
         user = _make_user()
-        result = apply_user_patch(
+        result, _ = apply_user_patch(
             [
                 _replace_op(
                     None,
@@ -207,8 +217,100 @@ class TestApplyUserPatch:
 
     def test_add_operation_works_like_replace(self) -> None:
         user = _make_user()
-        result = apply_user_patch([_add_op("externalId", "ext-456")], user)
+        result, _ = apply_user_patch([_add_op("externalId", "ext-456")], user)
         assert result.externalId == "ext-456"
+
+    def test_entra_capitalized_replace_op(self) -> None:
+        """Entra ID sends ``"Replace"`` instead of ``"replace"``."""
+        user = _make_user()
+        op = ScimPatchOperation(op="Replace", path="active", value=False)  # type: ignore[arg-type]
+        result, _ = apply_user_patch([op], user)
+        assert result.active is False
+
+    def test_entra_capitalized_add_op(self) -> None:
+        """Entra ID sends ``"Add"`` instead of ``"add"``."""
+        user = _make_user()
+        op = ScimPatchOperation(op="Add", path="externalId", value="ext-999")  # type: ignore[arg-type]
+        result, _ = apply_user_patch([op], user)
+        assert result.externalId == "ext-999"
+
+    def test_entra_enterprise_extension_handled(self) -> None:
+        """Entra sends the enterprise extension URN as a key in path-less
+        PATCH value dicts — enterprise data should be captured in ent_data."""
+        user = _make_user()
+        value = ScimPatchResourceValue(active=False)
+        # Simulate Entra including the enterprise extension URN as extra data
+        assert value.__pydantic_extra__ is not None
+        value.__pydantic_extra__[
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ] = {"department": "Engineering"}
+        result, ent_data = apply_user_patch(
+            [_replace_op(None, value)],
+            user,
+            ignored_paths=_ENTRA_IGNORED,
+        )
+        assert result.active is False
+        assert result.userName == "test@example.com"
+        assert ent_data["department"] == "Engineering"
+
+    def test_okta_handles_enterprise_extension_urn(self) -> None:
+        """Enterprise extension URN paths are handled universally, even
+        for Okta — the data is captured in the enterprise data dict."""
+        user = _make_user()
+        value = ScimPatchResourceValue(active=False)
+        assert value.__pydantic_extra__ is not None
+        value.__pydantic_extra__[
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        ] = {"department": "Engineering"}
+        result, ent_data = apply_user_patch(
+            [_replace_op(None, value)],
+            user,
+            ignored_paths=_OKTA_IGNORED,
+        )
+        assert result.active is False
+        assert ent_data["department"] == "Engineering"
+
+    def test_emails_primary_eq_true_value(self) -> None:
+        """emails[primary eq true].value should update the primary email entry."""
+        user = _make_user(
+            emails=[ScimEmail(value="old@example.com", type="work", primary=True)]
+        )
+        result, _ = apply_user_patch(
+            [_replace_op("emails[primary eq true].value", "new@example.com")], user
+        )
+        # userName should remain unchanged — emails and userName are separate
+        assert result.userName == "test@example.com"
+        assert len(result.emails) == 1
+        assert result.emails[0].value == "new@example.com"
+        assert result.emails[0].primary is True
+
+    def test_enterprise_urn_department_path(self) -> None:
+        """Dotted enterprise URN path should set department in ent_data."""
+        user = _make_user()
+        _, ent_data = apply_user_patch(
+            [
+                _replace_op(
+                    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+                    "Marketing",
+                )
+            ],
+            user,
+        )
+        assert ent_data["department"] == "Marketing"
+
+    def test_enterprise_urn_manager_path(self) -> None:
+        """Dotted enterprise URN path for manager should set manager."""
+        user = _make_user()
+        _, ent_data = apply_user_patch(
+            [
+                _replace_op(
+                    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager",
+                    ScimPatchResourceValue.model_validate({"value": "boss-id"}),
+                )
+            ],
+            user,
+        )
+        assert ent_data["manager"] == "boss-id"
 
 
 class TestApplyGroupPatch:

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -16,7 +16,7 @@ from ee.onyx.server.scim.api import get_user
 from ee.onyx.server.scim.api import list_users
 from ee.onyx.server.scim.api import patch_user
 from ee.onyx.server.scim.api import replace_user
-from ee.onyx.server.scim.models import ScimListResponse
+from ee.onyx.server.scim.models import ScimMappingFields
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimPatchOperation
 from ee.onyx.server.scim.models import ScimPatchOperationType
@@ -28,6 +28,8 @@ from tests.unit.onyx.server.scim.conftest import assert_scim_error
 from tests.unit.onyx.server.scim.conftest import make_db_user
 from tests.unit.onyx.server.scim.conftest import make_scim_user
 from tests.unit.onyx.server.scim.conftest import make_user_mapping
+from tests.unit.onyx.server.scim.conftest import parse_scim_list
+from tests.unit.onyx.server.scim.conftest import parse_scim_user
 
 
 class TestListUsers:
@@ -51,9 +53,9 @@ class TestListUsers:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimListResponse)
-        assert result.totalResults == 0
-        assert result.Resources == []
+        parsed = parse_scim_list(result)
+        assert parsed.totalResults == 0
+        assert parsed.Resources == []
 
     def test_returns_users_with_scim_shape(
         self,
@@ -77,10 +79,10 @@ class TestListUsers:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimListResponse)
-        assert result.totalResults == 1
-        assert len(result.Resources) == 1
-        resource = result.Resources[0]
+        parsed = parse_scim_list(result)
+        assert parsed.totalResults == 1
+        assert len(parsed.Resources) == 1
+        resource = parsed.Resources[0]
         assert isinstance(resource, ScimUserResource)
         assert resource.userName == "Alice@example.com"
         assert resource.externalId == "ext-abc"
@@ -146,9 +148,9 @@ class TestGetUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
-        assert result.userName == "alice@example.com"
-        assert result.id == str(user.id)
+        resource = parse_scim_user(result)
+        assert resource.userName == "alice@example.com"
+        assert resource.id == str(user.id)
 
     def test_invalid_uuid_returns_404(
         self,
@@ -207,8 +209,8 @@ class TestCreateUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
-        assert result.userName == "new@example.com"
+        resource = parse_scim_user(result, status=201)
+        assert resource.userName == "new@example.com"
         mock_dal.add_user.assert_called_once()
         mock_dal.commit.assert_called_once()
 
@@ -314,8 +316,8 @@ class TestCreateUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
-        assert result.externalId == "ext-123"
+        resource = parse_scim_user(result, status=201)
+        assert resource.externalId == "ext-123"
         mock_dal.create_user_mapping.assert_called_once()
 
 
@@ -344,7 +346,7 @@ class TestReplaceUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
+        parse_scim_user(result)
         mock_dal.update_user.assert_called_once()
         mock_dal.commit.assert_called_once()
 
@@ -412,9 +414,15 @@ class TestReplaceUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
+        parse_scim_user(result)
         mock_dal.sync_user_external_id.assert_called_once_with(
-            user.id, None, scim_username="test@example.com"
+            user.id,
+            None,
+            scim_username="test@example.com",
+            fields=ScimMappingFields(
+                given_name="Test",
+                family_name="User",
+            ),
         )
 
 
@@ -448,7 +456,7 @@ class TestPatchUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
+        parse_scim_user(result)
         mock_dal.update_user.assert_called_once()
 
     def test_not_found_returns_404(
@@ -507,7 +515,7 @@ class TestPatchUser:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
+        parse_scim_user(result)
         # Verify the update_user call received the new display name
         call_kwargs = mock_dal.update_user.call_args
         assert call_kwargs[1]["personal_name"] == "New Display Name"
@@ -605,10 +613,12 @@ class TestDeleteUser:
 class TestScimNameToStr:
     """Tests for _scim_name_to_str helper."""
 
-    def test_prefers_given_family_over_formatted(self) -> None:
-        """Okta may send stale formatted while updating givenName/familyName."""
-        name = ScimName(givenName="Jane", familyName="Smith", formatted="Old Name")
-        assert _scim_name_to_str(name) == "Jane Smith"
+    def test_prefers_formatted_over_components(self) -> None:
+        """When client provides formatted, use it — the client knows what it wants."""
+        name = ScimName(
+            givenName="Jane", familyName="Smith", formatted="Dr. Jane Smith"
+        )
+        assert _scim_name_to_str(name) == "Dr. Jane Smith"
 
     def test_given_name_only(self) -> None:
         name = ScimName(givenName="Jane")
@@ -653,9 +663,9 @@ class TestEmailCasePreservation:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
-        assert result.userName == "Alice@Example.COM"
-        assert result.emails[0].value == "Alice@Example.COM"
+        resource = parse_scim_user(result, status=201)
+        assert resource.userName == "Alice@Example.COM"
+        assert resource.emails[0].value == "Alice@Example.COM"
 
     def test_get_preserves_username_case(
         self,
@@ -681,6 +691,6 @@ class TestEmailCasePreservation:
             db_session=mock_db_session,
         )
 
-        assert isinstance(result, ScimUserResource)
-        assert result.userName == "Alice@Example.COM"
-        assert result.emails[0].value == "Alice@Example.COM"
+        resource = parse_scim_user(result)
+        assert resource.userName == "Alice@Example.COM"
+        assert resource.emails[0].value == "Alice@Example.COM"


### PR DESCRIPTION
## Description

Make the SCIM implementation pass Microsoft's Entra ID SCIM compliance validator while keeping Okta compatibility.

### Protocol compliance
- **`application/scim+json` content type** — all responses now use the RFC 7644 §3.1 media type via `ScimJSONResponse`
- **ListResponse envelope for discovery** — `/ResourceTypes` and `/Schemas` return a ListResponse object (not a bare array), which Entra ID requires
- **Enterprise User extension** — advertise `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` in schema discovery and user responses; round-trip `department` and `manager` fields through PATCH operations
- **`excludedAttributes` support** — implement RFC 7644 §3.4.2.5 so Entra can request `?excludedAttributes=members` on group endpoints
- **Case-insensitive PATCH ops** — normalize `"Replace"` / `"Add"` / `"Remove"` (Entra's capitalized form) to lowercase via a Pydantic validator

### Data round-tripping
- **`ScimMappingFields` dataclass** — bundle `department`, `manager`, `given_name`, `family_name`, and `scim_emails_json` into a single object passed through the DAL, replacing scattered keyword args
- **Name component storage** — store and round-trip `givenName` / `familyName` so Entra gets back exactly what it sent, rather than a `personal_name` split
- **Email storage** — serialize incoming email arrays to `scim_emails_json` and deserialize them on read, preserving multi-valued emails and the `primary` flag

### PATCH refactor
- **Dispatch tables** replace elif chains for simple field writes (`_USER_REPLACE_PATHS`, `_USER_REMOVE_PATHS`, `_GROUP_REPLACE_PATHS`)
- **`_UserPatchCtx` dataclass** bundles mutable state (`data`, `name_data`, `ent_data`) for cleaner function signatures
- **Enterprise extension support** — handle both dotted URN paths (`urn:...:department`) and value-dict form (`{urn:...: {department: "Eng"}}`)

### Provider abstraction
- **`EntraProvider`** subclass — sets `user_schemas` to include the enterprise extension URN and uses Entra-specific ignored PATCH paths
- **`build_scim_name` in base** — common stored-field-first logic (uses `given_name`/`family_name` when available, falls back to splitting `personal_name`)

### Other fixes
- **DELETE idempotency** — second DELETE returns 404 per RFC 7644 §3.6 (was silently succeeding)
- **Corrupt email fallback** — log a warning instead of silently swallowing `JSONDecodeError` in `_deserialize_emails`

## How Has This Been Tested?

Microsoft SCIM validator

[entra-id-scim-validator-results.json](https://github.com/user-attachments/files/25528662/entra-id-scim-validator-results.json)
Note: there is a failing test but it is due to a bug with the validator itself: https://learn.microsoft.com/en-us/answers/questions/2224894/microsoft-entra-id-scim-validator-test-failing-pat

I also ran the Okta tests again to validate they still behave as expected: https://www.runscope.com/radar/6eyw4a4mn8i5/66ad490e-2e8c-45bc-a834-76d3337ffb67/history/d8fa02cf-42aa-4f9e-b3a1-c02412bc6f36


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check