### PR TITLE
fix(fe): rm non-admin-confirmation max-width

### DIFF
--- a/web/src/refresh-components/onboarding/components/NonAdminStep.tsx
+++ b/web/src/refresh-components/onboarding/components/NonAdminStep.tsx
@@ -51,7 +51,7 @@ export default function NonAdminStep() {
     <>
       {showHeader && (
         <div
-          className="flex items-center justify-between w-full max-w-[800px] min-h-11 py-1 pl-3 pr-2 bg-background-tint-00 rounded-16 shadow-01 mb-2"
+          className="flex items-center justify-between w-full min-h-11 py-1 pl-3 pr-2 bg-background-tint-00 rounded-16 shadow-01 mb-2"
           aria-label="non-admin-confirmation"
         >
           <div className="flex items-center gap-1">


### PR DESCRIPTION
## How Has This Been Tested?

**before**
<img width="1662" height="2085" alt="20260223_14h26m26s_grim" src="https://github.com/user-attachments/assets/6cd51e12-e181-4a4c-8fba-582eaf491abe" />


**after**
<img width="1662" height="2085" alt="20260223_14h26m14s_grim" src="https://github.com/user-attachments/assets/f6ce75b8-8dcb-4e4e-8294-86ad55f6af49" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the NonAdminStep header layout by removing the 800px max-width constraint. The non-admin confirmation bar now spans the full width, improving readability on larger screens.

<sup>Written for commit 9ce8423a95919552e7137719d452935736722e27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

