### PR TITLE
fix: remove user info requirement for craft onboarding modal

### DIFF
--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -75,7 +75,7 @@ export function useOnboardingModal(): OnboardingModalController {
     level: existingPersona?.level,
   };
 
-  // Check if user has completed initial onboarding (persona cookie only, not name)
+  // Check if user has completed initial onboarding (only role required, not name)
   const hasUserInfo = useMemo(() => {
     return !!getBuildUserPersona()?.workArea;
   }, [user]);
@@ -93,7 +93,7 @@ export function useOnboardingModal(): OnboardingModalController {
   );
 
   // Auto-open initial onboarding modal on first load
-  // Shows if: user info (persona) missing OR (admin AND no providers configured)
+  // Shows if: user info (role) missing OR (admin AND no providers configured)
   useEffect(() => {
     if (hasInitialized || isLoadingLlm || !user) return;
 


### PR DESCRIPTION
## Description

Previously
- Craft onboarding modal would appear if user info was not set (there used to be a form on the modal to submit name)
- The name form was removed from the onboarding modal, but not from the display logic

Now
- Modal no longer checks for user info and only displays once 

## How Has This Been Tested?

Locally

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use persona role (workArea) instead of user name to control the Craft onboarding modal. The modal opens only when the role is missing or for admins with no providers configured.

- **Bug Fixes**
  - Switched user info check to persona role (workArea), removing name from the logic.
  - Updated hasUserInfo memo to depend on user to keep state in sync and prevent unnecessary triggers.

<sup>Written for commit 928f47ad2888313b8ba9752622b70fc23ca0e119. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



