### PR TITLE
feat(code-interpreter): Seed code interpreter server row

### DIFF
--- a/backend/alembic/versions/07b98176f1de_code_interpreter_seed.py
+++ b/backend/alembic/versions/07b98176f1de_code_interpreter_seed.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Seed the single instance of code_interpreter_server
-    # NOTE: There should always exist at most and at minimum 1 code_interpreter_server row
+    # NOTE: There should only exist at most and at minimum 1 code_interpreter_server row
     op.execute(
         sa.text("INSERT INTO code_interpreter_server (server_enabled) VALUES (true)")
     )


### PR DESCRIPTION
## Description
There should exist 1 code interpreter server row in the database. This acts as a config of sorts. This PR seeds it now, so that application code can be introduced soon that makes use of the fact that there is ONLY 1 row of this.

## How Has This Been Tested?
Alembic upgrade + downgrade + upgrade

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds a single code_interpreter_server row (server_enabled=true) as the default singleton config for the app. The Alembic migration inserts this row on upgrade and deletes all rows on downgrade.

<sup>Written for commit 3235d0ce5d5d91f68069780c6e1cb685d611c228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

