### PR TITLE
chore(llm): Scaffolding for Nightly LLM Tests

### DIFF
--- a/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
+++ b/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
@@ -1,11 +1,12 @@
 import json
 import os
 import time
-from dataclasses import dataclass
 from uuid import uuid4
 
 import pytest
 import requests
+from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from onyx.configs import app_configs
 from onyx.configs.constants import DocumentSource
@@ -26,8 +27,9 @@ _ENV_CUSTOM_CONFIG_JSON = "NIGHTLY_LLM_CUSTOM_CONFIG_JSON"
 _ENV_STRICT = "NIGHTLY_LLM_STRICT"
 
 
-@dataclass(frozen=True)
-class NightlyProviderConfig:
+class NightlyProviderConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     provider: str
     model_names: list[str]
     api_key: str | None


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding new scaffolding code to help with setting up the nightly llm tests

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Running in CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nightly integration test that provisions an LLM provider, sets it as default, runs a forced-tool chat, and verifies internal_search is called and an answer is returned. Cleans up the provider after each model run.

- New Features
  - Adds test_nightly_provider_chat_workflow with create → test → set-default → chat → delete, iterating over NIGHTLY_LLM_MODELS.
  - Config via env: NIGHTLY_LLM_PROVIDER, NIGHTLY_LLM_MODELS, NIGHTLY_LLM_API_KEY, NIGHTLY_LLM_API_BASE, NIGHTLY_LLM_CUSTOM_CONFIG_JSON, NIGHTLY_LLM_STRICT; requires INTEGRATION_TESTS_MODE=true.
  - Defaults: API base for openrouter and ollama_chat; auto OLLAMA_API_KEY custom_config for ollama_chat when provided.
  - Seeds a connector to expose SearchTool; forces internal_search and checks tool_call_debug plus message content.
  - Retries once to reduce flakes; skips or fails on misconfig based on strict mode; asserts provider is default after setting.

<sup>Written for commit 5bf2ef4062bd59490921f5d98e840695afac60f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

