### PR TITLE
chore: coerce doc metadata (#8703) to release v3.0

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 from pydantic import model_validator
 
 from onyx.access.models import ExternalAccess
@@ -166,6 +167,14 @@ class DocumentBase(BaseModel):
     # TODO(andrei): Ideally we could improve this to where each value is just a
     # list of strings.
     metadata: dict[str, str | list[str]]
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _coerce_metadata_values(cls, v: dict[str, Any]) -> dict[str, str | list[str]]:
+        return {
+            key: [str(item) for item in val] if isinstance(val, list) else str(val)
+            for key, val in v.items()
+        }
 
     # UTC time
     doc_updated_at: datetime | None = None

--- a/backend/tests/unit/onyx/connectors/test_document_metadata_coercion.py
+++ b/backend/tests/unit/onyx/connectors/test_document_metadata_coercion.py
@@ -1,0 +1,95 @@
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentBase
+from onyx.connectors.models import TextSection
+
+
+def _minimal_doc_kwargs(metadata: dict) -> dict:
+    return {
+        "id": "test-doc",
+        "sections": [TextSection(text="hello", link="http://example.com")],
+        "source": DocumentSource.NOT_APPLICABLE,
+        "semantic_identifier": "Test Doc",
+        "metadata": metadata,
+    }
+
+
+def test_int_values_coerced_to_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"count": 42}))
+    assert doc.metadata == {"count": "42"}
+
+
+def test_float_values_coerced_to_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"score": 3.14}))
+    assert doc.metadata == {"score": "3.14"}
+
+
+def test_bool_values_coerced_to_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"active": True}))
+    assert doc.metadata == {"active": "True"}
+
+
+def test_list_of_ints_coerced_to_list_of_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"ids": [1, 2, 3]}))
+    assert doc.metadata == {"ids": ["1", "2", "3"]}
+
+
+def test_list_of_mixed_types_coerced_to_list_of_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"tags": ["a", 1, True, 2.5]}))
+    assert doc.metadata == {"tags": ["a", "1", "True", "2.5"]}
+
+
+def test_list_of_dicts_coerced_to_list_of_str() -> None:
+    raw = {"nested": [{"key": "val"}, {"key2": "val2"}]}
+    doc = Document(**_minimal_doc_kwargs(raw))
+    assert doc.metadata == {"nested": ["{'key': 'val'}", "{'key2': 'val2'}"]}
+
+
+def test_dict_value_coerced_to_str() -> None:
+    raw = {"info": {"inner_key": "inner_val"}}
+    doc = Document(**_minimal_doc_kwargs(raw))
+    assert doc.metadata == {"info": "{'inner_key': 'inner_val'}"}
+
+
+def test_none_value_coerced_to_str() -> None:
+    doc = Document(**_minimal_doc_kwargs({"empty": None}))
+    assert doc.metadata == {"empty": "None"}
+
+
+def test_already_valid_str_values_unchanged() -> None:
+    doc = Document(**_minimal_doc_kwargs({"key": "value"}))
+    assert doc.metadata == {"key": "value"}
+
+
+def test_already_valid_list_of_str_unchanged() -> None:
+    doc = Document(**_minimal_doc_kwargs({"tags": ["a", "b", "c"]}))
+    assert doc.metadata == {"tags": ["a", "b", "c"]}
+
+
+def test_empty_metadata_unchanged() -> None:
+    doc = Document(**_minimal_doc_kwargs({}))
+    assert doc.metadata == {}
+
+
+def test_mixed_metadata_values() -> None:
+    raw = {
+        "str_val": "hello",
+        "int_val": 99,
+        "list_val": [1, "two", 3.0],
+        "dict_val": {"nested": True},
+    }
+    doc = Document(**_minimal_doc_kwargs(raw))
+    assert doc.metadata == {
+        "str_val": "hello",
+        "int_val": "99",
+        "list_val": ["1", "two", "3.0"],
+        "dict_val": "{'nested': True}",
+    }
+
+
+def test_coercion_works_on_base_class() -> None:
+    kwargs = _minimal_doc_kwargs({"count": 42})
+    kwargs.pop("source")
+    kwargs.pop("id")
+    doc = DocumentBase(**kwargs)
+    assert doc.metadata == {"count": "42"}


### PR DESCRIPTION
Cherry-pick of commit 6f6ef1e657b1d4d0d8670eb01520c7c0b544e22b to release/v3.0 branch.

Original PR: #8703

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerce document metadata values to strings (or list of strings) at model validation to ensure a consistent schema and prevent downstream type errors in v3.0.

- **Bug Fixes**
  - Added a Pydantic field_validator on DocumentBase.metadata to stringify values and list items (applies to Document as well); valid strings remain unchanged.
  - Added unit tests covering ints, floats, bools, dicts, None, mixed lists, and base class behavior.

<sup>Written for commit 9cc0370f5f2b9d8c54b647bba4a4b5810c5a3e4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

