### PR TITLE
fix(extensions): fix base url for chrome extension to

### DIFF
--- a/extensions/chrome/src/pages/onyx_home.js
+++ b/extensions/chrome/src/pages/onyx_home.js
@@ -132,9 +132,7 @@ import { getOnyxDomain } from "../utils/storage.js";
           return;
         }
 
-        setIframeSrc(
-          items[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN] + "/chat/nrf",
-        );
+        setIframeSrc(items[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN] + "/nrf");
       },
     );
   }


### PR DESCRIPTION
## Description

chrome extension is now at {BASE_URL}/nrf, update the extension to reflect this rather than using redirects

## How Has This Been Tested?

locally

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
