### PR TITLE
fix(nrf): hide search toggle when search mode is unavailable

### DIFF
--- a/web/src/app/nrf/NRFChrome.tsx
+++ b/web/src/app/nrf/NRFChrome.tsx
@@ -76,6 +76,7 @@ export default function NRFChrome() {
 
   const showModeToggle =
     isPaidEnterpriseFeaturesEnabled &&
+    settings.isSearchModeAvailable &&
     appFocus.isNewSession() &&
     !classification;
 


### PR DESCRIPTION
## Description

NRFChrome (the new tab page overlay used by the Chrome extension) showed the search/chat mode toggle based only on `isPaidEnterpriseFeaturesEnabled`, but `setAppMode("search")` in the EE `AppModeProvider` silently no-ops when `isSearchModeAvailable` is `false`. This caused a visible but non-functional toggle.

The fix adds the missing `settings.isSearchModeAvailable` check to `showModeToggle`, aligning it with the Header component in `app-layouts.tsx` which already has this guard.

## How Has This Been Tested?

- Verified the Header in `app-layouts.tsx` correctly hides the toggle when `isSearchModeAvailable` is false
- Confirmed the NRFChrome toggle now uses the same condition

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the search/chat mode toggle in NRFChrome when search mode isn’t available to prevent a non-functional UI. Adds settings.isSearchModeAvailable to the showModeToggle condition, matching the Header’s guard in app-layouts.tsx.

<sup>Written for commit b9fcf5bd6dbc7483c85aa2581a7a40833aa4869b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

