### PR TITLE
feat(image): support OpenAI historical image context edits

### DIFF
--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 
 
 class OpenAIImageGenerationProvider(ImageGenerationProvider):
+    _GPT_IMAGE_MODEL_PREFIX = "gpt-image-"
+    _DALL_E_2_MODEL_NAME = "dall-e-2"
+
     def __init__(
         self,
         api_key: str,
@@ -39,6 +42,25 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
             api_base=credentials.api_base,
         )
 
+    @property
+    def supports_reference_images(self) -> bool:
+        return True
+
+    @property
+    def max_reference_images(self) -> int:
+        # GPT image models support up to 16 input images for edits.
+        return 16
+
+    def _normalize_model_name(self, model: str) -> str:
+        return model.rsplit("/", 1)[-1]
+
+    def _model_supports_image_edits(self, model: str) -> bool:
+        normalized_model = self._normalize_model_name(model)
+        return (
+            normalized_model.startswith(self._GPT_IMAGE_MODEL_PREFIX)
+            or normalized_model == self._DALL_E_2_MODEL_NAME
+        )
+
     def generate_image(
         self,
         prompt: str,
@@ -46,9 +68,38 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
         size: str,
         n: int,
         quality: str | None = None,
-        reference_images: list[ReferenceImage] | None = None,  # noqa: ARG002
+        reference_images: list[ReferenceImage] | None = None,
         **kwargs: Any,
     ) -> ImageGenerationResponse:
+        if reference_images:
+            if not self._model_supports_image_edits(model):
+                raise ValueError(
+                    f"Model '{model}' does not support image edits with reference images."
+                )
+
+            normalized_model = self._normalize_model_name(model)
+            if (
+                normalized_model == self._DALL_E_2_MODEL_NAME
+                and len(reference_images) > 1
+            ):
+                raise ValueError(
+                    "Model 'dall-e-2' only supports a single reference image for edits."
+                )
+
+            from litellm import image_edit
+
+            return image_edit(
+                image=[image.data for image in reference_images],
+                prompt=prompt,
+                model=model,
+                api_key=self._api_key,
+                api_base=self._api_base,
+                size=size,
+                n=n,
+                quality=quality,
+                **kwargs,
+            )
+
         from litellm import image_generation
 
         return image_generation(

--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -1,10 +1,12 @@
 import json
+from unittest.mock import patch
 
 import pytest
 
 from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.factory import get_image_generation_provider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
+from onyx.image_gen.interfaces import ReferenceImage
 from onyx.image_gen.providers.azure_img_gen import AzureImageGenerationProvider
 from onyx.image_gen.providers.openai_img_gen import OpenAIImageGenerationProvider
 from onyx.image_gen.providers.vertex_img_gen import VertexImageGenerationProvider
@@ -45,6 +47,8 @@ def test_build_openai_provider_from_api_key_and_base() -> None:
     assert isinstance(image_gen_provider, OpenAIImageGenerationProvider)
     assert image_gen_provider._api_key == "test"
     assert image_gen_provider._api_base == "test"
+    assert image_gen_provider.supports_reference_images is True
+    assert image_gen_provider.max_reference_images == 16
 
 
 def test_build_openai_provider_fails_no_api_key() -> None:
@@ -133,3 +137,89 @@ def test_build_vertex_provider_with_missing_project_id() -> None:
 
     with pytest.raises(ImageProviderCredentialsError):
         get_image_generation_provider("vertex_ai", credentials)
+
+
+def test_openai_provider_uses_image_generation_without_reference_images() -> None:
+    provider = OpenAIImageGenerationProvider(
+        api_key="test-key",
+        api_base="test-base",
+    )
+    expected_response = object()
+
+    with (
+        patch("litellm.image_generation", return_value=expected_response) as mock_gen,
+        patch("litellm.image_edit") as mock_edit,
+    ):
+        response = provider.generate_image(
+            prompt="draw a mountain",
+            model="gpt-image-1",
+            size="1024x1024",
+            n=1,
+            quality="high",
+        )
+
+    assert response is expected_response
+    mock_gen.assert_called_once()
+    mock_edit.assert_not_called()
+
+
+def test_openai_provider_uses_image_edit_with_reference_images() -> None:
+    provider = OpenAIImageGenerationProvider(
+        api_key="test-key",
+        api_base="test-base",
+    )
+    reference_images = [
+        ReferenceImage(data=b"image-1-bytes", mime_type="image/png"),
+        ReferenceImage(data=b"image-2-bytes", mime_type="image/jpeg"),
+    ]
+    expected_response = object()
+
+    with (
+        patch("litellm.image_generation") as mock_gen,
+        patch("litellm.image_edit", return_value=expected_response) as mock_edit,
+    ):
+        response = provider.generate_image(
+            prompt="make this look watercolor",
+            model="gpt-image-1",
+            size="1024x1024",
+            n=1,
+            quality="high",
+            reference_images=reference_images,
+        )
+
+    assert response is expected_response
+    mock_gen.assert_not_called()
+    mock_edit.assert_called_once()
+    assert mock_edit.call_args.kwargs["image"] == [
+        b"image-1-bytes",
+        b"image-2-bytes",
+    ]
+
+
+def test_openai_provider_rejects_reference_images_for_unsupported_model() -> None:
+    provider = OpenAIImageGenerationProvider(api_key="test-key")
+
+    with pytest.raises(ValueError):
+        provider.generate_image(
+            prompt="edit this image",
+            model="dall-e-3",
+            size="1024x1024",
+            n=1,
+            reference_images=[ReferenceImage(data=b"image-1", mime_type="image/png")],
+        )
+
+
+def test_openai_provider_rejects_multiple_reference_images_for_dalle2() -> None:
+    provider = OpenAIImageGenerationProvider(api_key="test-key")
+
+    with pytest.raises(ValueError):
+        provider.generate_image(
+            prompt="edit this image",
+            model="dall-e-2",
+            size="1024x1024",
+            n=1,
+            reference_images=[
+                ReferenceImage(data=b"image-1", mime_type="image/png"),
+                ReferenceImage(data=b"image-2", mime_type="image/png"),
+            ],
+        )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

This PR is built on top of https://github.com/onyx-dot-app/onyx/pull/8603 and is extending the use case for OpenAI historical image gen as well.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

Tested this locally on my setup.  
![Screenshot 2026-02-24 at 9.23.51 AM.png](https://app.graphite.com/user-attachments/assets/f01c16e5-eb56-4d7b-9336-125996bbe0e8.png)



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->

---

## Summary by cubic

Add reference image support to the OpenAI image provider to enable historical image context edits. Requests with reference images now use image edits and enforce model-specific limits.

- New Features
    - Enable reference image edits for GPT image models (gpt-image-*) and DALL·E 2.
    - Limits: up to 16 images for GPT image models; DALL·E 2 supports 1.
    - Validate unsupported models or too many images; normalize model names; fall back to standard generation when no reference images are provided.

<sup>Written for commit 2bd39b07a03bd47136cc5295b1a4e4f94cb4e6f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->