### PR TITLE
feat(image): support Azure historical image context edits

### DIFF
--- a/backend/onyx/image_gen/providers/azure_img_gen.py
+++ b/backend/onyx/image_gen/providers/azure_img_gen.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 
 
 class AzureImageGenerationProvider(ImageGenerationProvider):
+    _GPT_IMAGE_MODEL_PREFIX = "gpt-image-"
+    _DALL_E_2_MODEL_NAME = "dall-e-2"
+
     def __init__(
         self,
         api_key: str,
@@ -53,6 +56,25 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
             deployment_name=credentials.deployment_name,
         )
 
+    @property
+    def supports_reference_images(self) -> bool:
+        return True
+
+    @property
+    def max_reference_images(self) -> int:
+        # Azure GPT image models support up to 16 input images for edits.
+        return 16
+
+    def _normalize_model_name(self, model: str) -> str:
+        return model.rsplit("/", 1)[-1]
+
+    def _model_supports_image_edits(self, model: str) -> bool:
+        normalized_model = self._normalize_model_name(model)
+        return (
+            normalized_model.startswith(self._GPT_IMAGE_MODEL_PREFIX)
+            or normalized_model == self._DALL_E_2_MODEL_NAME
+        )
+
     def generate_image(
         self,
         prompt: str,
@@ -60,13 +82,43 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
         size: str,
         n: int,
         quality: str | None = None,
-        reference_images: list[ReferenceImage] | None = None,  # noqa: ARG002
+        reference_images: list[ReferenceImage] | None = None,
         **kwargs: Any,
     ) -> ImageGenerationResponse:
-        from litellm import image_generation
-
         deployment = self._deployment_name or model
         model_name = f"azure/{deployment}"
+
+        if reference_images:
+            if not self._model_supports_image_edits(model):
+                raise ValueError(
+                    f"Model '{model}' does not support image edits with reference images."
+                )
+
+            normalized_model = self._normalize_model_name(model)
+            if (
+                normalized_model == self._DALL_E_2_MODEL_NAME
+                and len(reference_images) > 1
+            ):
+                raise ValueError(
+                    "Model 'dall-e-2' only supports a single reference image for edits."
+                )
+
+            from litellm import image_edit
+
+            return image_edit(
+                image=[image.data for image in reference_images],
+                prompt=prompt,
+                model=model_name,
+                api_key=self._api_key,
+                api_base=self._api_base,
+                api_version=self._api_version,
+                size=size,
+                n=n,
+                quality=quality,
+                **kwargs,
+            )
+
+        from litellm import image_generation
 
         return image_generation(
             prompt=prompt,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Building on top of https://github.com/onyx-dot-app/onyx/pull/8603 for Azure now

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

Tested this workflow locally on my Azure models for gpt image 1

## ![Screenshot 2026-02-24 at 9.48.24 AM.png](https://app.graphite.com/user-attachments/assets/c7c38e4a-10e5-47a2-9df7-2b596f13dad4.png)



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check