### PR TITLE
feat(scim): add additional entra id fields to ScimUserMapping 

### DIFF
--- a/backend/alembic/versions/7616121f6e97_add_enterprise_fields_to_scim_user_mapping.py
+++ b/backend/alembic/versions/7616121f6e97_add_enterprise_fields_to_scim_user_mapping.py
@@ -1,0 +1,48 @@
+"""add enterprise and name fields to scim_user_mapping
+
+Revision ID: 7616121f6e97
+Revises: 07b98176f1de
+Create Date: 2026-02-23 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7616121f6e97"
+down_revision = "07b98176f1de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("department", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("manager", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("given_name", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("family_name", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "scim_user_mapping",
+        sa.Column("scim_emails_json", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scim_user_mapping", "scim_emails_json")
+    op.drop_column("scim_user_mapping", "family_name")
+    op.drop_column("scim_user_mapping", "given_name")
+    op.drop_column("scim_user_mapping", "manager")
+    op.drop_column("scim_user_mapping", "department")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4940,6 +4940,11 @@ class ScimUserMapping(Base):
         ForeignKey("user.id", ondelete="CASCADE"), unique=True, nullable=False
     )
     scim_username: Mapped[str | None] = mapped_column(String, nullable=True)
+    department: Mapped[str | None] = mapped_column(String, nullable=True)
+    manager: Mapped[str | None] = mapped_column(String, nullable=True)
+    given_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    family_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    scim_emails_json: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False


### PR DESCRIPTION
## Description

Add new columns to the `scim_user_mapping` table to store additional SCIM attributes from Entra ID (Azure AD).

Entra ID sends these fields during SCIM provisioning (via PATCH/PUT/POST) and expects them returned verbatim in subsequent GET responses. Unlike Okta, which only provisions core fields (`userName`, `active`, `displayName`), Entra ID provisions structured name components, email metadata, and enterprise extension attributes. Without persisting these, Entra's SCIM compliance validator fails because the GET response is missing data that was previously written.

**New columns:**

- `department` — enterprise extension field (`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`)
- `manager` — enterprise extension field (manager `value` reference)
- `given_name` / `family_name` — structured name components (Entra sends these separately rather than just `displayName`)
- `scim_emails_json` — serialized SCIM email array preserving `type` and `primary` metadata that Entra expects round-tripped


## How Has This Been Tested?

ran alembic upgrade locally and ran the entra integration tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check