### PR TITLE
chore(image): Update test to be for Dall E 3 instead of 2

### DIFF
--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -211,13 +211,16 @@ def test_openai_provider_rejects_reference_images_for_unsupported_model() -> Non
         )
 
 
-def test_openai_provider_rejects_multiple_reference_images_for_dalle2() -> None:
+def test_openai_provider_rejects_multiple_reference_images_for_dalle3() -> None:
     provider = OpenAIImageGenerationProvider(api_key="test-key")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="does not support image edits with reference images",
+    ):
         provider.generate_image(
             prompt="edit this image",
-            model="dall-e-2",
+            model="dall-e-3",
             size="1024x1024",
             n=1,
             reference_images=[
@@ -307,17 +310,20 @@ def test_azure_provider_rejects_reference_images_for_unsupported_model() -> None
         )
 
 
-def test_azure_provider_rejects_multiple_reference_images_for_dalle2() -> None:
+def test_azure_provider_rejects_multiple_reference_images_for_dalle3() -> None:
     provider = AzureImageGenerationProvider(
         api_key="test-key",
         api_base="https://azure.example.com",
         api_version="2024-05-01-preview",
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="does not support image edits with reference images",
+    ):
         provider.generate_image(
             prompt="edit this image",
-            model="dall-e-2",
+            model="dall-e-3",
             size="1024x1024",
             n=1,
             reference_images=[


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
You can't configure Dall E 2 through the UI anymore so aligning the tests to match as well.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update image generation tests to target DALL-E 3 instead of DALL-E 2 to match current UI support. Tighten assertions by checking the exact error message when multiple reference images are used, for both OpenAI and Azure providers.

<sup>Written for commit 79f1baddf421bbb0bd5fff9f8531c932ad49f2cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

