### PR TITLE
chore(fe): update disabled "select" button color

### DIFF
--- a/web/lib/opal/src/core/interactive/styles.css
+++ b/web/lib/opal/src/core/interactive/styles.css
@@ -394,7 +394,7 @@
 }
 .interactive[data-interactive-base-variant="select"][data-disabled] {
   @apply bg-transparent;
-  --interactive-foreground: var(--text-02);
+  --interactive-foreground: var(--text-01);
 }
 .interactive[data-interactive-base-variant="select"][data-selected="true"][data-disabled] {
   --interactive-foreground: var(--action-link-03);


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3747/different-levels-of-greyed-out

## How Has This Been Tested?




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the disabled “select” button text color to use --text-01 instead of --text-02 for consistent disabled styling and better readability. Addresses Linear ENG-3747 by removing inconsistent grey levels across disabled states.

<sup>Written for commit 615e624d653ef5681ff4eab1a248880b37c6dbd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

