### PR TITLE
chore(fe): only left input items flex

### DIFF
--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -119,10 +119,10 @@ function HorizontalInputLayout({
         justifyContent="between"
         alignItems={center ? "center" : "start"}
       >
-        <div className="flex flex-col self-stretch flex-[2]">
+        <div className="flex flex-col flex-1 self-stretch">
           <TitleLayout {...titleLayoutProps} />
         </div>
-        <div className="flex flex-col flex-[1] items-end">{children}</div>
+        <div className="flex flex-col items-end">{children}</div>
       </Section>
       {name && <ErrorLayout name={name} />}
     </Section>


### PR DESCRIPTION
## Description

Related to https://linear.app/onyx-app/issue/ENG-3605/share-agent-menu-add-label-and-show-public-agent-message

## How Has This Been Tested?


**before**
<img width="1662" height="2085" alt="20260224_14h22m42s_grim" src="https://github.com/user-attachments/assets/0b707ccd-3ec1-4d39-9048-f66307406ea5" />

**after**
<img width="1662" height="2085" alt="20260224_14h23m24s_grim" src="https://github.com/user-attachments/assets/13f8cb06-6d58-4ae4-a4f7-3ea97fa899d8" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted HorizontalInputLayout so only the left column flexes and the right side keeps its natural width. Prevents children from stretching and improves alignment in forms.

<sup>Written for commit 321a174c114f61dbcf09bd32135bb65c89a1be5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

