### PR TITLE
chore(fe): foldable buttons display text via tooltip when disabled

### DIFF
--- a/web/lib/opal/src/components/buttons/Button/components.tsx
+++ b/web/lib/opal/src/components/buttons/Button/components.tsx
@@ -162,7 +162,9 @@ function Button({
 
   const resolvedTooltip =
     tooltip ??
-    (interactiveBaseProps.disabled && children ? children : undefined);
+    (foldable && interactiveBaseProps.disabled && children
+      ? children
+      : undefined);
 
   if (!resolvedTooltip) return button;
 


### PR DESCRIPTION
## Description

The `Deep Research` button typically reveals the text when hovered, but when it's disabled, so is this animation. In spite of that, show a tooltip with the same text when disabled.

When all of these buttons are disabled, it's the only one in the InputBar without a tooltip/hover animation.

<img width="1662" height="2085" alt="20260224_14h40m46s_grim" src="https://github.com/user-attachments/assets/bae62b15-9e31-40a7-ad1d-b1c984908156" />


## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled foldable buttons now show their label in a tooltip by default, so the Deep Research button matches other InputBar controls and stays discoverable. If a tooltip prop is provided, it’s used; non-foldable buttons are unchanged.

<sup>Written for commit 8146787945c9b08e7254eac56507f675911eb485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



