### PR TITLE
feat(scim): SCIM 2.0 protocol compliance fixes [1/3]

### DIFF
--- a/backend/ee/onyx/server/scim/providers/base.py
+++ b/backend/ee/onyx/server/scim/providers/base.py
@@ -16,6 +16,14 @@ from ee.onyx.server.scim.models import ScimUserResource
 from onyx.db.models import User
 from onyx.db.models import UserGroup
 
+COMMON_IGNORED_PATCH_PATHS: frozenset[str] = frozenset(
+    {
+        "id",
+        "schemas",
+        "meta",
+    }
+)
+
 
 class ScimProvider(ABC):
     """Base class for provider-specific SCIM behavior.

--- a/backend/ee/onyx/server/scim/providers/okta.py
+++ b/backend/ee/onyx/server/scim/providers/okta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ee.onyx.server.scim.providers.base import COMMON_IGNORED_PATCH_PATHS
 from ee.onyx.server.scim.providers.base import ScimProvider
 
 
@@ -22,4 +23,4 @@ class OktaProvider(ScimProvider):
 
     @property
     def ignored_patch_paths(self) -> frozenset[str]:
-        return frozenset({"id", "schemas", "meta"})
+        return COMMON_IGNORED_PATCH_PATHS

--- a/backend/tests/unit/onyx/server/scim/test_providers.py
+++ b/backend/tests/unit/onyx/server/scim/test_providers.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from uuid import UUID
 from uuid import uuid4
 
+from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
 from ee.onyx.server.scim.models import ScimEmail
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
@@ -9,6 +10,7 @@ from ee.onyx.server.scim.models import ScimMeta
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimUserGroupRef
 from ee.onyx.server.scim.models import ScimUserResource
+from ee.onyx.server.scim.providers.base import COMMON_IGNORED_PATCH_PATHS
 from ee.onyx.server.scim.providers.base import get_default_provider
 from ee.onyx.server.scim.providers.okta import OktaProvider
 
@@ -39,9 +41,7 @@ class TestOktaProvider:
         assert OktaProvider().name == "okta"
 
     def test_ignored_patch_paths(self) -> None:
-        assert OktaProvider().ignored_patch_paths == frozenset(
-            {"id", "schemas", "meta"}
-        )
+        assert OktaProvider().ignored_patch_paths == COMMON_IGNORED_PATCH_PATHS
 
     def test_build_user_resource_basic(self) -> None:
         provider = OktaProvider()
@@ -59,6 +59,12 @@ class TestOktaProvider:
             groups=[],
             meta=ScimMeta(resourceType="User"),
         )
+
+    def test_build_user_resource_has_core_schema_only(self) -> None:
+        provider = OktaProvider()
+        user = _make_mock_user()
+        result = provider.build_user_resource(user, "ext-123")
+        assert result.schemas == [SCIM_USER_SCHEMA]
 
     def test_build_user_resource_with_groups(self) -> None:
         provider = OktaProvider()


### PR DESCRIPTION
## Description

First PR in the SCIM 2.0 Entra ID compatibility stack (split from #8692). Fixes SCIM protocol compliance gaps that block  Entra ID provisioning — correct content types, list response envelopes, robust PATCH handling, and idempotent DELETE.

**Protocol compliance fixes:**
- `ScimJSONResponse` with `application/scim+json` content type (RFC 7644 §3.1)
- `/ResourceTypes` and `/Schemas` wrapped in ListResponse envelopes (Entra expects JSON objects, not bare arrays)
- `excludedAttributes` query parameter support (RFC 7644 §3.4.2.5)
- `_scim_name_to_str` fix — prefer `formatted` field over components (matches client intent)
- `_scim_error_response` helper with structured logging

**PATCH improvements:**
- Dispatch tables replacing elif chains in patch.py
- REMOVE operation support for user PATCH
- Email filter path support (`emails[primary eq true].value`)
- `normalize_op` validator for case-insensitive PATCH op matching (Entra sends `"Replace"` not `"replace"`)
- `COMMON_IGNORED_PATCH_PATHS` constant extracted to base provider

**DELETE fix:**
- Idempotent DELETE — checks SCIM mapping exists before deactivating (second DELETE returns 404 per RFC 7644 §3.6)

**Stack:** PR 1/3 → [PR 2/3: field round-tripping] → [PR 3/3: Entra support]

## How Has This Been Tested?

see 3rd pr in stack

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check