### PR TITLE
feat(scim): field round-tripping for IdP attribute preservation [2/3]

### DIFF
--- a/backend/ee/onyx/server/scim/models.py
+++ b/backend/ee/onyx/server/scim/models.py
@@ -7,6 +7,7 @@ SCIM protocol schemas follow the wire format defined in:
 Admin API schemas are internal to Onyx and used for SCIM token management.
 """
 
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 
@@ -69,6 +70,23 @@ class ScimUserGroupRef(BaseModel):
 
     value: str
     display: str | None = None
+
+
+@dataclass
+class ScimMappingFields:
+    """Stored SCIM mapping fields that need to round-trip through the IdP.
+
+    Entra ID sends structured name components, email metadata, and enterprise
+    extension attributes that must be returned verbatim in subsequent GET
+    responses. These fields are persisted on ScimUserMapping and threaded
+    through the DAL, provider, and endpoint layers.
+    """
+
+    department: str | None = None
+    manager: str | None = None
+    given_name: str | None = None
+    family_name: str | None = None
+    scim_emails_json: str | None = None
 
 
 class ScimUserResource(BaseModel):

--- a/backend/ee/onyx/server/scim/providers/base.py
+++ b/backend/ee/onyx/server/scim/providers/base.py
@@ -2,19 +2,28 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from abc import ABC
 from abc import abstractmethod
 from uuid import UUID
 
+from pydantic import ValidationError
+
+from ee.onyx.server.scim.models import SCIM_USER_SCHEMA
 from ee.onyx.server.scim.models import ScimEmail
 from ee.onyx.server.scim.models import ScimGroupMember
 from ee.onyx.server.scim.models import ScimGroupResource
+from ee.onyx.server.scim.models import ScimMappingFields
 from ee.onyx.server.scim.models import ScimMeta
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimUserGroupRef
 from ee.onyx.server.scim.models import ScimUserResource
 from onyx.db.models import User
 from onyx.db.models import UserGroup
+
+
+logger = logging.getLogger(__name__)
 
 COMMON_IGNORED_PATCH_PATHS: frozenset[str] = frozenset(
     {
@@ -49,12 +58,22 @@ class ScimProvider(ABC):
         """
         ...
 
+    @property
+    def user_schemas(self) -> list[str]:
+        """Schema URIs to include in User resource responses.
+
+        Override in subclasses to advertise additional schemas (e.g. the
+        enterprise extension for Entra ID).
+        """
+        return [SCIM_USER_SCHEMA]
+
     def build_user_resource(
         self,
         user: User,
         external_id: str | None = None,
         groups: list[tuple[int, str]] | None = None,
         scim_username: str | None = None,
+        fields: ScimMappingFields | None = None,
     ) -> ScimUserResource:
         """Build a SCIM User response from an Onyx User.
 
@@ -66,23 +85,27 @@ class ScimProvider(ABC):
                 for newly-created users.
             scim_username: The original-case userName from the IdP. Falls
                 back to ``user.email`` (lowercase) when not available.
+            fields: Stored mapping fields that the IdP expects round-tripped.
         """
+        f = fields or ScimMappingFields()
         group_refs = [
             ScimUserGroupRef(value=str(gid), display=gname)
             for gid, gname in (groups or [])
         ]
 
-        # Use original-case userName if stored, otherwise fall back to the
-        # lowercased email from the User model.
         username = scim_username or user.email
 
+        name = self.build_scim_name(user, f)
+        emails = _deserialize_emails(f.scim_emails_json, username)
+
         return ScimUserResource(
+            schemas=list(self.user_schemas),
             id=str(user.id),
             externalId=external_id,
             userName=username,
-            name=self._build_scim_name(user),
+            name=name,
             displayName=user.personal_name,
-            emails=[ScimEmail(value=username, type="work", primary=True)],
+            emails=emails,
             active=user.is_active,
             groups=group_refs,
             meta=ScimMeta(resourceType="User"),
@@ -106,9 +129,24 @@ class ScimProvider(ABC):
             meta=ScimMeta(resourceType="Group"),
         )
 
-    @staticmethod
-    def _build_scim_name(user: User) -> ScimName | None:
-        """Extract SCIM name components from a user's personal name."""
+    def build_scim_name(
+        self,
+        user: User,
+        fields: ScimMappingFields,
+    ) -> ScimName | None:
+        """Build SCIM name components for the response.
+
+        Round-trips stored ``given_name``/``family_name`` when available (so
+        the IdP gets back what it sent). Falls back to splitting
+        ``personal_name`` for users provisioned before we stored components.
+        Providers may override for custom behavior.
+        """
+        if fields.given_name is not None or fields.family_name is not None:
+            return ScimName(
+                givenName=fields.given_name,
+                familyName=fields.family_name,
+                formatted=user.personal_name,
+            )
         if not user.personal_name:
             return None
         parts = user.personal_name.split(" ", 1)
@@ -117,6 +155,27 @@ class ScimProvider(ABC):
             familyName=parts[1] if len(parts) > 1 else None,
             formatted=user.personal_name,
         )
+
+
+def _deserialize_emails(stored_json: str | None, username: str) -> list[ScimEmail]:
+    """Deserialize stored email entries or build a default work email."""
+    if stored_json:
+        try:
+            entries = json.loads(stored_json)
+            if isinstance(entries, list) and entries:
+                return [ScimEmail(**e) for e in entries]
+        except (json.JSONDecodeError, TypeError, ValidationError):
+            logger.warning(
+                "Corrupt scim_emails_json, falling back to default: %s", stored_json
+            )
+    return [ScimEmail(value=username, type="work", primary=True)]
+
+
+def serialize_emails(emails: list[ScimEmail]) -> str | None:
+    """Serialize SCIM email entries to JSON for storage."""
+    if not emails:
+        return None
+    return json.dumps([e.model_dump(exclude_none=True) for e in emails])
 
 
 def get_default_provider() -> ScimProvider:

--- a/backend/tests/unit/onyx/db/test_scim_dal.py
+++ b/backend/tests/unit/onyx/db/test_scim_dal.py
@@ -98,6 +98,11 @@ class TestScimDALUserMappings:
             "external_id": "ext-1",
             "user_id": user_id,
             "scim_username": None,
+            "department": None,
+            "manager": None,
+            "given_name": None,
+            "family_name": None,
+            "scim_emails_json": None,
         }
 
     def test_delete_user_mapping(

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -16,6 +16,7 @@ from ee.onyx.server.scim.api import get_user
 from ee.onyx.server.scim.api import list_users
 from ee.onyx.server.scim.api import patch_user
 from ee.onyx.server.scim.api import replace_user
+from ee.onyx.server.scim.models import ScimMappingFields
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimPatchOperation
 from ee.onyx.server.scim.models import ScimPatchOperationType
@@ -418,6 +419,10 @@ class TestReplaceUser:
             user.id,
             None,
             scim_username="test@example.com",
+            fields=ScimMappingFields(
+                given_name="Test",
+                family_name="User",
+            ),
         )
 
 


### PR DESCRIPTION
## Description

Second PR in the SCIM 2.0 Entra ID compatibility stack. Stacked on #8745. Ensures IdP-provided user attributes (name components, email metadata, department, manager) are persisted and echoed back verbatim on subsequent GET/LIST requests, which Entra ID requires for provisioning validation.

Adds field round-tripping so that IdP-provided attributes (name components, email metadata, enterprise extension fields) are persisted and returned verbatim in subsequent GET responses.

**Key changes:**
- `ScimMappingFields` dataclass — carries stored mapping fields (given_name, family_name, scim_emails_json, department, manager)
- `build_scim_name` concrete method on base provider — round-trips stored name components, falls back to splitting `personal_name` for legacy users
- Email serialization/deserialization (`serialize_emails`, `_deserialize_emails`)
- `user_schemas` property on base provider for schema extensibility
- DAL `create_user_mapping` and `sync_user_external_id` accept `fields` parameter
- `_mapping_to_fields` and `_fields_from_resource` helpers in api.py
- All user endpoints (`list`, `get`, `create`, `replace`, `patch`) thread `fields=` through

**Stack:** [PR 1/3: protocol compliance] → PR 2/3 → [PR 3/3: Entra support]

## How Has This Been Tested?

see 3rd pr in stack

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check