### PR TITLE
fix(fe): middle align human chat message text

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -209,7 +209,11 @@ const HumanMessage = React.memo(function HumanMessage({
                   }
                 }}
               >
-                <Text as="p" mainContentBody>
+                <Text
+                  as="p"
+                  className="inline-block align-middle"
+                  mainContentBody
+                >
                   {content}
                 </Text>
               </div>


### PR DESCRIPTION
## Description

The root issue for https://linear.app/onyx-app/issue/ENG-3744/the-user-input-is-misaligned is that we're using a custom `line-height` for `font-main-content-body`. Convert the human message text to an inline-block element so we can apply `vertical-align: middle;` (only applies to `inline` elements) to keep the text in the middle of the element. 

## How Has This Been Tested?

Captured by visual regression

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned human chat message text by rendering the message as inline-block and applying vertical-align: middle. Addresses Linear ENG-3744 where a custom line-height in mainContentBody caused the text to sit off-center.

<sup>Written for commit 95d8f4b6d877ccd89ffe6e518453e0b0e99873a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

