### PR TITLE
fix(fe): inline code-blocks respect header font-size (#8691) to release v2.12

### DIFF
--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -62,12 +62,13 @@ export const CodeBlock = memo(function CodeBlock({
   if (typeof children === "string" && !language) {
     return (
       <span
+        data-testid="code-block"
         className={cn(
           "font-mono",
           "text-text-05",
           "bg-background-tint-00",
           "rounded",
-          "text-xs",
+          "text-[0.75em]",
           "inline",
           "whitespace-pre-wrap",
           "break-words",


### PR DESCRIPTION
Cherry-pick of commit beb1c49c69b7ef2b6e09632a03e21b578d4ffde4 to release/v2.12 branch.

Original PR: #8691

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline code now scales with the surrounding text, so code in headings no longer looks too small. Also adds a stable test id for inline code.

- **Bug Fixes**
  - Replaced fixed text size with text-[0.75em] so inline code respects parent font size.
  - Added data-testid="code-block" for reliable test selection.

<sup>Written for commit 685c0533ec7103804cdca33b37fc055b40227007. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

