### PR TITLE
fix: Invoke generate_agents_md.py in K8s to populate knowledge sources

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1348,10 +1348,12 @@ if [ -d /workspace/skills ]; then
     echo "Linked skills to /workspace/skills"
 fi
 
-# Write agent instructions (scans files dir to populate knowledge sources)
+# Write agent instructions
 echo "Writing AGENTS.md"
-printf '%s' '{agent_instructions_escaped}' \
-  | python3 /usr/local/bin/generate_agents_md.py {session_path}/AGENTS.md {session_path}/files
+printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
+
+# Populate knowledge sources by scanning the files directory
+python3 /usr/local/bin/generate_agents_md.py {session_path}/AGENTS.md {session_path}/files || true
 
 # Write opencode config
 echo "Writing opencode.json"
@@ -1777,11 +1779,12 @@ set -e
 echo "Creating files symlink to {symlink_target}"
 ln -sf {symlink_target} {session_path}/files
 
-# Write agent instructions (scans files dir to populate knowledge sources)
+# Write agent instructions
 echo "Writing AGENTS.md"
-printf '%s' '{agent_instructions_escaped}' \
-  | python3 /usr/local/bin/generate_agents_md.py \
-  {session_path}/AGENTS.md {session_path}/files
+printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
+
+# Populate knowledge sources by scanning the files directory
+python3 /usr/local/bin/generate_agents_md.py {session_path}/AGENTS.md {session_path}/files || true
 
 # Write opencode config
 echo "Writing opencode.json"


### PR DESCRIPTION
## Description

The `{{KNOWLEDGE_SOURCES_SECTION}}` placeholder in AGENTS.md was never being replaced in Kubernetes environments, even though it worked locally. 

**Root cause:** The backend intentionally passes `files_path=None` to `generate_agent_instructions()` in K8s mode (since it can't access the pod filesystem), leaving the placeholder intact. The `generate_agents_md.py` script was baked into the container image to handle this at runtime, but was **never invoked** during session setup.

**Fix:**
- Updated `generate_agents_md.py` to accept CLI args (`<agents_md_path> <files_path>`) instead of reading from env vars, fitting the actual invocation context
- Added the script invocation in both the main session setup script and the config regeneration script, after AGENTS.md is written and after the files symlink is created
- Added early-exit with warning if the placeholder is not found
- Added `|| echo` fallback in the regeneration path to avoid partial update failures

## How Has This Been Tested?

- Verified Python files parse correctly
- Confirmed invocation order: files symlink is created before the script runs in both code paths
- Confirmed Dockerfile already copies the script to `/usr/local/bin/`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGENTS.md generation in Kubernetes by writing AGENTS.md and then calling generate_agents_md.py to populate {{KNOWLEDGE_SOURCES_SECTION}} by scanning the files symlink. K8s sessions now show the correct knowledge sources without breaking setup if the script fails.

- **Bug Fixes**
  - Write AGENTS.md with printf, then modify in place by invoking the script during both session setup and config regeneration; use "|| true" to avoid setup failures.
  - Update script to accept "<agents_md_path> <files_path>", resolve symlinks, replace the placeholder, and simplify logging.

<sup>Written for commit 59b5cf5d19ad02408f649ae540abb4fa2271a781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

