### PR TITLE
chore(gha): update `helm/chart-testing-action` version (#8536) to release v2.12

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -41,8 +41,7 @@ jobs:
           version: v3.19.0
 
       - name: Set up chart-testing
-        # NOTE: This is Jamison's patch from https://github.com/helm/chart-testing-action/pull/194
-        uses: helm/chart-testing-action@8958a6ac472cbd8ee9a8fbb6f1acbc1b0e966e44 # zizmor: ignore[impostor-commit]
+        uses: helm/chart-testing-action@b5eebdd9998021f29756c53432f48dab66394810
         with:
           uv_version: "0.9.9"
 


### PR DESCRIPTION
Cherry-pick of commit f688efbcd65f0260510003fdcabbed1bb42ef929 to release/v2.12 branch.

Original PR: #8536

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Helm chart-testing GitHub Action in pr-helm-chart-testing.yml to the upstream version, removing the temporary patch reference. This aligns CI for chart tests with the v2.12 release branch and improves maintainability.

<sup>Written for commit 44db0658c3bcf4c3dbd917ccd3530f26d4db3bf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

