### PR TITLE
chore(llm): Add Anthropic Integration Test

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat-anthropic.yml
+++ b/.github/workflows/nightly-llm-provider-chat-anthropic.yml
@@ -1,0 +1,44 @@
+name: Nightly LLM Provider Chat Tests (Anthropic)
+concurrency:
+  group: Nightly-LLM-Provider-Chat-Anthropic-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # Runs daily at 10:45 UTC (2:45 AM PST / 3:45 AM PDT)
+    - cron: "45 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  anthropic-provider-chat-test:
+    uses: ./.github/workflows/reusable-nightly-llm-provider-chat.yml
+    with:
+      provider: anthropic
+      models: ${{ vars.NIGHTLY_LLM_ANTHROPIC_MODELS }}
+      strict: true
+    secrets:
+      provider_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+  notify-slack-on-failure:
+    needs: [anthropic-provider-chat-test]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Send Slack notification
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          failed-jobs: anthropic-provider-chat-test
+          title: "🚨 Scheduled Anthropic Provider Chat Tests failed!"
+          ref-name: ${{ github.ref_name }}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nightly GitHub Actions workflow for Anthropic provider chat tests. Runs daily and posts Slack alerts on failure.

- **New Features**
  - Adds .github/workflows/nightly-llm-provider-chat-anthropic.yml using the reusable chat test workflow with provider=anthropic, strict mode, models from NIGHTLY_LLM_ANTHROPIC_MODELS, and ANTHROPIC_API_KEY.
  - Schedules at 10:45 UTC and supports manual runs; uses concurrency to cancel in-progress runs.
  - Sends Slack notification on failure for scheduled runs only.

<sup>Written for commit 66c58afde083b13bc2e120eff56436662da68d4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

