### PR TITLE
fix(billing): handle manual license users without Stripe subscription

### DIFF
--- a/web/lib/opal/src/icons/organization.tsx
+++ b/web/lib/opal/src/icons/organization.tsx
@@ -12,7 +12,7 @@ const SvgOrganization = ({ size, ...props }: IconProps) => (
   >
     <path
       d="M7.5 14H13.5C14.0523 14 14.5 13.5523 14.5 13V6C14.5 5.44772 14.0523 5 13.5 5H7.5M7.5 14V11M7.5 14H4.5M7.5 5V3C7.5 2.44772 7.05228 2 6.5 2H4.5M7.5 5H1.5M7.5 5V8M1.5 5V3C1.5 2.44772 1.94772 2 2.5 2H4.5M1.5 5V8M7.5 8V11M7.5 8H4.5M1.5 8V11M1.5 8H4.5M7.5 11H4.5M1.5 11V13C1.5 13.5523 1.94772 14 2.5 14H4.5M1.5 11H4.5M4.5 2V8M4.5 14V11M4.5 11V8M10 8H12M10 11H12"
-      strokeWidth={1}
+      strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -19,6 +19,7 @@ interface LicenseActivationCardProps {
   onClose: () => void;
   onSuccess: () => void;
   license?: LicenseStatus;
+  hideClose?: boolean;
 }
 
 export default function LicenseActivationCard({
@@ -26,6 +27,7 @@ export default function LicenseActivationCard({
   onClose,
   onSuccess,
   license,
+  hideClose,
 }: LicenseActivationCardProps) {
   const [licenseKey, setLicenseKey] = useState("");
   const [isActivating, setIsActivating] = useState(false);
@@ -120,9 +122,11 @@ export default function LicenseActivationCard({
             <Button main secondary onClick={() => setShowInput(true)}>
               Update Key
             </Button>
-            <Button main tertiary onClick={handleClose}>
-              Close
-            </Button>
+            {!hideClose && (
+              <Button main tertiary onClick={handleClose}>
+                Close
+              </Button>
+            )}
           </Section>
         </Section>
       </Card>


### PR DESCRIPTION
## Description

Closes: https://linear.app/onyx-app/issue/ENG-3752/billing-page-cleanup

Fixes billing page for customers who received a manual license but don't pay through Stripe. Previously, these users saw broken "Manage Plan" and "Update Seats" buttons that failed silently.

Changes:
- Add `isManualLicenseOnly` derived state to distinguish manual-license-without-Stripe from air-gapped and normal flows
- Replace "Manage Plan" button with sales contact text for manual license users
- Hide "Update Seats" button entirely for manual license users
- Move LicenseActivationCard inline between subscription and seats cards (instead of in footer)
- Restore back button on Plans page for users with a license (manual or otherwise)
- Add `hideClose` prop to LicenseActivationCard for permanently displayed inline usage

## How Has This Been Tested?

manually uploaded a license locally 

<img width="1036" height="671" alt="Screenshot 2026-02-25 at 8 12 44 PM" src="https://github.com/user-attachments/assets/e3347f1b-ba60-4428-a3f6-2c658697a349" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check