### PR TITLE
fix(devtools): persist ods binary across branch switches during cherry-pick

### DIFF
--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -88,7 +88,8 @@ Example usage:
 }
 
 func runCherryPick(cmd *cobra.Command, args []string, opts *CherryPickOptions) {
-	git.SkipUvSync()
+	git.DisablePostCheckoutHook()
+	defer git.EnablePostCheckoutHook()
 	git.CheckGitHubCLI()
 
 	commitSHAs := args
@@ -286,7 +287,8 @@ func finishCherryPick(state *git.CherryPickState, stashResult *git.StashResult) 
 // It finishes any in-progress git cherry-pick, then falls into the normal
 // cherryPickToRelease path which handles skip-applied-commits, push, and PR creation.
 func runCherryPickContinue() {
-	git.SkipUvSync()
+	git.DisablePostCheckoutHook()
+	defer git.EnablePostCheckoutHook()
 	git.CheckGitHubCLI()
 
 	state, err := git.LoadCherryPickState()


### PR DESCRIPTION
## Description

When `ods cp` switches to a release branch, the `uv-sync` post-checkout hook rebuilds `onyx-devtools` from that branch's source, overwriting `.venv/bin/ods` with an older version that may lack `cp` and `--continue`. This makes it impossible to resume a cherry-pick after a merge conflict on older release branches.

Fix: stash the running binary to `.git/ods-bin` at the start of a cherry-pick, and `syscall.Exec` from it on `--continue` if the installed binary has been overwritten. The stashed binary is cleaned up when the operation completes.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents uv-sync from overwriting the ods binary during ods cp branch switches by temporarily disabling the post-checkout hook, so cp and --continue keep working on older release branches.

- **Bug Fixes**
  - Add git.DisablePostCheckoutHook() and git.EnablePostCheckoutHook() to rename/restore the post-checkout hook.
  - Call these at the start of cp and --continue to skip uv-sync during branch switches and re-enable the hook afterward.

<sup>Written for commit 8bb13ec11029cffe86b2193c90b977797d32e90d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

