### PR TITLE
chore(opensearch): Allow programatic schema updates

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -329,17 +329,17 @@ class OpenSearchIndexClient(OpenSearchClient):
     def put_mapping(self, mappings: dict[str, Any]) -> None:
         """Updates the index mapping in an idempotent manner.
 
-        This operation is idempotent:
-        - Existing fields with the same definition: No-op (succeeds silently)
-        - New fields: Added to the index
-        - Existing fields with different types: Raises exception (requires reindex)
+        - Existing fields with the same definition: No-op (succeeds silently).
+        - New fields: Added to the index.
+        - Existing fields with different types: Raises exception (requires
+          reindex).
 
         See the OpenSearch documentation for more information:
         https://docs.opensearch.org/latest/api-reference/index-apis/put-mapping/
 
         Args:
             mappings: The complete mapping definition to apply. This will be
-                merged with existing mappings.
+                merged with existing mappings in the index.
 
         Raises:
             Exception: There was an error updating the mappings, such as
@@ -353,7 +353,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         )
         if not response.get("acknowledged", False):
             raise RuntimeError(
-                f"OpenSearch did not acknowledge the mapping update for index {self._index_name}."
+                f"Failed to put the mapping update for index {self._index_name}."
             )
         logger.debug(f"Successfully put mappings for index {self._index_name}.")
 

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -574,18 +574,13 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 settings=index_settings,
             )
         else:
-            # Index exists - ensure schema is up to date by applying mappings.
-            # This is idempotent: existing fields with same type = no-op, new fields = added.
-            # Will raise an exception if someone changed a field type (requires reindex).
+            # Ensure schema is up to date by applying the current mappings.
             try:
-                self._os_client.put_mapping(expected_mappings)
-                logger.info(
-                    f"Successfully ensured schema is up to date for index {self._index_name}"
-                )
+                self._client.put_mapping(expected_mappings)
             except Exception as e:
                 logger.error(
-                    f"Failed to update mappings for index {self._index_name}. "
-                    f"This likely means a field type was changed which requires reindexing. Error: {e}"
+                    f"Failed to update mappings for index {self._index_name}. This likely means a "
+                    f"field type was changed which requires reindexing. Error: {e}"
                 )
                 raise
 

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -249,12 +249,12 @@ class TestOpenSearchClient:
         test_client.create_index(mappings=mappings, settings=settings)
 
         # Under test.
-        # Applying the same mappings again should succeed (idempotent).
+        # Applying the same mappings again should succeed.
         test_client.put_mapping(mappings)
 
         # Postcondition.
         # Index should still be valid.
-        assert test_client.validate_index(expected_mappings=mappings) is True
+        assert test_client.validate_index(expected_mappings=mappings)
 
     def test_put_mapping_adds_new_field(
         self, test_client: OpenSearchIndexClient
@@ -309,7 +309,7 @@ class TestOpenSearchClient:
 
         # Postcondition.
         # Validate the new schema includes the new field.
-        assert test_client.validate_index(expected_mappings=updated_mappings) is True
+        assert test_client.validate_index(expected_mappings=updated_mappings)
 
     def test_put_mapping_fails_on_type_change(
         self, test_client: OpenSearchIndexClient
@@ -326,7 +326,7 @@ class TestOpenSearchClient:
         settings = DocumentSchema.get_index_settings()
         test_client.create_index(mappings=initial_mappings, settings=settings)
 
-        # Under test.
+        # Under test and postcondition.
         # Try to change test_field type from keyword to text.
         conflicting_mappings = {
             "properties": {
@@ -334,8 +334,6 @@ class TestOpenSearchClient:
                 "test_field": {"type": "text"},  # Changed from keyword to text
             },
         }
-
-        # Postcondition.
         # Should raise because field type cannot be changed.
         with pytest.raises(Exception, match="mapper|illegal_argument_exception"):
             test_client.put_mapping(conflicting_mappings)
@@ -351,7 +349,6 @@ class TestOpenSearchClient:
         )
 
         # Under test and postcondition.
-        # Should raise because index doesn't exist.
         with pytest.raises(Exception, match="index_not_found_exception|404"):
             test_client.put_mapping(mappings)
 


### PR DESCRIPTION
## Description
If someone adds fields to the schema the product should still work automatically. This does not include invalid changes to the schema, such as changing the type of a field. The product will still fail on start in this case.

## How Has This Been Tested?
Added tests for the client `put_index` method.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically applies OpenSearch mapping updates so new fields are added without manual reindexing. Incompatible type changes still fail fast and require reindexing.

- **New Features**
  - Added OpenSearchIndexClient.put_mapping for idempotent mapping updates (no-op for same fields, adds new fields, errors on type changes).
  - verify_and_create_index_if_necessary now updates mappings when the index exists, instead of only validating.

- **Tests**
  - Coverage for idempotency, adding new fields, failure on type changes, and non-existent index behavior.

<sup>Written for commit 326123c4b2163a33b5b29e211405e64f59b2c6dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

