### PR TITLE
fix(docker): prefer user runtime docker socket

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -533,7 +533,7 @@ services:
       - path: .env
         required: false
 
-    # Below is needed for the `docker-out-of-docker` execution mode.
+    # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock
     user: root
     volumes:


### PR DESCRIPTION
## Description

tl;dr, I use [rootless docker](https://docs.docker.com/engine/security/rootless/) which does not have access to a `/var/run/docker.sock` and instead uses a `DOCKER_HOST=unix:///run/user/1000/docker.sock`. This updates the code-interpreter container to use this when applicable and fixes these errors,

```
code-interpreter-1  | No Docker socket found but running with privileges - enabling Docker-in-Docker mode
code-interpreter-1  | Starting Docker daemon for Docker-in-Docker mode...
code-interpreter-1  | mkdir: cannot create directory ‘/sys/fs/cgroup/init’: Read-only file system
```

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the user runtime Docker socket to support rootless Docker and avoid Docker-in-Docker. Keeps macOS/Docker Desktop working via fallback.

- **Bug Fixes**
  - Mount ${DOCKER_SOCK_PATH:-/var/run/docker.sock} to /var/run/docker.sock in code-interpreter; add inline guidance to set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock for rootless Docker.
  - Prevents “No Docker socket found” and cgroup write errors under rootless Docker.

<sup>Written for commit 815a35253f26cddc2c522ef6a501c0dbe58888c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

