### PR TITLE
fix(ee): show subscription text on expired access page for cloud users

### DIFF
--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -41,8 +41,14 @@ export default function AccessRestricted() {
   const [error, setError] = useState<string | null>(null);
   const { data: license } = useLicense();
 
-  // Distinguish between "never had a license" vs "license lapsed"
-  const hasLicenseLapsed = license?.has_license === true;
+  const hadPreviousLicense = license?.has_license === true;
+  const showRenewalMessage = NEXT_PUBLIC_CLOUD_ENABLED || hadPreviousLicense;
+
+  const initialModalMessage = showRenewalMessage
+    ? NEXT_PUBLIC_CLOUD_ENABLED
+      ? "Your access to Onyx has been temporarily suspended due to a lapse in your subscription."
+      : "Your access to Onyx has been temporarily suspended due to a lapse in your license."
+    : "An Enterprise license is required to use Onyx. Your data is protected and will be available once a license is activated.";
 
   const handleResubscribe = async () => {
     setIsLoading(true);
@@ -72,11 +78,7 @@ export default function AccessRestricted() {
         <SvgLock className="stroke-status-error-05 w-[1.5rem] h-[1.5rem]" />
       </div>
 
-      <Text text03>
-        {hasLicenseLapsed
-          ? "Your access to Onyx has been temporarily suspended due to a lapse in your subscription."
-          : "An Enterprise license is required to use Onyx. Your data is protected and will be available once a license is activated."}
-      </Text>
+      <Text text03>{initialModalMessage}</Text>
 
       {NEXT_PUBLIC_CLOUD_ENABLED ? (
         <>
@@ -111,7 +113,7 @@ export default function AccessRestricted() {
       ) : (
         <>
           <Text text03>
-            {hasLicenseLapsed
+            {hadPreviousLicense
               ? "To reinstate your access and continue using Onyx, please contact your system administrator to renew your license."
               : "To get started, please contact your system administrator to obtain an Enterprise license."}
           </Text>
@@ -121,8 +123,8 @@ export default function AccessRestricted() {
             <Link className={linkClassName} href="/admin/billing">
               Admin Billing
             </Link>{" "}
-            page to {hasLicenseLapsed ? "renew" : "activate"} your license, sign
-            up through Stripe or reach out to{" "}
+            page to {hadPreviousLicense ? "renew" : "activate"} your license,
+            sign up through Stripe or reach out to{" "}
             <a className={linkClassName} href="mailto:support@onyx.app">
               support@onyx.app
             </a>


### PR DESCRIPTION
## Description

On the multi-tenant cloud, when a user's subscription expires, the Access Restricted page incorrectly shows "An Enterprise license is required to use Onyx" instead of subscription-related messaging.

The root cause: the `useLicense` hook intentionally skips the license API call on cloud (`NEXT_PUBLIC_CLOUD_ENABLED ? null : "/api/license"`), so `hasLicenseLapsed` is always `false`, and the "Enterprise license" fallback text always renders.

Fix: gate the text on `NEXT_PUBLIC_CLOUD_ENABLED || hasLicenseLapsed` — on cloud, if you're on this page, your subscription has lapsed by definition.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Access Restricted page to show the correct subscription or license lapse message instead of the Enterprise license text. On cloud (NEXT_PUBLIC_CLOUD_ENABLED), always show the subscription-lapse text; on self-hosted, show license-lapse text if the user had a previous license, and toggle the follow-up copy between “renew” and “activate.”

<sup>Written for commit f33e503cce82cd394e776dcea6ed7e5a6c9ff91f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

