### PR TITLE
feat(scim): add SCIM-compliant error handling and externalId conflict detection

### DIFF
--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -32,6 +32,7 @@ from ee.onyx.server.query_and_chat.search_backend import router as search_router
 from ee.onyx.server.query_history.api import router as query_history_router
 from ee.onyx.server.reporting.usage_export_api import router as usage_export_router
 from ee.onyx.server.scim.api import scim_router
+from ee.onyx.server.scim.error_handlers import register_scim_error_handlers
 from ee.onyx.server.seeding import seed_db
 from ee.onyx.server.tenants.api import router as tenants_router
 from ee.onyx.server.token_rate_limits.api import (
@@ -167,6 +168,7 @@ def get_application() -> FastAPI:
     # they use their own SCIM bearer token auth).
     # Not behind APP_API_PREFIX because IdPs expect /scim/v2/... directly.
     application.include_router(scim_router)
+    register_scim_error_handlers(application)
 
     # Ensure all routes have auth enabled or are explicitly marked as public
     check_ee_router_auth(application)

--- a/backend/ee/onyx/server/scim/error_handlers.py
+++ b/backend/ee/onyx/server/scim/error_handlers.py
@@ -1,0 +1,110 @@
+"""SCIM-specific exception handlers.
+
+IdPs like Okta and Azure AD/Entra ID expect error responses in the
+SCIM error format (RFC 7644 §3.12) with ``Content-Type: application/scim+json``.
+Without these handlers, FastAPI's default exception handling returns errors in
+its own format (``{"detail": ...}`` for HTTPException, 422 for validation errors)
+which IdPs cannot parse, leading to opaque errors in the IdP admin console.
+
+These handlers intercept exceptions for ``/scim/v2/`` routes and return
+SCIM-compliant JSON while preserving default behavior for all other routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi.exception_handlers import (
+    http_exception_handler as _default_http_handler,
+)
+from fastapi.exception_handlers import (
+    request_validation_exception_handler as _default_validation_handler,
+)
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from ee.onyx.server.scim.models import ScimError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_SCIM_PREFIX = "/scim/v2/"
+
+
+def _is_scim_request(request: Request) -> bool:
+    return request.url.path.startswith(_SCIM_PREFIX)
+
+
+def _build_scim_error_response(
+    status_code: int,
+    detail: str,
+) -> dict:
+    """Build a SCIM error body dict."""
+    return ScimError(
+        status=str(status_code),
+        detail=detail,
+    ).model_dump(exclude_none=True)
+
+
+def register_scim_error_handlers(app: FastAPI) -> None:
+    """Register exception handlers that return SCIM-formatted errors.
+
+    For requests to ``/scim/v2/*``, exceptions are converted to RFC 7644
+    §3.12 error responses. All other routes use FastAPI's default handlers.
+    """
+    # Import here to avoid circular imports at module level
+    from ee.onyx.server.scim.api import ScimJSONResponse
+
+    @app.exception_handler(StarletteHTTPException)
+    async def scim_http_exception_handler(
+        request: Request,
+        exc: StarletteHTTPException,
+    ) -> ScimJSONResponse:
+        if not _is_scim_request(request):
+            return await _default_http_handler(request, exc)  # type: ignore[return-value]
+
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return ScimJSONResponse(
+            status_code=exc.status_code,
+            content=_build_scim_error_response(exc.status_code, detail),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def scim_validation_error_handler(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> ScimJSONResponse:
+        if not _is_scim_request(request):
+            return await _default_validation_handler(request, exc)  # type: ignore[return-value]
+
+        # Flatten Pydantic validation errors into a single human-readable string.
+        parts: list[str] = []
+        for err in exc.errors():
+            loc = ".".join(str(segment) for segment in err.get("loc", []))
+            msg = err.get("msg", "validation error")
+            parts.append(f"{loc}: {msg}" if loc else msg)
+        detail = "; ".join(parts) or "Invalid request body"
+
+        return ScimJSONResponse(
+            status_code=400,
+            content=_build_scim_error_response(400, detail),
+        )
+
+    @app.exception_handler(Exception)
+    async def scim_generic_exception_handler(
+        request: Request,
+        exc: Exception,
+    ) -> ScimJSONResponse:
+        if not _is_scim_request(request):
+            # Re-raise so FastAPI's default 500 handler picks it up
+            raise exc
+
+        logger.exception(
+            "Unhandled exception in SCIM endpoint %s %s",
+            request.method,
+            request.url.path,
+        )
+        return ScimJSONResponse(
+            status_code=500,
+            content=_build_scim_error_response(500, "Internal server error"),
+        )

--- a/backend/tests/unit/onyx/server/scim/test_error_handlers.py
+++ b/backend/tests/unit/onyx/server/scim/test_error_handlers.py
@@ -1,0 +1,214 @@
+"""Tests for SCIM exception handlers.
+
+These tests use FastAPI's TestClient to exercise the full request lifecycle,
+ensuring that HTTPExceptions (e.g. auth failures), validation errors, and
+unhandled exceptions are converted to SCIM-formatted error responses for
+``/scim/v2/*`` paths while preserving default FastAPI behavior elsewhere.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastapi import APIRouter
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from ee.onyx.server.scim.api import _get_provider
+from ee.onyx.server.scim.api import scim_router
+from ee.onyx.server.scim.auth import verify_scim_token
+from ee.onyx.server.scim.error_handlers import register_scim_error_handlers
+from ee.onyx.server.scim.models import SCIM_ERROR_SCHEMA
+from onyx.db.engine.sql_engine import get_session
+
+
+def _mock_session() -> Generator[MagicMock, None, None]:
+    yield MagicMock()
+
+
+def _deny_auth() -> None:
+    """Dependency override that always rejects with 401."""
+    raise HTTPException(status_code=401, detail="Invalid SCIM bearer token")
+
+
+def _allow_auth() -> MagicMock:
+    """Dependency override that always allows auth."""
+    token = MagicMock()
+    token.id = 1
+    return token
+
+
+def _build_test_app() -> FastAPI:
+    """Build a minimal FastAPI app with SCIM and a non-SCIM route.
+
+    Overrides ``get_session`` so the test app doesn't need a real database.
+    """
+    app = FastAPI()
+    app.include_router(scim_router)
+
+    # Override get_session so dependency resolution doesn't require a DB engine
+    app.dependency_overrides[get_session] = _mock_session
+
+    # A non-SCIM route to verify default behavior is preserved
+    other = APIRouter()
+
+    @other.get("/api/health")
+    def health() -> dict:
+        return {"ok": True}
+
+    @other.get("/api/error")
+    def error() -> None:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    app.include_router(other)
+    register_scim_error_handlers(app)
+    return app
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return _build_test_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestScimAuthErrors:
+    """Auth failures should return SCIM error format for /scim/v2/ paths."""
+
+    def test_missing_token_returns_scim_error(self, client: TestClient) -> None:
+        """GET /scim/v2/Users without token → 401 in SCIM format."""
+        response = client.get("/scim/v2/Users")
+        assert response.status_code == 401
+        body = response.json()
+        assert SCIM_ERROR_SCHEMA in body.get("schemas", [])
+        assert body["status"] == "401"
+        assert "detail" in body
+
+    def test_invalid_token_returns_scim_error(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """GET /scim/v2/Users with bad token → 401 in SCIM format."""
+        app.dependency_overrides[verify_scim_token] = _deny_auth
+        response = client.get(
+            "/scim/v2/Users",
+            headers={"Authorization": "Bearer onyx_scim_bad_token"},
+        )
+        assert response.status_code == 401
+        body = response.json()
+        assert SCIM_ERROR_SCHEMA in body.get("schemas", [])
+        assert body["status"] == "401"
+
+    def test_content_type_is_scim_json(self, client: TestClient) -> None:
+        """SCIM error responses use application/scim+json content type."""
+        response = client.get("/scim/v2/Users")
+        assert "application/scim+json" in response.headers.get("content-type", "")
+
+
+class TestScimValidationErrors:
+    """Pydantic validation failures should return SCIM 400 for /scim/v2/ paths."""
+
+    def test_missing_required_field_returns_400(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """POST /scim/v2/Users with empty body → 400 in SCIM format."""
+        app.dependency_overrides[verify_scim_token] = _allow_auth
+        app.dependency_overrides[_get_provider] = MagicMock
+
+        response = client.post(
+            "/scim/v2/Users",
+            json={},
+            headers={"Authorization": "Bearer onyx_scim_test"},
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert SCIM_ERROR_SCHEMA in body.get("schemas", [])
+        assert body["status"] == "400"
+        assert "userName" in body.get("detail", "").lower() or "detail" in body
+
+    def test_invalid_json_returns_400(self, client: TestClient) -> None:
+        """POST /scim/v2/Users with malformed JSON → 400 in SCIM format."""
+        response = client.post(
+            "/scim/v2/Users",
+            content=b"not-json",
+            headers={
+                "Authorization": "Bearer onyx_scim_test",
+                "Content-Type": "application/json",
+            },
+        )
+
+        # FastAPI may return 400 or 422 for malformed JSON — either way,
+        # the response should be SCIM-formatted for SCIM paths
+        assert response.status_code in (400, 422)
+        body = response.json()
+        assert SCIM_ERROR_SCHEMA in body.get("schemas", [])
+
+
+class TestNonScimRoutesPreserved:
+    """Non-SCIM routes should use FastAPI's default error format."""
+
+    def test_non_scim_http_exception_uses_default_format(
+        self, client: TestClient
+    ) -> None:
+        """GET /api/error → default FastAPI error format (not SCIM)."""
+        response = client.get("/api/error")
+        assert response.status_code == 403
+        body = response.json()
+        # Default FastAPI format: {"detail": "forbidden"}
+        assert body == {"detail": "forbidden"}
+        assert "schemas" not in body
+
+    def test_non_scim_route_works_normally(self, client: TestClient) -> None:
+        """GET /api/health → normal response."""
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+
+class TestScimServiceDiscovery:
+    """Service discovery endpoints should work without auth."""
+
+    def test_service_provider_config(self, client: TestClient) -> None:
+        response = client.get("/scim/v2/ServiceProviderConfig")
+        assert response.status_code == 200
+
+    def test_resource_types(self, client: TestClient) -> None:
+        response = client.get("/scim/v2/ResourceTypes")
+        assert response.status_code == 200
+
+    def test_schemas(self, client: TestClient) -> None:
+        response = client.get("/scim/v2/Schemas")
+        assert response.status_code == 200
+
+
+class TestUnhandledExceptions:
+    """Unhandled exceptions in SCIM routes should return SCIM 500."""
+
+    def test_unhandled_exception_returns_scim_500(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Simulate an unhandled exception in a SCIM endpoint."""
+        app.dependency_overrides[verify_scim_token] = _allow_auth
+
+        with patch(
+            "ee.onyx.server.scim.api.parse_scim_filter",
+            side_effect=RuntimeError("unexpected"),
+        ):
+            response = client.get(
+                "/scim/v2/Users",
+                headers={"Authorization": "Bearer onyx_scim_test"},
+            )
+
+        assert response.status_code == 500
+        body = response.json()
+        assert SCIM_ERROR_SCHEMA in body.get("schemas", [])
+        assert body["status"] == "500"
+        assert body["detail"] == "Internal server error"
+        assert "application/scim+json" in response.headers.get("content-type", "")


### PR DESCRIPTION
## Description

Add SCIM RFC 7644 §3.12 compliant error responses for `/scim/v2/*` endpoints. Previously, auth failures returned FastAPI's default `{"detail": "..."}` format and validation errors returned 422 — neither of which IdPs (Okta, Entra ID) can parse.

**Error handlers** (`error_handlers.py`):
- HTTPException → SCIM error format with `application/scim+json` for SCIM paths
- RequestValidationError → SCIM 400 (instead of FastAPI's default 422) for SCIM paths
- Unhandled Exception → SCIM 500 with generic message for SCIM paths
- Non-SCIM routes preserve default FastAPI behavior

**externalId conflict detection** (`api.py`):
- Catches `IntegrityError` on `create_user_mapping`, `sync_user_external_id`, `create_group_mapping`, `sync_group_external_id` → returns 409 Conflict instead of 500

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SCIM RFC 7644 error responses for all /scim/v2/* endpoints and returns 409 on externalId conflicts to improve Okta/Entra compatibility. Addresses ENG-3653 by making SCIM errors parseable and handling mapping collisions cleanly.

- New Features
  - SCIM error handlers for HTTPException, RequestValidationError (422 → SCIM 400), and unhandled exceptions (SCIM 500) with Content-Type: application/scim+json.
  - Scoped to /scim/v2/* only; non-SCIM routes keep FastAPI defaults.

- Bug Fixes
  - Return 409 Conflict on externalId collisions in user/group create/replace/patch flows; transactions are rolled back and a clear message is returned.

<sup>Written for commit 62f7f2d0f11305739d97315c3dd394978f14d861. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

