### PR TITLE
chore(llm): add Vertex AI nightly tests

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -19,11 +19,13 @@ jobs:
       openai_models: ${{ vars.NIGHTLY_LLM_OPENAI_MODELS }}
       anthropic_models: ${{ vars.NIGHTLY_LLM_ANTHROPIC_MODELS }}
       bedrock_models: ${{ vars.NIGHTLY_LLM_BEDROCK_MODELS }}
+      vertex_ai_models: ${{ vars.NIGHTLY_LLM_VERTEX_AI_MODELS }}
       strict: true
     secrets:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       bedrock_api_key: ${{ secrets.BEDROCK_API_KEY }}
+      vertex_ai_custom_config_json: ${{ secrets.NIGHTLY_LLM_VERTEX_AI_CUSTOM_CONFIG_JSON }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ""
         type: string
+      vertex_ai_models:
+        description: "Comma-separated models for vertex_ai"
+        required: false
+        default: ""
+        type: string
       strict:
         description: "Default NIGHTLY_LLM_STRICT passed to tests"
         required: false
@@ -29,6 +34,8 @@ on:
       anthropic_api_key:
         required: false
       bedrock_api_key:
+        required: false
+      vertex_ai_custom_config_json:
         required: false
       DOCKER_USERNAME:
         required: true
@@ -138,12 +145,23 @@ jobs:
           - provider: openai
             models: ${{ inputs.openai_models }}
             api_key_secret: openai_api_key
+            custom_config_secret: ""
+            required: true
           - provider: anthropic
             models: ${{ inputs.anthropic_models }}
             api_key_secret: anthropic_api_key
+            custom_config_secret: ""
+            required: true
           - provider: bedrock
             models: ${{ inputs.bedrock_models }}
             api_key_secret: bedrock_api_key
+            custom_config_secret: ""
+            required: false
+          - provider: vertex_ai
+            models: ${{ inputs.vertex_ai_models }}
+            api_key_secret: ""
+            custom_config_secret: vertex_ai_custom_config_json
+            required: false
     runs-on:
       - runs-on
       - runner=4cpu-linux-arm64
@@ -165,6 +183,7 @@ jobs:
           models: ${{ matrix.models }}
           provider-api-key: ${{ matrix.api_key_secret && secrets[matrix.api_key_secret] || '' }}
           strict: ${{ inputs.strict && 'true' || 'false' }}
+          custom-config-json: ${{ matrix.custom_config_secret && secrets[matrix.custom_config_secret] || '' }}
           runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
           run-id: ${{ github.run_id }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Vertex AI to nightly provider chat tests to validate Vertex models nightly. Introduce a provider-level required flag; OpenAI/Anthropic always run, Bedrock/Vertex are optional.

- New Features
  - Add vertex_ai_models input and vertex_ai_custom_config_json secret.
  - Add vertex_ai to the test matrix and pass custom-config-json to the action (Vertex uses custom config, no API key).

- Refactors
  - Use matrix.required to control execution (OpenAI/Anthropic required; Bedrock/Vertex optional).

<sup>Written for commit 1f9eaa9af5b8aea8a9e2cff6338d81cd6759392c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

