### PR TITLE
chore(llm): add Azure nightly tests

### DIFF
--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: "Optional NIGHTLY_LLM_API_BASE"
     required: false
     default: ""
+  api-version:
+    description: "Optional NIGHTLY_LLM_API_VERSION"
+    required: false
+    default: ""
+  deployment-name:
+    description: "Optional NIGHTLY_LLM_DEPLOYMENT_NAME"
+    required: false
+    default: ""
   custom-config-json:
     description: "Optional NIGHTLY_LLM_CUSTOM_CONFIG_JSON"
     required: false
@@ -84,6 +92,8 @@ runs:
         NIGHTLY_LLM_PROVIDER: ${{ inputs.provider }}
         NIGHTLY_LLM_API_KEY: ${{ inputs.provider-api-key }}
         NIGHTLY_LLM_API_BASE: ${{ inputs.api-base }}
+        NIGHTLY_LLM_API_VERSION: ${{ inputs.api-version }}
+        NIGHTLY_LLM_DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
         NIGHTLY_LLM_CUSTOM_CONFIG_JSON: ${{ inputs.custom-config-json }}
         NIGHTLY_LLM_STRICT: ${{ inputs.strict }}
         RUNS_ON_ECR_CACHE: ${{ inputs.runs-on-ecr-cache }}
@@ -112,6 +122,8 @@ runs:
             -e NIGHTLY_LLM_MODELS="${MODELS}" \
             -e NIGHTLY_LLM_API_KEY="${NIGHTLY_LLM_API_KEY}" \
             -e NIGHTLY_LLM_API_BASE="${NIGHTLY_LLM_API_BASE}" \
+            -e NIGHTLY_LLM_API_VERSION="${NIGHTLY_LLM_API_VERSION}" \
+            -e NIGHTLY_LLM_DEPLOYMENT_NAME="${NIGHTLY_LLM_DEPLOYMENT_NAME}" \
             -e NIGHTLY_LLM_CUSTOM_CONFIG_JSON="${NIGHTLY_LLM_CUSTOM_CONFIG_JSON}" \
             -e NIGHTLY_LLM_STRICT="${NIGHTLY_LLM_STRICT}" \
             ${RUNS_ON_ECR_CACHE}:nightly-llm-it-${RUN_ID} \

--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -20,12 +20,15 @@ jobs:
       anthropic_models: ${{ vars.NIGHTLY_LLM_ANTHROPIC_MODELS }}
       bedrock_models: ${{ vars.NIGHTLY_LLM_BEDROCK_MODELS }}
       vertex_ai_models: ${{ vars.NIGHTLY_LLM_VERTEX_AI_MODELS }}
+      azure_models: ${{ vars.NIGHTLY_LLM_AZURE_MODELS }}
+      azure_api_base: ${{ vars.NIGHTLY_LLM_AZURE_API_BASE }}
       strict: true
     secrets:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       bedrock_api_key: ${{ secrets.BEDROCK_API_KEY }}
       vertex_ai_custom_config_json: ${{ secrets.NIGHTLY_LLM_VERTEX_AI_CUSTOM_CONFIG_JSON }}
+      azure_api_key: ${{ secrets.AZURE_API_KEY }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -23,6 +23,16 @@ on:
         required: false
         default: ""
         type: string
+      azure_models:
+        description: "Comma-separated models for azure"
+        required: false
+        default: ""
+        type: string
+      azure_api_base:
+        description: "API base for azure provider"
+        required: false
+        default: ""
+        type: string
       strict:
         description: "Default NIGHTLY_LLM_STRICT passed to tests"
         required: false
@@ -36,6 +46,8 @@ on:
       bedrock_api_key:
         required: false
       vertex_ai_custom_config_json:
+        required: false
+      azure_api_key:
         required: false
       DOCKER_USERNAME:
         required: true
@@ -146,21 +158,41 @@ jobs:
             models: ${{ inputs.openai_models }}
             api_key_secret: openai_api_key
             custom_config_secret: ""
+            api_base: ""
+            api_version: ""
+            deployment_name: ""
             required: true
           - provider: anthropic
             models: ${{ inputs.anthropic_models }}
             api_key_secret: anthropic_api_key
             custom_config_secret: ""
+            api_base: ""
+            api_version: ""
+            deployment_name: ""
             required: true
           - provider: bedrock
             models: ${{ inputs.bedrock_models }}
             api_key_secret: bedrock_api_key
             custom_config_secret: ""
+            api_base: ""
+            api_version: ""
+            deployment_name: ""
             required: false
           - provider: vertex_ai
             models: ${{ inputs.vertex_ai_models }}
             api_key_secret: ""
             custom_config_secret: vertex_ai_custom_config_json
+            api_base: ""
+            api_version: ""
+            deployment_name: ""
+            required: false
+          - provider: azure
+            models: ${{ inputs.azure_models }}
+            api_key_secret: azure_api_key
+            custom_config_secret: ""
+            api_base: ${{ inputs.azure_api_base }}
+            api_version: "2025-04-01-preview"
+            deployment_name: ""
             required: false
     runs-on:
       - runs-on
@@ -183,6 +215,9 @@ jobs:
           models: ${{ matrix.models }}
           provider-api-key: ${{ matrix.api_key_secret && secrets[matrix.api_key_secret] || '' }}
           strict: ${{ inputs.strict && 'true' || 'false' }}
+          api-base: ${{ matrix.api_base }}
+          api-version: ${{ matrix.api_version }}
+          deployment-name: ${{ matrix.deployment_name }}
           custom-config-json: ${{ matrix.custom_config_secret && secrets[matrix.custom_config_secret] || '' }}
           runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
           run-id: ${{ github.run_id }}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure to the nightly LLM provider chat tests. Workflows and tests now support api_base, api_version, and deployment_name.

- **New Features**
  - Add Azure to the reusable matrix with api_version set to 2025-04-01-preview; add api_base, api_version, and deployment_name fields for all providers.
  - Update action and reusable workflow to accept and pass api-base, api-version, and deployment-name; export NIGHTLY_LLM_API_VERSION and NIGHTLY_LLM_DEPLOYMENT_NAME to runner and container.
  - Wire azure_models, azure_api_base, and azure_api_key in nightly workflow; tests read the new env vars, include them in the provider payload, and require api_base and api_version for Azure.

<sup>Written for commit c78fd3e83e9a957ef399634cb13f74633ba88519. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

