### PR TITLE
chore(llm): add Ollama nightly tests

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -22,6 +22,7 @@ jobs:
       vertex_ai_models: ${{ vars.NIGHTLY_LLM_VERTEX_AI_MODELS }}
       azure_models: ${{ vars.NIGHTLY_LLM_AZURE_MODELS }}
       azure_api_base: ${{ vars.NIGHTLY_LLM_AZURE_API_BASE }}
+      ollama_models: ${{ vars.NIGHTLY_LLM_OLLAMA_MODELS }}
       strict: true
     secrets:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
@@ -29,6 +30,7 @@ jobs:
       bedrock_api_key: ${{ secrets.BEDROCK_API_KEY }}
       vertex_ai_custom_config_json: ${{ secrets.NIGHTLY_LLM_VERTEX_AI_CUSTOM_CONFIG_JSON }}
       azure_api_key: ${{ secrets.AZURE_API_KEY }}
+      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ""
         type: string
+      ollama_models:
+        description: "Comma-separated models for ollama_chat"
+        required: false
+        default: ""
+        type: string
       azure_api_base:
         description: "API base for azure provider"
         required: false
@@ -48,6 +53,8 @@ on:
       vertex_ai_custom_config_json:
         required: false
       azure_api_key:
+        required: false
+      ollama_api_key:
         required: false
       DOCKER_USERNAME:
         required: true
@@ -192,6 +199,14 @@ jobs:
             custom_config_secret: ""
             api_base: ${{ inputs.azure_api_base }}
             api_version: "2025-04-01-preview"
+            deployment_name: ""
+            required: false
+          - provider: ollama_chat
+            models: ${{ inputs.ollama_models }}
+            api_key_secret: ollama_api_key
+            custom_config_secret: ""
+            api_base: "https://ollama.com"
+            api_version: ""
             deployment_name: ""
             required: false
     runs-on:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ollama to the nightly LLM provider chat workflows. Extends the reusable matrix with an ollama_chat provider (models input, optional OLLAMA_API_KEY, api_base https://ollama.com) and wires NIGHTLY_LLM_OLLAMA_MODELS and OLLAMA_API_KEY into the nightly workflow.

- **Migration**
  - Set repo var NIGHTLY_LLM_OLLAMA_MODELS with comma-separated models.
  - Add OLLAMA_API_KEY secret if needed.

<sup>Written for commit 2ec7d4fd94960472cb208744ec1fa960f9a61788. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

