### PR TITLE
chore(llm): add OpenRouter nightly tests

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -23,6 +23,7 @@ jobs:
       azure_models: ${{ vars.NIGHTLY_LLM_AZURE_MODELS }}
       azure_api_base: ${{ vars.NIGHTLY_LLM_AZURE_API_BASE }}
       ollama_models: ${{ vars.NIGHTLY_LLM_OLLAMA_MODELS }}
+      openrouter_models: ${{ vars.NIGHTLY_LLM_OPENROUTER_MODELS }}
       strict: true
     secrets:
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
@@ -31,6 +32,7 @@ jobs:
       vertex_ai_custom_config_json: ${{ secrets.NIGHTLY_LLM_VERTEX_AI_CUSTOM_CONFIG_JSON }}
       azure_api_key: ${{ secrets.AZURE_API_KEY }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+      openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ""
         type: string
+      openrouter_models:
+        description: "Comma-separated models for openrouter"
+        required: false
+        default: ""
+        type: string
       azure_api_base:
         description: "API base for azure provider"
         required: false
@@ -55,6 +60,8 @@ on:
       azure_api_key:
         required: false
       ollama_api_key:
+        required: false
+      openrouter_api_key:
         required: false
       DOCKER_USERNAME:
         required: true
@@ -206,6 +213,14 @@ jobs:
             api_key_secret: ollama_api_key
             custom_config_secret: ""
             api_base: "https://ollama.com"
+            api_version: ""
+            deployment_name: ""
+            required: false
+          - provider: openrouter
+            models: ${{ inputs.openrouter_models }}
+            api_key_secret: openrouter_api_key
+            custom_config_secret: ""
+            api_base: "https://openrouter.ai/api/v1"
             api_version: ""
             deployment_name: ""
             required: false


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenRouter to nightly LLM provider chat tests to expand coverage and catch provider-specific issues early. Integrated into the reusable workflow and wired through the nightly job.

- **New Features**
  - Reusable workflow: openrouter_models input, openrouter_api_key secret, provider matrix entry (api_base https://openrouter.ai/api/v1).
  - Nightly workflow: forwards NIGHTLY_LLM_OPENROUTER_MODELS and OPENROUTER_API_KEY to the reusable job.

- **Migration**
  - Set NIGHTLY_LLM_OPENROUTER_MODELS (comma-separated) in repo/org variables.
  - Add OPENROUTER_API_KEY in repo/org secrets.

<sup>Written for commit 1c134554eff17183aa4ea589a728adbfd00641ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

