### PR TITLE
test(scim): add integration tests for SCIM token management

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -322,6 +322,7 @@ def list_users(
     """List users with optional SCIM filter and pagination."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
+    dal.commit()
 
     try:
         scim_filter = parse_scim_filter(filter)
@@ -365,6 +366,7 @@ def get_user(
     """Get a single user by ID."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
+    dal.commit()
 
     result = _fetch_user_or_404(user_id, dal)
     if isinstance(result, ScimJSONResponse):
@@ -721,6 +723,7 @@ def list_groups(
     """List groups with optional SCIM filter and pagination."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
+    dal.commit()
 
     try:
         scim_filter = parse_scim_filter(filter)
@@ -757,6 +760,7 @@ def get_group(
     """Get a single group by ID."""
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
+    dal.commit()
 
     result = _fetch_group_or_404(group_id, dal)
     if isinstance(result, ScimJSONResponse):

--- a/backend/tests/integration/common_utils/managers/scim_token.py
+++ b/backend/tests/integration/common_utils/managers/scim_token.py
@@ -1,0 +1,79 @@
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.test_models import DATestScimToken
+from tests.integration.common_utils.test_models import DATestUser
+
+
+class ScimTokenManager:
+    @staticmethod
+    def create(
+        name: str,
+        user_performing_action: DATestUser,
+    ) -> DATestScimToken:
+        response = requests.post(
+            f"{API_SERVER_URL}/admin/enterprise-settings/scim/token",
+            json={"name": name},
+            headers=user_performing_action.headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return DATestScimToken(
+            id=data["id"],
+            name=data["name"],
+            token_display=data["token_display"],
+            is_active=data["is_active"],
+            created_at=data["created_at"],
+            last_used_at=data.get("last_used_at"),
+            raw_token=data["raw_token"],
+        )
+
+    @staticmethod
+    def get_active(
+        user_performing_action: DATestUser,
+    ) -> DATestScimToken | None:
+        response = requests.get(
+            f"{API_SERVER_URL}/admin/enterprise-settings/scim/token",
+            headers=user_performing_action.headers,
+            timeout=60,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        return DATestScimToken(
+            id=data["id"],
+            name=data["name"],
+            token_display=data["token_display"],
+            is_active=data["is_active"],
+            created_at=data["created_at"],
+            last_used_at=data.get("last_used_at"),
+        )
+
+    @staticmethod
+    def get_scim_headers(raw_token: str) -> dict[str, str]:
+        return {
+            **GENERAL_HEADERS,
+            "Authorization": f"Bearer {raw_token}",
+        }
+
+    @staticmethod
+    def scim_get(
+        path: str,
+        raw_token: str,
+    ) -> requests.Response:
+        return requests.get(
+            f"{API_SERVER_URL}/scim/v2{path}",
+            headers=ScimTokenManager.get_scim_headers(raw_token),
+            timeout=60,
+        )
+
+    @staticmethod
+    def scim_get_no_auth(path: str) -> requests.Response:
+        return requests.get(
+            f"{API_SERVER_URL}/scim/v2{path}",
+            headers=GENERAL_HEADERS,
+            timeout=60,
+        )

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -42,6 +42,18 @@ class DATestPAT(BaseModel):
     last_used_at: str | None = None
 
 
+class DATestScimToken(BaseModel):
+    """SCIM bearer token model for testing."""
+
+    id: int
+    name: str
+    raw_token: str | None = None  # Only present on initial creation
+    token_display: str
+    is_active: bool
+    created_at: str
+    last_used_at: str | None = None
+
+
 class DATestAPIKey(BaseModel):
     api_key_id: int
     api_key_display: str

--- a/backend/tests/integration/tests/scim/test_scim_tokens.py
+++ b/backend/tests/integration/tests/scim/test_scim_tokens.py
@@ -1,0 +1,166 @@
+"""Integration tests for SCIM token management.
+
+Covers the admin token API and SCIM bearer-token authentication:
+1. Token lifecycle: create, retrieve metadata, use for SCIM requests
+2. Token rotation: creating a new token revokes previous tokens
+3. Revoked tokens are rejected by SCIM endpoints
+4. Non-admin users cannot manage SCIM tokens
+5. SCIM requests without a token are rejected
+6. Service discovery endpoints work without authentication
+7. last_used_at is updated after a SCIM request
+"""
+
+import time
+
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.scim_token import ScimTokenManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_scim_token_lifecycle(admin_user: DATestUser) -> None:
+    """Create token → retrieve metadata → use for SCIM request."""
+    token = ScimTokenManager.create(
+        name="Test SCIM Token",
+        user_performing_action=admin_user,
+    )
+
+    assert token.raw_token is not None
+    assert token.raw_token.startswith("onyx_scim_")
+    assert token.is_active is True
+    assert "****" in token.token_display
+
+    # GET returns the same metadata but raw_token is None because the
+    # server only reveals the raw token once at creation time (it stores
+    # only the SHA-256 hash).
+    active = ScimTokenManager.get_active(user_performing_action=admin_user)
+    assert active == token.model_copy(update={"raw_token": None})
+
+    # Token works for SCIM requests
+    response = ScimTokenManager.scim_get("/Users", token.raw_token)
+    assert response.status_code == 200
+    body = response.json()
+    assert "Resources" in body
+    assert body["totalResults"] >= 0
+
+
+def test_scim_token_rotation_revokes_previous(admin_user: DATestUser) -> None:
+    """Creating a new token automatically revokes the previous one."""
+    first = ScimTokenManager.create(
+        name="First Token",
+        user_performing_action=admin_user,
+    )
+    assert first.raw_token is not None
+
+    response = ScimTokenManager.scim_get("/Users", first.raw_token)
+    assert response.status_code == 200
+
+    # Create second token — should revoke first
+    second = ScimTokenManager.create(
+        name="Second Token",
+        user_performing_action=admin_user,
+    )
+    assert second.raw_token is not None
+
+    # Active token should now be the second one
+    active = ScimTokenManager.get_active(user_performing_action=admin_user)
+    assert active == second.model_copy(update={"raw_token": None})
+
+    # First token rejected, second works
+    assert ScimTokenManager.scim_get("/Users", first.raw_token).status_code == 401
+    assert ScimTokenManager.scim_get("/Users", second.raw_token).status_code == 200
+
+
+def test_scim_request_without_token_rejected(
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    """SCIM endpoints reject requests with no Authorization header."""
+    assert ScimTokenManager.scim_get_no_auth("/Users").status_code == 401
+
+
+def test_scim_request_with_bad_token_rejected(
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    """SCIM endpoints reject requests with an invalid token."""
+    assert (
+        ScimTokenManager.scim_get("/Users", "onyx_scim_bogus_token_value").status_code
+        == 401
+    )
+
+
+def test_non_admin_cannot_create_token(
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    """Non-admin users get 403 when trying to create a SCIM token."""
+    basic_user = UserManager.create(name="scim_basic_user")
+
+    response = requests.post(
+        f"{API_SERVER_URL}/admin/enterprise-settings/scim/token",
+        json={"name": "Should Fail"},
+        headers=basic_user.headers,
+        timeout=60,
+    )
+    assert response.status_code == 403
+
+
+def test_non_admin_cannot_get_token(
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    """Non-admin users get 403 when trying to retrieve SCIM token metadata."""
+    basic_user = UserManager.create(name="scim_basic_user2")
+
+    response = requests.get(
+        f"{API_SERVER_URL}/admin/enterprise-settings/scim/token",
+        headers=basic_user.headers,
+        timeout=60,
+    )
+    assert response.status_code == 403
+
+
+def test_no_active_token_returns_404(new_admin_user: DATestUser) -> None:
+    """GET active token returns 404 when no token exists."""
+    # new_admin_user depends on the reset fixture, ensuring a clean DB
+    # with no active SCIM tokens.
+    active = ScimTokenManager.get_active(user_performing_action=new_admin_user)
+    assert active is None
+
+    response = requests.get(
+        f"{API_SERVER_URL}/admin/enterprise-settings/scim/token",
+        headers=new_admin_user.headers,
+        timeout=60,
+    )
+    assert response.status_code == 404
+
+
+def test_service_discovery_no_auth_required(
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    """Service discovery endpoints work without any authentication."""
+    for path in ["/ServiceProviderConfig", "/ResourceTypes", "/Schemas"]:
+        response = ScimTokenManager.scim_get_no_auth(path)
+        assert response.status_code == 200, f"{path} returned {response.status_code}"
+
+
+def test_last_used_at_updated_after_scim_request(
+    admin_user: DATestUser,
+) -> None:
+    """last_used_at timestamp is updated after using the token."""
+    token = ScimTokenManager.create(
+        name="Last Used Token",
+        user_performing_action=admin_user,
+    )
+    assert token.raw_token is not None
+
+    active = ScimTokenManager.get_active(user_performing_action=admin_user)
+    assert active is not None
+    assert active.last_used_at is None
+
+    # Make a SCIM request, then verify last_used_at is set
+    assert ScimTokenManager.scim_get("/Users", token.raw_token).status_code == 200
+    time.sleep(0.5)
+
+    active_after = ScimTokenManager.get_active(user_performing_action=admin_user)
+    assert active_after is not None
+    assert active_after.last_used_at is not None


### PR DESCRIPTION
## Description

Integration tests for the SCIM admin token API and SCIM bearer-token authentication:

- **Token lifecycle**: create → retrieve metadata → use for SCIM request
- **Token rotation**: new token auto-revokes previous; old token returns 401
- **Auth rejection**: no token → 401, bad token → 401
- **RBAC**: non-admin users get 403 on token create/get
- **No active token**: returns 404 (uses `reset` fixture for clean state)
- **Service discovery**: `/ServiceProviderConfig`, `/ResourceTypes`, `/Schemas` work without auth
- **last_used_at tracking**: timestamp updates after SCIM request

Also adds `ScimTokenManager` and `DATestScimToken` test utilities for reuse in upcoming SCIM user/group integration tests (ENG-3655, ENG-3656).

**Bug fix:** Read-only SCIM endpoints (`list_users`, `get_user`, `list_groups`, `get_group`) called `dal.update_token_last_used()` but never `dal.commit()`, so the `last_used_at` timestamp was silently rolled back. Added `dal.commit()` after the update in all four read endpoints.

Linear: [ENG-3654](https://linear.app/onyx-app/issue/ENG-3654)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check