### PR TITLE
docs(best practices): Add comment about import-time side effects and main.py files

### DIFF
--- a/contributing_guides/best_practices.md
+++ b/contributing_guides/best_practices.md
@@ -167,11 +167,12 @@ Add clear comments:
   effects. Essentially every piece of meaningful logic should exist within some
   function that has to be explicitly invoked. Acceptable exceptions to this may
   include loading environment variables or setting up loggers.
-  - If you find yourself needing something like this, you maybe want that logic
-    to exist in a `main.py` file which should never be imported by anything else
-    and only run explicitly.
-- Related to the above, never add files which are both modules that are intended
-  to be imported and scripts which are intended to be run directly. If you want
-  to directly invoke the contents of a Python file from the command line for
-  example, always encapsulate that file with a `main.py` file, even if all that
-  main file does is import said module and call a function for example.
+  - If you find yourself needing something like this, you may want that logic to
+    exist in a file dedicated for manual execution (contains `if __name__ ==
+    "__main__":`) which should not be imported by anything else.
+- Related to the above, do not conflate Python scripts you intend to run from
+  the command line (contains `if __name__ == "__main__":`) with modules you
+  intend to import from elsewhere. If for some unlikely reason they have to be
+  the same file, any logic specific to executing the file (including imports)
+  should be contained in the `if __name__ == "__main__":` block.
+  - Generally these executable files exist in `backend/scripts/`.


### PR DESCRIPTION
## Description
Title and content.

## How Has This Been Tested?
It wasn't.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document best practices to avoid import-time side effects: keep logic in functions, not at module import, with narrow exceptions (env loading, logger setup). Clarifies separation of modules and CLI scripts by using dedicated executable files guarded by if __name__ == "__main__" (typically in backend/scripts/); if a file must serve both, keep execution-only logic and imports inside the main guard.

<sup>Written for commit 6c39298be076e9b780d79cb989f0be74d0310ad5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

