### PR TITLE
feat(metrics): add per-tenant Prometheus metrics

### DIFF
--- a/backend/onyx/server/metrics/per_tenant.py
+++ b/backend/onyx/server/metrics/per_tenant.py
@@ -1,0 +1,27 @@
+"""Per-tenant request counter metric.
+
+Increments a counter on every request, labelled by tenant, so Grafana can
+answer "which tenant is generating the most traffic?"
+"""
+
+from prometheus_client import Counter
+from prometheus_fastapi_instrumentator.metrics import Info
+
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+_requests_by_tenant = Counter(
+    "onyx_api_requests_by_tenant_total",
+    "Total API requests by tenant",
+    ["tenant_id", "method", "handler", "status"],
+)
+
+
+def per_tenant_request_callback(info: Info) -> None:
+    """Increment per-tenant request counter for every request."""
+    tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get() or "unknown"
+    _requests_by_tenant.labels(
+        tenant_id=tenant_id,
+        method=info.method,
+        handler=info.modified_handler,
+        status=info.modified_status,
+    ).inc()

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -14,6 +14,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from starlette.applications import Starlette
 
+from onyx.server.metrics.per_tenant import per_tenant_request_callback
 from onyx.server.metrics.postgres_connection_pool import pool_timeout_handler
 from onyx.server.metrics.slow_requests import slow_request_callback
 
@@ -60,5 +61,6 @@ def setup_prometheus_metrics(app: Starlette) -> None:
     )
 
     instrumentator.add(slow_request_callback)
+    instrumentator.add(per_tenant_request_callback)
 
     instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(app)


### PR DESCRIPTION
## Description

Add per-tenant Prometheus metrics to identify which tenant is driving API traffic spikes and holding DB connections. This was motivated by a 189-connection spike on `/chat/send-chat-message` with no way to attribute it to a tenant.

**Changes:**
- New `onyx_api_requests_by_tenant_total` Counter (labels: `tenant_id`, `method`, `handler`, `status`) that fires on every request
- Added `tenant_id` label to the existing `onyx_db_connections_held_by_endpoint` Gauge, stored via `conn_record.info` during checkout/checkin/invalidate
- Companion Grafana dashboard (`onyx-tenant-usage.json`) with overview, drill-down, and DB attribution panels

Cardinality is bounded (~75K series for the counter, ~15K for the gauge). No tenant label on histograms to avoid bucket explosion.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tenant Prometheus metrics so we can attribute API traffic spikes and DB connection usage to specific tenants. Makes it easy to see who is driving load during incidents.

- **New Features**
  - New Counter: onyx_api_requests_by_tenant_total (labels: tenant_id, method, handler, status) counted on every request.
  - Added tenant_id label to onyx_db_connections_held_by_endpoint Gauge; tracked across checkout, checkin, and invalidate.
  - Wired the per-tenant request callback into the Prometheus instrumentator.
  - Cardinality kept in check; no tenant label added to histograms.

- **Migration**
  - Import the new Grafana dashboard (onyx-tenant-usage.json) if you want per-tenant views.
  - Ensure CURRENT_TENANT_ID_CONTEXTVAR is set on requests; otherwise metrics will show tenant_id="unknown".

<sup>Written for commit e7ca46b8275d1bf8f0a5c7d24da9ac2bf49216e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

