### PR TITLE
fix: Admin page modal centering excludes sidebar

### DIFF
--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -72,6 +72,7 @@ export function ClientLayout({
             enableEnterpriseSS={enableEnterprise}
           />
           <div
+            data-main-container
             className={cn(
               "flex flex-1 flex-col min-w-0 min-h-0 overflow-y-auto",
               !hasOwnLayout && "py-10 px-4 md:px-12"


### PR DESCRIPTION
## Description
Centers the modals such that they exclude the sidebar

Before:
<img width="1917" height="990" alt="Screenshot 2026-02-26 at 1 56 32 PM" src="https://github.com/user-attachments/assets/c5ac5aae-7da7-4b80-9598-9af53af7b604" />

After:
<img width="1917" height="990" alt="Screenshot 2026-02-26 at 1 56 20 PM" src="https://github.com/user-attachments/assets/61fb0b1a-690a-43c6-a3f5-53ad1b6afc24" />


## How Has This Been Tested?
Manual

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed admin modal centering to use the main content area only, excluding the sidebar. Added a data-main-container attribute to the main layout div to anchor modal positioning.

<sup>Written for commit e8cd63e40fb720d34964d8644b2d8e0077054b0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

