### PR TITLE
fix(fe): Search Actions popover has consistent hover states

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -179,7 +179,7 @@ export default function ActionLineItem({
               )}
 
               {isSearchToolAndNotInProject && (
-                <IconButton
+                <Button
                   icon={
                     isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
                   }
@@ -188,11 +188,8 @@ export default function ActionLineItem({
                       router.push("/admin/add-connector");
                     else onSourceManagementOpen?.();
                   })}
-                  internal
-                  className={cn(
-                    isSearchToolWithNoConnectors &&
-                      "invisible group-hover/LineItem:visible"
-                  )}
+                  prominence="tertiary"
+                  size="sm"
                   tooltip={
                     isSearchToolWithNoConnectors
                       ? "Add Connectors"


### PR DESCRIPTION
## Description

Settings icons are now always visible in the ActionsPopover.

Related to https://linear.app/onyx-app/issue/ENG-3756/actions-not-set-up-state-needs-to-be-consistent

## How Has This Been Tested?

<img width="1572" height="2085" alt="20260226_14h57m03s_grim" src="https://github.com/user-attachments/assets/5043efd2-dc32-4922-8b93-a5b18db70d66" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Search Actions popover consistent by replacing the icon button with a small tertiary Button and aligning its hover behavior with Internal Search. This addresses ENG-3756’s consistency requirement and reduces accidental clicks.

<sup>Written for commit 073ce8a1ea197a6c8260ae652d07156794d2e088. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



