### PR TITLE
fix(slack): sanitize HTML tags and broken citation links in bot responses (#8767) to release v2.10

### DIFF
--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -592,11 +592,8 @@ def build_slack_response_blocks(
         )
 
     citations_blocks = []
-    document_blocks = []
     if answer.citation_info:
         citations_blocks = _build_citations_blocks(answer)
-    else:
-        document_blocks = _priority_ordered_documents_blocks(answer)
 
     citations_divider = [DividerBlock()] if citations_blocks else []
     buttons_divider = [DividerBlock()] if web_follow_up_block or follow_up_block else []
@@ -608,7 +605,6 @@ def build_slack_response_blocks(
         + ai_feedback_block
         + citations_divider
         + citations_blocks
-        + document_blocks
         + buttons_divider
         + web_follow_up_block
         + follow_up_block

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -1,12 +1,149 @@
-from mistune import Markdown  # type: ignore[import-untyped]
-from mistune import Renderer
+import re
+from collections.abc import Callable
+from typing import Any
+
+from mistune import create_markdown
+from mistune import HTMLRenderer
+
+# Tags that should be replaced with a newline (line-break and block-level elements)
+_HTML_NEWLINE_TAG_PATTERN = re.compile(
+    r"<br\s*/?>|</(?:p|div|li|h[1-6]|tr|blockquote|section|article)>",
+    re.IGNORECASE,
+)
+
+# Strips HTML tags but excludes autolinks like <https://...> and <mailto:...>
+_HTML_TAG_PATTERN = re.compile(
+    r"<(?!https?://|mailto:)/?[a-zA-Z][^>]*>",
+)
+
+# Matches fenced code blocks (``` ... ```) so we can skip sanitization inside them
+_FENCED_CODE_BLOCK_PATTERN = re.compile(r"```[\s\S]*?```")
+
+# Matches the start of any markdown link: [text]( or [[n]](
+# The inner group handles nested brackets for citation links like [[1]](.
+_MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
+
+# Matches Slack-style links <url|text> that LLMs sometimes output directly.
+# Mistune doesn't recognise this syntax, so text() would escape the angle
+# brackets and Slack would render them as literal text instead of links.
+_SLACK_LINK_PATTERN = re.compile(r"<(https?://[^|>]+)\|([^>]+)>")
+
+
+def _sanitize_html(text: str) -> str:
+    """Strip HTML tags from a text fragment.
+
+    Block-level closing tags and <br> are converted to newlines.
+    All other HTML tags are removed. Autolinks (<https://...>) are preserved.
+    """
+    text = _HTML_NEWLINE_TAG_PATTERN.sub("\n", text)
+    text = _HTML_TAG_PATTERN.sub("", text)
+    return text
+
+
+def _transform_outside_code_blocks(
+    message: str, transform: Callable[[str], str]
+) -> str:
+    """Apply *transform* only to text outside fenced code blocks."""
+    parts = _FENCED_CODE_BLOCK_PATTERN.split(message)
+    code_blocks = _FENCED_CODE_BLOCK_PATTERN.findall(message)
+
+    result: list[str] = []
+    for i, part in enumerate(parts):
+        result.append(transform(part))
+        if i < len(code_blocks):
+            result.append(code_blocks[i])
+
+    return "".join(result)
+
+
+def _extract_link_destination(message: str, start_idx: int) -> tuple[str, int | None]:
+    """Extract markdown link destination, allowing nested parentheses in the URL."""
+    depth = 0
+    i = start_idx
+
+    while i < len(message):
+        curr = message[i]
+        if curr == "\\":
+            i += 2
+            continue
+
+        if curr == "(":
+            depth += 1
+        elif curr == ")":
+            if depth == 0:
+                return message[start_idx:i], i
+            depth -= 1
+        i += 1
+
+    return message[start_idx:], None
+
+
+def _normalize_link_destinations(message: str) -> str:
+    """Wrap markdown link URLs in angle brackets so the parser handles special chars safely.
+
+    Markdown link syntax [text](url) breaks when the URL contains unescaped
+    parentheses, spaces, or other special characters. Wrapping the URL in angle
+    brackets — [text](<url>) — tells the parser to treat everything inside as
+    a literal URL. This applies to all links, not just citations.
+    """
+    if "](" not in message:
+        return message
+
+    normalized_parts: list[str] = []
+    cursor = 0
+
+    while match := _MARKDOWN_LINK_PATTERN.search(message, cursor):
+        normalized_parts.append(message[cursor : match.end()])
+        destination_start = match.end()
+        destination, end_idx = _extract_link_destination(message, destination_start)
+        if end_idx is None:
+            normalized_parts.append(message[destination_start:])
+            return "".join(normalized_parts)
+
+        already_wrapped = destination.startswith("<") and destination.endswith(">")
+        if destination and not already_wrapped:
+            destination = f"<{destination}>"
+
+        normalized_parts.append(destination)
+        normalized_parts.append(")")
+        cursor = end_idx + 1
+
+    normalized_parts.append(message[cursor:])
+    return "".join(normalized_parts)
+
+
+def _convert_slack_links_to_markdown(message: str) -> str:
+    """Convert Slack-style <url|text> links to standard markdown [text](url).
+
+    LLMs sometimes emit Slack mrkdwn link syntax directly. Mistune doesn't
+    recognise it, so the angle brackets would be escaped by text() and Slack
+    would render the link as literal text instead of a clickable link.
+    """
+    return _transform_outside_code_blocks(
+        message, lambda text: _SLACK_LINK_PATTERN.sub(r"[\2](\1)", text)
+    )
 
 
 def format_slack_message(message: str | None) -> str:
-    return Markdown(renderer=SlackRenderer()).render(message)
+    if message is None:
+        return ""
+    message = _transform_outside_code_blocks(message, _sanitize_html)
+    message = _convert_slack_links_to_markdown(message)
+    normalized_message = _normalize_link_destinations(message)
+    md = create_markdown(renderer=SlackRenderer(), plugins=["strikethrough"])
+    result = md(normalized_message)
+    # With HTMLRenderer, result is always str (not AST list)
+    assert isinstance(result, str)
+    return result.rstrip("\n")
 
 
-class SlackRenderer(Renderer):
+class SlackRenderer(HTMLRenderer):
+    """Renders markdown as Slack mrkdwn format instead of HTML.
+
+    Overrides all HTMLRenderer methods that produce HTML tags to ensure
+    no raw HTML ever appears in Slack messages.
+    """
+
     SPECIALS: dict[str, str] = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
 
     def escape_special(self, text: str) -> str:
@@ -14,8 +151,8 @@ class SlackRenderer(Renderer):
             text = text.replace(special, replacement)
         return text
 
-    def header(self, text: str, level: int, raw: str | None = None) -> str:
-        return f"*{text}*\n"
+    def heading(self, text: str, level: int, **attrs: Any) -> str:  # noqa: ARG002
+        return f"*{text}*\n\n"
 
     def emphasis(self, text: str) -> str:
         return f"_{text}_"
@@ -34,7 +171,7 @@ class SlackRenderer(Renderer):
                 count += 1
                 prefix = f"{count}. " if ordered else "• "
                 lines[i] = f"{prefix}{line[4:]}"
-        return "\n".join(lines)
+        return "\n".join(lines) + "\n"
 
     def list_item(self, text: str) -> str:
         return f"li: {text}\n"
@@ -55,11 +192,31 @@ class SlackRenderer(Renderer):
     def codespan(self, text: str) -> str:
         return f"`{text}`"
 
-    def block_code(self, text: str, lang: str | None) -> str:
-        return f"```\n{text}\n```\n"
+    def block_code(self, code: str, info: str | None = None) -> str:  # noqa: ARG002
+        return f"```\n{code.rstrip(chr(10))}\n```\n\n"
+
+    def linebreak(self) -> str:
+        return "\n"
+
+    def thematic_break(self) -> str:
+        return "---\n\n"
+
+    def block_quote(self, text: str) -> str:
+        lines = text.strip().split("\n")
+        quoted = "\n".join(f">{line}" for line in lines)
+        return quoted + "\n\n"
+
+    def block_html(self, html: str) -> str:
+        return _sanitize_html(html) + "\n\n"
+
+    def block_error(self, text: str) -> str:
+        return f"```\n{text}\n```\n\n"
+
+    def text(self, text: str) -> str:
+        # Only escape the three entities Slack recognizes: & < >
+        # HTMLRenderer.text() also escapes " to &quot; which Slack renders
+        # as literal &quot; text since Slack doesn't recognize that entity.
+        return self.escape_special(text)
 
     def paragraph(self, text: str) -> str:
-        return f"{text}\n"
-
-    def autolink(self, link: str, is_email: bool) -> str:
-        return link if is_email else self.link(link, None, None)
+        return f"{text}\n\n"

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -1,0 +1,106 @@
+from onyx.onyxbot.slack.formatting import _convert_slack_links_to_markdown
+from onyx.onyxbot.slack.formatting import _normalize_link_destinations
+from onyx.onyxbot.slack.formatting import _sanitize_html
+from onyx.onyxbot.slack.formatting import _transform_outside_code_blocks
+from onyx.onyxbot.slack.formatting import format_slack_message
+from onyx.onyxbot.slack.utils import remove_slack_text_interactions
+from onyx.utils.text_processing import decode_escapes
+
+
+def test_normalize_citation_link_wraps_url_with_parentheses() -> None:
+    message = (
+        "See [[1]](https://example.com/Access%20ID%20Card(s)%20Guide.pdf) for details."
+    )
+
+    normalized = _normalize_link_destinations(message)
+
+    assert (
+        "See [[1]](<https://example.com/Access%20ID%20Card(s)%20Guide.pdf>) for details."
+        == normalized
+    )
+
+
+def test_normalize_citation_link_keeps_existing_angle_brackets() -> None:
+    message = "[[1]](<https://example.com/Access%20ID%20Card(s)%20Guide.pdf>)"
+
+    normalized = _normalize_link_destinations(message)
+
+    assert message == normalized
+
+
+def test_normalize_citation_link_handles_multiple_links() -> None:
+    message = (
+        "[[1]](https://example.com/(USA)%20Guide.pdf) "
+        "[[2]](https://example.com/Plan(s)%20Overview.pdf)"
+    )
+
+    normalized = _normalize_link_destinations(message)
+
+    assert "[[1]](<https://example.com/(USA)%20Guide.pdf>)" in normalized
+    assert "[[2]](<https://example.com/Plan(s)%20Overview.pdf>)" in normalized
+
+
+def test_format_slack_message_keeps_parenthesized_citation_links_intact() -> None:
+    message = (
+        "Download [[1]](https://example.com/(USA)%20Access%20ID%20Card(s)%20Guide.pdf)"
+    )
+
+    formatted = format_slack_message(message)
+    rendered = decode_escapes(remove_slack_text_interactions(formatted))
+
+    assert (
+        "<https://example.com/(USA)%20Access%20ID%20Card(s)%20Guide.pdf|[1]>"
+        in rendered
+    )
+    assert "|[1]>%20Access%20ID%20Card" not in rendered
+
+
+def test_slack_style_links_converted_to_clickable_links() -> None:
+    message = "Visit <https://example.com/page|Example Page> for details."
+
+    formatted = format_slack_message(message)
+
+    assert "<https://example.com/page|Example Page>" in formatted
+    assert "&lt;" not in formatted
+
+
+def test_slack_style_links_preserved_inside_code_blocks() -> None:
+    message = "```\n<https://example.com|click>\n```"
+
+    converted = _convert_slack_links_to_markdown(message)
+
+    assert "<https://example.com|click>" in converted
+
+
+def test_html_tags_stripped_outside_code_blocks() -> None:
+    message = "Hello<br/>world ```<div>code</div>``` after"
+
+    sanitized = _transform_outside_code_blocks(message, _sanitize_html)
+
+    assert "<br" not in sanitized
+    assert "<div>code</div>" in sanitized
+
+
+def test_format_slack_message_block_spacing() -> None:
+    message = "Paragraph one.\n\nParagraph two."
+
+    formatted = format_slack_message(message)
+
+    assert "Paragraph one.\n\nParagraph two." == formatted
+
+
+def test_format_slack_message_code_block_no_trailing_blank_line() -> None:
+    message = "```python\nprint('hi')\n```"
+
+    formatted = format_slack_message(message)
+
+    assert formatted.endswith("print('hi')\n```")
+
+
+def test_format_slack_message_ampersand_not_double_escaped() -> None:
+    message = 'She said "hello" & goodbye.'
+
+    formatted = format_slack_message(message)
+
+    assert "&amp;" in formatted
+    assert "&quot;" not in formatted


### PR DESCRIPTION
Cherry-pick of commit f2e8cb3114b8e5e7876830f5dbcbc0dc17c9b947 to release/v2.10 branch.

Original PR: #8767

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Slack bot responses to remove raw HTML and fix broken citation links so messages render cleanly and links are clickable. Also improves spacing/escaping and hides document blocks when there are no citations.

- **Bug Fixes**
  - Strip HTML tags; convert <br> and closing block tags to newlines.
  - Normalize markdown link URLs by wrapping in angle brackets to handle parentheses/spaces; fixes [[n]] citation links.
  - Convert Slack-style <url|text> to clickable links, skipping inside fenced code blocks.
  - Improve renderer output: consistent newlines, no extra code block blank line, escape only &, <, >; do not show document blocks when no citations.

<sup>Written for commit b71c14d30ae73fd52725245808b13f132958e4e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

