### PR TITLE
chore(devtools): upgrade `ods`: v0.6.1->v0.6.2 (#8773) to release v2.10

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -298,7 +298,7 @@ numpy==2.4.1
     #   pandas-stubs
     #   shapely
     #   voyageai
-onyx-devtools==0.3.2
+onyx-devtools==0.6.2
     # via onyx
 openai==2.14.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dev = [
     "matplotlib==3.10.8",
     "mypy-extensions==1.0.0",
     "mypy==1.13.0",
-    "onyx-devtools==0.3.2",
+    "onyx-devtools==0.6.2",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4777,7 +4777,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==2.4.1" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.3.2" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.6.2" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "openapi-generator-cli", marker = "extra == 'dev'", specifier = "==7.17.0" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
@@ -4880,20 +4880,20 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.3.2"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/02/740f0afebfaa2537b9b016b1352f39e750ee282dbfd3b7fd793baebd4e69/onyx_devtools-0.3.2-py3-none-any.whl", hash = "sha256:c8d495fe0701a793acfca10145135314031c9892dc43cc2a146a0bfb56eb4fe5", size = 1348309, upload-time = "2026-01-15T20:28:23.124Z" },
-    { url = "https://files.pythonhosted.org/packages/52/4b/87a79b8a972406a9698b0cb29564d0b1686c074a6b242635ece0fac575b1/onyx_devtools-0.3.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ca1868c64e68d1a129e542e253744d998b316837e8c77fe1ab69693a65efb36c", size = 1350995, upload-time = "2026-01-15T20:28:25.721Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ac/8d40e968627a075d127774a62667c42f59ad1866d167542e14897c57eb87/onyx_devtools-0.3.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cfbafbf1fdddc6a2ea9278ba595cc0bf3430f588e09ddcba496d7fa95110c905", size = 1273049, upload-time = "2026-01-15T20:28:26.254Z" },
-    { url = "https://files.pythonhosted.org/packages/42/a4/668b4d32c1534fa591ffbd9873e3b9d3b2fc82988d6ecbb2d3e96f340441/onyx_devtools-0.3.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:52877fdad82f54d24c50bd4f718c77097cc7f6d3944e586cc28d437457b27e6e", size = 1240860, upload-time = "2026-01-15T20:28:22.097Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2e/e58597364c40a2fadccc334f0961edd6caa502777e625ea07bb61a29e2c7/onyx_devtools-0.3.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:f0192f36a9505e16c5cb039f6c4f595471a48434fc539b3d8c0971415b998294", size = 1348326, upload-time = "2026-01-15T20:28:19.941Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/00/a31790f5835f789dc6259a2e467a64407482dca28bf3a86eadb1f6d8dca6/onyx_devtools-0.3.2-py3-none-win_amd64.whl", hash = "sha256:90164068e99abcfc5cb24539e3fe9946e8acb14116ad0f93deebb149851ef22a", size = 1424264, upload-time = "2026-01-15T20:28:23.747Z" },
-    { url = "https://files.pythonhosted.org/packages/39/0c/4d02a6229b333af088a0cfd06f236de221baaf16ebf3806529d2c7dfb0da/onyx_devtools-0.3.2-py3-none-win_arm64.whl", hash = "sha256:a2da66ab167cc2dc612cfbecf1e04a517e3a1d5e9ea121d07a90478a3dc8e307", size = 1297957, upload-time = "2026-01-15T20:28:26.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/20/d9f6089616044b0fb6e097cbae82122de24f3acd97820be4868d5c28ee3f/onyx_devtools-0.6.2-py3-none-any.whl", hash = "sha256:e48d14695d39d62ec3247a4c76ea56604bc5fb635af84c4ff3e9628bcc67b4fb", size = 3785941, upload-time = "2026-02-25T22:33:43.585Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/f754a717f6b011050eb52ef09895cfa2f048f567f4aa3d5e0f773657dea4/onyx_devtools-0.6.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:505f9910a04868ab62d99bb483dc37c9f4ad94fa80e6ac0e6a10b86351c31420", size = 3832182, upload-time = "2026-02-25T22:33:43.283Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/35/6e653398c62078e87ebb0d03dc944df6691d92ca427c92867309d2d803b7/onyx_devtools-0.6.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edec98e3acc0fa22cf9102c2070409ea7bcf99d7ded72bd8cb184ece8171c36a", size = 3576948, upload-time = "2026-02-25T22:33:42.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/97/cff707c5c3d2acd714365b1023f0100676abc99816a29558319e8ef01d5f/onyx_devtools-0.6.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:97abab61216866cdccd8c0a7e27af328776083756ce4fb57c4bd723030449e3b", size = 3439359, upload-time = "2026-02-25T22:33:44.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/98/3b768d18e5599178834b966b447075626d224e048d6eb264d89d19abacb4/onyx_devtools-0.6.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:681b038ab6f1457409d14b2490782c7a8014fc0f0f1b9cd69bb2b7199f99aef1", size = 3785959, upload-time = "2026-02-25T22:33:44.342Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/38/9b047f9e61c14ccf22b8f386c7a57da3965f90737453f3a577a97da45cdf/onyx_devtools-0.6.2-py3-none-win_amd64.whl", hash = "sha256:a2063be6be104b50a7538cf0d26c7f7ab9159d53327dd6f3e91db05d793c95f3", size = 3878776, upload-time = "2026-02-25T22:33:45.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0f/742f644bae84f5f8f7b500094a2f58da3ff8027fc739944622577e2e2850/onyx_devtools-0.6.2-py3-none-win_arm64.whl", hash = "sha256:00fb90a49a15c932b5cacf818b1b4918e5b5c574bde243dc1828b57690dd5046", size = 3501112, upload-time = "2026-02-25T22:33:41.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of commit e5ebb45a202894214bcd88c779bd357aa3d9905b to release/v2.10 branch.

Original PR: #8773

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade onyx-devtools to 0.6.2 in dev dependencies for the v2.10 release.

<sup>Written for commit c98731b5436d4700aeaf44ac566e12c90d1d9147. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

