### PR TITLE
chore(devtools): upgrade `ods`: v0.6.1->v0.6.2 (#8773) to release v2.12

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -317,7 +317,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-onyx-devtools==0.5.1
+onyx-devtools==0.6.2
     # via onyx
 openai==2.14.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ dev = [
     "matplotlib==3.10.8",
     "mypy-extensions==1.0.0",
     "mypy==1.13.0",
-    "onyx-devtools==0.5.1",
+    "onyx-devtools==0.6.2",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4763,7 +4763,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'model-server'", specifier = "==2.4.1" },
     { name = "oauthlib", marker = "extra == 'backend'", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", marker = "extra == 'backend'", specifier = "==2.5.9" },
-    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.5.1" },
+    { name = "onyx-devtools", marker = "extra == 'dev'", specifier = "==0.6.2" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "openapi-generator-cli", marker = "extra == 'dev'", specifier = "==7.17.0" },
     { name = "openinference-instrumentation", marker = "extra == 'backend'", specifier = "==0.1.42" },
@@ -4868,20 +4868,20 @@ requires-dist = [{ name = "onyx", extras = ["backend", "dev", "ee"], editable = 
 
 [[package]]
 name = "onyx-devtools"
-version = "0.5.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/37/bc043a8d6e3763f032282bb924c7edbed9c868ebab15e38a20e451e83dca/onyx_devtools-0.5.1-py3-none-any.whl", hash = "sha256:eb14f3fd9dcc5219439b5b568fd98d1088927a2d35d706811d4dfdee6ccb63d7", size = 2891955, upload-time = "2026-02-09T22:59:19.53Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/93/c0d623e2bd0780f5b6ccc025698e0eaa5e50939b0a0edaad2ee068b7be83/onyx_devtools-0.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4ac7a500e2a4cbc4f943890d68525f92cd1ea5f9d8eada1c2ed9ff2e81771cd", size = 2909887, upload-time = "2026-02-09T22:59:28.213Z" },
-    { url = "https://files.pythonhosted.org/packages/51/45/94098a852f846c8f2b4226a595e9b95f4ed535a86939dd0601b1ffe8bb73/onyx_devtools-0.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edac64d3ae5691c3aa12363bb2eaee13e6f9e62a3c6385d390a95c29f60fb95e", size = 2713796, upload-time = "2026-02-09T22:59:17.919Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b8/7ed5486b6302f9d717f6f4f98d4a6162bc63f3eb964feed438eb5875176a/onyx_devtools-0.5.1-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2d713aa258a0799743cf8a37c0a39727deed3d2e7d3033fe08d8920cbeecbb8c", size = 2623042, upload-time = "2026-02-09T22:59:27.833Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/7e/e1a6d0a02ea0dddf48057ae12417cc126902cc2e74078dd33c8ab5e3bb39/onyx_devtools-0.5.1-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:117cc62d3a0637e7eb9a417bbd2dbc045f887da3278708e6d4fcae122c43e4bf", size = 2891968, upload-time = "2026-02-09T22:59:19.941Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/96/fecee71880b65c4ae33c6a3fa7a58d868956d6debfc075cb494d0a142047/onyx_devtools-0.5.1-py3-none-win_amd64.whl", hash = "sha256:e33c8b27cd5568c6925e58c0f8d502d88d96817af879fb78d4b564e7ff2bbc16", size = 2974809, upload-time = "2026-02-09T22:59:23.564Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/37/f59bca099132fae209e4dd2c5158cd1dee729507d4f810e1ea306279e12c/onyx_devtools-0.5.1-py3-none-win_arm64.whl", hash = "sha256:f4987ab6f07797c18067f7a5edccfc12af9d52ae22a6075d0109b924b6791706", size = 2685469, upload-time = "2026-02-09T22:59:27.536Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/20/d9f6089616044b0fb6e097cbae82122de24f3acd97820be4868d5c28ee3f/onyx_devtools-0.6.2-py3-none-any.whl", hash = "sha256:e48d14695d39d62ec3247a4c76ea56604bc5fb635af84c4ff3e9628bcc67b4fb", size = 3785941, upload-time = "2026-02-25T22:33:43.585Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/f754a717f6b011050eb52ef09895cfa2f048f567f4aa3d5e0f773657dea4/onyx_devtools-0.6.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:505f9910a04868ab62d99bb483dc37c9f4ad94fa80e6ac0e6a10b86351c31420", size = 3832182, upload-time = "2026-02-25T22:33:43.283Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/35/6e653398c62078e87ebb0d03dc944df6691d92ca427c92867309d2d803b7/onyx_devtools-0.6.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edec98e3acc0fa22cf9102c2070409ea7bcf99d7ded72bd8cb184ece8171c36a", size = 3576948, upload-time = "2026-02-25T22:33:42.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/97/cff707c5c3d2acd714365b1023f0100676abc99816a29558319e8ef01d5f/onyx_devtools-0.6.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:97abab61216866cdccd8c0a7e27af328776083756ce4fb57c4bd723030449e3b", size = 3439359, upload-time = "2026-02-25T22:33:44.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/98/3b768d18e5599178834b966b447075626d224e048d6eb264d89d19abacb4/onyx_devtools-0.6.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:681b038ab6f1457409d14b2490782c7a8014fc0f0f1b9cd69bb2b7199f99aef1", size = 3785959, upload-time = "2026-02-25T22:33:44.342Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/38/9b047f9e61c14ccf22b8f386c7a57da3965f90737453f3a577a97da45cdf/onyx_devtools-0.6.2-py3-none-win_amd64.whl", hash = "sha256:a2063be6be104b50a7538cf0d26c7f7ab9159d53327dd6f3e91db05d793c95f3", size = 3878776, upload-time = "2026-02-25T22:33:45.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0f/742f644bae84f5f8f7b500094a2f58da3ff8027fc739944622577e2e2850/onyx_devtools-0.6.2-py3-none-win_arm64.whl", hash = "sha256:00fb90a49a15c932b5cacf818b1b4918e5b5c574bde243dc1828b57690dd5046", size = 3501112, upload-time = "2026-02-25T22:33:41.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of commit e5ebb45a202894214bcd88c779bd357aa3d9905b to release/v2.12 branch.

Original PR: #8773

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded onyx-devtools to 0.6.2 for the v2.12 release. Aligns dev tooling with the latest fixes and has no runtime impact.

- **Dependencies**
  - Bumped onyx-devtools from 0.5.1 to 0.6.2 in backend/requirements/dev.txt and pyproject.toml.
  - Updated uv.lock to reflect the new version.

<sup>Written for commit 6c34d90db21d984e8036ee63a3e6c1bee03f20aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

