### PR TITLE
fix(metrics): restore default HTTP request counter and histogram metrics

### DIFF
--- a/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
+++ b/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
@@ -82,7 +82,7 @@ def test_setup_attaches_instrumentator_to_app() -> None:
             inprogress_labels=True,
             excluded_handlers=["/health", "/metrics", "/openapi.json"],
         )
-        assert mock_instance.add.call_count == 2
+        assert mock_instance.add.call_count == 3
         mock_instance.instrument.assert_called_once_with(
             app,
             latency_lowr_buckets=(


### PR DESCRIPTION
## Description

Fixes a bug where `http_requests_total` and `http_request_duration_seconds` metrics were silently dropped from the API server's `/metrics` endpoint.

**Root cause:** The `prometheus-fastapi-instrumentator` library skips creating its default metrics (counter, histograms) when *any* custom callbacks are registered via `.add()`. When `slow_request_callback` was added, the library's `__init__` took the `if instrumentations:` branch and never called `metrics.default()`, so `http_requests_total` and `http_request_duration_seconds` were never created. Only `http_requests_inprogress` survived because it's created separately in the middleware, not by the default callback.

**Fix:** Explicitly call `metrics.default(latency_lowr_buckets=...)` and add the returned callback alongside our custom instrumentations.

**Verified:** `kubectl exec` confirmed the API server pod's `/metrics` endpoint had 0 lines for `http_requests_total` and `http_request_duration_seconds`, while `http_requests_inprogress` had 157 lines.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores default HTTP request counter and duration histogram metrics on the API /metrics endpoint. Explicitly registers the library’s default metrics when custom callbacks are present to prevent them from being dropped.

- **Bug Fixes**
  - Root cause: prometheus-fastapi-instrumentator skips default metrics if any custom instrumentations are added.
  - Fix: call metrics.default(...) and add its callback before our custom callbacks.

<sup>Written for commit 331b5624d727f38dcc012caaa0232965bf63193e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

