### PR TITLE
chore: narrow no_vector_db supported scope

### DIFF
--- a/backend/tests/unit/onyx/test_startup_validation.py
+++ b/backend/tests/unit/onyx/test_startup_validation.py
@@ -1,0 +1,52 @@
+"""Tests for startup validation in no-vector-DB mode.
+
+Verifies that DISABLE_VECTOR_DB raises RuntimeError when combined with
+incompatible settings (MULTI_TENANT, ENABLE_CRAFT).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestValidateNoVectorDbSettings:
+    @patch("onyx.main.DISABLE_VECTOR_DB", False)
+    def test_no_error_when_vector_db_enabled(self) -> None:
+        from onyx.main import validate_no_vector_db_settings
+
+        validate_no_vector_db_settings()
+
+    @patch("onyx.main.DISABLE_VECTOR_DB", True)
+    @patch("onyx.main.MULTI_TENANT", False)
+    @patch("onyx.server.features.build.configs.ENABLE_CRAFT", False)
+    def test_no_error_when_no_conflicts(self) -> None:
+        from onyx.main import validate_no_vector_db_settings
+
+        validate_no_vector_db_settings()
+
+    @patch("onyx.main.DISABLE_VECTOR_DB", True)
+    @patch("onyx.main.MULTI_TENANT", True)
+    def test_raises_on_multi_tenant(self) -> None:
+        from onyx.main import validate_no_vector_db_settings
+
+        with pytest.raises(RuntimeError, match="MULTI_TENANT"):
+            validate_no_vector_db_settings()
+
+    @patch("onyx.main.DISABLE_VECTOR_DB", True)
+    @patch("onyx.main.MULTI_TENANT", False)
+    @patch("onyx.server.features.build.configs.ENABLE_CRAFT", True)
+    def test_raises_on_enable_craft(self) -> None:
+        from onyx.main import validate_no_vector_db_settings
+
+        with pytest.raises(RuntimeError, match="ENABLE_CRAFT"):
+            validate_no_vector_db_settings()
+
+    @patch("onyx.main.DISABLE_VECTOR_DB", True)
+    @patch("onyx.main.MULTI_TENANT", True)
+    @patch("onyx.server.features.build.configs.ENABLE_CRAFT", True)
+    def test_multi_tenant_checked_before_craft(self) -> None:
+        """MULTI_TENANT is checked first, so it should be the error raised."""
+        from onyx.main import validate_no_vector_db_settings
+
+        with pytest.raises(RuntimeError, match="MULTI_TENANT"):
+            validate_no_vector_db_settings()


### PR DESCRIPTION
## Description

disallow deployments running with no_vector_db from being multi-tenant or using craft

## How Has This Been Tested?

unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds startup validation to block DISABLE_VECTOR_DB when combined with MULTI_TENANT or ENABLE_CRAFT. This fails fast and limits no-vector-DB mode to single-tenant, no-Craft deployments.

- **Migration**
  - If DISABLE_VECTOR_DB=true, set MULTI_TENANT=false.
  - Set ENABLE_CRAFT=false when disabling the vector DB.

<sup>Written for commit 033aeeed4924625baac60c01fcd714207d1b4579. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

