### PR TITLE
test: file reader tool

### DIFF
--- a/backend/tests/unit/onyx/tools/test_construct_tools_no_vectordb.py
+++ b/backend/tests/unit/onyx/tools/test_construct_tools_no_vectordb.py
@@ -1,0 +1,196 @@
+"""Tests for tool construction when DISABLE_VECTOR_DB is True.
+
+Verifies that:
+- SearchTool.is_available() returns False when vector DB is disabled
+- OpenURLTool.is_available() returns False when vector DB is disabled
+- The force-add SearchTool block is suppressed when DISABLE_VECTOR_DB
+- FileReaderTool.is_available() returns True when vector DB is disabled
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import FileReaderTool
+
+APP_CONFIGS_MODULE = "onyx.configs.app_configs"
+FILE_READER_MODULE = "onyx.tools.tool_implementations.file_reader.file_reader_tool"
+
+
+# ------------------------------------------------------------------
+# SearchTool.is_available()
+# ------------------------------------------------------------------
+
+
+class TestSearchToolAvailability:
+    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", True)
+    def test_unavailable_when_vector_db_disabled(self) -> None:
+        from onyx.tools.tool_implementations.search.search_tool import SearchTool
+
+        assert SearchTool.is_available(MagicMock()) is False
+
+    @patch("onyx.db.connector.check_user_files_exist", return_value=True)
+    @patch(
+        "onyx.tools.tool_implementations.search.search_tool.check_federated_connectors_exist",
+        return_value=False,
+    )
+    @patch(
+        "onyx.tools.tool_implementations.search.search_tool.check_connectors_exist",
+        return_value=False,
+    )
+    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", False)
+    def test_available_when_vector_db_enabled_and_files_exist(
+        self,
+        mock_connectors: MagicMock,  # noqa: ARG002
+        mock_federated: MagicMock,  # noqa: ARG002
+        mock_user_files: MagicMock,  # noqa: ARG002
+    ) -> None:
+        from onyx.tools.tool_implementations.search.search_tool import SearchTool
+
+        assert SearchTool.is_available(MagicMock()) is True
+
+
+# ------------------------------------------------------------------
+# OpenURLTool.is_available()
+# ------------------------------------------------------------------
+
+
+class TestOpenURLToolAvailability:
+    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", True)
+    def test_unavailable_when_vector_db_disabled(self) -> None:
+        from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+
+        assert OpenURLTool.is_available(MagicMock()) is False
+
+    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", False)
+    def test_available_when_vector_db_enabled(self) -> None:
+        from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+
+        assert OpenURLTool.is_available(MagicMock()) is True
+
+
+# ------------------------------------------------------------------
+# FileReaderTool.is_available()
+# ------------------------------------------------------------------
+
+
+class TestFileReaderToolAvailability:
+    @patch(f"{FILE_READER_MODULE}.DISABLE_VECTOR_DB", True)
+    def test_available_when_vector_db_disabled(self) -> None:
+        assert FileReaderTool.is_available(MagicMock()) is True
+
+    @patch(f"{FILE_READER_MODULE}.DISABLE_VECTOR_DB", False)
+    def test_unavailable_when_vector_db_enabled(self) -> None:
+        assert FileReaderTool.is_available(MagicMock()) is False
+
+
+# ------------------------------------------------------------------
+# Force-add SearchTool suppression
+# ------------------------------------------------------------------
+
+
+class TestForceAddSearchToolGuard:
+    def test_force_add_block_checks_disable_vector_db(self) -> None:
+        """The force-add SearchTool block in construct_tools should include
+        `not DISABLE_VECTOR_DB` so that forced search is also suppressed
+        without a vector DB."""
+        import inspect
+
+        from onyx.tools.tool_constructor import construct_tools
+
+        source = inspect.getsource(construct_tools)
+        assert "DISABLE_VECTOR_DB" in source, (
+            "construct_tools should reference DISABLE_VECTOR_DB "
+            "to suppress force-adding SearchTool"
+        )
+
+
+# ------------------------------------------------------------------
+# Persona API — _validate_vector_db_knowledge
+# ------------------------------------------------------------------
+
+
+class TestValidateVectorDbKnowledge:
+    @patch(
+        "onyx.server.features.persona.api.DISABLE_VECTOR_DB",
+        True,
+    )
+    def test_rejects_document_set_ids(self) -> None:
+        from fastapi import HTTPException
+
+        from onyx.server.features.persona.api import _validate_vector_db_knowledge
+
+        request = MagicMock()
+        request.document_set_ids = [1]
+        request.hierarchy_node_ids = []
+        request.document_ids = []
+
+        with __import__("pytest").raises(HTTPException) as exc_info:
+            _validate_vector_db_knowledge(request)
+        assert exc_info.value.status_code == 400
+        assert "document sets" in exc_info.value.detail
+
+    @patch(
+        "onyx.server.features.persona.api.DISABLE_VECTOR_DB",
+        True,
+    )
+    def test_rejects_hierarchy_node_ids(self) -> None:
+        from fastapi import HTTPException
+
+        from onyx.server.features.persona.api import _validate_vector_db_knowledge
+
+        request = MagicMock()
+        request.document_set_ids = []
+        request.hierarchy_node_ids = [1]
+        request.document_ids = []
+
+        with __import__("pytest").raises(HTTPException) as exc_info:
+            _validate_vector_db_knowledge(request)
+        assert exc_info.value.status_code == 400
+        assert "hierarchy nodes" in exc_info.value.detail
+
+    @patch(
+        "onyx.server.features.persona.api.DISABLE_VECTOR_DB",
+        True,
+    )
+    def test_rejects_document_ids(self) -> None:
+        from fastapi import HTTPException
+
+        from onyx.server.features.persona.api import _validate_vector_db_knowledge
+
+        request = MagicMock()
+        request.document_set_ids = []
+        request.hierarchy_node_ids = []
+        request.document_ids = ["doc-abc"]
+
+        with __import__("pytest").raises(HTTPException) as exc_info:
+            _validate_vector_db_knowledge(request)
+        assert exc_info.value.status_code == 400
+        assert "documents" in exc_info.value.detail
+
+    @patch(
+        "onyx.server.features.persona.api.DISABLE_VECTOR_DB",
+        True,
+    )
+    def test_allows_user_files_only(self) -> None:
+        from onyx.server.features.persona.api import _validate_vector_db_knowledge
+
+        request = MagicMock()
+        request.document_set_ids = []
+        request.hierarchy_node_ids = []
+        request.document_ids = []
+
+        _validate_vector_db_knowledge(request)
+
+    @patch(
+        "onyx.server.features.persona.api.DISABLE_VECTOR_DB",
+        False,
+    )
+    def test_allows_everything_when_vector_db_enabled(self) -> None:
+        from onyx.server.features.persona.api import _validate_vector_db_knowledge
+
+        request = MagicMock()
+        request.document_set_ids = [1, 2]
+        request.hierarchy_node_ids = [3]
+        request.document_ids = ["doc-x"]
+
+        _validate_vector_db_knowledge(request)

--- a/backend/tests/unit/onyx/tools/test_file_reader_tool.py
+++ b/backend/tests/unit/onyx/tools/test_file_reader_tool.py
@@ -1,0 +1,237 @@
+"""Tests for the FileReaderTool.
+
+Verifies:
+- Tool definition schema is well-formed
+- File ID validation (allowlist, UUID format)
+- Character range extraction and clamping
+- Error handling for missing parameters and non-text files
+- is_available() reflects DISABLE_VECTOR_DB
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from onyx.file_store.models import ChatFileType
+from onyx.file_store.models import InMemoryChatFile
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.models import ToolCallException
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import FILE_ID_FIELD
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import FileReaderTool
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import MAX_NUM_CHARS
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import NUM_CHARS_FIELD
+from onyx.tools.tool_implementations.file_reader.file_reader_tool import (
+    START_CHAR_FIELD,
+)
+
+TOOL_MODULE = "onyx.tools.tool_implementations.file_reader.file_reader_tool"
+_PLACEMENT = Placement(turn_index=0)
+
+
+def _make_tool(
+    user_file_ids: list | None = None,
+    chat_file_ids: list | None = None,
+) -> FileReaderTool:
+    emitter = MagicMock()
+    return FileReaderTool(
+        tool_id=99,
+        emitter=emitter,
+        user_file_ids=user_file_ids or [],
+        chat_file_ids=chat_file_ids or [],
+    )
+
+
+def _text_file(content: str, filename: str = "test.txt") -> InMemoryChatFile:
+    return InMemoryChatFile(
+        file_id="some-file-id",
+        content=content.encode("utf-8"),
+        file_type=ChatFileType.PLAIN_TEXT,
+        filename=filename,
+    )
+
+
+# ------------------------------------------------------------------
+# Tool metadata
+# ------------------------------------------------------------------
+
+
+class TestToolMetadata:
+    def test_tool_name(self) -> None:
+        tool = _make_tool()
+        assert tool.name == "read_file"
+
+    def test_tool_definition_schema(self) -> None:
+        tool = _make_tool()
+        defn = tool.tool_definition()
+        assert defn["type"] == "function"
+        func = defn["function"]
+        assert func["name"] == "read_file"
+        props = func["parameters"]["properties"]
+        assert FILE_ID_FIELD in props
+        assert START_CHAR_FIELD in props
+        assert NUM_CHARS_FIELD in props
+        assert func["parameters"]["required"] == [FILE_ID_FIELD]
+
+
+# ------------------------------------------------------------------
+# File ID validation
+# ------------------------------------------------------------------
+
+
+class TestFileIdValidation:
+    def test_rejects_invalid_uuid(self) -> None:
+        tool = _make_tool()
+        with pytest.raises(ToolCallException, match="Invalid file_id"):
+            tool._validate_file_id("not-a-uuid")
+
+    def test_rejects_file_not_in_allowlist(self) -> None:
+        tool = _make_tool(user_file_ids=[uuid4()])
+        other_id = uuid4()
+        with pytest.raises(ToolCallException, match="not in available files"):
+            tool._validate_file_id(str(other_id))
+
+    def test_accepts_user_file_id(self) -> None:
+        uid = uuid4()
+        tool = _make_tool(user_file_ids=[uid])
+        assert tool._validate_file_id(str(uid)) == uid
+
+    def test_accepts_chat_file_id(self) -> None:
+        cid = uuid4()
+        tool = _make_tool(chat_file_ids=[cid])
+        assert tool._validate_file_id(str(cid)) == cid
+
+
+# ------------------------------------------------------------------
+# run() — character range extraction
+# ------------------------------------------------------------------
+
+
+class TestRun:
+    @patch(f"{TOOL_MODULE}.get_session_with_current_tenant")
+    @patch(f"{TOOL_MODULE}.load_user_file")
+    def test_returns_full_content_by_default(
+        self,
+        mock_load_user_file: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        uid = uuid4()
+        content = "Hello, world!"
+        mock_load_user_file.return_value = _text_file(content)
+        mock_get_session.return_value.__enter__.return_value = MagicMock()
+
+        tool = _make_tool(user_file_ids=[uid])
+        resp = tool.run(
+            placement=_PLACEMENT,
+            override_kwargs=MagicMock(),
+            **{FILE_ID_FIELD: str(uid)},
+        )
+        assert content in resp.llm_facing_response
+
+    @patch(f"{TOOL_MODULE}.get_session_with_current_tenant")
+    @patch(f"{TOOL_MODULE}.load_user_file")
+    def test_respects_start_char_and_num_chars(
+        self,
+        mock_load_user_file: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        uid = uuid4()
+        content = "abcdefghijklmnop"
+        mock_load_user_file.return_value = _text_file(content)
+        mock_get_session.return_value.__enter__.return_value = MagicMock()
+
+        tool = _make_tool(user_file_ids=[uid])
+        resp = tool.run(
+            placement=_PLACEMENT,
+            override_kwargs=MagicMock(),
+            **{FILE_ID_FIELD: str(uid), START_CHAR_FIELD: 4, NUM_CHARS_FIELD: 6},
+        )
+        assert "efghij" in resp.llm_facing_response
+
+    @patch(f"{TOOL_MODULE}.get_session_with_current_tenant")
+    @patch(f"{TOOL_MODULE}.load_user_file")
+    def test_clamps_num_chars_to_max(
+        self,
+        mock_load_user_file: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        uid = uuid4()
+        content = "x" * (MAX_NUM_CHARS + 500)
+        mock_load_user_file.return_value = _text_file(content)
+        mock_get_session.return_value.__enter__.return_value = MagicMock()
+
+        tool = _make_tool(user_file_ids=[uid])
+        resp = tool.run(
+            placement=_PLACEMENT,
+            override_kwargs=MagicMock(),
+            **{FILE_ID_FIELD: str(uid), NUM_CHARS_FIELD: MAX_NUM_CHARS + 9999},
+        )
+        assert f"Characters 0-{MAX_NUM_CHARS}" in resp.llm_facing_response
+
+    @patch(f"{TOOL_MODULE}.get_session_with_current_tenant")
+    @patch(f"{TOOL_MODULE}.load_user_file")
+    def test_includes_continuation_hint(
+        self,
+        mock_load_user_file: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        uid = uuid4()
+        content = "x" * 100
+        mock_load_user_file.return_value = _text_file(content)
+        mock_get_session.return_value.__enter__.return_value = MagicMock()
+
+        tool = _make_tool(user_file_ids=[uid])
+        resp = tool.run(
+            placement=_PLACEMENT,
+            override_kwargs=MagicMock(),
+            **{FILE_ID_FIELD: str(uid), NUM_CHARS_FIELD: 10},
+        )
+        assert "use start_char=10 to continue reading" in resp.llm_facing_response
+
+    def test_raises_on_missing_file_id(self) -> None:
+        tool = _make_tool()
+        with pytest.raises(ToolCallException, match="Missing required"):
+            tool.run(
+                placement=_PLACEMENT,
+                override_kwargs=MagicMock(),
+            )
+
+    @patch(f"{TOOL_MODULE}.get_session_with_current_tenant")
+    @patch(f"{TOOL_MODULE}.load_user_file")
+    def test_raises_on_non_text_file(
+        self,
+        mock_load_user_file: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        uid = uuid4()
+        mock_load_user_file.return_value = InMemoryChatFile(
+            file_id="img",
+            content=b"\x89PNG",
+            file_type=ChatFileType.IMAGE,
+            filename="photo.png",
+        )
+        mock_get_session.return_value.__enter__.return_value = MagicMock()
+
+        tool = _make_tool(user_file_ids=[uid])
+        with pytest.raises(ToolCallException, match="not a text file"):
+            tool.run(
+                placement=_PLACEMENT,
+                override_kwargs=MagicMock(),
+                **{FILE_ID_FIELD: str(uid)},
+            )
+
+
+# ------------------------------------------------------------------
+# is_available()
+# ------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    @patch(f"{TOOL_MODULE}.DISABLE_VECTOR_DB", True)
+    def test_available_when_vector_db_disabled(self) -> None:
+        assert FileReaderTool.is_available(MagicMock()) is True
+
+    @patch(f"{TOOL_MODULE}.DISABLE_VECTOR_DB", False)
+    def test_unavailable_when_vector_db_enabled(self) -> None:
+        assert FileReaderTool.is_available(MagicMock()) is False


### PR DESCRIPTION
## Description

test the file reader tool and tool construction flows

## How Has This Been Tested?

new tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat/no-bg-container3","parentHead":"947b11899df4a266c727602a8cd97d3d3a65715e","parentPull":8854,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for FileReaderTool and tool construction to verify behavior when the vector DB is disabled. Tests cover tool availability gates (SearchTool, OpenURLTool, FileReaderTool), suppression of forced SearchTool, Persona API validation, schema correctness, file ID allowlist/UUID checks, default and ranged reads with clamping and continuation hints, and errors for missing parameters and non-text files.

<sup>Written for commit 34ba4044e05c7e41cf46e3acfe07a912acb436c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

