### PR TITLE
chore(whitelabeling): always show sidebar icon without logo icon

### DIFF
--- a/web/src/sections/sidebar/SidebarWrapper.tsx
+++ b/web/src/sections/sidebar/SidebarWrapper.tsx
@@ -54,7 +54,6 @@ function LogoSection({ folded, onFoldClick }: LogoSectionProps) {
           </div>
         </>
       ) : folded ? (
-      ) : folded ? (
         <div className="flex w-full justify-center">{closeButton(false)}</div>
       ) : (
         <>


### PR DESCRIPTION
## Description

There is a whitelabeling option to disable the Logo Icon. In this configuration, the place where the logo typically belongs is empty until hover. In this case, always show the sidebar toggle button to fill the empty space.

## How Has This Been Tested?

**before**
<img width="1557" height="2085" alt="20260227_11h49m46s_grim" src="https://github.com/user-attachments/assets/7da87260-b51e-43d8-96af-3e8280f02c8b" />

**after**
<img width="1557" height="2085" alt="20260227_11h49m27s_grim" src="https://github.com/user-attachments/assets/27090e28-f165-46f4-a253-3f61ecfbc441" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the sidebar toggle button when the logo icon is disabled by whitelabeling. This fills the empty logo space in the folded sidebar and improves discoverability.

- **Bug Fixes**
  - In folded state with logo_display_style set to "name_only", show the toggle centered and always visible (no hover needed).
  - Keep existing hover behavior when a logo icon is present.

<sup>Written for commit fa94ffd4aa616561f1e67039331fb38088009d07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

