### PR TITLE
fix(gong): Respecting Retry Timeout Header

### DIFF
--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -429,17 +429,16 @@ def cleanup_tenant(
             print(f"{'=' * 80}\n")
 
             if force:
-                print(
-                    f"[FORCE MODE] Proceeding with cleanup for non-GATED_ACCESS tenant {tenant_id}"
-                )
-            else:
-                # Always ask for confirmation if not gated
-                response = input(
-                    "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
-                )
-                if response.lower() != "yes":
-                    print("Cleanup aborted - tenant is not GATED_ACCESS")
-                    return False
+                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+                return False
+
+            # Always ask for confirmation if not gated
+            response = input(
+                "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
+            )
+            if response.lower() != "yes":
+                print("Cleanup aborted - tenant is not GATED_ACCESS")
+                return False
         elif tenant_status == "GATED_ACCESS":
             print("✓ Tenant status is GATED_ACCESS - safe to proceed with cleanup")
         elif tenant_status is None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Making the Gong connector respect the retry timeout header that is returned when we hit a 429

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle Gong API calls and honor server Retry-After to reduce 429s. When call details remain missing after retries, skip them instead of failing.

- **Bug Fixes**
  - Gong: add a throttled request wrapper (0.5s minimum interval), increase retries to 10, and rely on Retry-After; applied to workspaces, transcript, and call details endpoints.
  - Gong: after max attempts, log and proceed, skipping missing call IDs instead of raising.

<sup>Written for commit 888c87606c67feda8ddcb97c775d9776ff972a7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



