### PR TITLE
refactor: add abstraction for cache backend

### DIFF
--- a/backend/onyx/cache/factory.py
+++ b/backend/onyx/cache/factory.py
@@ -1,0 +1,45 @@
+from collections.abc import Callable
+
+from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CacheBackendType
+from onyx.configs.app_configs import CACHE_BACKEND
+
+
+def _build_redis_backend(tenant_id: str) -> CacheBackend:
+    from onyx.cache.redis_backend import RedisCacheBackend
+    from onyx.redis.redis_pool import redis_pool
+
+    return RedisCacheBackend(redis_pool.get_client(tenant_id))
+
+
+_BACKEND_BUILDERS: dict[CacheBackendType, Callable[[str], CacheBackend]] = {
+    CacheBackendType.REDIS: _build_redis_backend,
+    # CacheBackendType.POSTGRES will be added in a follow-up PR.
+}
+
+
+def get_cache_backend(*, tenant_id: str | None = None) -> CacheBackend:
+    """Return a tenant-aware ``CacheBackend``.
+
+    If *tenant_id* is ``None``, the current tenant is read from the
+    thread-local context variable (same behaviour as ``get_redis_client``).
+    """
+    if tenant_id is None:
+        from shared_configs.contextvars import get_current_tenant_id
+
+        tenant_id = get_current_tenant_id()
+
+    builder = _BACKEND_BUILDERS.get(CACHE_BACKEND)
+    if builder is None:
+        raise ValueError(
+            f"Unsupported CACHE_BACKEND={CACHE_BACKEND!r}. "
+            f"Supported values: {[t.value for t in CacheBackendType]}"
+        )
+    return builder(tenant_id)
+
+
+def get_shared_cache_backend() -> CacheBackend:
+    """Return a ``CacheBackend`` in the shared (cross-tenant) namespace."""
+    from shared_configs.configs import DEFAULT_REDIS_PREFIX
+
+    return get_cache_backend(tenant_id=DEFAULT_REDIS_PREFIX)

--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -1,0 +1,89 @@
+import abc
+from enum import Enum
+
+
+class CacheBackendType(str, Enum):
+    REDIS = "redis"
+    POSTGRES = "postgres"
+
+
+class CacheLock(abc.ABC):
+    """Abstract distributed lock returned by CacheBackend.lock()."""
+
+    @abc.abstractmethod
+    def acquire(
+        self,
+        blocking: bool = True,
+        blocking_timeout: float | None = None,
+    ) -> bool:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def release(self) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def owned(self) -> bool:
+        raise NotImplementedError
+
+
+class CacheBackend(abc.ABC):
+    """Thin abstraction over a key-value cache with TTL, locks, and blocking lists.
+
+    Covers the subset of Redis operations used outside of Celery. When
+    CACHE_BACKEND=postgres, a PostgreSQL-backed implementation is used instead.
+    """
+
+    # -- basic key/value ---------------------------------------------------
+
+    @abc.abstractmethod
+    def get(self, key: str) -> bytes | None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def set(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def exists(self, key: str) -> bool:
+        raise NotImplementedError
+
+    # -- TTL ---------------------------------------------------------------
+
+    @abc.abstractmethod
+    def expire(self, key: str, seconds: int) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def ttl(self, key: str) -> int:
+        """Return remaining TTL in seconds. -1 if no expiry, -2 if key missing."""
+        raise NotImplementedError
+
+    # -- distributed lock --------------------------------------------------
+
+    @abc.abstractmethod
+    def lock(self, name: str, timeout: float | None = None) -> CacheLock:
+        raise NotImplementedError
+
+    # -- blocking list (used by MCP OAuth BLPOP pattern) -------------------
+
+    @abc.abstractmethod
+    def rpush(self, key: str, value: str | bytes) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:
+        """Block until a value is available on one of *keys*, or *timeout* expires.
+
+        Returns ``(key, value)`` or ``None`` on timeout.
+        """
+        raise NotImplementedError

--- a/backend/onyx/cache/redis_backend.py
+++ b/backend/onyx/cache/redis_backend.py
@@ -1,0 +1,92 @@
+from typing import cast
+
+from redis.client import Redis
+from redis.lock import Lock as RedisLock
+
+from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CacheLock
+
+
+class RedisCacheLock(CacheLock):
+    """Wraps ``redis.lock.Lock`` behind the ``CacheLock`` interface."""
+
+    def __init__(self, lock: RedisLock) -> None:
+        self._lock = lock
+
+    def acquire(
+        self,
+        blocking: bool = True,
+        blocking_timeout: float | None = None,
+    ) -> bool:
+        return bool(
+            self._lock.acquire(
+                blocking=blocking,
+                blocking_timeout=blocking_timeout,
+            )
+        )
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def owned(self) -> bool:
+        return bool(self._lock.owned())
+
+
+class RedisCacheBackend(CacheBackend):
+    """``CacheBackend`` implementation that delegates to a ``redis.Redis`` client.
+
+    This is a thin pass-through — every method maps 1-to-1 to the underlying
+    Redis command.  ``TenantRedis`` key-prefixing is handled by the client
+    itself (provided by ``get_redis_client``).
+    """
+
+    def __init__(self, redis_client: Redis) -> None:
+        self._r = redis_client
+
+    # -- basic key/value ---------------------------------------------------
+
+    def get(self, key: str) -> bytes | None:
+        val = self._r.get(key)
+        if val is None:
+            return None
+        if isinstance(val, bytes):
+            return val
+        return str(val).encode()
+
+    def set(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> None:
+        self._r.set(key, value, ex=ex)
+
+    def delete(self, key: str) -> None:
+        self._r.delete(key)
+
+    def exists(self, key: str) -> bool:
+        return bool(self._r.exists(key))
+
+    # -- TTL ---------------------------------------------------------------
+
+    def expire(self, key: str, seconds: int) -> None:
+        self._r.expire(key, seconds)
+
+    def ttl(self, key: str) -> int:
+        return cast(int, self._r.ttl(key))
+
+    # -- distributed lock --------------------------------------------------
+
+    def lock(self, name: str, timeout: float | None = None) -> CacheLock:
+        return RedisCacheLock(self._r.lock(name, timeout=timeout))
+
+    # -- blocking list (MCP OAuth BLPOP pattern) ---------------------------
+
+    def rpush(self, key: str, value: str | bytes) -> None:
+        self._r.rpush(key, value)
+
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:
+        result = cast(list[bytes] | None, self._r.blpop(keys, timeout=timeout))
+        if result is None:
+            return None
+        return (result[0], result[1])

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -6,6 +6,7 @@ from datetime import timezone
 from typing import cast
 
 from onyx.auth.schemas import AuthBackend
+from onyx.cache.interface import CacheBackendType
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import QueryHistoryType
 from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
@@ -53,6 +54,12 @@ DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() ==
 # Disables vector DB (Vespa/OpenSearch) entirely. When True, connectors and RAG search
 # are disabled but core chat, tools, user file uploads, and Projects still work.
 DISABLE_VECTOR_DB = os.environ.get("DISABLE_VECTOR_DB", "").lower() == "true"
+
+# Which backend to use for caching, locks, and ephemeral state.
+# "redis" (default) or "postgres" (only valid when DISABLE_VECTOR_DB=true).
+CACHE_BACKEND = CacheBackendType(
+    os.environ.get("CACHE_BACKEND", CacheBackendType.REDIS)
+)
 
 # Maximum token count for a single uploaded file. Files exceeding this are rejected.
 # Defaults to 100k tokens (or 10M when vector DB is disabled).


### PR DESCRIPTION
## Description

New abstraction for cache backend. This is to prepare for having a postgres cache backend option that will be used for Onyx Lite, where we won't deploy with Redis.

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat/no-bg-container7","parentHead":"3e9fd9c2b9f656c7339b6b1f527d6e512b768c9e","parentPull":8867,"trunk":"main"}
```
-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a tenant-aware cache backend with a Redis adapter and startup validation, paving the way for a Postgres-backed cache in no-vector-DB deployments.

- New Features
  - Added CacheBackend/CacheLock interfaces (get/set, TTL, locks, rpush/blpop) and CacheBackendType (redis|postgres).
  - Implemented RedisCacheBackend; preserves tenant prefixing.
  - Added get_cache_backend(tenant_id=...) and get_shared_cache_backend().
  - New CACHE_BACKEND env var (default: redis); validation blocks postgres unless DISABLE_VECTOR_DB=true.

- Migration
  - No changes needed; Redis remains default.
  - Selecting postgres now will error until the backend lands.

<sup>Written for commit 8bf29401f0805fde4d8885a984f7b766414af39b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



