### PR TITLE
fix(ee): show Access Restricted page when seat limit exceeded

### DIFF
--- a/backend/ee/onyx/server/settings/api.py
+++ b/backend/ee/onyx/server/settings/api.py
@@ -109,6 +109,12 @@ def apply_license_status_to_settings(settings: Settings) -> Settings:
             if metadata.status == _BLOCKING_STATUS:
                 settings.application_status = metadata.status
                 settings.ee_features_enabled = False
+            elif metadata.used_seats > metadata.seats:
+                # License is valid but seat limit exceeded
+                settings.application_status = ApplicationStatus.SEAT_LIMIT_EXCEEDED
+                settings.seat_count = metadata.seats
+                settings.used_seats = metadata.used_seats
+                settings.ee_features_enabled = True
             else:
                 # Has a valid license (GRACE_PERIOD/PAYMENT_REMINDER still allow EE features)
                 settings.ee_features_enabled = True

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -19,6 +19,7 @@ class ApplicationStatus(str, Enum):
     PAYMENT_REMINDER = "payment_reminder"
     GRACE_PERIOD = "grace_period"
     GATED_ACCESS = "gated_access"
+    SEAT_LIMIT_EXCEEDED = "seat_limit_exceeded"
 
 
 class Notification(BaseModel):
@@ -81,6 +82,10 @@ class Settings(BaseModel):
 
     # Default Assistant settings
     disable_default_assistant: bool | None = False
+
+    # Seat usage - populated by license enforcement when seat limit is exceeded
+    seat_count: int | None = None
+    used_seats: int | None = None
 
     # OpenSearch migration
     opensearch_indexing_enabled: bool = False

--- a/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
+++ b/backend/tests/unit/ee/onyx/server/settings/test_license_enforcement_settings.py
@@ -9,6 +9,19 @@ from redis.exceptions import RedisError
 from onyx.server.settings.models import ApplicationStatus
 from onyx.server.settings.models import Settings
 
+# Fields we assert on across all tests
+_ASSERT_FIELDS = {
+    "application_status",
+    "ee_features_enabled",
+    "seat_count",
+    "used_seats",
+}
+
+
+def _pick(settings: Settings) -> dict:
+    """Extract only the fields under test from a Settings object."""
+    return settings.model_dump(include=_ASSERT_FIELDS)
+
 
 @pytest.fixture
 def base_settings() -> Settings:
@@ -27,17 +40,17 @@ class TestApplyLicenseStatusToSettings:
     def test_enforcement_disabled_enables_ee_features(
         self, base_settings: Settings
     ) -> None:
-        """When LICENSE_ENFORCEMENT_ENABLED=False, EE features are enabled.
-
-        If we're running the EE apply function, EE code was loaded via
-        ENABLE_PAID_ENTERPRISE_EDITION_FEATURES, so features should be on.
-        """
+        """When LICENSE_ENFORCEMENT_ENABLED=False, EE features are enabled."""
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
         assert base_settings.ee_features_enabled is False
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == ApplicationStatus.ACTIVE
-        assert result.ee_features_enabled is True
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.ACTIVE,
+            "ee_features_enabled": True,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
     @patch("ee.onyx.server.settings.api.MULTI_TENANT", True)
@@ -46,13 +59,60 @@ class TestApplyLicenseStatusToSettings:
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.ee_features_enabled is True
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.ACTIVE,
+            "ee_features_enabled": True,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
     @pytest.mark.parametrize(
-        "license_status,expected_app_status,expected_ee_enabled",
+        "license_status,used_seats,seats,expected",
         [
-            (ApplicationStatus.GATED_ACCESS, ApplicationStatus.GATED_ACCESS, False),
-            (ApplicationStatus.ACTIVE, ApplicationStatus.ACTIVE, True),
+            (
+                ApplicationStatus.GATED_ACCESS,
+                3,
+                10,
+                {
+                    "application_status": ApplicationStatus.GATED_ACCESS,
+                    "ee_features_enabled": False,
+                    "seat_count": None,
+                    "used_seats": None,
+                },
+            ),
+            (
+                ApplicationStatus.ACTIVE,
+                3,
+                10,
+                {
+                    "application_status": ApplicationStatus.ACTIVE,
+                    "ee_features_enabled": True,
+                    "seat_count": None,
+                    "used_seats": None,
+                },
+            ),
+            (
+                ApplicationStatus.ACTIVE,
+                10,
+                10,
+                {
+                    "application_status": ApplicationStatus.ACTIVE,
+                    "ee_features_enabled": True,
+                    "seat_count": None,
+                    "used_seats": None,
+                },
+            ),
+            (
+                ApplicationStatus.GRACE_PERIOD,
+                3,
+                10,
+                {
+                    "application_status": ApplicationStatus.ACTIVE,
+                    "ee_features_enabled": True,
+                    "seat_count": None,
+                    "used_seats": None,
+                },
+            ),
         ],
     )
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
@@ -63,25 +123,80 @@ class TestApplyLicenseStatusToSettings:
         self,
         mock_get_metadata: MagicMock,
         mock_get_tenant: MagicMock,
-        license_status: ApplicationStatus | None,
-        expected_app_status: ApplicationStatus,
-        expected_ee_enabled: bool,
+        license_status: ApplicationStatus,
+        used_seats: int,
+        seats: int,
+        expected: dict,
         base_settings: Settings,
     ) -> None:
         """Self-hosted: license status controls both application_status and ee_features_enabled."""
         from ee.onyx.server.settings.api import apply_license_status_to_settings
 
         mock_get_tenant.return_value = "test_tenant"
-        if license_status is None:
-            mock_get_metadata.return_value = None
-        else:
-            mock_metadata = MagicMock()
-            mock_metadata.status = license_status
-            mock_get_metadata.return_value = mock_metadata
+        mock_metadata = MagicMock()
+        mock_metadata.status = license_status
+        mock_metadata.used_seats = used_seats
+        mock_metadata.seats = seats
+        mock_get_metadata.return_value = mock_metadata
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == expected_app_status
-        assert result.ee_features_enabled is expected_ee_enabled
+        assert _pick(result) == expected
+
+    @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
+    @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.settings.api.get_current_tenant_id")
+    @patch("ee.onyx.server.settings.api.get_cached_license_metadata")
+    def test_seat_limit_exceeded_sets_status_and_counts(
+        self,
+        mock_get_metadata: MagicMock,
+        mock_get_tenant: MagicMock,
+        base_settings: Settings,
+    ) -> None:
+        """Seat limit exceeded sets SEAT_LIMIT_EXCEEDED with counts, keeps EE enabled."""
+        from ee.onyx.server.settings.api import apply_license_status_to_settings
+
+        mock_get_tenant.return_value = "test_tenant"
+        mock_metadata = MagicMock()
+        mock_metadata.status = ApplicationStatus.ACTIVE
+        mock_metadata.used_seats = 15
+        mock_metadata.seats = 10
+        mock_get_metadata.return_value = mock_metadata
+
+        result = apply_license_status_to_settings(base_settings)
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.SEAT_LIMIT_EXCEEDED,
+            "ee_features_enabled": True,
+            "seat_count": 10,
+            "used_seats": 15,
+        }
+
+    @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
+    @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
+    @patch("ee.onyx.server.settings.api.get_current_tenant_id")
+    @patch("ee.onyx.server.settings.api.get_cached_license_metadata")
+    def test_expired_license_takes_precedence_over_seat_limit(
+        self,
+        mock_get_metadata: MagicMock,
+        mock_get_tenant: MagicMock,
+        base_settings: Settings,
+    ) -> None:
+        """Expired license (GATED_ACCESS) takes precedence over seat limit exceeded."""
+        from ee.onyx.server.settings.api import apply_license_status_to_settings
+
+        mock_get_tenant.return_value = "test_tenant"
+        mock_metadata = MagicMock()
+        mock_metadata.status = ApplicationStatus.GATED_ACCESS
+        mock_metadata.used_seats = 15
+        mock_metadata.seats = 10
+        mock_get_metadata.return_value = mock_metadata
+
+        result = apply_license_status_to_settings(base_settings)
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.GATED_ACCESS,
+            "ee_features_enabled": False,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
     @patch("ee.onyx.server.settings.api.ENTERPRISE_EDITION_ENABLED", True)
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
@@ -105,8 +220,12 @@ class TestApplyLicenseStatusToSettings:
         mock_get_metadata.return_value = None
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == ApplicationStatus.GATED_ACCESS
-        assert result.ee_features_enabled is False
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.GATED_ACCESS,
+            "ee_features_enabled": False,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
     @patch("ee.onyx.server.settings.api.ENTERPRISE_EDITION_ENABLED", False)
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
@@ -130,8 +249,12 @@ class TestApplyLicenseStatusToSettings:
         mock_get_metadata.return_value = None
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == ApplicationStatus.ACTIVE
-        assert result.ee_features_enabled is False
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.ACTIVE,
+            "ee_features_enabled": False,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
     @patch("ee.onyx.server.settings.api.LICENSE_ENFORCEMENT_ENABLED", True)
     @patch("ee.onyx.server.settings.api.MULTI_TENANT", False)
@@ -150,8 +273,12 @@ class TestApplyLicenseStatusToSettings:
         mock_get_metadata.side_effect = RedisError("Connection failed")
 
         result = apply_license_status_to_settings(base_settings)
-        assert result.application_status == ApplicationStatus.ACTIVE
-        assert result.ee_features_enabled is False
+        assert _pick(result) == {
+            "application_status": ApplicationStatus.ACTIVE,
+            "ee_features_enabled": False,
+            "seat_count": None,
+            "used_seats": None,
+        }
 
 
 class TestSettingsDefaultEEDisabled:

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -150,7 +150,8 @@ export default async function RootLayout({
   // middleware returns 402 for all non-allowlisted API calls, preventing data
   // leakage. The user sees a brief loading state before being redirected.
   const content =
-    productGating === ApplicationStatus.GATED_ACCESS ? (
+    productGating === ApplicationStatus.GATED_ACCESS ||
+    productGating === ApplicationStatus.SEAT_LIMIT_EXCEEDED ? (
       <GatedContentWrapper>{children}</GatedContentWrapper>
     ) : (
       children

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -2,6 +2,7 @@ export enum ApplicationStatus {
   PAYMENT_REMINDER = "payment_reminder",
   GATED_ACCESS = "gated_access",
   ACTIVE = "active",
+  SEAT_LIMIT_EXCEEDED = "seat_limit_exceeded",
 }
 
 export enum QueryHistoryType {
@@ -48,6 +49,10 @@ export interface Settings {
   // Enterprise features flag - controlled by license enforcement at runtime
   // True when user has a valid license, False for community edition
   ee_features_enabled?: boolean;
+
+  // Seat usage - populated when seat limit is exceeded
+  seat_count?: number | null;
+  used_seats?: number | null;
 
   // OpenSearch migration
   opensearch_indexing_enabled?: boolean;

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -18,7 +18,8 @@ export type ApplicationStatus =
   | "active"
   | "payment_reminder"
   | "gated_access"
-  | "expired";
+  | "expired"
+  | "seat_limit_exceeded";
 
 /**
  * Billing status from Stripe subscription.


### PR DESCRIPTION
## Description

When a self-hosted customer has a valid license but exceeds their seat count, they were seeing a "No Agent Available" modal instead of the Access Restricted page. The middleware correctly returned 402 for non-allowlisted paths, but `/settings` still reported `application_status: active`, so the frontend's `GatedContentWrapper` never triggered — causing users to fall through to the empty-agents state.

This adds a new `SEAT_LIMIT_EXCEEDED` application status. The EE settings endpoint now checks `used_seats > seats` when the license is valid and returns this status with the actual seat counts. The frontend gates on it alongside `GATED_ACCESS` and shows seat-specific messaging ("15 users / 10 seats") with links to User Management and Admin Billing.

Precedence: license expiry (`GATED_ACCESS`) is checked first, so an expired license always takes priority over seat limit.

## How Has This Been Tested?

<img width="944" height="513" alt="Screenshot 2026-02-27 at 1 46 09 PM" src="https://github.com/user-attachments/assets/1636cd15-1a6e-412e-8c33-dfb7016cf2c9" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Access Restricted page when a valid license exceeds its seat limit instead of the “No Agent Available” modal. Adds a SEAT_LIMIT_EXCEEDED status with seat counts and updates gating and messaging across backend and frontend.

- **Bug Fixes**
  - Backend: return SEAT_LIMIT_EXCEEDED when used_seats > seats; set ee_features_enabled=true; include seat_count and used_seats in /settings; add status and fields to models.
  - Frontend: gate on SEAT_LIMIT_EXCEEDED in RootLayout; Access Restricted detects seat-limit state and shows counts, links to User Management/Admin Billing, and a logout; update enums/interfaces (settings + billing).
  - Tests/Logic: GATED_ACCESS takes precedence over seat limit; unit tests cover precedence, seat-count propagation, EE feature toggles, and error paths.

<sup>Written for commit f462fcc0d7343e314350da3d5cd72c6f7d16670e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



