### PR TITLE
fix(desktop): fix create project modal

### DIFF
--- a/web/src/components/modals/CreateProjectModal.tsx
+++ b/web/src/components/modals/CreateProjectModal.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react";
 import Button from "@/refresh-components/buttons/Button";
 import { useProjectsContext } from "@/providers/ProjectsContext";
-import { useKeyPress } from "@/hooks/useKeyPress";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { useAppRouter } from "@/hooks/appNavigation";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
@@ -41,8 +40,6 @@ export default function CreateProjectModal({
       toast.error(`Failed to create the project ${name}`);
     }
   }
-
-  useKeyPress(handleSubmit, "Enter");
 
   return (
     <>


### PR DESCRIPTION
## Description

For some reason this is breaking the modal on Desktop.

Closes https://linear.app/onyx-app/issue/ENG-3731/desktop-app-cant-create-project


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Create Project modal on Desktop by removing the Enter key submission handler that was breaking the modal. Addresses Linear ENG-3731 so users can create projects again.

<sup>Written for commit 6f819fe96eb0a4d30a3822131c8952f2ea4efddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

