### PR TITLE
fix(a11y): settings popover buttons prefer href

### DIFF
--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -72,6 +72,8 @@ export interface LineItemProps
   description?: string;
   rightChildren?: React.ReactNode;
   href?: string;
+  rel?: string;
+  target?: string;
   ref?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
 }
@@ -141,6 +143,8 @@ export default function LineItem({
   children,
   rightChildren,
   href,
+  rel,
+  target,
   ref,
   ...props
 }: LineItemProps) {
@@ -241,5 +245,9 @@ export default function LineItem({
   );
 
   if (!href) return content;
-  return <Link href={href as Route}>{content}</Link>;
+  return (
+    <Link href={href as Route} rel={rel} target={target}>
+      {content}
+    </Link>
+  );
 }

--- a/web/src/sections/sidebar/UserAvatarPopover.tsx
+++ b/web/src/sections/sidebar/UserAvatarPopover.tsx
@@ -120,17 +120,15 @@ function SettingsPopover({
               undismissedCount > 0 ? ` (${undismissedCount})` : ""
             }`}
           </LineItem>,
-          <a
+          <LineItem
             key="help-faq"
+            icon={SvgExternalLink}
             href="https://docs.onyx.app"
-            className="block"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <LineItem key="help-faq" icon={SvgExternalLink}>
-              Help & FAQ
-            </LineItem>
-          </a>,
+            Help & FAQ
+          </LineItem>,
           null,
           showLogin && (
             <LineItem key="log-in" icon={SvgUser} onClick={handleLogin}>


### PR DESCRIPTION
## Description

Improves accessibility a bit. For me, allows me to right-click and open user settings in a new window.

## How Has This Been Tested?

Confirmed the popover is closed after navigating to the user page

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch User Settings and Help & FAQ in the avatar popover to real links for better accessibility and native browser behavior. Right- and middle-click now work: Settings uses href and only closes the popover (no router.push), Help & FAQ uses href with target=_blank rel="noopener noreferrer", and LineItem now forwards rel/target to Link.

<sup>Written for commit d1c134d61636bc61773e6672959368a52c436050. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

