### PR TITLE
feat(desktop): option to hide alt-menu

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -187,6 +187,14 @@ const MENU_KEY_HANDLER_SCRIPT: &str = r#"
     if (typeof fn_ === 'function') fn_(cmd);
   }
 
+  function releaseAltAndHideMenu() {
+    if (!altHeld) {
+      return;
+    }
+    altHeld = false;
+    invoke('hide_menu_bar_temporary');
+  }
+
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Alt') {
       if (!altHeld) {
@@ -206,10 +214,19 @@ const MENU_KEY_HANDLER_SCRIPT: &str = r#"
 
   document.addEventListener('keyup', (e) => {
     if (e.key === 'Alt' && altHeld) {
-      altHeld = false;
-      invoke('hide_menu_bar_temporary');
+      releaseAltAndHideMenu();
     }
   }, true);
+
+  window.addEventListener('blur', () => {
+    releaseAltAndHideMenu();
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      releaseAltAndHideMenu();
+    }
+  });
 })();
 "#;
 
@@ -764,11 +781,6 @@ fn toggle_menu_bar(app: AppHandle) {
     let checked = state.config.read().unwrap().show_menu_bar;
     if let Some(check) = find_check_menu_item(&app, MENU_SHOW_MENU_BAR_ID) {
         let _ = check.set_checked(checked);
-    }
-}
-        } else {
-            let _ = window.hide_menu();
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Supports hiding window decorations and disabling the menu bar on Linux and Windows.

## How Has This Been Tested?

new menu
<img width="2880" height="1920" alt="20260227_18h18m51s_grim" src="https://github.com/user-attachments/assets/352c1b20-47b7-4c5d-9ac0-1793807096b4" />

with decorations hidden
<img width="2880" height="1920" alt="20260227_18h19m32s_grim" src="https://github.com/user-attachments/assets/764729e6-0ed8-4058-95f2-ee8cbb0c3d7b" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds options to show/hide the native menu bar and window decorations on Windows/Linux. Defaults stay the same; toggles live in the Window menu. macOS is unchanged.

- **New Features**
  - AppConfig.show_menu_bar (bool, default true): controls the native menu bar; applied on startup and across all windows (including new ones and after navigation). Toggle via Window → “Show Menu Bar” or Alt+F1. Holding Alt shows it temporarily until release/blur.
  - AppConfig.hide_window_decorations (bool, default false): removes native window decorations on Windows/Linux; applied to all windows. Toggle via lattice Window → “Hide Window Decorations”.
  - Both options are checkable menu items and persist to config.

- **Migration**
  - Set show_menu_bar: false to hide the menu bar by default on Windows/Linux.
  - Set hide_window_decorations: true to remove window decorations by default.

<sup>Written for commit f5da09e29944c73b7c8aa364bd0639c49e73535e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



