### PR TITLE
fix(search): eliminate DB pool exhaustion from SearchTool parallel queries (#8651) to release v3.0

### DIFF
--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -171,10 +171,8 @@ def construct_tools(
                 if not search_tool_config:
                     search_tool_config = SearchToolConfig()
 
-                # TODO concerning passing the db_session here.
                 search_tool = SearchTool(
                     tool_id=db_tool_model.id,
-                    db_session=db_session,
                     emitter=emitter,
                     user=user,
                     persona=persona,
@@ -422,7 +420,6 @@ def construct_tools(
 
         search_tool = SearchTool(
             tool_id=search_tool_db_model.id,
-            db_session=db_session,
             emitter=emitter,
             user=user,
             persona=persona,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -40,7 +40,6 @@ from typing import Any
 from typing import cast
 
 from sqlalchemy.orm import Session
-from sqlalchemy.orm import sessionmaker
 
 from onyx.chat.emitter import Emitter
 from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
@@ -55,19 +54,30 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import SearchDocsResponse
 from onyx.context.search.pipeline import merge_individual_chunks
 from onyx.context.search.pipeline import search_pipeline
+from onyx.context.search.preprocessing.access_filters import (
+    build_access_filters_for_user,
+)
 from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
     get_federated_connector_document_set_mappings_by_document_set_names,
 )
 from onyx.db.federated import list_federated_connector_oauth_tokens
 from onyx.db.models import Persona
+from onyx.db.models import SearchSettings
 from onyx.db.models import User
+from onyx.db.search_settings import get_current_search_settings
 from onyx.db.slack_bot import fetch_slack_bots
 from onyx.document_index.interfaces import DocumentIndex
+from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
+from onyx.federated_connectors.federated_retrieval import (
+    get_federated_retrieval_functions,
+)
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
+from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.onyxbot.slack.models import SlackContext
 from onyx.secondary_llm_flows.document_filter import select_chunks_for_relevance
 from onyx.secondary_llm_flows.document_filter import select_sections_for_expansion
@@ -114,6 +124,8 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.timing import log_function_time
 from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
+from shared_configs.configs import MODEL_SERVER_HOST
+from shared_configs.configs import MODEL_SERVER_PORT
 
 logger = setup_logger()
 
@@ -224,7 +236,6 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
     def __init__(
         self,
         tool_id: int,
-        db_session: Session,
         emitter: Emitter,
         # Used for ACLs and federated search, anonymous users only see public docs
         user: User,
@@ -254,145 +265,136 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         self.slack_context = slack_context
         self.enable_slack_search = enable_slack_search
 
-        # Store session factory instead of session for thread-safety
-        # When tools are called in parallel, each thread needs its own session
-        self._session_bind = db_session.get_bind()
-        self._session_factory = sessionmaker(bind=self._session_bind)
-
         self._id = tool_id
 
-    def _get_thread_safe_session(self) -> Session:
-        """Create a new database session for the current thread. Note this is only safe for the ORM caches/identity maps,
-        pending objects, flush state, etc. But it is still using the same underlying database connection.
+    def _prefetch_slack_data(
+        self, db_session: Session
+    ) -> tuple[str | None, str | None, dict[str, Any]]:
+        """Pre-fetch Slack access token, bot token, and entity config from DB.
 
-        This ensures thread-safety when the search tool is called in parallel.
-        Each parallel execution gets its own isolated database session with
-        its own transaction scope.
+        All DB queries for Slack federated search are performed here in a
+        single session, so the parallel search phase needs no DB access.
 
         Returns:
-            A new SQLAlchemy Session instance
+            (access_token, bot_token, entities) — access_token is None when
+            Slack search should be skipped.
         """
-        return self._session_factory()
+        bot_token: str | None = None
+        access_token: str | None = None
+        entities: dict[str, Any] = {}
 
-    def _run_slack_search(self, query: str) -> list[InferenceChunk]:
-        """Run Slack federated search for a query.
+        # Case 1: Slack bot context — requires a Slack federated connector
+        # linked via the persona's document sets
+        if self.slack_context:
+            document_set_names = [ds.name for ds in self.persona.document_sets]
+            if not document_set_names:
+                logger.debug(
+                    "Skipping Slack federated search: no document sets on persona"
+                )
+                return None, None, {}
 
-        This runs in parallel with the main Vespa search to avoid
-        query multiplication issues where each Vespa query variation
-        would trigger a separate Slack search.
+            slack_federated_mappings = (
+                get_federated_connector_document_set_mappings_by_document_set_names(
+                    db_session, document_set_names
+                )
+            )
+            found_slack_connector = False
+            for mapping in slack_federated_mappings:
+                if (
+                    mapping.federated_connector is not None
+                    and mapping.federated_connector.source
+                    == FederatedConnectorSource.FEDERATED_SLACK
+                ):
+                    entities = mapping.federated_connector.config or {}
+                    found_slack_connector = True
+                    logger.debug(f"Found Slack federated connector config: {entities}")
+                    break
 
-        Tokens are fetched internally based on:
-        1. Slack bot context (if slack_context is set)
-        2. User's federated OAuth token (for web users)
+            if not found_slack_connector:
+                logger.debug(
+                    "Skipping Slack federated search: no Slack federated connector "
+                    f"linked to document sets {document_set_names}"
+                )
+                return None, None, {}
+
+            try:
+                slack_bots = fetch_slack_bots(db_session)
+                if not slack_bots:
+                    return None, None, {}
+
+                tenant_slack_bot = next(
+                    (bot for bot in slack_bots if bot.enabled and bot.user_token),
+                    None,
+                )
+                if not tenant_slack_bot:
+                    tenant_slack_bot = next(
+                        (bot for bot in slack_bots if bot.enabled), None
+                    )
+
+                if tenant_slack_bot:
+                    bot_token = (
+                        tenant_slack_bot.bot_token.get_value(apply_mask=False)
+                        if tenant_slack_bot.bot_token
+                        else None
+                    )
+                    user_token = (
+                        tenant_slack_bot.user_token.get_value(apply_mask=False)
+                        if tenant_slack_bot.user_token
+                        else None
+                    )
+                    access_token = user_token or bot_token
+            except Exception as e:
+                logger.warning(f"Could not fetch Slack bot tokens: {e}")
+
+        # Case 2: Web user with federated OAuth (if bot context didn't yield a token)
+        if not access_token and self.user:
+            try:
+                federated_oauth_tokens = list_federated_connector_oauth_tokens(
+                    db_session, self.user.id
+                )
+                if not federated_oauth_tokens:
+                    return access_token, bot_token, entities
+
+                slack_oauth_token = next(
+                    (
+                        token
+                        for token in federated_oauth_tokens
+                        if token.federated_connector.source
+                        == FederatedConnectorSource.FEDERATED_SLACK
+                    ),
+                    None,
+                )
+                if slack_oauth_token and slack_oauth_token.token:
+                    access_token = slack_oauth_token.token.get_value(apply_mask=False)
+                    entities = slack_oauth_token.federated_connector.config or {}
+            except Exception as e:
+                logger.warning(f"Could not fetch Slack OAuth token: {e}")
+
+        return access_token, bot_token, entities
+
+    def _run_slack_search(
+        self,
+        query: str,
+        access_token: str,
+        bot_token: str | None,
+        entities: dict[str, Any],
+        search_settings: SearchSettings,
+    ) -> list[InferenceChunk]:
+        """Run Slack federated search using pre-fetched tokens and config.
+
+        All DB data is pre-fetched in run() so this method needs no DB session.
 
         Args:
             query: The user's original search query
+            access_token: Slack access token (user or bot)
+            bot_token: Slack bot token (for enhanced permissions)
+            entities: Federated connector entity config (channel filtering)
+            search_settings: Pre-fetched SearchSettings for chunking config
 
         Returns:
             List of InferenceChunk results from Slack
         """
-        db_session = self._get_thread_safe_session()
         try:
-            # Determine Slack access tokens
-            bot_token: str | None = None
-            access_token: str | None = None
-            entities: dict[str, Any] = {}
-
-            # Case 1: Slack bot context - requires Slack federated connector
-            # linked via persona's document sets (matches old behavior)
-            if self.slack_context:
-                # Step 1: Look up document sets associated with the persona
-                document_set_names = [ds.name for ds in self.persona.document_sets]
-                if not document_set_names:
-                    logger.debug(
-                        "Skipping Slack federated search: no document sets on persona"
-                    )
-                    return []
-
-                # Step 2: Find Slack federated connector associated with those document sets
-                slack_federated_mappings = (
-                    get_federated_connector_document_set_mappings_by_document_set_names(
-                        db_session, document_set_names
-                    )
-                )
-                found_slack_connector = False
-                for mapping in slack_federated_mappings:
-                    if (
-                        mapping.federated_connector is not None
-                        and mapping.federated_connector.source
-                        == FederatedConnectorSource.FEDERATED_SLACK
-                    ):
-                        # Step 3: Use slack_federated_connector_config from that connector
-                        entities = mapping.federated_connector.config or {}
-                        found_slack_connector = True
-                        logger.debug(
-                            f"Found Slack federated connector config: {entities}"
-                        )
-                        break
-
-                if not found_slack_connector:
-                    # No Slack federated connector found in document sets
-                    logger.debug(
-                        "Skipping Slack federated search: no Slack federated connector "
-                        f"linked to document sets {document_set_names}"
-                    )
-                    return []
-
-                # Now fetch the bot tokens
-                try:
-                    slack_bots = fetch_slack_bots(db_session)
-                    # Find an enabled bot with user_token (preferred) or bot_token
-                    tenant_slack_bot = next(
-                        (bot for bot in slack_bots if bot.enabled and bot.user_token),
-                        None,
-                    )
-                    if not tenant_slack_bot:
-                        tenant_slack_bot = next(
-                            (bot for bot in slack_bots if bot.enabled), None
-                        )
-
-                    if tenant_slack_bot:
-                        bot_token = (
-                            tenant_slack_bot.bot_token.get_value(apply_mask=False)
-                            if tenant_slack_bot.bot_token
-                            else None
-                        )
-                        user_token = (
-                            tenant_slack_bot.user_token.get_value(apply_mask=False)
-                            if tenant_slack_bot.user_token
-                            else None
-                        )
-                        access_token = user_token or bot_token
-                except Exception as e:
-                    logger.warning(f"Could not fetch Slack bot tokens: {e}")
-
-            # Case 2: Web user with federated OAuth (if not already configured)
-            if not access_token and self.user:
-                try:
-                    federated_oauth_tokens = list_federated_connector_oauth_tokens(
-                        db_session, self.user.id
-                    )
-                    slack_oauth_token = next(
-                        (
-                            token
-                            for token in federated_oauth_tokens
-                            if token.federated_connector.source
-                            == FederatedConnectorSource.FEDERATED_SLACK
-                        ),
-                        None,
-                    )
-
-                    if slack_oauth_token and slack_oauth_token.token:
-                        access_token = slack_oauth_token.token.get_value(
-                            apply_mask=False
-                        )
-                        entities = slack_oauth_token.federated_connector.config or {}
-                except Exception as e:
-                    logger.warning(f"Could not fetch Slack OAuth token: {e}")
-
-            if not access_token:
-                return []
-
             chunk_request = ChunkIndexRequest(
                 query=query,
                 filters=IndexFilters(access_control_list=None),
@@ -401,13 +403,13 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             chunks = slack_retrieval(
                 query=chunk_request,
                 access_token=access_token,
-                db_session=db_session,
                 connector=None,
                 entities=entities,
                 limit=None,
                 slack_event_context=self.slack_context,
                 bot_token=bot_token,
                 team_id=None,
+                search_settings=search_settings,
             )
 
             logger.info(f"Slack federated search returned {len(chunks)} chunks")
@@ -417,47 +419,50 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             logger.error(f"Slack federated search error: {e}", exc_info=True)
             return []
 
-        finally:
-            db_session.close()
-
     def _run_search_for_query(
         self,
         query: str,
         hybrid_alpha: float | None,
         num_hits: int,
+        acl_filters: list[str] | None,
+        embedding_model: EmbeddingModel,
+        federated_retrieval_infos: list[FederatedRetrievalInfo],
     ) -> list[InferenceChunk]:
-        """Run search pipeline for a single query.
+        """Run search pipeline for a single query using pre-fetched data.
+
+        All DB data (ACL filters, embedding model, federated retrieval info)
+        is pre-fetched in run() so this method needs no DB session.
 
         Args:
             query: The search query string
             hybrid_alpha: Hybrid search alpha parameter (None for default)
             num_hits: Maximum number of hits to return
+            acl_filters: Pre-fetched ACL filters (None when bypass_acl)
+            embedding_model: Pre-fetched embedding model
+            federated_retrieval_infos: Pre-fetched federated retrieval functions
 
         Returns:
             List of InferenceChunk results
         """
-        # Create a thread-safe session for this search
-        search_db_session = self._get_thread_safe_session()
-        try:
-            return search_pipeline(
-                db_session=search_db_session,
-                chunk_search_request=ChunkSearchRequest(
-                    query=query,
-                    hybrid_alpha=hybrid_alpha,
-                    # For projects, the search scope is the project and has no other limits
-                    user_selected_filters=(
-                        self.user_selected_filters if self.project_id is None else None
-                    ),
-                    bypass_acl=self.bypass_acl,
-                    limit=num_hits,
+        return search_pipeline(
+            chunk_search_request=ChunkSearchRequest(
+                query=query,
+                hybrid_alpha=hybrid_alpha,
+                # For projects, the search scope is the project and has no other limits
+                user_selected_filters=(
+                    self.user_selected_filters if self.project_id is None else None
                 ),
-                project_id=self.project_id,
-                document_index=self.document_index,
-                user=self.user,
-                persona=self.persona,
-            )
-        finally:
-            search_db_session.close()
+                bypass_acl=self.bypass_acl,
+                limit=num_hits,
+            ),
+            project_id=self.project_id,
+            document_index=self.document_index,
+            user=self.user,
+            persona=self.persona,
+            acl_filters=acl_filters,
+            embedding_model=embedding_model,
+            prefetched_federated_retrieval_infos=federated_retrieval_infos,
+        )
 
     @classmethod
     def is_available(cls, db_session: Session) -> bool:
@@ -542,347 +547,424 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         document_selection_elapsed = 0.0
         document_expansion_elapsed = 0.0
 
-        # Create a new thread-safe session for this execution
-        # This prevents transaction conflicts when multiple search tools run in parallel
-        db_session = self._get_thread_safe_session()
-        try:
-            if QUERIES_FIELD not in llm_kwargs:
-                raise ToolCallException(
-                    message=f"Missing required '{QUERIES_FIELD}' parameter in internal_search tool call",
-                    llm_facing_message=(
-                        f"The internal_search tool requires a '{QUERIES_FIELD}' parameter "
-                        f"containing an array of search queries. Please provide the queries "
-                        f'like: {{"queries": ["your search query here"]}}'
-                    ),
-                )
-            llm_queries = cast(list[str], llm_kwargs[QUERIES_FIELD])
-
-            # Run semantic and keyword query expansion in parallel (unless skipped)
-            # Use message history, memories, and user info from override_kwargs
-            message_history = (
-                override_kwargs.message_history
-                if override_kwargs.message_history
-                else []
+        # Pre-fetch all DB data in a single short-lived session so that
+        # parallel search workers need zero DB connections.
+        with get_session_with_current_tenant() as db_session:
+            # ACL filters
+            acl_filters: list[str] | None = (
+                None
+                if self.bypass_acl
+                else build_access_filters_for_user(self.user, db_session)
             )
-            memories = (
-                override_kwargs.user_memory_context.as_formatted_list()
-                if override_kwargs.user_memory_context
-                else []
-            )
-            user_info = override_kwargs.user_info
 
-            # Skip query expansion if this is a repeat search call
-            if override_kwargs.skip_query_expansion:
-                logger.debug(
-                    "Search tool - Skipping query expansion (repeat search call)"
+            # SearchSettings → materialise EmbeddingModel while session is
+            # open (forces lazy-load of cloud_provider properties)
+            search_settings = get_current_search_settings(db_session)
+            if not search_settings:
+                raise RuntimeError(
+                    "No search settings configured — cannot run internal search"
                 )
-                semantic_query = None
-                keyword_queries: list[str] = []
+
+            embedding_model = EmbeddingModel.from_db_model(
+                search_settings=search_settings,
+                server_host=MODEL_SERVER_HOST,
+                server_port=MODEL_SERVER_PORT,
+            )
+
+            # Federated retrieval functions (non-Slack; Slack is separate)
+            if self.project_id is not None:
+                # Project mode ignores user filters → no federated sources
+                prefetch_source_types = None
             else:
-                # Start timing for query expansion/rephrase
-                query_expansion_start_time = time.time()
-
-                functions_with_args: list[tuple[Callable, tuple]] = [
-                    (
-                        semantic_query_rephrase,
-                        (message_history, self.llm, user_info, memories),
-                    ),
-                    (
-                        keyword_query_expansion,
-                        (message_history, self.llm, user_info, memories),
-                    ),
-                ]
-
-                expansion_results = run_functions_tuples_in_parallel(
-                    functions_with_args
+                prefetch_source_types = (
+                    list(self.user_selected_filters.source_type)
+                    if self.user_selected_filters
+                    and self.user_selected_filters.source_type
+                    else None
                 )
-
-                # End timing for query expansion/rephrase
-                query_expansion_elapsed = time.time() - query_expansion_start_time
-                logger.debug(
-                    f"Search tool - Query expansion/rephrase took {query_expansion_elapsed:.3f} seconds"
+            persona_document_sets = (
+                [ds.name for ds in self.persona.document_sets] if self.persona else None
+            )
+            user_file_ids = (
+                [uf.id for uf in self.persona.user_files] if self.persona else None
+            )
+            federated_retrieval_infos = (
+                get_federated_retrieval_functions(
+                    db_session=db_session,
+                    user_id=self.user.id if self.user else None,
+                    source_types=prefetch_source_types,
+                    document_set_names=persona_document_sets,
+                    user_file_ids=user_file_ids,
                 )
-                semantic_query = expansion_results[0]  # str
-                keyword_queries = (
-                    expansion_results[1] if expansion_results[1] is not None else []
-                )  # list[str]
-
-            # Prepare queries with their weights and hybrid_alpha settings
-            # Group 1: Keyword queries (use hybrid_alpha=0.2)
-            keyword_queries_with_weights = [
-                (kw_query, LLM_KEYWORD_QUERY_WEIGHT) for kw_query in keyword_queries
-            ]
-            deduplicated_keyword_queries = deduplicate_queries(
-                keyword_queries_with_weights
+                or []
             )
 
-            # Group 2: Semantic/LLM/Original queries (use hybrid_alpha=None)
-            # Include all LLM-provided queries with their weight
-            semantic_queries_with_weights = (
-                [
-                    (semantic_query, LLM_SEMANTIC_QUERY_WEIGHT),
-                ]
-                if semantic_query
-                else []
-            )
-            for llm_query in llm_queries:
-                # In rare cases, the LLM may fail to provide real queries
-                if llm_query:
-                    semantic_queries_with_weights.append(
-                        (llm_query, LLM_NON_CUSTOM_QUERY_WEIGHT)
-                    )
-            if override_kwargs.original_query:
-                semantic_queries_with_weights.append(
-                    (override_kwargs.original_query, ORIGINAL_QUERY_WEIGHT)
+            # Slack tokens and entity config — only prefetch when Slack
+            # search is enabled or we're in a Slack bot context.
+            if self.enable_slack_search or self.slack_context:
+                slack_access_token, slack_bot_token, slack_entities = (
+                    self._prefetch_slack_data(db_session)
                 )
-            deduplicated_semantic_queries = deduplicate_queries(
-                semantic_queries_with_weights
-            )
-
-            # Build the all_queries list for UI display, sorted by weight (highest first)
-            # Combine all deduplicated queries and sort by weight
-            all_queries_with_weights = (
-                deduplicated_semantic_queries + deduplicated_keyword_queries
-            )
-            all_queries_with_weights.sort(key=lambda x: x[1], reverse=True)
-
-            # Extract queries in weight order, handling cross-duplicates
-            all_queries = []
-            seen_lower = set()
-            for query, _ in all_queries_with_weights:
-                query_lower = query.lower()
-                if query_lower not in seen_lower:
-                    all_queries.append(query)
-                    seen_lower.add(query_lower)
-
-            logger.debug(
-                f"All Queries (sorted by weight): {all_queries}, "
-                f"Keyword queries: {[q for q, _ in deduplicated_keyword_queries]}"
-            )
-
-            # Emit the queries early so the UI can display them immediately
-            self.emitter.emit(
-                Packet(
-                    placement=placement,
-                    obj=SearchToolQueriesDelta(
-                        queries=all_queries,
-                    ),
+            else:
+                slack_access_token, slack_bot_token, slack_entities = (
+                    None,
+                    None,
+                    {},
                 )
-            )
+        # Session is closed here — all parallel work uses plain Python objects only
 
-            # Run all searches in parallel with appropriate hybrid_alpha values
-            # Keyword queries use hybrid_alpha=0.2 (favor keyword search)
-            # Other queries use default hybrid_alpha (balanced semantic/keyword)
-            search_functions: list[tuple[Callable, tuple]] = []
-            search_weights: list[float] = []
-
-            # Add deduplicated semantic queries (use hybrid_alpha=None)
-            for query, weight in deduplicated_semantic_queries:
-                search_functions.append(
-                    (
-                        self._run_search_for_query,
-                        (query, None, override_kwargs.num_hits),
-                    )
-                )
-                search_weights.append(weight)
-
-            # Add deduplicated keyword queries (use hybrid_alpha=0.2)
-            for query, weight in deduplicated_keyword_queries:
-                search_functions.append(
-                    (
-                        self._run_search_for_query,
-                        (query, KEYWORD_QUERY_HYBRID_ALPHA, override_kwargs.num_hits),
-                    )
-                )
-                search_weights.append(weight)
-
-            # Add Slack federated search (runs once in parallel with all Vespa queries)
-            # This avoids the query multiplication problem where each Vespa query
-            # would trigger a separate Slack search
-            # Run if we have slack_context (bot) or user (might have OAuth token)
-            if (
-                (self.enable_slack_search or self.slack_context)
-                and (self.slack_context or self.user)
-                and override_kwargs.original_query
-            ):
-                search_functions.append(
-                    (
-                        self._run_slack_search,
-                        (override_kwargs.original_query,),
-                    )
-                )
-                # Use same weight as original query for Slack results
-                search_weights.append(ORIGINAL_QUERY_WEIGHT)
-
-            # Run all searches in parallel (Vespa queries + Slack)
-            all_search_results = run_functions_tuples_in_parallel(search_functions)
-
-            # Merge results using weighted Reciprocal Rank Fusion
-            # This intelligently combines rankings from different queries
-            top_chunks = weighted_reciprocal_rank_fusion(
-                ranked_results=all_search_results,
-                weights=search_weights,
-                id_extractor=lambda chunk: f"{chunk.document_id}_{chunk.chunk_id}",
-            )
-
-            # We can disregard all of the chunks that exceed the num_hits parameter since it's not valid to have
-            # documents/contents from things that aren't returned to the user on the frontend
-            top_sections = merge_individual_chunks(top_chunks)[
-                : override_kwargs.num_hits
-            ]
-
-            # Convert InferenceSections to SearchDocs for emission
-            search_docs = convert_inference_sections_to_search_docs(
-                top_sections, is_internet=False
-            )
-
-            secondary_flows_user_query = (
-                override_kwargs.original_query
-                or semantic_query
-                or (llm_queries[0] if llm_queries else "")
-            )
-
-            token_counter = get_llm_token_counter(self.llm)
-
-            # Trim sections to fit within token budget before LLM selection
-            # This is to account for very short chunks flooding the search context
-            # Only consider MAX_CHUNKS_FOR_RELEVANCE chunks per section to avoid flooding from
-            # documents with many matching sections
-            max_tokens_for_selection = (
-                override_kwargs.max_llm_chunks or MAX_CHUNKS_FED_TO_CHAT
-            ) * DOC_EMBEDDING_CONTEXT_SIZE
-
-            # This is approximate since it doesn't build the exact string of the call below
-            # Some things are estimated and may be under (like the metadata tokens)
-            sections_for_selection = _trim_sections_by_tokens(
-                sections=top_sections,
-                max_tokens=max_tokens_for_selection,
-                token_counter=token_counter,
-                max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
-            )
-
-            # Start timing for LLM document selection
-            document_selection_start_time = time.time()
-
-            # Use LLM to select the most relevant sections for expansion
-            selected_sections, best_doc_ids = select_sections_for_expansion(
-                sections=sections_for_selection,
-                user_query=secondary_flows_user_query,
-                llm=self.llm,
-                max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
-            )
-
-            # End timing for LLM document selection
-            document_selection_elapsed = time.time() - document_selection_start_time
-            logger.debug(
-                f"Search tool - LLM picking documents took {document_selection_elapsed:.3f} seconds "
-                f"(selected {len(selected_sections)} sections)"
-            )
-
-            # Create a set of best document IDs for quick lookup
-            best_doc_ids_set = set(best_doc_ids) if best_doc_ids else set()
-
-            # To show the users, we only pass in the docs that are determined to be good by the LLM
-            final_ui_docs = convert_inference_sections_to_search_docs(
-                selected_sections, is_internet=False
-            )
-
-            self.emitter.emit(
-                Packet(
-                    placement=placement,
-                    obj=SearchToolDocumentsDelta(
-                        documents=final_ui_docs,
-                    ),
-                )
-            )
-
-            # Create wrapper function to handle errors gracefully
-            def expand_section_safe(
-                section: InferenceSection,
-                user_query: str,
-                llm: LLM,
-                document_index: DocumentIndex,
-                expand_override: bool,
-            ) -> InferenceSection:
-                """Wrapper that handles exceptions and returns original section on error."""
-                try:
-                    expanded_section = expand_section_with_context(
-                        section=section,
-                        user_query=user_query,
-                        llm=llm,
-                        document_index=document_index,
-                        expand_override=expand_override,
-                    )
-                    # Return expanded section if not None, otherwise original
-                    return expanded_section if expanded_section is not None else section
-                except Exception as e:
-                    logger.warning(
-                        f"Error processing section context expansion: {e}. Using original section."
-                    )
-                    return section
-
-            # Build parallel function calls for all sections
-            expansion_functions: list[tuple[Callable, tuple]] = [
-                (
-                    expand_section_safe,
-                    (
-                        section,
-                        secondary_flows_user_query,
-                        self.llm,
-                        self.document_index,
-                        section.center_chunk.document_id in best_doc_ids_set,
-                    ),
-                )
-                for section in selected_sections
-            ]
-
-            # Start timing for document expansion
-            document_expansion_start_time = time.time()
-
-            # Run all expansions in parallel
-            expanded_sections = run_functions_tuples_in_parallel(expansion_functions)
-
-            # End timing for document expansion
-            document_expansion_elapsed = time.time() - document_expansion_start_time
-            logger.debug(
-                f"Search tool - Expansion of selected documents took {document_expansion_elapsed:.3f} seconds "
-                f"(expanded {len(expanded_sections)} sections)"
-            )
-
-            if not expanded_sections:
-                expanded_sections = selected_sections
-
-            # Merge sections from the same document that have adjacent or overlapping chunks
-            # This prevents duplicate content and reduces token usage
-            merged_sections = merge_overlapping_sections(expanded_sections)
-
-            docs_str, citation_mapping = convert_inference_sections_to_llm_string(
-                top_sections=merged_sections,
-                citation_start=override_kwargs.starting_citation_num,
-                limit=override_kwargs.max_llm_chunks,
-                include_document_id=False,
-            )
-
-            # End overall timing
-            overall_elapsed = time.time() - overall_start_time
-            logger.debug(
-                f"Search tool - Total execution time: {overall_elapsed:.3f} seconds "
-                f"(query expansion: {query_expansion_elapsed:.3f}s, "
-                f"document selection: {document_selection_elapsed:.3f}s, "
-                f"document expansion: {document_expansion_elapsed:.3f}s)"
-            )
-
-            return ToolResponse(
-                # Typically the rich response will give more docs in case it needs to be displayed in the UI
-                rich_response=SearchDocsResponse(
-                    search_docs=search_docs,
-                    citation_mapping=citation_mapping,
-                    displayed_docs=final_ui_docs or None,
+        if QUERIES_FIELD not in llm_kwargs:
+            raise ToolCallException(
+                message=f"Missing required '{QUERIES_FIELD}' parameter in internal_search tool call",
+                llm_facing_message=(
+                    f"The internal_search tool requires a '{QUERIES_FIELD}' parameter "
+                    f"containing an array of search queries. Please provide the queries "
+                    f'like: {{"queries": ["your search query here"]}}'
                 ),
-                # The LLM facing response typically includes less docs to cut down on noise and token usage
-                llm_facing_response=docs_str,
+            )
+        llm_queries = cast(list[str], llm_kwargs[QUERIES_FIELD])
+
+        # Run semantic and keyword query expansion in parallel (unless skipped)
+        # Use message history, memories, and user info from override_kwargs
+        message_history = (
+            override_kwargs.message_history if override_kwargs.message_history else []
+        )
+        memories = (
+            override_kwargs.user_memory_context.as_formatted_list()
+            if override_kwargs.user_memory_context
+            else []
+        )
+        user_info = override_kwargs.user_info
+
+        # Skip query expansion if this is a repeat search call
+        if override_kwargs.skip_query_expansion:
+            logger.debug("Search tool - Skipping query expansion (repeat search call)")
+            semantic_query = None
+            keyword_queries: list[str] = []
+        else:
+            # Start timing for query expansion/rephrase
+            query_expansion_start_time = time.time()
+
+            functions_with_args: list[tuple[Callable, tuple]] = [
+                (
+                    semantic_query_rephrase,
+                    (message_history, self.llm, user_info, memories),
+                ),
+                (
+                    keyword_query_expansion,
+                    (message_history, self.llm, user_info, memories),
+                ),
+            ]
+
+            expansion_results = run_functions_tuples_in_parallel(functions_with_args)
+
+            # End timing for query expansion/rephrase
+            query_expansion_elapsed = time.time() - query_expansion_start_time
+            logger.debug(
+                f"Search tool - Query expansion/rephrase took {query_expansion_elapsed:.3f} seconds"
+            )
+            semantic_query = expansion_results[0]  # str
+            keyword_queries = (
+                expansion_results[1] if expansion_results[1] is not None else []
+            )  # list[str]
+
+        # Prepare queries with their weights and hybrid_alpha settings
+        # Group 1: Keyword queries (use hybrid_alpha=0.2)
+        keyword_queries_with_weights = [
+            (kw_query, LLM_KEYWORD_QUERY_WEIGHT) for kw_query in keyword_queries
+        ]
+        deduplicated_keyword_queries = deduplicate_queries(keyword_queries_with_weights)
+
+        # Group 2: Semantic/LLM/Original queries (use hybrid_alpha=None)
+        # Include all LLM-provided queries with their weight
+        semantic_queries_with_weights = (
+            [
+                (semantic_query, LLM_SEMANTIC_QUERY_WEIGHT),
+            ]
+            if semantic_query
+            else []
+        )
+        for llm_query in llm_queries:
+            # In rare cases, the LLM may fail to provide real queries
+            if llm_query:
+                semantic_queries_with_weights.append(
+                    (llm_query, LLM_NON_CUSTOM_QUERY_WEIGHT)
+                )
+        if override_kwargs.original_query:
+            semantic_queries_with_weights.append(
+                (override_kwargs.original_query, ORIGINAL_QUERY_WEIGHT)
+            )
+        deduplicated_semantic_queries = deduplicate_queries(
+            semantic_queries_with_weights
+        )
+
+        # Build the all_queries list for UI display, sorted by weight (highest first)
+        # Combine all deduplicated queries and sort by weight
+        all_queries_with_weights = (
+            deduplicated_semantic_queries + deduplicated_keyword_queries
+        )
+        all_queries_with_weights.sort(key=lambda x: x[1], reverse=True)
+
+        # Extract queries in weight order, handling cross-duplicates
+        all_queries = []
+        seen_lower = set()
+        for query, _ in all_queries_with_weights:
+            query_lower = query.lower()
+            if query_lower not in seen_lower:
+                all_queries.append(query)
+                seen_lower.add(query_lower)
+
+        logger.debug(
+            f"All Queries (sorted by weight): {all_queries}, "
+            f"Keyword queries: {[q for q, _ in deduplicated_keyword_queries]}"
+        )
+
+        # Emit the queries early so the UI can display them immediately
+        self.emitter.emit(
+            Packet(
+                placement=placement,
+                obj=SearchToolQueriesDelta(
+                    queries=all_queries,
+                ),
+            )
+        )
+
+        # Run all searches in parallel with appropriate hybrid_alpha values
+        # Keyword queries use hybrid_alpha=0.2 (favor keyword search)
+        # Other queries use default hybrid_alpha (balanced semantic/keyword)
+        search_functions: list[tuple[Callable, tuple]] = []
+        search_weights: list[float] = []
+
+        # Add deduplicated semantic queries (use hybrid_alpha=None)
+        for query, weight in deduplicated_semantic_queries:
+            search_functions.append(
+                (
+                    self._run_search_for_query,
+                    (
+                        query,
+                        None,
+                        override_kwargs.num_hits,
+                        acl_filters,
+                        embedding_model,
+                        federated_retrieval_infos,
+                    ),
+                )
+            )
+            search_weights.append(weight)
+
+        # Add deduplicated keyword queries (use hybrid_alpha=0.2)
+        for query, weight in deduplicated_keyword_queries:
+            search_functions.append(
+                (
+                    self._run_search_for_query,
+                    (
+                        query,
+                        KEYWORD_QUERY_HYBRID_ALPHA,
+                        override_kwargs.num_hits,
+                        acl_filters,
+                        embedding_model,
+                        federated_retrieval_infos,
+                    ),
+                )
+            )
+            search_weights.append(weight)
+
+        # Add Slack federated search (runs once in parallel with all Vespa queries)
+        # This avoids the query multiplication problem where each Vespa query
+        # would trigger a separate Slack search.
+        # Only run if pre-fetch found a valid Slack access token.
+        if slack_access_token and override_kwargs.original_query:
+            search_functions.append(
+                (
+                    self._run_slack_search,
+                    (
+                        override_kwargs.original_query,
+                        slack_access_token,
+                        slack_bot_token,
+                        slack_entities,
+                        search_settings,
+                    ),
+                )
+            )
+            # Use same weight as original query for Slack results
+            search_weights.append(ORIGINAL_QUERY_WEIGHT)
+
+        # Run all searches in parallel (Vespa queries + Slack)
+        all_search_results = run_functions_tuples_in_parallel(search_functions)
+        if not all_search_results:
+            all_search_results = []
+
+        # Merge results using weighted Reciprocal Rank Fusion
+        # This intelligently combines rankings from different queries
+        top_chunks = weighted_reciprocal_rank_fusion(
+            ranked_results=all_search_results,
+            weights=search_weights,
+            id_extractor=lambda chunk: f"{chunk.document_id}_{chunk.chunk_id}",
+        )
+
+        # We can disregard all of the chunks that exceed the num_hits parameter since it's not valid to have
+        # documents/contents from things that aren't returned to the user on the frontend
+        top_sections = merge_individual_chunks(top_chunks)[: override_kwargs.num_hits]
+
+        if not top_sections:
+            logger.info("Search tool - no results found, returning empty response")
+            return ToolResponse(
+                rich_response=SearchDocsResponse(
+                    search_docs=[],
+                    citation_mapping={},
+                    displayed_docs=None,
+                ),
+                llm_facing_response="",
             )
 
-        finally:
-            # Always close the session to release database connections
-            db_session.close()
+        # Convert InferenceSections to SearchDocs for emission
+        search_docs = convert_inference_sections_to_search_docs(
+            top_sections, is_internet=False
+        )
+
+        secondary_flows_user_query = (
+            override_kwargs.original_query
+            or semantic_query
+            or (llm_queries[0] if llm_queries else "")
+        )
+
+        token_counter = get_llm_token_counter(self.llm)
+
+        # Trim sections to fit within token budget before LLM selection
+        # This is to account for very short chunks flooding the search context
+        # Only consider MAX_CHUNKS_FOR_RELEVANCE chunks per section to avoid flooding from
+        # documents with many matching sections
+        max_tokens_for_selection = (
+            override_kwargs.max_llm_chunks or MAX_CHUNKS_FED_TO_CHAT
+        ) * DOC_EMBEDDING_CONTEXT_SIZE
+
+        # This is approximate since it doesn't build the exact string of the call below
+        # Some things are estimated and may be under (like the metadata tokens)
+        sections_for_selection = _trim_sections_by_tokens(
+            sections=top_sections,
+            max_tokens=max_tokens_for_selection,
+            token_counter=token_counter,
+            max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
+        )
+
+        # Start timing for LLM document selection
+        document_selection_start_time = time.time()
+
+        # Use LLM to select the most relevant sections for expansion
+        selected_sections, best_doc_ids = select_sections_for_expansion(
+            sections=sections_for_selection,
+            user_query=secondary_flows_user_query,
+            llm=self.llm,
+            max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
+        )
+
+        # End timing for LLM document selection
+        document_selection_elapsed = time.time() - document_selection_start_time
+        logger.debug(
+            f"Search tool - LLM picking documents took {document_selection_elapsed:.3f} seconds "
+            f"(selected {len(selected_sections)} sections)"
+        )
+
+        # Create a set of best document IDs for quick lookup
+        best_doc_ids_set = set(best_doc_ids) if best_doc_ids else set()
+
+        # To show the users, we only pass in the docs that are determined to be good by the LLM
+        final_ui_docs = convert_inference_sections_to_search_docs(
+            selected_sections, is_internet=False
+        )
+
+        self.emitter.emit(
+            Packet(
+                placement=placement,
+                obj=SearchToolDocumentsDelta(
+                    documents=final_ui_docs,
+                ),
+            )
+        )
+
+        # Create wrapper function to handle errors gracefully
+        def expand_section_safe(
+            section: InferenceSection,
+            user_query: str,
+            llm: LLM,
+            document_index: DocumentIndex,
+            expand_override: bool,
+        ) -> InferenceSection:
+            """Wrapper that handles exceptions and returns original section on error."""
+            try:
+                expanded_section = expand_section_with_context(
+                    section=section,
+                    user_query=user_query,
+                    llm=llm,
+                    document_index=document_index,
+                    expand_override=expand_override,
+                )
+                # Return expanded section if not None, otherwise original
+                return expanded_section if expanded_section is not None else section
+            except Exception as e:
+                logger.warning(
+                    f"Error processing section context expansion: {e}. Using original section."
+                )
+                return section
+
+        # Build parallel function calls for all sections
+        expansion_functions: list[tuple[Callable, tuple]] = [
+            (
+                expand_section_safe,
+                (
+                    section,
+                    secondary_flows_user_query,
+                    self.llm,
+                    self.document_index,
+                    section.center_chunk.document_id in best_doc_ids_set,
+                ),
+            )
+            for section in selected_sections
+        ]
+
+        # Start timing for document expansion
+        document_expansion_start_time = time.time()
+
+        # Run all expansions in parallel
+        expanded_sections = run_functions_tuples_in_parallel(expansion_functions)
+
+        # End timing for document expansion
+        document_expansion_elapsed = time.time() - document_expansion_start_time
+        logger.debug(
+            f"Search tool - Expansion of selected documents took {document_expansion_elapsed:.3f} seconds "
+            f"(expanded {len(expanded_sections)} sections)"
+        )
+
+        if not expanded_sections:
+            expanded_sections = selected_sections
+
+        # Merge sections from the same document that have adjacent or overlapping chunks
+        # This prevents duplicate content and reduces token usage
+        merged_sections = merge_overlapping_sections(expanded_sections)
+
+        docs_str, citation_mapping = convert_inference_sections_to_llm_string(
+            top_sections=merged_sections,
+            citation_start=override_kwargs.starting_citation_num,
+            limit=override_kwargs.max_llm_chunks,
+            include_document_id=False,
+        )
+
+        # End overall timing
+        overall_elapsed = time.time() - overall_start_time
+        logger.debug(
+            f"Search tool - Total execution time: {overall_elapsed:.3f} seconds "
+            f"(query expansion: {query_expansion_elapsed:.3f}s, "
+            f"document selection: {document_selection_elapsed:.3f}s, "
+            f"document expansion: {document_expansion_elapsed:.3f}s)"
+        )
+
+        return ToolResponse(
+            # Typically the rich response will give more docs in case it needs to be displayed in the UI
+            rich_response=SearchDocsResponse(
+                search_docs=search_docs,
+                citation_mapping=citation_mapping,
+                displayed_docs=final_ui_docs or None,
+            ),
+            # The LLM facing response typically includes less docs to cut down on noise and token usage
+            llm_facing_response=docs_str,
+        )


### PR DESCRIPTION
Cherry-pick of commit c516aa3e3cca70ba164e2ff91ad8362fde15a09f to release/v3.0 branch.

Original PR: #8651

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops DB pool exhaustion in SearchTool by prefetching all DB data once, then running parallel searches without any DB access. This stabilizes search under load and removes redundant DB queries.

- **Bug Fixes**
  - Removed per-thread sessions and parallel DB calls in SearchTool; prefetch ACL filters, SearchSettings, embedding model, and federated retrieval info in a single session.
  - Slack federated search now uses pre-fetched tokens/config and accepts pre-fetched SearchSettings to avoid DB calls in parallel.
  - Added guards so functions accept either a db_session or pre-fetched data, preventing accidental DB access during parallel runs.

- **Refactors**
  - Made db_session optional in pipeline, search_runner, and utils; added acl_filters, embedding_model, and prefetched_federated_retrieval_infos parameters.
  - Removed db_session from SearchTool constructor and tool_constructor; use get_session_with_current_tenant for short-lived prefetch.
  - Updated tests to mock the prefetch path and new parameters.

<sup>Written for commit 9c4db90b171faac86a708633cee9929e4bf7ab55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

