### PR TITLE
refactor(opal): rename Content internal layouts to size-based names

### DIFF
--- a/web/lib/opal/src/components/Tag/README.md
+++ b/web/lib/opal/src/components/Tag/README.md
@@ -42,7 +42,7 @@ import SvgStar from "@opal/icons/star";
 
 ## Usage inside Content
 
-Tag can be rendered as an accessory inside `Content`'s LabelLayout via the `tag` prop:
+Tag can be rendered as an accessory inside `Content`'s ContentMd via the `tag` prop:
 
 ```tsx
 import { Content } from "@opal/layouts";

--- a/web/lib/opal/src/layouts/Content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/Content/ContentLg.tsx
@@ -11,10 +11,10 @@ import { useRef, useState } from "react";
 // Types
 // ---------------------------------------------------------------------------
 
-type HeadingSizePreset = "headline" | "section";
-type HeadingVariant = "heading" | "section";
+type ContentLgSizePreset = "headline" | "section";
+type ContentLgVariant = "heading" | "section";
 
-interface HeadingPresetConfig {
+interface ContentLgPresetConfig {
   /** Icon width/height (CSS value). */
   iconSize: string;
   /** Tailwind padding class for the icon container. */
@@ -31,7 +31,7 @@ interface HeadingPresetConfig {
   editButtonPadding: string;
 }
 
-interface HeadingLayoutProps {
+interface ContentLgProps {
   /** Optional icon component. */
   icon?: IconFunctionComponent;
 
@@ -48,17 +48,17 @@ interface HeadingLayoutProps {
   onTitleChange?: (newTitle: string) => void;
 
   /** Size preset. Default: `"headline"`. */
-  sizePreset?: HeadingSizePreset;
+  sizePreset?: ContentLgSizePreset;
 
   /** Variant controls icon placement. `"heading"` = top, `"section"` = inline. Default: `"heading"`. */
-  variant?: HeadingVariant;
+  variant?: ContentLgVariant;
 }
 
 // ---------------------------------------------------------------------------
 // Presets
 // ---------------------------------------------------------------------------
 
-const HEADING_PRESETS: Record<HeadingSizePreset, HeadingPresetConfig> = {
+const CONTENT_LG_PRESETS: Record<ContentLgSizePreset, ContentLgPresetConfig> = {
   headline: {
     iconSize: "2rem",
     iconContainerPadding: "p-0.5",
@@ -80,10 +80,10 @@ const HEADING_PRESETS: Record<HeadingSizePreset, HeadingPresetConfig> = {
 };
 
 // ---------------------------------------------------------------------------
-// HeadingLayout
+// ContentLg
 // ---------------------------------------------------------------------------
 
-function HeadingLayout({
+function ContentLg({
   sizePreset = "headline",
   variant = "heading",
   icon: Icon,
@@ -91,12 +91,12 @@ function HeadingLayout({
   description,
   editable,
   onTitleChange,
-}: HeadingLayoutProps) {
+}: ContentLgProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(title);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const config = HEADING_PRESETS[sizePreset];
+  const config = CONTENT_LG_PRESETS[sizePreset];
   const iconPlacement = variant === "heading" ? "top" : "left";
 
   function startEditing() {
@@ -112,41 +112,38 @@ function HeadingLayout({
 
   return (
     <div
-      className="opal-content-heading"
+      className="opal-content-lg"
       data-icon-placement={iconPlacement}
       style={{ gap: iconPlacement === "left" ? config.gap : undefined }}
     >
       {Icon && (
         <div
           className={cn(
-            "opal-content-heading-icon-container shrink-0",
+            "opal-content-lg-icon-container shrink-0",
             config.iconContainerPadding
           )}
           style={{ minHeight: config.lineHeight }}
         >
           <Icon
-            className="opal-content-heading-icon"
+            className="opal-content-lg-icon"
             style={{ width: config.iconSize, height: config.iconSize }}
           />
         </div>
       )}
 
-      <div className="opal-content-heading-body">
-        <div className="opal-content-heading-title-row">
+      <div className="opal-content-lg-body">
+        <div className="opal-content-lg-title-row">
           {editing ? (
-            <div className="opal-content-heading-input-sizer">
+            <div className="opal-content-lg-input-sizer">
               <span
-                className={cn(
-                  "opal-content-heading-input-mirror",
-                  config.titleFont
-                )}
+                className={cn("opal-content-lg-input-mirror", config.titleFont)}
               >
                 {editValue || "\u00A0"}
               </span>
               <input
                 ref={inputRef}
                 className={cn(
-                  "opal-content-heading-input",
+                  "opal-content-lg-input",
                   config.titleFont,
                   "text-text-04"
                 )}
@@ -169,7 +166,7 @@ function HeadingLayout({
           ) : (
             <span
               className={cn(
-                "opal-content-heading-title",
+                "opal-content-lg-title",
                 config.titleFont,
                 "text-text-04",
                 editable && "cursor-pointer"
@@ -184,7 +181,7 @@ function HeadingLayout({
           {editable && !editing && (
             <div
               className={cn(
-                "opal-content-heading-edit-button",
+                "opal-content-lg-edit-button",
                 config.editButtonPadding
               )}
             >
@@ -201,7 +198,7 @@ function HeadingLayout({
         </div>
 
         {description && (
-          <div className="opal-content-heading-description font-secondary-body text-text-03">
+          <div className="opal-content-lg-description font-secondary-body text-text-03">
             {description}
           </div>
         )}
@@ -210,4 +207,4 @@ function HeadingLayout({
   );
 }
 
-export { HeadingLayout, type HeadingLayoutProps, type HeadingSizePreset };
+export { ContentLg, type ContentLgProps, type ContentLgSizePreset };

--- a/web/lib/opal/src/layouts/Content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/Content/ContentMd.tsx
@@ -15,11 +15,11 @@ import { useRef, useState } from "react";
 // Types
 // ---------------------------------------------------------------------------
 
-type LabelSizePreset = "main-content" | "main-ui" | "secondary";
+type ContentMdSizePreset = "main-content" | "main-ui" | "secondary";
 
-type LabelAuxIcon = "info-gray" | "info-blue" | "warning" | "error";
+type ContentMdAuxIcon = "info-gray" | "info-blue" | "warning" | "error";
 
-interface LabelPresetConfig {
+interface ContentMdPresetConfig {
   iconSize: string;
   iconContainerPadding: string;
   iconColorClass: string;
@@ -34,7 +34,7 @@ interface LabelPresetConfig {
   auxIconSize: string;
 }
 
-interface LabelLayoutProps {
+interface ContentMdProps {
   /** Optional icon component. */
   icon?: IconFunctionComponent;
 
@@ -54,20 +54,20 @@ interface LabelLayoutProps {
   optional?: boolean;
 
   /** Auxiliary status icon rendered beside the title. */
-  auxIcon?: LabelAuxIcon;
+  auxIcon?: ContentMdAuxIcon;
 
   /** Tag rendered beside the title. */
   tag?: TagProps;
 
   /** Size preset. Default: `"main-ui"`. */
-  sizePreset?: LabelSizePreset;
+  sizePreset?: ContentMdSizePreset;
 }
 
 // ---------------------------------------------------------------------------
 // Presets
 // ---------------------------------------------------------------------------
 
-const LABEL_PRESETS: Record<LabelSizePreset, LabelPresetConfig> = {
+const CONTENT_MD_PRESETS: Record<ContentMdSizePreset, ContentMdPresetConfig> = {
   "main-content": {
     iconSize: "1rem",
     iconContainerPadding: "p-1",
@@ -107,11 +107,11 @@ const LABEL_PRESETS: Record<LabelSizePreset, LabelPresetConfig> = {
 };
 
 // ---------------------------------------------------------------------------
-// LabelLayout
+// ContentMd
 // ---------------------------------------------------------------------------
 
 const AUX_ICON_CONFIG: Record<
-  LabelAuxIcon,
+  ContentMdAuxIcon,
   { icon: IconFunctionComponent; colorClass: string }
 > = {
   "info-gray": { icon: SvgAlertCircle, colorClass: "text-text-02" },
@@ -120,7 +120,7 @@ const AUX_ICON_CONFIG: Record<
   error: { icon: SvgXOctagon, colorClass: "text-status-error-05" },
 };
 
-function LabelLayout({
+function ContentMd({
   icon: Icon,
   title,
   description,
@@ -130,12 +130,12 @@ function LabelLayout({
   auxIcon,
   tag,
   sizePreset = "main-ui",
-}: LabelLayoutProps) {
+}: ContentMdProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(title);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const config = LABEL_PRESETS[sizePreset];
+  const config = CONTENT_MD_PRESETS[sizePreset];
 
   function startEditing() {
     setEditValue(title);
@@ -149,38 +149,35 @@ function LabelLayout({
   }
 
   return (
-    <div className="opal-content-label" style={{ gap: config.gap }}>
+    <div className="opal-content-md" style={{ gap: config.gap }}>
       {Icon && (
         <div
           className={cn(
-            "opal-content-label-icon-container shrink-0",
+            "opal-content-md-icon-container shrink-0",
             config.iconContainerPadding
           )}
           style={{ minHeight: config.lineHeight }}
         >
           <Icon
-            className={cn("opal-content-label-icon", config.iconColorClass)}
+            className={cn("opal-content-md-icon", config.iconColorClass)}
             style={{ width: config.iconSize, height: config.iconSize }}
           />
         </div>
       )}
 
-      <div className="opal-content-label-body">
-        <div className="opal-content-label-title-row">
+      <div className="opal-content-md-body">
+        <div className="opal-content-md-title-row">
           {editing ? (
-            <div className="opal-content-label-input-sizer">
+            <div className="opal-content-md-input-sizer">
               <span
-                className={cn(
-                  "opal-content-label-input-mirror",
-                  config.titleFont
-                )}
+                className={cn("opal-content-md-input-mirror", config.titleFont)}
               >
                 {editValue || "\u00A0"}
               </span>
               <input
                 ref={inputRef}
                 className={cn(
-                  "opal-content-label-input",
+                  "opal-content-md-input",
                   config.titleFont,
                   "text-text-04"
                 )}
@@ -203,7 +200,7 @@ function LabelLayout({
           ) : (
             <span
               className={cn(
-                "opal-content-label-title",
+                "opal-content-md-title",
                 config.titleFont,
                 "text-text-04",
                 editable && "cursor-pointer"
@@ -229,7 +226,7 @@ function LabelLayout({
               const { icon: AuxIcon, colorClass } = AUX_ICON_CONFIG[auxIcon];
               return (
                 <div
-                  className="opal-content-label-aux-icon shrink-0 p-0.5"
+                  className="opal-content-md-aux-icon shrink-0 p-0.5"
                   style={{ height: config.lineHeight }}
                 >
                   <AuxIcon
@@ -248,7 +245,7 @@ function LabelLayout({
           {editable && !editing && (
             <div
               className={cn(
-                "opal-content-label-edit-button",
+                "opal-content-md-edit-button",
                 config.editButtonPadding
               )}
             >
@@ -265,7 +262,7 @@ function LabelLayout({
         </div>
 
         {description && (
-          <div className="opal-content-label-description font-secondary-body text-text-03">
+          <div className="opal-content-md-description font-secondary-body text-text-03">
             {description}
           </div>
         )}
@@ -275,8 +272,8 @@ function LabelLayout({
 }
 
 export {
-  LabelLayout,
-  type LabelLayoutProps,
-  type LabelSizePreset,
-  type LabelAuxIcon,
+  ContentMd,
+  type ContentMdProps,
+  type ContentMdSizePreset,
+  type ContentMdAuxIcon,
 };

--- a/web/lib/opal/src/layouts/Content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/Content/ContentSm.tsx
@@ -7,11 +7,11 @@ import { cn } from "@opal/utils";
 // Types
 // ---------------------------------------------------------------------------
 
-type BodySizePreset = "main-content" | "main-ui" | "secondary";
-type BodyOrientation = "vertical" | "inline" | "reverse";
-type BodyProminence = "default" | "muted";
+type ContentSmSizePreset = "main-content" | "main-ui" | "secondary";
+type ContentSmOrientation = "vertical" | "inline" | "reverse";
+type ContentSmProminence = "default" | "muted";
 
-interface BodyPresetConfig {
+interface ContentSmPresetConfig {
   /** Icon width/height (CSS value). */
   iconSize: string;
   /** Tailwind padding class for the icon container. */
@@ -24,8 +24,8 @@ interface BodyPresetConfig {
   gap: string;
 }
 
-/** Props for {@link BodyLayout}. Does not support editing or descriptions. */
-interface BodyLayoutProps {
+/** Props for {@link ContentSm}. Does not support editing or descriptions. */
+interface ContentSmProps {
   /** Optional icon component. */
   icon?: IconFunctionComponent;
 
@@ -33,20 +33,20 @@ interface BodyLayoutProps {
   title: string;
 
   /** Size preset. Default: `"main-ui"`. */
-  sizePreset?: BodySizePreset;
+  sizePreset?: ContentSmSizePreset;
 
   /** Layout orientation. Default: `"inline"`. */
-  orientation?: BodyOrientation;
+  orientation?: ContentSmOrientation;
 
   /** Title prominence. Default: `"default"`. */
-  prominence?: BodyProminence;
+  prominence?: ContentSmProminence;
 }
 
 // ---------------------------------------------------------------------------
 // Presets
 // ---------------------------------------------------------------------------
 
-const BODY_PRESETS: Record<BodySizePreset, BodyPresetConfig> = {
+const CONTENT_SM_PRESETS: Record<ContentSmSizePreset, ContentSmPresetConfig> = {
   "main-content": {
     iconSize: "1rem",
     iconContainerPadding: "p-1",
@@ -71,36 +71,36 @@ const BODY_PRESETS: Record<BodySizePreset, BodyPresetConfig> = {
 };
 
 // ---------------------------------------------------------------------------
-// BodyLayout
+// ContentSm
 // ---------------------------------------------------------------------------
 
-function BodyLayout({
+function ContentSm({
   icon: Icon,
   title,
   sizePreset = "main-ui",
   orientation = "inline",
   prominence = "default",
-}: BodyLayoutProps) {
-  const config = BODY_PRESETS[sizePreset];
+}: ContentSmProps) {
+  const config = CONTENT_SM_PRESETS[sizePreset];
   const titleColorClass =
     prominence === "muted" ? "text-text-03" : "text-text-04";
 
   return (
     <div
-      className="opal-content-body"
+      className="opal-content-sm"
       data-orientation={orientation}
       style={{ gap: config.gap }}
     >
       {Icon && (
         <div
           className={cn(
-            "opal-content-body-icon-container shrink-0",
+            "opal-content-sm-icon-container shrink-0",
             config.iconContainerPadding
           )}
           style={{ minHeight: config.lineHeight }}
         >
           <Icon
-            className="opal-content-body-icon text-text-03"
+            className="opal-content-sm-icon text-text-03"
             style={{ width: config.iconSize, height: config.iconSize }}
           />
         </div>
@@ -108,7 +108,7 @@ function BodyLayout({
 
       <span
         className={cn(
-          "opal-content-body-title",
+          "opal-content-sm-title",
           config.titleFont,
           titleColorClass
         )}
@@ -121,9 +121,9 @@ function BodyLayout({
 }
 
 export {
-  BodyLayout,
-  type BodyLayoutProps,
-  type BodySizePreset,
-  type BodyOrientation,
-  type BodyProminence,
+  ContentSm,
+  type ContentSmProps,
+  type ContentSmSizePreset,
+  type ContentSmOrientation,
+  type ContentSmProminence,
 };

--- a/web/lib/opal/src/layouts/Content/README.md
+++ b/web/lib/opal/src/layouts/Content/README.md
@@ -8,14 +8,14 @@ A two-axis layout component for displaying icon + title + description rows. Rout
 
 ### `sizePreset` — controls sizing (icon, padding, gap, font)
 
-#### HeadingLayout presets
+#### ContentLg presets
 
 | Preset | Icon | Icon padding | Gap | Title font | Line-height |
 |---|---|---|---|---|---|
 | `headline` | 2rem (32px) | `p-0.5` (2px) | 0.25rem (4px) | `font-heading-h2` | 2.25rem (36px) |
 | `section` | 1.25rem (20px) | `p-1` (4px) | 0rem | `font-heading-h3` | 1.75rem (28px) |
 
-#### LabelLayout presets
+#### ContentMd presets
 
 | Preset | Icon | Icon padding | Icon color | Gap | Title font | Line-height |
 |---|---|---|---|---|---|---|
@@ -29,18 +29,18 @@ A two-axis layout component for displaying icon + title + description rows. Rout
 
 | variant | Description |
 |---|---|
-| `heading` | Icon on **top** (flex-col) — HeadingLayout |
-| `section` | Icon **inline** (flex-row) — HeadingLayout or LabelLayout |
-| `body` | Body text layout — BodyLayout (future) |
+| `heading` | Icon on **top** (flex-col) — ContentLg |
+| `section` | Icon **inline** (flex-row) — ContentLg or ContentMd |
+| `body` | Body text layout — ContentSm |
 
 ### Valid Combinations -> Internal Routing
 
 | sizePreset | variant | Routes to |
 |---|---|---|
-| `headline` / `section` | `heading` | **HeadingLayout** (icon on top) |
-| `headline` / `section` | `section` | **HeadingLayout** (icon inline) |
-| `main-content` / `main-ui` / `secondary` | `section` | **LabelLayout** |
-| `main-content` / `main-ui` / `secondary` | `body` | BodyLayout (future) |
+| `headline` / `section` | `heading` | **ContentLg** (icon on top) |
+| `headline` / `section` | `section` | **ContentLg** (icon inline) |
+| `main-content` / `main-ui` / `secondary` | `section` | **ContentMd** |
+| `main-content` / `main-ui` / `secondary` | `body` | **ContentSm** |
 
 Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are excluded at the type level.
 
@@ -58,11 +58,11 @@ Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are exclude
 
 ## Internal Layouts
 
-### HeadingLayout
+### ContentLg
 
 For `headline` / `section` presets. Supports `variant="heading"` (icon on top) and `variant="section"` (icon inline). Description is always `font-secondary-body text-text-03`.
 
-### LabelLayout
+### ContentMd
 
 For `main-content` / `main-ui` / `secondary` presets. Always inline. Both `icon` and `description` are optional. Description is always `font-secondary-body text-text-03`.
 
@@ -72,7 +72,7 @@ For `main-content` / `main-ui` / `secondary` presets. Always inline. Both `icon`
 import { Content } from "@opal/layouts";
 import SvgSearch from "@opal/icons/search";
 
-// HeadingLayout — headline, icon on top
+// ContentLg — headline, icon on top
 <Content
   icon={SvgSearch}
   sizePreset="headline"
@@ -81,7 +81,7 @@ import SvgSearch from "@opal/icons/search";
   description="Configure your agent's behavior"
 />
 
-// HeadingLayout — section, icon inline
+// ContentLg — section, icon inline
 <Content
   icon={SvgSearch}
   sizePreset="section"
@@ -90,7 +90,7 @@ import SvgSearch from "@opal/icons/search";
   description="Connected integrations"
 />
 
-// LabelLayout — with icon and description
+// ContentMd — with icon and description
 <Content
   icon={SvgSearch}
   sizePreset="main-ui"
@@ -98,7 +98,7 @@ import SvgSearch from "@opal/icons/search";
   description="Agent system prompt"
 />
 
-// LabelLayout — title only (no icon, no description)
+// ContentMd — title only (no icon, no description)
 <Content
   sizePreset="main-content"
   title="Featured Agent"

--- a/web/lib/opal/src/layouts/Content/components.tsx
+++ b/web/lib/opal/src/layouts/Content/components.tsx
@@ -1,17 +1,17 @@
 import "@opal/layouts/Content/styles.css";
 import {
-  BodyLayout,
-  type BodyOrientation,
-  type BodyProminence,
-} from "@opal/layouts/Content/BodyLayout";
+  ContentSm,
+  type ContentSmOrientation,
+  type ContentSmProminence,
+} from "@opal/layouts/Content/ContentSm";
 import {
-  HeadingLayout,
-  type HeadingLayoutProps,
-} from "@opal/layouts/Content/HeadingLayout";
+  ContentLg,
+  type ContentLgProps,
+} from "@opal/layouts/Content/ContentLg";
 import {
-  LabelLayout,
-  type LabelLayoutProps,
-} from "@opal/layouts/Content/LabelLayout";
+  ContentMd,
+  type ContentMdProps,
+} from "@opal/layouts/Content/ContentMd";
 import type { TagProps } from "@opal/components/Tag/components";
 import type { IconFunctionComponent } from "@opal/types";
 import { widthVariants, type WidthVariant } from "@opal/shared";
@@ -80,7 +80,7 @@ type LabelContentProps = ContentBaseProps & {
   tag?: TagProps;
 };
 
-/** BodyLayout does not support descriptions or inline editing. */
+/** ContentSm does not support descriptions or inline editing. */
 type BodyContentProps = Omit<
   ContentBaseProps,
   "description" | "editable" | "onTitleChange"
@@ -88,9 +88,9 @@ type BodyContentProps = Omit<
   sizePreset: "main-content" | "main-ui" | "secondary";
   variant: "body";
   /** Layout orientation. Default: `"inline"`. */
-  orientation?: BodyOrientation;
+  orientation?: ContentSmOrientation;
   /** Title prominence. Default: `"default"`. */
-  prominence?: BodyProminence;
+  prominence?: ContentSmProminence;
 };
 
 type ContentProps = HeadingContentProps | LabelContentProps | BodyContentProps;
@@ -111,34 +111,34 @@ function Content(props: ContentProps) {
 
   let layout: React.ReactNode = null;
 
-  // Heading layout: headline/section presets with heading/section variant
+  // ContentLg: headline/section presets with heading/section variant
   if (sizePreset === "headline" || sizePreset === "section") {
     layout = (
-      <HeadingLayout
+      <ContentLg
         sizePreset={sizePreset}
-        variant={variant as HeadingLayoutProps["variant"]}
+        variant={variant as ContentLgProps["variant"]}
         {...rest}
       />
     );
   }
 
-  // Label layout: main-content/main-ui/secondary with section variant
+  // ContentMd: main-content/main-ui/secondary with section variant
   else if (variant === "section" || variant === "heading") {
     layout = (
-      <LabelLayout
+      <ContentMd
         sizePreset={sizePreset}
-        {...(rest as Omit<LabelLayoutProps, "sizePreset">)}
+        {...(rest as Omit<ContentMdProps, "sizePreset">)}
       />
     );
   }
 
-  // Body layout: main-content/main-ui/secondary with body variant
+  // ContentSm: main-content/main-ui/secondary with body variant
   else if (variant === "body") {
     layout = (
-      <BodyLayout
+      <ContentSm
         sizePreset={sizePreset}
         {...(rest as Omit<
-          React.ComponentProps<typeof BodyLayout>,
+          React.ComponentProps<typeof ContentSm>,
           "sizePreset"
         >)}
       />

--- a/web/lib/opal/src/layouts/Content/styles.css
+++ b/web/lib/opal/src/layouts/Content/styles.css
@@ -1,5 +1,5 @@
 /* ---------------------------------------------------------------------------
-   Content — HeadingLayout
+   Content — ContentLg
 
    Two icon placement modes (driven by variant):
      left  (variant="section") : flex-row  — icon beside content
@@ -13,15 +13,15 @@
    Layout — icon placement
    --------------------------------------------------------------------------- */
 
-.opal-content-heading {
+.opal-content-lg {
   @apply flex items-start;
 }
 
-.opal-content-heading[data-icon-placement="left"] {
+.opal-content-lg[data-icon-placement="left"] {
   @apply flex-row;
 }
 
-.opal-content-heading[data-icon-placement="top"] {
+.opal-content-lg[data-icon-placement="top"] {
   @apply flex-col;
 }
 
@@ -29,13 +29,13 @@
    Icon
    --------------------------------------------------------------------------- */
 
-.opal-content-heading-icon-container {
+.opal-content-lg-icon-container {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.opal-content-heading-icon {
+.opal-content-lg-icon {
   color: var(--text-04);
 }
 
@@ -43,7 +43,7 @@
    Body column
    --------------------------------------------------------------------------- */
 
-.opal-content-heading-body {
+.opal-content-lg-body {
   @apply flex flex-1 flex-col items-start;
   min-width: 0.0625rem;
 }
@@ -52,12 +52,12 @@
    Title row — title (or input) + edit button
    --------------------------------------------------------------------------- */
 
-.opal-content-heading-title-row {
+.opal-content-lg-title-row {
   @apply flex items-center w-full;
   gap: 0.25rem;
 }
 
-.opal-content-heading-title {
+.opal-content-lg-title {
   @apply text-left overflow-hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -66,23 +66,23 @@
   min-width: 0.0625rem;
 }
 
-.opal-content-heading-input-sizer {
+.opal-content-lg-input-sizer {
   display: inline-grid;
   align-items: stretch;
 }
 
-.opal-content-heading-input-sizer > * {
+.opal-content-lg-input-sizer > * {
   grid-area: 1 / 1;
   padding: 0 0.125rem;
   min-width: 0.0625rem;
 }
 
-.opal-content-heading-input-mirror {
+.opal-content-lg-input-mirror {
   visibility: hidden;
   white-space: pre;
 }
 
-.opal-content-heading-input {
+.opal-content-lg-input {
   @apply bg-transparent outline-none border-none;
 }
 
@@ -90,11 +90,11 @@
    Edit button — visible only on hover of the outer container
    --------------------------------------------------------------------------- */
 
-.opal-content-heading-edit-button {
+.opal-content-lg-edit-button {
   @apply opacity-0 transition-opacity shrink-0;
 }
 
-.opal-content-heading:hover .opal-content-heading-edit-button {
+.opal-content-lg:hover .opal-content-lg-edit-button {
   @apply opacity-100;
 }
 
@@ -102,13 +102,13 @@
    Description
    --------------------------------------------------------------------------- */
 
-.opal-content-heading-description {
+.opal-content-lg-description {
   @apply text-left w-full;
   padding: 0 0.125rem;
 }
 
 /* ===========================================================================
-   Content — LabelLayout
+   Content — ContentMd
 
    Always inline (flex-row). Icon color varies per sizePreset and is applied
    via Tailwind class from the component.
@@ -118,7 +118,7 @@
    Layout
    --------------------------------------------------------------------------- */
 
-.opal-content-label {
+.opal-content-md {
   @apply flex flex-row items-start;
 }
 
@@ -126,7 +126,7 @@
    Icon
    --------------------------------------------------------------------------- */
 
-.opal-content-label-icon-container {
+.opal-content-md-icon-container {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -136,7 +136,7 @@
    Body column
    --------------------------------------------------------------------------- */
 
-.opal-content-label-body {
+.opal-content-md-body {
   @apply flex flex-1 flex-col items-start;
   min-width: 0.0625rem;
 }
@@ -145,12 +145,12 @@
    Title row — title (or input) + edit button
    --------------------------------------------------------------------------- */
 
-.opal-content-label-title-row {
+.opal-content-md-title-row {
   @apply flex items-center w-full;
   gap: 0.25rem;
 }
 
-.opal-content-label-title {
+.opal-content-md-title {
   @apply text-left overflow-hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -159,23 +159,23 @@
   min-width: 0.0625rem;
 }
 
-.opal-content-label-input-sizer {
+.opal-content-md-input-sizer {
   display: inline-grid;
   align-items: stretch;
 }
 
-.opal-content-label-input-sizer > * {
+.opal-content-md-input-sizer > * {
   grid-area: 1 / 1;
   padding: 0 0.125rem;
   min-width: 0.0625rem;
 }
 
-.opal-content-label-input-mirror {
+.opal-content-md-input-mirror {
   visibility: hidden;
   white-space: pre;
 }
 
-.opal-content-label-input {
+.opal-content-md-input {
   @apply bg-transparent outline-none border-none;
 }
 
@@ -183,7 +183,7 @@
    Aux icon
    --------------------------------------------------------------------------- */
 
-.opal-content-label-aux-icon {
+.opal-content-md-aux-icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -193,11 +193,11 @@
    Edit button — visible only on hover of the outer container
    --------------------------------------------------------------------------- */
 
-.opal-content-label-edit-button {
+.opal-content-md-edit-button {
   @apply opacity-0 transition-opacity shrink-0;
 }
 
-.opal-content-label:hover .opal-content-label-edit-button {
+.opal-content-md:hover .opal-content-md-edit-button {
   @apply opacity-100;
 }
 
@@ -205,13 +205,13 @@
    Description
    --------------------------------------------------------------------------- */
 
-.opal-content-label-description {
+.opal-content-md-description {
   @apply text-left w-full;
   padding: 0 0.125rem;
 }
 
 /* ===========================================================================
-   Content — BodyLayout
+   Content — ContentSm
 
    Three orientation modes (driven by orientation prop):
      inline  : flex-row         — icon left, title right
@@ -226,19 +226,19 @@
    Layout — orientation
    --------------------------------------------------------------------------- */
 
-.opal-content-body {
+.opal-content-sm {
   @apply flex items-start;
 }
 
-.opal-content-body[data-orientation="inline"] {
+.opal-content-sm[data-orientation="inline"] {
   @apply flex-row;
 }
 
-.opal-content-body[data-orientation="vertical"] {
+.opal-content-sm[data-orientation="vertical"] {
   @apply flex-col;
 }
 
-.opal-content-body[data-orientation="reverse"] {
+.opal-content-sm[data-orientation="reverse"] {
   @apply flex-row-reverse;
 }
 
@@ -246,7 +246,7 @@
    Icon
    --------------------------------------------------------------------------- */
 
-.opal-content-body-icon-container {
+.opal-content-sm-icon-container {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -256,7 +256,7 @@
    Title
    --------------------------------------------------------------------------- */
 
-.opal-content-body-title {
+.opal-content-sm-title {
   @apply text-left overflow-hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;

--- a/web/lib/opal/src/layouts/README.md
+++ b/web/lib/opal/src/layouts/README.md
@@ -8,7 +8,7 @@ Layout primitives for composing icon + title + description rows. These component
 
 | Component | Description | Docs |
 |---|---|---|
-| [`Content`](./Content/README.md) | Icon + title + description row. Routes to an internal layout (`HeadingLayout`, `LabelLayout`, or `BodyLayout`) based on `sizePreset` and `variant`. | [Content README](./Content/README.md) |
+| [`Content`](./Content/README.md) | Icon + title + description row. Routes to an internal layout (`ContentLg`, `ContentMd`, or `ContentSm`) based on `sizePreset` and `variant`. | [Content README](./Content/README.md) |
 | [`ContentAction`](./ContentAction/README.md) | Wraps `Content` in a flex-row with an optional `rightChildren` slot for action buttons. Adds padding alignment via the shared `SizeVariant` scale. | [ContentAction README](./ContentAction/README.md) |
 
 ## Quick Start
@@ -88,6 +88,6 @@ These are not exported — `Content` routes to them automatically:
 
 | Layout | Used when | File |
 |---|---|---|
-| `HeadingLayout` | `sizePreset` is `headline` or `section` | `Content/HeadingLayout.tsx` |
-| `LabelLayout` | `sizePreset` is `main-content`, `main-ui`, or `secondary` with `variant="section"` | `Content/LabelLayout.tsx` |
-| `BodyLayout` | `variant="body"` | `Content/BodyLayout.tsx` |
+| `ContentLg` | `sizePreset` is `headline` or `section` | `Content/ContentLg.tsx` |
+| `ContentMd` | `sizePreset` is `main-content`, `main-ui`, or `secondary` with `variant="section"` | `Content/ContentMd.tsx` |
+| `ContentSm` | `variant="body"` | `Content/ContentSm.tsx` |

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -16,7 +16,7 @@
 //   - Interactive.Container  (height + min-width + padding)
 //   - Button                 (icon sizing)
 //   - ContentAction          (padding only)
-//   - Content (HeadingLayout / LabelLayout)  (edit-button size)
+//   - Content (ContentLg / ContentMd)  (edit-button size)
 // ---------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
## Description

Renames the internal layout components inside `web/lib/opal/src/layouts/Content/` from purpose-based names to size-based names:

- `HeadingLayout` → `ContentLg`
- `LabelLayout` → `ContentMd`
- `BodyLayout` → `ContentSm`

This aligns the internal naming convention with the size-based scale used elsewhere in opal (e.g., `SizeVariant`). These components are internal — only `Content` is exported. No external API changes.

**Files changed:**
- Renamed `HeadingLayout.tsx` → `ContentLg.tsx` (all types, consts, CSS classes)
- Renamed `LabelLayout.tsx` → `ContentMd.tsx` (all types, consts, CSS classes)
- Renamed `BodyLayout.tsx` → `ContentSm.tsx` (all types, consts, CSS classes)
- Updated `components.tsx` imports and references
- Updated `styles.css` class prefixes (`opal-content-heading-*` → `opal-content-lg-*`, etc.)
- Updated READMEs and comment references in `shared.ts` and `Tag/README.md`

## How Has This Been Tested?

- `bun run build` passes
- Grepped for all old names (`HeadingLayout`, `LabelLayout`, `BodyLayout`, `opal-content-heading`, `opal-content-label`, `opal-content-body`) — zero remaining references

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Content’s internal layouts to size-based names to match our size scale. Internal-only change; the exported Content API is unchanged.

- **Refactors**
  - HeadingLayout → ContentLg, LabelLayout → ContentMd, BodyLayout → ContentSm (files, types, exports).
  - Updated routing in Content/components.tsx to use new components and type names.
  - Migrated CSS classes: opal-content-heading/label/body-* → opal-content-lg/md/sm-*.
  - Refreshed docs and references (Content README, layouts README, Tag README, shared.ts).
  - Build passes; removed all references to old names.

<sup>Written for commit 9678b085c2ec4b0ecbf8f09f04a80f7ed6ece028. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

