### PR TITLE
feat: add mixed content handler for chat and image generation packets (#8494) to release v2.12

### DIFF
--- a/web/src/app/app/message/messageComponents/renderMessageComponent.tsx
+++ b/web/src/app/app/message/messageComponents/renderMessageComponent.tsx
@@ -1,6 +1,7 @@
 import React, { JSX, memo } from "react";
 import {
   ChatPacket,
+  ImageGenerationToolPacket,
   Packet,
   PacketType,
   ReasoningPacket,
@@ -26,7 +27,7 @@ import { InternalSearchToolRenderer } from "./timeline/renderers/search/Internal
 import { SearchToolStart } from "../../services/streamingModels";
 
 // Different types of chat packets using discriminated unions
-export interface GroupedPackets {
+interface GroupedPackets {
   packets: Packet[];
 }
 
@@ -134,6 +135,53 @@ export function findRenderer(
   return null;
 }
 
+// Handles display groups containing both chat text and image generation packets
+function MixedContentHandler({
+  chatPackets,
+  imagePackets,
+  chatState,
+  onComplete,
+  animate,
+  stopPacketSeen,
+  stopReason,
+  children,
+}: {
+  chatPackets: Packet[];
+  imagePackets: Packet[];
+  chatState: FullChatState;
+  onComplete: () => void;
+  animate: boolean;
+  stopPacketSeen: boolean;
+  stopReason?: StopReason;
+  children: (result: RendererOutput) => JSX.Element;
+}) {
+  return (
+    <MessageTextRenderer
+      packets={chatPackets as ChatPacket[]}
+      state={chatState}
+      onComplete={() => {}}
+      animate={animate}
+      renderType={RenderType.FULL}
+      stopPacketSeen={stopPacketSeen}
+      stopReason={stopReason}
+    >
+      {(textResults) => (
+        <ImageToolRenderer
+          packets={imagePackets as ImageGenerationToolPacket[]}
+          state={chatState}
+          onComplete={onComplete}
+          animate={animate}
+          renderType={RenderType.FULL}
+          stopPacketSeen={stopPacketSeen}
+          stopReason={stopReason}
+        >
+          {(imageResults) => children([...textResults, ...imageResults])}
+        </ImageToolRenderer>
+      )}
+    </MessageTextRenderer>
+  );
+}
+
 // Props interface for RendererComponent
 interface RendererComponentProps {
   packets: Packet[];
@@ -142,7 +190,6 @@ interface RendererComponentProps {
   animate: boolean;
   stopPacketSeen: boolean;
   stopReason?: StopReason;
-  useShortRenderer?: boolean;
   children: (result: RendererOutput) => JSX.Element;
 }
 
@@ -156,7 +203,6 @@ function areRendererPropsEqual(
     prev.stopPacketSeen === next.stopPacketSeen &&
     prev.stopReason === next.stopReason &&
     prev.animate === next.animate &&
-    prev.useShortRenderer === next.useShortRenderer &&
     prev.chatState.assistant?.id === next.chatState.assistant?.id
     // Skip: onComplete, children (function refs), chatState (memoized upstream)
   );
@@ -170,11 +216,47 @@ export const RendererComponent = memo(function RendererComponent({
   animate,
   stopPacketSeen,
   stopReason,
-  useShortRenderer = false,
   children,
 }: RendererComponentProps) {
+  // Detect mixed display groups (both chat text and image generation)
+  const hasChatPackets = packets.some((p) => isChatPacket(p));
+  const hasImagePackets = packets.some((p) => isImageToolPacket(p));
+
+  if (hasChatPackets && hasImagePackets) {
+    const sharedTypes = new Set<string>([
+      PacketType.SECTION_END,
+      PacketType.ERROR,
+    ]);
+
+    const chatPackets = packets.filter(
+      (p) =>
+        isChatPacket(p) ||
+        p.obj.type === PacketType.CITATION_INFO ||
+        sharedTypes.has(p.obj.type as string)
+    );
+    const imagePackets = packets.filter(
+      (p) =>
+        isImageToolPacket(p) ||
+        p.obj.type === PacketType.IMAGE_GENERATION_TOOL_DELTA ||
+        sharedTypes.has(p.obj.type as string)
+    );
+
+    return (
+      <MixedContentHandler
+        chatPackets={chatPackets}
+        imagePackets={imagePackets}
+        chatState={chatState}
+        onComplete={onComplete}
+        animate={animate}
+        stopPacketSeen={stopPacketSeen}
+        stopReason={stopReason}
+      >
+        {children}
+      </MixedContentHandler>
+    );
+  }
+
   const RendererFn = findRenderer({ packets });
-  const renderType = useShortRenderer ? RenderType.HIGHLIGHT : RenderType.FULL;
 
   if (!RendererFn) {
     return children([{ icon: null, status: null, content: <></> }]);
@@ -186,7 +268,7 @@ export const RendererComponent = memo(function RendererComponent({
       state={chatState}
       onComplete={onComplete}
       animate={animate}
-      renderType={renderType}
+      renderType={RenderType.FULL}
       stopPacketSeen={stopPacketSeen}
       stopReason={stopReason}
     >

--- a/web/src/app/app/message/messageComponents/timeline/CollapsedStreamingContent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/CollapsedStreamingContent.tsx
@@ -25,7 +25,6 @@ export const CollapsedStreamingContent = React.memo(
     stopReason,
     renderTypeOverride,
   }: CollapsedStreamingContentProps) {
-    const noopComplete = useCallback(() => {}, []);
     const renderContentOnly = useCallback(
       (results: TimelineRendererOutput) => (
         <>
@@ -44,7 +43,6 @@ export const CollapsedStreamingContent = React.memo(
             key={`${step.key}-compact`}
             packets={step.packets}
             chatState={chatState}
-            onComplete={noopComplete}
             animate={true}
             stopPacketSeen={false}
             stopReason={stopReason}

--- a/web/src/app/app/message/messageComponents/timeline/ExpandedTimelineContent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/ExpandedTimelineContent.tsx
@@ -36,8 +36,6 @@ interface TimelineStepProps {
   isStreaming?: boolean;
 }
 
-const noopCallback = () => {};
-
 const TimelineStep = React.memo(function TimelineStep({
   step,
   chatState,
@@ -97,7 +95,6 @@ const TimelineStep = React.memo(function TimelineStep({
     <TimelineRendererComponent
       packets={step.packets}
       chatState={chatState}
-      onComplete={noopCallback}
       animate={!stopPacketSeen}
       stopPacketSeen={stopPacketSeen}
       stopReason={stopReason}

--- a/web/src/app/app/message/messageComponents/timeline/ParallelTimelineTabs.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/ParallelTimelineTabs.tsx
@@ -51,8 +51,6 @@ export function ParallelTimelineTabs({
   const handleToggle = useCallback(() => setIsExpanded((prev) => !prev), []);
   const handleHeaderEnter = useCallback(() => setIsHover(true), []);
   const handleHeaderLeave = useCallback(() => setIsHover(false), []);
-  const noopComplete = useCallback(() => {}, []);
-
   const topSpacerVariant = isFirstTurnGroup ? "first" : "none";
   const shouldShowResults = !(!isExpanded && stopPacketSeen);
 
@@ -164,7 +162,6 @@ export function ParallelTimelineTabs({
             key={`${activeTab}-${isExpanded}`}
             packets={activeStep.packets}
             chatState={chatState}
-            onComplete={noopComplete}
             animate={!stopPacketSeen}
             stopPacketSeen={stopPacketSeen}
             stopReason={stopReason}

--- a/web/src/app/app/message/messageComponents/timeline/TimelineRendererComponent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/TimelineRendererComponent.tsx
@@ -34,8 +34,6 @@ export interface TimelineRendererComponentProps {
   packets: Packet[];
   /** Chat state for rendering */
   chatState: FullChatState;
-  /** Completion callback */
-  onComplete: () => void;
   /** Whether to animate streaming */
   animate: boolean;
   /** Whether stop packet has been seen */
@@ -77,7 +75,6 @@ export const TimelineRendererComponent = React.memo(
   function TimelineRendererComponent({
     packets,
     chatState,
-    onComplete,
     animate,
     stopPacketSeen,
     stopReason,
@@ -125,7 +122,7 @@ export const TimelineRendererComponent = React.memo(
       <RendererFn
         packets={packets as any}
         state={chatState}
-        onComplete={onComplete}
+        onComplete={() => {}}
         animate={animate}
         renderType={renderType}
         stopPacketSeen={stopPacketSeen}

--- a/web/src/app/app/message/messageComponents/timeline/hooks/packetProcessor.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/packetProcessor.ts
@@ -346,11 +346,11 @@ function processPacket(state: ProcessorState, packet: Packet): void {
     if (isDisplayPacket(packet)) {
       state.displayGroupKeys.add(groupKey);
     }
+  }
 
-    // Track image generation for header display
-    if (packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START) {
-      state.isGeneratingImage = true;
-    }
+  // Track image generation for header display (regardless of group position)
+  if (packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START) {
+    state.isGeneratingImage = true;
   }
 
   // Count generated images from DELTA packets

--- a/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
@@ -169,8 +169,6 @@ export const ResearchAgentRenderer: MessageRenderer<
   );
 
   // Stable callbacks to avoid creating new functions on every render
-  const noopComplete = useCallback(() => {}, []);
-
   // renderReport renders the processed content
   // Uses pre-computed processedReportContent since ExpandableTextDisplay
   // passes the same fullReportContent that we processed above
@@ -221,7 +219,6 @@ export const ResearchAgentRenderer: MessageRenderer<
             key={latestGroup.sub_turn_index}
             packets={latestGroup.packets}
             chatState={state}
-            onComplete={noopComplete}
             animate={!stopPacketSeen && !latestGroup.isComplete}
             stopPacketSeen={stopPacketSeen}
             defaultExpanded={false}
@@ -327,7 +324,6 @@ export const ResearchAgentRenderer: MessageRenderer<
               key={group.sub_turn_index}
               packets={group.packets}
               chatState={state}
-              onComplete={noopComplete}
               animate={!stopPacketSeen && !group.isComplete}
               stopPacketSeen={stopPacketSeen}
               defaultExpanded={true}


### PR DESCRIPTION
Cherry-pick of commit ac7f9838bc01c341ade4713d0f03407397dfc75d to release/v2.12 branch.

Original PR: #8494

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mixed content support so chat text and image generation packets render together in the same display group. Improves timeline rendering and image-generation status handling in v2.12.

- New Features
  - Detects groups with both chat and image generation packets.
  - Streams text and images via dedicated renderers, then combines results in order.
  - Handles shared packet types (errors, section end, citations) across both renderers.

- Refactors
  - Removed onComplete from timeline components; TimelineRendererComponent now uses an internal noop.
  - Always uses FULL render type (removes useShortRenderer path).
  - Tracks IMAGE_GENERATION_TOOL_START across all groups to keep the header “generating image” state accurate.

<sup>Written for commit 4e3b5f8e83d05e90be6052a0400da49b3bb408b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

