### PR TITLE
perf(open-url): parallelize URL fetching with split connect/read timeouts (#8580) to release v2.12

### DIFF
--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 
 from onyx.file_processing.html_utils import ParsedHTML
 from onyx.file_processing.html_utils import web_html_cleanup
@@ -21,10 +22,22 @@ from onyx.utils.web_content import title_from_url
 
 logger = setup_logger()
 
-DEFAULT_TIMEOUT_SECONDS = 15
+DEFAULT_READ_TIMEOUT_SECONDS = 15
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 5
 DEFAULT_USER_AGENT = "OnyxWebCrawler/1.0 (+https://www.onyx.app)"
 DEFAULT_MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024  # 50 MB
 DEFAULT_MAX_HTML_SIZE_BYTES = 20 * 1024 * 1024  # 20 MB
+DEFAULT_MAX_WORKERS = 5
+
+
+def _failed_result(url: str) -> WebContent:
+    return WebContent(
+        title="",
+        link=url,
+        full_content="",
+        published_date=None,
+        scrape_successful=False,
+    )
 
 
 class OnyxWebCrawler(WebContentProvider):
@@ -37,12 +50,14 @@ class OnyxWebCrawler(WebContentProvider):
     def __init__(
         self,
         *,
-        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        timeout_seconds: int = DEFAULT_READ_TIMEOUT_SECONDS,
+        connect_timeout_seconds: int = DEFAULT_CONNECT_TIMEOUT_SECONDS,
         user_agent: str = DEFAULT_USER_AGENT,
         max_pdf_size_bytes: int | None = None,
         max_html_size_bytes: int | None = None,
     ) -> None:
-        self._timeout_seconds = timeout_seconds
+        self._read_timeout_seconds = timeout_seconds
+        self._connect_timeout_seconds = connect_timeout_seconds
         self._max_pdf_size_bytes = max_pdf_size_bytes
         self._max_html_size_bytes = max_html_size_bytes
         self._headers = {
@@ -51,75 +66,68 @@ class OnyxWebCrawler(WebContentProvider):
         }
 
     def contents(self, urls: Sequence[str]) -> list[WebContent]:
-        results: list[WebContent] = []
-        for url in urls:
-            results.append(self._fetch_url(url))
-        return results
+        if not urls:
+            return []
+
+        max_workers = min(DEFAULT_MAX_WORKERS, len(urls))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(self._fetch_url_safe, urls))
+
+    def _fetch_url_safe(self, url: str) -> WebContent:
+        """Wrapper that catches all exceptions so one bad URL doesn't kill the batch."""
+        try:
+            return self._fetch_url(url)
+        except Exception as exc:
+            logger.warning(
+                "Onyx crawler unexpected error for %s (%s)",
+                url,
+                exc.__class__.__name__,
+            )
+            return _failed_result(url)
 
     def _fetch_url(self, url: str) -> WebContent:
         try:
-            # Use SSRF-safe request to prevent DNS rebinding attacks
             response = ssrf_safe_get(
-                url, headers=self._headers, timeout=self._timeout_seconds
+                url,
+                headers=self._headers,
+                timeout=(self._connect_timeout_seconds, self._read_timeout_seconds),
             )
         except SSRFException as exc:
             logger.error(
-                "SSRF protection blocked request to %s: %s",
+                "SSRF protection blocked request to %s (%s)",
                 url,
-                str(exc),
+                exc.__class__.__name__,
             )
-            return WebContent(
-                title="",
-                link=url,
-                full_content="",
-                published_date=None,
-                scrape_successful=False,
-            )
-        except Exception as exc:  # pragma: no cover - network failures vary
+            return _failed_result(url)
+        except Exception as exc:
             logger.warning(
                 "Onyx crawler failed to fetch %s (%s)",
                 url,
                 exc.__class__.__name__,
             )
-            return WebContent(
-                title="",
-                link=url,
-                full_content="",
-                published_date=None,
-                scrape_successful=False,
-            )
+            return _failed_result(url)
 
         if response.status_code >= 400:
             logger.warning("Onyx crawler received %s for %s", response.status_code, url)
-            return WebContent(
-                title="",
-                link=url,
-                full_content="",
-                published_date=None,
-                scrape_successful=False,
-            )
+            return _failed_result(url)
 
         content_type = response.headers.get("Content-Type", "")
-        content_sniff = response.content[:1024] if response.content else None
+        content = response.content
+
+        content_sniff = content[:1024] if content else None
         if is_pdf_resource(url, content_type, content_sniff):
             if (
                 self._max_pdf_size_bytes is not None
-                and len(response.content) > self._max_pdf_size_bytes
+                and len(content) > self._max_pdf_size_bytes
             ):
                 logger.warning(
                     "PDF content too large (%d bytes) for %s, max is %d",
-                    len(response.content),
+                    len(content),
                     url,
                     self._max_pdf_size_bytes,
                 )
-                return WebContent(
-                    title="",
-                    link=url,
-                    full_content="",
-                    published_date=None,
-                    scrape_successful=False,
-                )
-            text_content, metadata = extract_pdf_text(response.content)
+                return _failed_result(url)
+            text_content, metadata = extract_pdf_text(content)
             title = title_from_pdf_metadata(metadata) or title_from_url(url)
             return WebContent(
                 title=title,
@@ -131,25 +139,19 @@ class OnyxWebCrawler(WebContentProvider):
 
         if (
             self._max_html_size_bytes is not None
-            and len(response.content) > self._max_html_size_bytes
+            and len(content) > self._max_html_size_bytes
         ):
             logger.warning(
                 "HTML content too large (%d bytes) for %s, max is %d",
-                len(response.content),
+                len(content),
                 url,
                 self._max_html_size_bytes,
             )
-            return WebContent(
-                title="",
-                link=url,
-                full_content="",
-                published_date=None,
-                scrape_successful=False,
-            )
+            return _failed_result(url)
 
         try:
             decoded_html = decode_html_bytes(
-                response.content,
+                content,
                 content_type=content_type,
                 fallback_encoding=response.apparent_encoding or response.encoding,
             )

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -146,7 +146,7 @@ MAX_REDIRECTS = 10
 def _make_ssrf_safe_request(
     url: str,
     headers: dict[str, str] | None = None,
-    timeout: int = 15,
+    timeout: float | tuple[float, float] = 15,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -204,7 +204,7 @@ def _make_ssrf_safe_request(
 def ssrf_safe_get(
     url: str,
     headers: dict[str, str] | None = None,
-    timeout: int = 15,
+    timeout: float | tuple[float, float] = 15,
     follow_redirects: bool = True,
     **kwargs: Any,
 ) -> requests.Response:

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+import time
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
 from pydantic import BaseModel
 
 import onyx.tools.tool_implementations.open_url.onyx_web_crawler as crawler_module
+from onyx.tools.tool_implementations.open_url.onyx_web_crawler import (
+    DEFAULT_CONNECT_TIMEOUT_SECONDS,
+)
+from onyx.tools.tool_implementations.open_url.onyx_web_crawler import (
+    DEFAULT_READ_TIMEOUT_SECONDS,
+)
 from onyx.tools.tool_implementations.open_url.onyx_web_crawler import OnyxWebCrawler
 
 
@@ -181,3 +191,163 @@ def test_fetch_url_html_within_size_limit(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert "hello world" in result.full_content
     assert result.scrape_successful is True
+
+
+# ---------------------------------------------------------------------------
+# Helpers for parallel / failure-isolation / timeout tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response(
+    *,
+    status_code: int = 200,
+    content: bytes = b"<html><body>Hello</body></html>",
+    content_type: str = "text/html",
+    delay: float = 0.0,
+) -> MagicMock:
+    """Create a mock response that behaves like a requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {"Content-Type": content_type}
+
+    if delay:
+        original_content = content
+
+        @property  # type: ignore[misc]
+        def _delayed_content(_self: object) -> bytes:
+            time.sleep(delay)
+            return original_content
+
+        type(resp).content = _delayed_content
+    else:
+        resp.content = content
+
+    resp.apparent_encoding = None
+    resp.encoding = None
+
+    return resp
+
+
+class TestParallelExecution:
+    """Verify that contents() fetches URLs in parallel."""
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_multiple_urls_fetched_concurrently(self, mock_get: MagicMock) -> None:
+        """With a per-URL delay, parallel execution should be much faster than sequential."""
+        per_url_delay = 0.3
+        num_urls = 5
+        urls = [f"http://example.com/page{i}" for i in range(num_urls)]
+
+        mock_get.return_value = _make_mock_response(delay=per_url_delay)
+
+        crawler = OnyxWebCrawler()
+        start = time.monotonic()
+        results = crawler.contents(urls)
+        elapsed = time.monotonic() - start
+
+        # Sequential would take ~1.5s; parallel should be well under that
+        assert elapsed < per_url_delay * num_urls * 0.7
+        assert len(results) == num_urls
+        assert all(r.scrape_successful for r in results)
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_empty_urls_returns_empty(self, mock_get: MagicMock) -> None:
+        crawler = OnyxWebCrawler()
+        results = crawler.contents([])
+        assert results == []
+        mock_get.assert_not_called()
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_single_url(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_mock_response()
+        crawler = OnyxWebCrawler()
+        results = crawler.contents(["http://example.com"])
+        assert len(results) == 1
+        assert results[0].scrape_successful
+
+
+class TestFailureIsolation:
+    """Verify that one URL failure doesn't affect others in the batch."""
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_one_failure_doesnt_kill_batch(self, mock_get: MagicMock) -> None:
+        good_resp = _make_mock_response()
+        bad_resp = _make_mock_response(status_code=500)
+
+        # First and third URLs succeed, second fails
+        mock_get.side_effect = [good_resp, bad_resp, good_resp]
+
+        crawler = OnyxWebCrawler()
+        results = crawler.contents(["http://a.com", "http://b.com", "http://c.com"])
+
+        assert len(results) == 3
+        assert results[0].scrape_successful
+        assert not results[1].scrape_successful
+        assert results[2].scrape_successful
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_exception_doesnt_kill_batch(self, mock_get: MagicMock) -> None:
+        good_resp = _make_mock_response()
+
+        # Second URL raises an exception
+        mock_get.side_effect = [
+            good_resp,
+            RuntimeError("connection reset"),
+            _make_mock_response(),
+        ]
+
+        crawler = OnyxWebCrawler()
+        results = crawler.contents(["http://a.com", "http://b.com", "http://c.com"])
+
+        assert len(results) == 3
+        assert results[0].scrape_successful
+        assert not results[1].scrape_successful
+        assert results[2].scrape_successful
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_ssrf_exception_doesnt_kill_batch(self, mock_get: MagicMock) -> None:
+        from onyx.utils.url import SSRFException
+
+        good_resp = _make_mock_response()
+        mock_get.side_effect = [
+            good_resp,
+            SSRFException("blocked"),
+            _make_mock_response(),
+        ]
+
+        crawler = OnyxWebCrawler()
+        results = crawler.contents(
+            ["http://a.com", "http://internal.local", "http://c.com"]
+        )
+
+        assert len(results) == 3
+        assert results[0].scrape_successful
+        assert not results[1].scrape_successful
+        assert results[2].scrape_successful
+
+
+class TestTupleTimeout:
+    """Verify that separate connect and read timeouts are passed correctly."""
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_default_tuple_timeout(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_mock_response()
+
+        crawler = OnyxWebCrawler()
+        crawler.contents(["http://example.com"])
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["timeout"] == (
+            DEFAULT_CONNECT_TIMEOUT_SECONDS,
+            DEFAULT_READ_TIMEOUT_SECONDS,
+        )
+
+    @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+    def test_custom_tuple_timeout(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_mock_response()
+
+        crawler = OnyxWebCrawler(timeout_seconds=30, connect_timeout_seconds=3)
+        crawler.contents(["http://example.com"])
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["timeout"] == (3, 30)

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -291,7 +291,7 @@ class TestSsrfSafeGet:
                 assert call_args[1]["headers"]["User-Agent"] == "TestBot/1.0"
 
     def test_passes_timeout(self) -> None:
-        """Test that timeout is passed through."""
+        """Test that timeout is passed through, including tuple form."""
         mock_response = MagicMock()
         mock_response.is_redirect = False
 
@@ -301,7 +301,7 @@ class TestSsrfSafeGet:
             with patch("onyx.utils.url.requests.get") as mock_get:
                 mock_get.return_value = mock_response
 
-                ssrf_safe_get("http://example.com/", timeout=30)
+                ssrf_safe_get("http://example.com/", timeout=(5, 15))
 
                 call_args = mock_get.call_args
-                assert call_args[1]["timeout"] == 30
+                assert call_args[1]["timeout"] == (5, 15)


### PR DESCRIPTION
Cherry-pick of commit 29958f1a52b9f73c1ad1c37b86e08bd257a65c95 to release/v2.12 branch.

Original PR: #8580

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelize URL fetching in OnyxWebCrawler and add split connect/read timeouts to reduce latency and prevent long hangs. Hardens batch behavior so one bad URL doesn’t affect others.

- **New Features**
  - Fetch URLs concurrently with ThreadPoolExecutor (up to 5 workers).
  - Use separate connect/read timeouts (default 5s connect, 15s read) and pass them to ssrf_safe_get; URL utils now accept tuple timeouts.
  - Isolate per-URL failures and HTTP errors; return a safe “failed” result instead of aborting the batch.
  - Added unit tests for parallelism, failure isolation, and tuple timeouts.

<sup>Written for commit 22896e4dc7f1ba08dcb95d3cef6fb9880fdecebd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

