### PR TITLE
fix(popover): prevent viewport overflow with dynamic max-height and collision padding (#8675) to release v2.12

### DIFF
--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -135,8 +135,10 @@ function PopoverContent({
         ref={ref}
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={8}
         className={cn(
           "bg-background-neutral-00 p-1 z-popover rounded-12 overflow-hidden border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "max-h-[var(--radix-popover-content-available-height)]",
           widthClasses[width]
         )}
         {...props}


### PR DESCRIPTION
Cherry-pick of commit a4387f230b7758319b394fb7be9b1ac15e75f94c to release/v2.12 branch.

Original PR: #8675

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented Popover from overflowing the viewport by adding a dynamic max-height and 8px collision padding. Popovers now stay within screen bounds and keep a small gap from edges.

<sup>Written for commit fd4222822815baf0b7f9b50b2a105843b56ae289. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

