### PR TITLE
chore(gha): rm docker-compose.opensearch.yml ref

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -160,7 +160,7 @@ jobs:
           cd deployment/docker_compose
 
           # Get list of running containers
-          containers=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.opensearch.yml ps -q)
+          containers=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml ps -q)
 
           # Collect logs from each container
           for container in $containers; do


### PR DESCRIPTION
## Description

This file no longer exists and causes an error when these tests fail, https://github.com/onyx-dot-app/onyx/actions/runs/22586720487/job/65433598380?pr=8880#step:12:72

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the docker-compose.opensearch.yml reference in the PR external-dependency unit tests workflow to prevent errors during container log collection when tests fail. The workflow now composes with docker-compose.yml and docker-compose.dev.yml only.

<sup>Written for commit d3f1f50393f65a3238ae34d42e9687c54771e438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

