### PR TITLE
chore(playwright): hide actions toolbar buttons in screenshots

### DIFF
--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -705,6 +705,7 @@ const AppInputBar = React.memo(
 
                 {/* Controls that load in when data is ready */}
                 <div
+                  data-testid="actions-container"
                   className={cn(
                     "flex flex-row items-center",
                     controlsLoading && "invisible"

--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -32,7 +32,7 @@ const DEFAULT_MASK_SELECTORS: string[] = [
 const DEFAULT_HIDE_SELECTORS: string[] = [
   '[data-testid="toast-container"]',
   // TODO: Remove once it loads consistently.
-  '[data-testid="action-management-toggle"]',
+  '[data-testid="actions-container"]',
 ];
 
 interface ScreenshotOptions {


### PR DESCRIPTION
## Description

I meant to look into improving the load time of these buttons last week, but didn't get to it, so let's just hide them by default until I can find time to investigate -- don't want to build a tolerance for flaky visual regression reports.

Like these,
<img width="1633" height="807" alt="20260302_10h33m23s_grim" src="https://github.com/user-attachments/assets/89932f65-7ee9-4244-94bd-ed4baef3569d" />


## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Actions toolbar container in Playwright screenshots to prevent flaky visual diffs from inconsistent load times. Added a data-testid="actions-container" and hid it via DEFAULT_HIDE_SELECTORS in visualRegression.ts; will remove once it loads consistently.

<sup>Written for commit f20a07e5f0be83c51c6ff8d0c4cb764e96824768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



