### PR TITLE
chore: Bump code interpreter to 0.3.1

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 5.4.0
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
-  version: 0.3.0
-digest: sha256:cf8f01906d46034962c6ce894770621ee183ac761e6942951118aeb48540eddd
-generated: "2026-02-24T10:59:38.78318-08:00"
+  version: 0.3.1
+digest: sha256:4965b6ea3674c37163832a2192cd3bc8004f2228729fca170af0b9f457e8f987
+generated: "2026-03-02T15:29:39.632344-08:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.3.0
+    version: 0.3.1
     repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description
Bumps code interpreter version


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade code-interpreter Helm dependency from 0.3.0 to 0.3.1 in the Onyx chart to pull in the latest fixes.

- **Dependencies**
  - code-interpreter: 0.3.0 → 0.3.1 (updated Chart.yaml and Chart.lock)

<sup>Written for commit 26be88916c75cb89e9f2fd1aa1e30c6231999a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

