### PR TITLE
chore(fe): space between Manage All connectors button

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -472,7 +472,7 @@ function ChatPreferencesForm() {
 
                   <Section
                     flexDirection="row"
-                    justifyContent="start"
+                    justifyContent="between"
                     alignItems="center"
                     gap={0.25}
                   >
@@ -480,22 +480,29 @@ function ChatPreferencesForm() {
                       <EmptyMessage title="No connectors set up" />
                     ) : (
                       <>
-                        {uniqueSources.slice(0, 3).map((source) => {
-                          const meta = getSourceMetadata(source);
-                          return (
-                            <Card
-                              key={source}
-                              padding={0.75}
-                              className="w-[10rem]"
-                            >
-                              <Content
-                                icon={meta.icon}
-                                title={meta.displayName}
-                                sizePreset="main-ui"
-                              />
-                            </Card>
-                          );
-                        })}
+                        <Section
+                          flexDirection="row"
+                          justifyContent="start"
+                          alignItems="center"
+                          gap={0.25}
+                        >
+                          {uniqueSources.slice(0, 3).map((source) => {
+                            const meta = getSourceMetadata(source);
+                            return (
+                              <Card
+                                key={source}
+                                padding={0.75}
+                                className="w-[10rem]"
+                              >
+                                <Content
+                                  icon={meta.icon}
+                                  title={meta.displayName}
+                                  sizePreset="main-ui"
+                                />
+                              </Card>
+                            );
+                          })}
+                        </Section>
 
                         <Button
                           href="/admin/indexing/status"


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3762/manage-all-for-connectors-should-be-aligned-on-the-right

## How Has This Been Tested?

<img width="1707" height="2085" alt="20260302_15h36m56s_grim" src="https://github.com/user-attachments/assets/6f6c301b-af85-40ae-b6ed-7a87312ceed3" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the "Manage All" connectors button to the right and adds spacing from the connector cards on the Chat Preferences page. Fulfills Linear ENG-3762.

- **Bug Fixes**
  - Set parent Section to justifyContent="between" and grouped connector cards in a child Section justified "start" to keep cards together and push the button right.

<sup>Written for commit 7a6cb20f4cfeea2791776d371c01a2f9e2e1045b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

