### PR TITLE
fix: Sticky background in CSV Preview Variant

### DIFF
--- a/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
@@ -46,7 +46,7 @@ export const csvVariant: PreviewVariant = {
     return (
       <Section justifyContent="start" alignItems="start" padding={1}>
         <Table>
-          <TableHeader className="sticky top-0 z-sticky">
+          <TableHeader className="sticky top-0 z-sticky bg-background-tint-01">
             <TableRow noHover>
               {headers.map((h: string, i: number) => (
                 <TableHead key={i}>
@@ -64,7 +64,7 @@ export const csvVariant: PreviewVariant = {
                   <TableCell
                     key={cIdx}
                     className={cn(
-                      cIdx === 0 && "sticky left-0",
+                      cIdx === 0 && "sticky left-0 bg-background-tint-01",
                       "py-4 px-4 whitespace-normal break-words"
                     )}
                   >


### PR DESCRIPTION
## Description
Currently for the sticky header + first col, the following background is transparent. When scrolling, this leads to overlapping display. This adds a background to the sticky header and first col so that now that lies over the top of everything.

<img width="1918" height="984" alt="Screenshot 2026-03-02 at 3 45 11 PM" src="https://github.com/user-attachments/assets/8d13e295-b790-47b3-83b6-9b6fb6a1eee7" />


## How Has This Been Tested?
Visual / Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping content in the CSV Preview when using a sticky header and first column. The sticky areas now have a background so they sit cleanly above scrolled content.

- **Bug Fixes**
  - Added bg-background-tint-01 to TableHeader and first-column cells to prevent transparency during scroll.

<sup>Written for commit 8781a879c8bf43ea9b174717daf7cafc1701478a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

