### PR TITLE
fix(a11y): settings popover buttons prefer href (#8880) to release v3.0

### DIFF
--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -72,6 +72,8 @@ export interface LineItemProps
   description?: string;
   rightChildren?: React.ReactNode;
   href?: string;
+  rel?: string;
+  target?: string;
   ref?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
 }
@@ -141,6 +143,8 @@ export default function LineItem({
   children,
   rightChildren,
   href,
+  rel,
+  target,
   ref,
   ...props
 }: LineItemProps) {
@@ -241,5 +245,9 @@ export default function LineItem({
   );
 
   if (!href) return content;
-  return <Link href={href as Route}>{content}</Link>;
+  return (
+    <Link href={href as Route} rel={rel} target={target}>
+      {content}
+    </Link>
+  );
 }

--- a/web/src/sections/sidebar/UserAvatarPopover.tsx
+++ b/web/src/sections/sidebar/UserAvatarPopover.tsx
@@ -102,7 +102,11 @@ function SettingsPopover({
       <PopoverMenu>
         {[
           <div key="user-settings" data-testid="Settings/user-settings">
-            <LineItem icon={SvgUser} onClick={onUserSettingsClick}>
+            <LineItem
+              icon={SvgUser}
+              href="/app/settings"
+              onClick={onUserSettingsClick}
+            >
               User Settings
             </LineItem>
           </div>,
@@ -118,13 +122,9 @@ function SettingsPopover({
           <LineItem
             key="help-faq"
             icon={SvgExternalLink}
-            onClick={() =>
-              window.open(
-                "https://docs.onyx.app",
-                "_blank",
-                "noopener,noreferrer"
-              )
-            }
+            href="https://docs.onyx.app"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Help & FAQ
           </LineItem>,
@@ -233,7 +233,6 @@ export default function UserAvatarPopover({
           <SettingsPopover
             onUserSettingsClick={() => {
               setPopupState(undefined);
-              router.push("/app/settings");
             }}
             onOpenNotifications={() => setPopupState("Notifications")}
           />


### PR DESCRIPTION
Cherry-pick of commit 9c05bd215df50ad7454a06c84586be2da2c42908 to release/v3.0 branch.

Original PR: #8880

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make settings popover actions use actual links for navigation to improve accessibility and browser semantics. External docs now open safely in a new tab.

- **Bug Fixes**
  - Added rel and target props to LineItem and pass them to Link.
  - User Settings now navigates via href="/app/settings" instead of programmatic push.
  - Help & FAQ uses href with target="_blank" and rel="noopener noreferrer".
  - Improves keyboard navigation and link semantics in the popover.

<sup>Written for commit 1f50c1fcca5cb5e2a3697de1d4c07437c18e84d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

