### PR TITLE
fix(fe): rm non-admin-confirmation max-width (#8693) to release v3.0

### DIFF
--- a/web/src/refresh-components/onboarding/components/NonAdminStep.tsx
+++ b/web/src/refresh-components/onboarding/components/NonAdminStep.tsx
@@ -51,7 +51,7 @@ export default function NonAdminStep() {
     <>
       {showHeader && (
         <div
-          className="flex items-center justify-between w-full max-w-[800px] min-h-11 py-1 pl-3 pr-2 bg-background-tint-00 rounded-16 shadow-01 mb-2"
+          className="flex items-center justify-between w-full min-h-11 py-1 pl-3 pr-2 bg-background-tint-00 rounded-16 shadow-01 mb-2"
           aria-label="non-admin-confirmation"
         >
           <div className="flex items-center gap-1">


### PR DESCRIPTION
Cherry-pick of commit c4556515beb97657309c4b48d0ac76ecffaf708e to release/v3.0 branch.

Original PR: #8693

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 800px max-width from the non-admin confirmation banner in onboarding. The banner now uses the full available width, fixing cramped layout on larger screens.

<sup>Written for commit d2a09909f9ac2214e594cc440fa38c9a55439074. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

