### PR TITLE
fix(fe): inline code-blocks respect header font-size (#8691) to release v3.0

### DIFF
--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -62,12 +62,13 @@ export const CodeBlock = memo(function CodeBlock({
   if (typeof children === "string" && !language) {
     return (
       <span
+        data-testid="code-block"
         className={cn(
           "font-mono",
           "text-text-05",
           "bg-background-tint-00",
           "rounded",
-          "text-xs",
+          "text-[0.75em]",
           "inline",
           "whitespace-pre-wrap",
           "break-words",

--- a/web/tests/e2e/chat/chat_message_rendering.spec.ts
+++ b/web/tests/e2e/chat/chat_message_rendering.spec.ts
@@ -707,6 +707,58 @@ The platform architecture document provides additional context on how these impr
       });
     });
 
+    test.describe("Header Levels", () => {
+      const HEADINGS_RESPONSE = `# Getting Started
+
+This is the introductory paragraph.
+
+## Installing the \`onyx-sdk\`
+
+Follow these steps to install the SDK.
+
+### Configuration Options
+
+Some details about configuration.
+
+#### The \`max_results\` Parameter
+
+Set \`max_results\` to limit the number of returned documents.`;
+
+      test("h1 through h4 headings with inline code render correctly", async ({
+        page,
+      }) => {
+        await openChat(page);
+        await mockChatEndpoint(page, HEADINGS_RESPONSE);
+
+        await sendMessage(page, "Show me all heading levels");
+
+        const aiMessage = page.getByTestId("onyx-ai-message").first();
+
+        await expect(aiMessage.locator("h1")).toContainText("Getting Started");
+        await expect(aiMessage.locator("h2")).toContainText("Installing the");
+        await expect(
+          aiMessage.locator("h2").locator('[data-testid="code-block"]')
+        ).toContainText("onyx-sdk");
+        await expect(aiMessage.locator("h3")).toContainText(
+          "Configuration Options"
+        );
+        await expect(aiMessage.locator("h4")).toContainText("Parameter");
+        await expect(
+          aiMessage.locator("h4").locator('[data-testid="code-block"]')
+        ).toContainText("max_results");
+
+        await expect(aiMessage.locator("h1")).toHaveCount(1);
+        await expect(aiMessage.locator("h2")).toHaveCount(1);
+        await expect(aiMessage.locator("h3")).toHaveCount(1);
+        await expect(aiMessage.locator("h4")).toHaveCount(1);
+
+        await screenshotChatContainer(
+          page,
+          `chat-heading-levels-h1-h4-${theme}`
+        );
+      });
+    });
+
     test.describe("Message Interaction States", () => {
       test("hovering over user message shows action buttons", async ({
         page,


### PR DESCRIPTION
Cherry-pick of commit beb1c49c69b7ef2b6e09632a03e21b578d4ffde4 to release/v3.0 branch.

Original PR: #8691

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline code inside headings now scales with the heading size in chat messages. This fixes tiny inline code in h1–h4 and improves readability.

- **Bug Fixes**
  - Use text-[0.75em] for inline code so it scales with header font-size.
  - Add data-testid="code-block" and e2e tests for h1–h4 with inline code.

<sup>Written for commit bfe16ba1f1e547efec32c5ee478e7abe0b5e2f7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

