### PR TITLE
fix(welcome): add back agent description (#8716) to release v3.0

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -40,6 +40,7 @@ import useAgentController from "@/hooks/useAgentController";
 import useChatSessionController from "@/hooks/useChatSessionController";
 import useDeepResearchToggle from "@/hooks/useDeepResearchToggle";
 import useIsDefaultAgent from "@/hooks/useIsDefaultAgent";
+import AgentDescription from "@/app/app/components/AgentDescription";
 import {
   useChatSessionStore,
   useCurrentMessageHistory,
@@ -889,6 +890,15 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
                 {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
                 <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full">
+                  {/* Agent description below input */}
+                  {(appFocus.isNewSession() || appFocus.isAgent()) &&
+                    !isDefaultAgent && (
+                      <>
+                        <Spacer rem={1} />
+                        <AgentDescription agent={liveAssistant} />
+                        <Spacer rem={1.5} />
+                      </>
+                    )}
                   {/* ProjectChatSessionList */}
                   {appFocus.isProject() && (
                     <div className="w-full max-w-[var(--app-page-main-content-width)] h-full overflow-y-auto overscroll-y-none mx-auto">

--- a/web/tests/e2e/assistants/create_and_edit_assistant.spec.ts
+++ b/web/tests/e2e/assistants/create_and_edit_assistant.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, Browser } from "@playwright/test";
-import { loginAs, loginAsRandomUser } from "@tests/e2e/utils/auth";
+import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
 
 // --- Locator Helper Functions ---
 const getNameInput = (page: Page) => page.locator('input[name="name"]');
@@ -138,13 +139,11 @@ test.describe("Assistant Creation and Edit Verification", () => {
 
     test("should create assistant with user files when no connectors exist @exclusive", async ({
       page,
-    }: {
-      page: Page;
-    }) => {
+    }, testInfo) => {
       await page.context().clearCookies();
-      await loginAsRandomUser(page);
+      await loginAsWorkerUser(page, testInfo.workerIndex);
 
-      const assistantName = `User Files Test ${Date.now()}`;
+      const assistantName = "E2E User Files Assistant";
       const assistantDescription =
         "Testing user file uploads without connectors";
       const assistantInstructions = "Help users with their documents.";
@@ -220,9 +219,7 @@ test.describe("Assistant Creation and Edit Verification", () => {
 
     test("should create and edit assistant with Knowledge enabled", async ({
       page,
-    }: {
-      page: Page;
-    }) => {
+    }, testInfo) => {
       // Login as admin to create connector and document set (requires admin permissions)
       await page.context().clearCookies();
       await loginAs(page, "admin");
@@ -241,17 +238,17 @@ test.describe("Assistant Creation and Edit Verification", () => {
 
       // Now login as a regular user to test the assistant creation
       await page.context().clearCookies();
-      await loginAsRandomUser(page);
+      await loginAsWorkerUser(page, testInfo.workerIndex);
 
       // --- Initial Values ---
-      const assistantName = `Test Assistant ${Date.now()}`;
+      const assistantName = "Test Assistant 1";
       const assistantDescription = "This is a test assistant description.";
       const assistantInstructions = "These are the test instructions.";
       const assistantReminder = "Initial reminder.";
       const assistantStarterMessage = "Initial starter message?";
 
       // --- Edited Values ---
-      const editedAssistantName = `Edited Assistant ${Date.now()}`;
+      const editedAssistantName = "Edited Assistant";
       const editedAssistantDescription = "This is the edited description.";
       const editedAssistantInstructions = "These are the edited instructions.";
       const editedAssistantReminder = "Edited reminder.";
@@ -296,6 +293,7 @@ test.describe("Assistant Creation and Edit Verification", () => {
       expect(assistantIdMatch).toBeTruthy();
       const assistantId = assistantIdMatch ? assistantIdMatch[1] : null;
       expect(assistantId).not.toBeNull();
+      await expectScreenshot(page, { name: "welcome-page-with-assistant" });
 
       // Store assistant ID for cleanup
       knowledgeAssistantId = Number(assistantId);


### PR DESCRIPTION
Cherry-pick of commit 82aad5e2537d9bb6630644a98affae921ad23d1a to release/v3.0 branch.

Original PR: #8716

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the agent description on the welcome screen so users see what an assistant does when starting a new chat. Also strengthens E2E coverage for this view.

- **Bug Fixes**
  - Show AgentDescription below the input when starting a new session or viewing an agent, if the agent isn’t the default.
  - Add small spacers around the description for clean layout.
  - E2E: switch to worker-scoped login, use stable assistant names, and add a visual check (welcome-page-with-assistant).

<sup>Written for commit 510925beff76c0526f0add6027c39f8fd433b12f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

