### PR TITLE
fix(fe): middle align human chat message text (#8756) to release v3.0

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -209,7 +209,11 @@ const HumanMessage = React.memo(function HumanMessage({
                   }
                 }}
               >
-                <Text as="p" mainContentBody>
+                <Text
+                  as="p"
+                  className="inline-block align-middle"
+                  mainContentBody
+                >
                   {content}
                 </Text>
               </div>


### PR DESCRIPTION
Cherry-pick of commit 52799e9c7a864fc574e91047ff5d30ae2b9a1c7a to release/v3.0 branch.

Original PR: #8756

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Middle-align human chat message text to fix vertical misalignment with the bubble and adjacent elements in v3.0.

- **Bug Fixes**
  - Set Text to inline-block and align-middle in HumanMessage to vertically center the message content.

<sup>Written for commit ad2cc80c88084995ad664043182ff486415c6a2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

