### PR TITLE
chore(whitelabeling): always show sidebar icon without logo icon (#8860) to release v3.0

### DIFF
--- a/web/src/sections/sidebar/SidebarWrapper.tsx
+++ b/web/src/sections/sidebar/SidebarWrapper.tsx
@@ -13,6 +13,7 @@ interface LogoSectionProps {
 function LogoSection({ folded, onFoldClick }: LogoSectionProps) {
   const settings = useSettingsContext();
   const applicationName = settings.enterpriseSettings?.application_name;
+  const logoDisplayStyle = settings.enterpriseSettings?.logo_display_style;
 
   const logo = useCallback(
     (className?: string) => <Logo folded={folded} className={className} />,
@@ -43,7 +44,7 @@ function LogoSection({ folded, onFoldClick }: LogoSectionProps) {
     >
       {folded === undefined ? (
         <div className="p-1">{logo()}</div>
-      ) : folded ? (
+      ) : folded && logoDisplayStyle !== "name_only" ? (
         <>
           <div className="group-hover/SidebarWrapper:hidden pt-1.5">
             {logo()}
@@ -52,6 +53,8 @@ function LogoSection({ folded, onFoldClick }: LogoSectionProps) {
             {closeButton(false)}
           </div>
         </>
+      ) : folded ? (
+        <div className="flex w-full justify-center">{closeButton(false)}</div>
       ) : (
         <>
           <div className="p-1"> {logo()}</div>


### PR DESCRIPTION
Cherry-pick of commit d2deefd1f1fdbb70f5e6b40759e1ed1543e06bc7 to release/v3.0 branch.

Original PR: #8860

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the sidebar toggle visible when whitelabeling hides the logo (logo_display_style = "name_only"). In folded mode, the logo icon is hidden and the toggle button is centered so users can still expand the sidebar.

<sup>Written for commit feb5de943a14e45c5abd8f698d007a06315603d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

