### PR TITLE
chore(gha): rm docker-compose.opensearch.yml ref (#8912) to release v3.0

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -161,7 +161,7 @@ jobs:
           cd deployment/docker_compose
 
           # Get list of running containers
-          containers=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.opensearch.yml ps -q)
+          containers=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml ps -q)
 
           # Collect logs from each container
           for container in $containers; do


### PR DESCRIPTION
Cherry-pick of commit 59d3725fc696494e1cb5991ac418bdb2aff5233e to release/v3.0 branch.

Original PR: #8912

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove docker-compose.opensearch.yml from the external dependency unit test workflow to align with v3.0 and prevent missing-file errors during log collection. The job now uses only docker-compose.yml and docker-compose.dev.yml.

<sup>Written for commit ca5f8cb3bdb5fe1245d57a6194d41f562992fc7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

