### PR TITLE
chore(playwright): hide actions toolbar buttons in screenshots (#8914) to release v3.0

### DIFF
--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -695,6 +695,7 @@ const AppInputBar = React.memo(
 
                 {/* Controls that load in when data is ready */}
                 <div
+                  data-testid="actions-container"
                   className={cn(
                     "flex flex-row items-center",
                     controlsLoading && "invisible"

--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -29,7 +29,11 @@ const DEFAULT_MASK_SELECTORS: string[] = [
  * Default selectors to hide (visibility: hidden) across all screenshots.
  * These elements are overlays or ephemeral UI that would cause spurious diffs.
  */
-const DEFAULT_HIDE_SELECTORS: string[] = ['[data-testid="toast-container"]'];
+const DEFAULT_HIDE_SELECTORS: string[] = [
+  '[data-testid="toast-container"]',
+  // TODO: Remove once it loads consistently.
+  '[data-testid="actions-container"]',
+];
 
 interface ScreenshotOptions {
   /**


### PR DESCRIPTION
Cherry-pick of commit 4f3c54f282c29e403d474daabbf3c9fde26ee4fc to release/v3.0 branch.

Original PR: #8914

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the actions toolbar in Playwright visual regression screenshots to avoid flaky diffs from late-loading UI. Improves test stability for v3.0.

- **Bug Fixes**
  - Added data-testid="actions-container" to the toolbar container.
  - Hid '[data-testid="actions-container"]' via DEFAULT_HIDE_SELECTORS in visualRegression.ts (temporary until load is consistent).

<sup>Written for commit ec31393b80efbbc7c4e57162255efb404f8c0397. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

