### PR TITLE
fix(fe): Search Actions popover has consistent hover states (#8826) to release v3.0

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -184,7 +184,7 @@ export default function ActionLineItem({
               )}
 
               {isSearchToolAndNotInProject && (
-                <IconButton
+                <Button
                   icon={
                     isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
                   }
@@ -193,11 +193,8 @@ export default function ActionLineItem({
                       router.push("/admin/add-connector");
                     else onSourceManagementOpen?.();
                   })}
-                  internal
-                  className={cn(
-                    isSearchToolWithNoConnectors &&
-                      "invisible group-hover/LineItem:visible"
-                  )}
+                  prominence="tertiary"
+                  size="sm"
                   tooltip={
                     isSearchToolWithNoConnectors
                       ? "Add Connectors"


### PR DESCRIPTION
Cherry-pick of commit 6b28c6bbfc6ac9daf364372ff4b991bb99fb38a8 to release/v3.0 branch.

Original PR: #8826

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent hover behavior in the Search Actions popover by replacing the trailing IconButton with a standard tertiary, small Button and removing hover-only visibility logic. This ensures the action button has consistent styling, visibility, and hover states in v3.0.

- **Bug Fixes**
  - In ActionLineItem, swap IconButton → Button (prominence="tertiary", size="sm") for search tool actions.
  - Remove invisible/group-hover class and the unused "internal" prop; keep tooltip and navigation behavior unchanged.

<sup>Written for commit d23c12f072031a09c6cc90d14d3a2a1ae0ea8268. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

