### PR TITLE
chore(fe): update disabled "select" button color (#8733) to release v3.0

### DIFF
--- a/web/lib/opal/src/core/interactive/styles.css
+++ b/web/lib/opal/src/core/interactive/styles.css
@@ -394,7 +394,7 @@
 }
 .interactive[data-interactive-base-variant="select"][data-disabled] {
   @apply bg-transparent;
-  --interactive-foreground: var(--text-02);
+  --interactive-foreground: var(--text-01);
 }
 .interactive[data-interactive-base-variant="select"][data-selected="true"][data-disabled] {
   --interactive-foreground: var(--action-link-03);


### PR DESCRIPTION
Cherry-pick of commit a5c1f50a8a360cf3e74a2304338ea65f40519007 to release/v3.0 branch.

Original PR: #8733

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the disabled “select” button to use --text-01 (was --text-02) for its foreground color. This improves contrast and keeps the style consistent with v3.0 design tokens.

<sup>Written for commit b8bfc2c95cc2b3e20f433afc56c826ff5ef5a590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

