### PR TITLE
chore(fe): opal button implements responsiveHideText (#8764) to release v3.0

### DIFF
--- a/web/lib/opal/src/components/buttons/Button/components.tsx
+++ b/web/lib/opal/src/components/buttons/Button/components.tsx
@@ -59,18 +59,21 @@ type ButtonContentProps =
       icon: IconFunctionComponent;
       children: string;
       rightIcon?: IconFunctionComponent;
+      responsiveHideText?: never;
     }
   | {
       foldable?: false;
       icon?: IconFunctionComponent;
       children: string;
       rightIcon?: IconFunctionComponent;
+      responsiveHideText?: never;
     }
   | {
       foldable?: false;
       icon: IconFunctionComponent;
       children?: string;
       rightIcon?: IconFunctionComponent;
+      responsiveHideText?: boolean;
     };
 
 type ButtonProps = InteractiveBaseProps &
@@ -105,6 +108,7 @@ function Button({
   width,
   tooltip,
   tooltipSide = "top",
+  responsiveHideText = false,
   ...interactiveBaseProps
 }: ButtonProps) {
   const isLarge = size === "lg";
@@ -113,7 +117,8 @@ function Button({
     <span
       className={cn(
         "opal-button-label",
-        isLarge ? "font-main-ui-body " : "font-secondary-body"
+        isLarge ? "font-main-ui-body " : "font-secondary-body",
+        responsiveHideText && "hidden md:inline"
       )}
     >
       {children}
@@ -143,13 +148,25 @@ function Button({
             <div className="opal-button-foldable">
               <div className="opal-button-foldable-inner">
                 {labelEl}
-                {iconWrapper(RightIcon, size, !!children)}
+                {responsiveHideText ? (
+                  <span className="hidden md:inline-flex">
+                    {iconWrapper(RightIcon, size, !!children)}
+                  </span>
+                ) : (
+                  iconWrapper(RightIcon, size, !!children)
+                )}
               </div>
             </div>
           ) : (
             <>
               {labelEl}
-              {iconWrapper(RightIcon, size, !!children)}
+              {responsiveHideText ? (
+                <span className="hidden md:inline-flex">
+                  {iconWrapper(RightIcon, size, !!children)}
+                </span>
+              ) : (
+                iconWrapper(RightIcon, size, !!children)
+              )}
             </>
           )}
         </div>

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -23,7 +23,7 @@
 import { cn, ensureHrefProtocol, noProp } from "@/lib/utils";
 import type { Components } from "react-markdown";
 import Text from "@/refresh-components/texts/Text";
-import Button from "@/refresh-components/buttons/Button";
+import RefreshButton from "@/refresh-components/buttons/Button";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import { useAppBackground } from "@/providers/AppBackgroundProvider";
 import { useTheme } from "next-themes";
@@ -47,7 +47,7 @@ import Popover, { PopoverMenu } from "@/refresh-components/Popover";
 import { PopoverSearchInput } from "@/sections/sidebar/ChatButton";
 import SimplePopover from "@/refresh-components/SimplePopover";
 import { Interactive } from "@opal/core";
-import { OpenButton } from "@opal/components";
+import { Button, OpenButton } from "@opal/components";
 import { LineItemLayout } from "@/layouts/general-layouts";
 import { useAppSidebarContext } from "@/providers/AppSidebarProvider";
 import useScreenSize from "@/hooks/useScreenSize";
@@ -280,9 +280,9 @@ function Header() {
           icon={SvgTrash}
           onClose={() => setDeleteModalOpen(false)}
           submit={
-            <Button danger onClick={handleDeleteChat}>
+            <RefreshButton danger onClick={handleDeleteChat}>
               Delete
-            </Button>
+            </RefreshButton>
           }
         >
           Are you sure you want to delete this chat? This action cannot be
@@ -383,13 +383,14 @@ function Header() {
           {appFocus.isChat() && currentChatSession && (
             <FrostedDiv className="flex shrink flex-row items-center">
               <Button
-                leftIcon={SvgShare}
+                icon={SvgShare}
+                prominence="tertiary"
                 transient={showShareModal}
-                tertiary
+                responsiveHideText
                 onClick={() => setShowShareModal(true)}
                 aria-label="share-chat-button"
               >
-                {isMobile ? "" : "Share Chat"}
+                Share Chat
               </Button>
               <SimplePopover
                 trigger={


### PR DESCRIPTION
Cherry-pick of commit bdc89d9e3f6b50019b7c97833dc2709f30db661a to release/v3.0 branch.

Original PR: #8764

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add responsiveHideText to the Opal Button to hide the label (and right icon) on small screens. Update the Chat header “Share Chat” button to use it, showing icon-only on mobile and label + icon on larger screens.

<sup>Written for commit 87e0e6179bcce26b60fa6dd01310c1a3145a6c72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

