### PR TITLE
chore(fe): foldable buttons display text via tooltip when disabled (#8735) to release v3.0

### DIFF
--- a/web/lib/opal/src/components/buttons/Button/components.tsx
+++ b/web/lib/opal/src/components/buttons/Button/components.tsx
@@ -157,7 +157,13 @@ function Button({
     </Interactive.Base>
   );
 
-  if (!tooltip) return button;
+  const resolvedTooltip =
+    tooltip ??
+    (foldable && interactiveBaseProps.disabled && children
+      ? children
+      : undefined);
+
+  if (!resolvedTooltip) return button;
 
   return (
     <TooltipPrimitive.Root>
@@ -168,7 +174,7 @@ function Button({
           side={tooltipSide}
           sideOffset={4}
         >
-          {tooltip}
+          {resolvedTooltip}
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>


### PR DESCRIPTION
Cherry-pick of commit aef009cc97eb84ff83dcac9d871614ffd9cd8201 to release/v3.0 branch.

Original PR: #8735

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foldable buttons now display their label as a tooltip when disabled, unless a custom tooltip is provided. This improves clarity by preserving the button text when interaction is blocked.

<sup>Written for commit d2b5e808a92fbfcf415c1f67dc629db1b48e549a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

