### PR TITLE
chore: proxy cloud ph

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -79,6 +79,16 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: "/ph_ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ph_ingest/:path*",
+        destination: `${
+          process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com"
+        }/:path*`,
+      },
+      {
         source: "/api/docs/:path*", // catch /api/docs and /api/docs/...
         destination: `${
           process.env.INTERNAL_URL || "http://localhost:8080"

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -3,9 +3,7 @@ import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { useEffect } from "react";
 
-const isPostHogEnabled = !!(
-  process.env.NEXT_PUBLIC_POSTHOG_KEY && process.env.NEXT_PUBLIC_POSTHOG_HOST
-);
+const isPostHogEnabled = !!process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
 type PHProviderProps = { children: React.ReactNode };
 
@@ -13,7 +11,9 @@ export function PHProvider({ children }: PHProviderProps) {
   useEffect(() => {
     if (isPostHogEnabled) {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST!,
+        api_host: "/ph_ingest",
+        ui_host:
+          process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.posthog.com",
         person_profiles: "identified_only",
         capture_pageview: false,
         session_recording: {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy PostHog Cloud ingestion and static assets through /ph_ingest and point posthog-js to the proxy. This reduces browser exposure to external hosts and defaults to the US region when no host is set.

- **Migration**
  - Set NEXT_PUBLIC_POSTHOG_KEY. NEXT_PUBLIC_POSTHOG_HOST is optional (defaults to https://us.i.posthog.com for ingest and https://us.posthog.com for UI).
  - No code changes needed; /ph_ingest rewrites handle routing.

<sup>Written for commit e98833f610cf96480955d0fa957ac2d88914fa34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

