### PR TITLE
fix: Block deleting default provider

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -479,16 +479,19 @@ def put_llm_provider(
 @admin_router.delete("/provider/{provider_id}")
 def delete_llm_provider(
     provider_id: int,
+    force: bool = Query(False),
     _: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     try:
-        model = fetch_default_llm_model(db_session)
+        if not force:
+            model = fetch_default_llm_model(db_session)
 
-        if model and model.llm_provider_id == provider_id:
-            raise HTTPException(
-                status_code=400, detail="Cannot delete the default LLM provider"
-            )
+            if model and model.llm_provider_id == provider_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot delete the default LLM provider",
+                )
 
         remove_llm_provider(db_session, provider_id)
     except ValueError as e:

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -506,6 +506,62 @@ def test_delete_non_default_llm_provider_with_default_set(
     assert default_data is not None
 
 
+def test_force_delete_default_llm_provider(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Force-deleting the default LLM provider should succeed."""
+    admin_user = UserManager.create(name="admin_user")
+
+    # Create a provider
+    response = requests.put(
+        f"{API_SERVER_URL}/admin/llm/provider?is_creation=true",
+        headers=admin_user.headers,
+        json={
+            "name": "test-provider-force-delete",
+            "provider": LlmProviderNames.OPENAI,
+            "api_key": "sk-000000000000000000000000000000000000000000000000",
+            "model_configurations": [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True
+                ).model_dump()
+            ],
+            "is_public": True,
+            "groups": [],
+        },
+    )
+    assert response.status_code == 200
+    created_provider = response.json()
+
+    # Set this provider as the default
+    set_default_response = requests.post(
+        f"{API_SERVER_URL}/admin/llm/default",
+        headers=admin_user.headers,
+        json={
+            "provider_id": created_provider["id"],
+            "model_name": "gpt-4o-mini",
+        },
+    )
+    assert set_default_response.status_code == 200
+
+    # Attempt to delete without force — should be rejected
+    delete_response = requests.delete(
+        f"{API_SERVER_URL}/admin/llm/provider/{created_provider['id']}",
+        headers=admin_user.headers,
+    )
+    assert delete_response.status_code == 400
+
+    # Force delete — should succeed
+    force_delete_response = requests.delete(
+        f"{API_SERVER_URL}/admin/llm/provider/{created_provider['id']}?force=true",
+        headers=admin_user.headers,
+    )
+    assert force_delete_response.status_code == 200
+
+    # Verify provider is gone
+    provider_data = _get_provider_by_id(admin_user, created_provider["id"])
+    assert provider_data is None
+
+
 def test_delete_default_vision_provider_clears_vision_default(
     reset: None,  # noqa: ARG001
 ) -> None:

--- a/web/tests/e2e/onboarding/onboarding_flow.spec.ts
+++ b/web/tests/e2e/onboarding/onboarding_flow.spec.ts
@@ -20,7 +20,7 @@ async function deleteAllProviders(client: OnyxApiClient): Promise<void> {
   const providers = await client.listLlmProviders();
   for (const provider of providers) {
     try {
-      await client.deleteProvider(provider.id);
+      await client.deleteProvider(provider.id, { force: true });
     } catch (error) {
       console.warn(
         `Failed to delete provider ${provider.id}: ${String(error)}`

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -526,8 +526,14 @@ export class OnyxApiClient {
    *
    * @param providerId - The provider ID to delete
    */
-  async deleteProvider(providerId: number): Promise<void> {
-    const response = await this.delete(`/admin/llm/provider/${providerId}`);
+  async deleteProvider(
+    providerId: number,
+    { force = false }: { force?: boolean } = {}
+  ): Promise<void> {
+    const query = force ? "?force=true" : "";
+    const response = await this.delete(
+      `/admin/llm/provider/${providerId}${query}`
+    );
 
     await this.handleResponseSoft(
       response,


### PR DESCRIPTION
## Description
This stops the deletion of the default provider at the api level

## How Has This Been Tested?
Integration tests
Manual

<img width="1849" height="1030" alt="Screenshot 2026-03-02 at 5 40 50 PM" src="https://github.com/user-attachments/assets/3c927ddf-c172-49bf-a7bf-7e977b5328d8" />


## Additional Options
closes https://linear.app/onyx-app/issue/ENG-3775/there-must-be-some-global-default

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deletion of the default LLM provider to keep the global default model intact (ENG-3775).

- **Bug Fixes**
  - Added API guard using fetch_default_llm_model; returns 400 "Cannot delete the default LLM provider" unless force=true.
  - Introduced optional ?force=true override; updated OnyxApiClient and onboarding E2E to use it for cleanup.
  - Non-default provider deletion unchanged; deleting a default vision provider succeeds and clears the vision default.

<sup>Written for commit fdccc04b4aaa283943b6883e138843d68aa2146b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



