### PR TITLE
fix: Default code interpreter base url

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -819,7 +819,9 @@ RERANK_COUNT = int(os.environ.get("RERANK_COUNT") or 1000)
 # Tool Configs
 #####
 # Code Interpreter Service Configuration
-CODE_INTERPRETER_BASE_URL = os.environ.get("CODE_INTERPRETER_BASE_URL")
+CODE_INTERPRETER_BASE_URL = os.environ.get(
+    "CODE_INTERPRETER_BASE_URL", "http://localhost:8000"
+)
 
 CODE_INTERPRETER_DEFAULT_TIMEOUT_MS = int(
     os.environ.get("CODE_INTERPRETER_DEFAULT_TIMEOUT_MS") or 60_000


### PR DESCRIPTION
## Description
Defaults the base url for code interpreter to `http://localhost:8000`. This is the location set by `restart_containers.sh`.

## How Has This Been Tested?
Manual

## Additional Options
closes https://linear.app/onyx-app/issue/ENG-3783/restart-containerssh-and-restarting-services-does-not-find-code

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a default CODE_INTERPRETER_BASE_URL to http://localhost:8000 to match restart_containers.sh so local restarts find the code interpreter service, addressing ENG-3783. Deployments that set CODE_INTERPRETER_BASE_URL are unaffected.

<sup>Written for commit 15c828d0e25bade150a57a48ab9527816ee0e819. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

