### PR TITLE
fix(web-search): Properly cast queries to avoid list-comprehension issue

### DIFF
--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -1,6 +1,5 @@
 import json
 from typing import Any
-from typing import cast
 
 from sqlalchemy.orm import Session
 from typing_extensions import override
@@ -189,7 +188,12 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
                     f'like: {{"queries": ["your search query here"]}}'
                 ),
             )
-        raw_queries = cast(list[str], llm_kwargs[QUERIES_FIELD])
+        raw_queries = llm_kwargs[QUERIES_FIELD]
+        # LLMs occasionally return a bare string instead of a JSON array; coerce it.
+        if isinstance(raw_queries, str):
+            raw_queries = [raw_queries]
+        elif not isinstance(raw_queries, list):
+            raw_queries = []
 
         # Normalize queries:
         # - remove control characters (null bytes, etc.) that LLMs sometimes produce

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
@@ -1,0 +1,90 @@
+"""Unit tests for WebSearchTool.run(), focusing on query coercion and dispatch."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.models import WebSearchToolOverrideKwargs
+from onyx.tools.tool_implementations.web_search.models import WebSearchResult
+from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
+
+
+def _make_result(title: str = "Title", link: str = "https://example.com") -> WebSearchResult:
+    return WebSearchResult(title=title, link=link, snippet="snippet")
+
+
+def _make_tool(mock_provider: Any) -> WebSearchTool:
+    """Instantiate WebSearchTool with all DB/provider deps mocked out."""
+    provider_model = MagicMock()
+    provider_model.provider_type = "brave"
+    provider_model.api_key = MagicMock()
+    provider_model.api_key.get_value.return_value = "fake-key"
+    provider_model.config = {}
+
+    with (
+        patch(
+            "onyx.tools.tool_implementations.web_search.web_search_tool.get_session_with_current_tenant"
+        ) as mock_session_ctx,
+        patch(
+            "onyx.tools.tool_implementations.web_search.web_search_tool.fetch_active_web_search_provider",
+            return_value=provider_model,
+        ),
+        patch(
+            "onyx.tools.tool_implementations.web_search.web_search_tool.build_search_provider_from_config",
+            return_value=mock_provider,
+        ),
+    ):
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        tool = WebSearchTool(tool_id=1, emitter=MagicMock())
+
+    return tool
+
+
+def _run(tool: WebSearchTool, queries: Any) -> list[str]:
+    """Call tool.run() and return the list of query strings passed to provider.search."""
+    placement = Placement(turn_index=0, tab_index=0)
+    override_kwargs = WebSearchToolOverrideKwargs(starting_citation_num=1)
+    tool.run(placement=placement, override_kwargs=override_kwargs, queries=queries)
+    return [call.args[0] for call in tool._provider.search.call_args_list]  # noqa: SLF001
+
+
+class TestWebSearchToolRunQueryCoercion:
+    def test_list_of_strings_dispatches_each_query(self) -> None:
+        """Normal case: list of queries → one search call per query."""
+        mock_provider = MagicMock()
+        mock_provider.search.return_value = [_make_result()]
+        mock_provider.supports_site_filter = False
+        tool = _make_tool(mock_provider)
+
+        dispatched = _run(tool, ["python decorators", "python generators"])
+
+        assert dispatched == ["python decorators", "python generators"]
+
+    def test_bare_string_dispatches_as_single_query(self) -> None:
+        """LLM returns a bare string instead of an array — must NOT be split char-by-char."""
+        mock_provider = MagicMock()
+        mock_provider.search.return_value = [_make_result()]
+        mock_provider.supports_site_filter = False
+        tool = _make_tool(mock_provider)
+
+        dispatched = _run(tool, "what is the capital of France")
+
+        assert len(dispatched) == 1
+        assert dispatched[0] == "what is the capital of France"
+
+    def test_bare_string_does_not_search_individual_characters(self) -> None:
+        """Regression: single-char searches must not occur."""
+        mock_provider = MagicMock()
+        mock_provider.search.return_value = [_make_result()]
+        mock_provider.supports_site_filter = False
+        tool = _make_tool(mock_provider)
+
+        _run(tool, "hi")
+
+        for call in mock_provider.search.call_args_list:
+            query_arg = call.args[0]
+            assert len(query_arg) > 1, f"Single-character query dispatched: {query_arg!r}"


### PR DESCRIPTION
## Description

From a cursory search, it did not seem that the tool calls returned from the LLMs are type-checked anywhere, but I might be wrong. If the LLM messes up and returns a single string instead of an array when using the web-search tool, the list comprehension below will trigger a search for each character in the query. This could quickly saturate the threadpool, and bring down your Onyx deployment.

Replace the no-op `typing.cast` with a runtime isinstance check that wraps a string into a single-element list.

## How Has This Been Tested?

Added unit tests covering the normal list case, the bare-string coercion case, and a regression guard that no single-character queries are dispatched.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerce web-search "queries" to a list when the LLM returns a bare string to prevent per-character searches that can flood the provider and saturate the threadpool. Added unit tests for list and string inputs, plus a regression check to block single-character query dispatch.

<sup>Written for commit 55cdb1815c669be17542951703d3f0e9f4d0029d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

