### PR TITLE
fix(a11y): prevent show password button losing focus on tab

### DIFF
--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
@@ -227,9 +227,17 @@ export default function PasswordInputTypeIn({
         return;
       }
       setIsFocused(false);
-      onBlur?.(e as unknown as React.FocusEvent<HTMLInputElement>);
+
+      if (onBlur) {
+        const syntheticEvent = {
+          ...e,
+          target: { name: props.name ?? "" },
+          currentTarget: { name: props.name ?? "" },
+        } as unknown as React.FocusEvent<HTMLInputElement>;
+        onBlur(syntheticEvent);
+      }
     },
-    [onBlur]
+    [onBlur, props.name]
   );
 
   // Track selection before any change occurs (used by both onSelect and onKeyDown)


### PR DESCRIPTION
## Description

This show password toggle button is hidden when the input is not in focus which means when a user tabs focus from the input to the button, this button is removed. This in turn resets the tabindex to the input and prevents the user from tabbing out (in my case, to tab to the `Create an Account` link). Now, include if the button is focused in determining whether to show the button.

## How Has This Been Tested?

Tabbed on the login page and confirmed expected tabbing behavior.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a keyboard focus trap in the login form by keeping the password input focused when tabbing to the “Show password” button and only hiding the toggle after focus leaves both. Defers onBlur until then so focus doesn’t jump back and users can tab to the next control.

<sup>Written for commit 1c545a3d24ee19d38506848bf09eecb6e53c2f5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



