### PR TITLE
chore: Add greptile.json configuration file

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,72 @@
+{
+    "labels": [],
+    "comment": "",
+    "fixWithAI": true,
+    "hideFooter": false,
+    "strictness": 2,
+    "statusCheck": true,
+    "commentTypes": [
+      "logic",
+      "syntax",
+      "style"
+    ],
+    "instructions": "",
+    "disabledLabels": [],
+    "excludeAuthors": [
+      "dependabot[bot]",
+      "renovate[bot]"
+    ],
+    "ignoreKeywords": "",
+    "ignorePatterns": "greptile.json\n",
+    "includeAuthors": [],
+    "summarySection": {
+      "included": true,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "excludeBranches": [],
+    "fileChangeLimit": 300,
+    "includeBranches": [],
+    "includeKeywords": "",
+    "triggerOnUpdates": true,
+    "updateExistingSummaryComment": true,
+    "updateSummaryOnly": false,
+    "issuesTableSection": {
+      "included": true,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "statusCommentsEnabled": true,
+    "confidenceScoreSection": {
+      "included": true,
+      "collapsible": false
+    },
+    "sequenceDiagramSection": {
+      "included": true,
+      "collapsible": false,
+      "defaultOpen": false
+    },
+    "shouldUpdateDescription": false,
+    "customContext": {
+      "other": [
+        {
+          "scope": [],
+          "content": ""
+        }
+      ],
+      "rules": [
+        {
+          "scope": [],
+          "rule": ""
+        }
+      ],
+      "files": [
+        {
+          "scope": [],
+          "path": "",
+          "description": ""
+        }
+      ]
+    }
+  }
+  


### PR DESCRIPTION
## Description

Added Greptile configuration file to enable AI-powered code review with logic, syntax, and style comment types. The configuration excludes bot authors (dependabot and renovate), enables status checks, and includes sections for issues table, confidence scores, and sequence diagrams. File change limit is set to 300 with strictness level 2.

Referenced https://www.greptile.com/docs/code-review-bot/greptile-json 

## How Has This Been Tested?

Configuration file follows standard JSON format and includes all required Greptile settings for automated code review functionality.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add greptile.json to configure Greptile automated code review with logic, syntax, and style comments. Enables status checks with strictness 2 and caps file changes at 300.

- **New Features**
  - Excludes dependabot[bot] and renovate[bot].
  - Triggers on PR updates and updates the existing summary comment.
  - Includes issues table, confidence score, and sequence diagram sections.
  - Ignores greptile.json to avoid self-comments.

<sup>Written for commit d52fa9bef33f73e040a1009842431d2d6f7c21fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

