### PR TITLE
chore: remove dead code from expandable content component

### DIFF
--- a/web/src/components/tools/CSVContent.tsx
+++ b/web/src/components/tools/CSVContent.tsx
@@ -16,8 +16,6 @@ import { cn } from "@/lib/utils";
 
 const CsvContent: React.FC<ContentComponentProps> = ({
   fileDescriptor,
-  isLoading,
-  fadeIn,
   expanded = false,
 }) => {
   const [data, setData] = useState<Record<string, string>[]>([]);
@@ -94,7 +92,7 @@ const CsvContent: React.FC<ContentComponentProps> = ({
     }
   };
 
-  if (isLoading || isFetching) {
+  if (isFetching) {
     return (
       <div className="flex items-center justify-center h-[300px]">
         <SimpleLoader />

--- a/web/src/components/tools/ExpandableContentWrapper.tsx
+++ b/web/src/components/tools/ExpandableContentWrapper.tsx
@@ -1,5 +1,5 @@
 // ExpandableContentWrapper
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { SvgDownloadCloud, SvgFold, SvgMaximize2, SvgX } from "@opal/icons";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@opal/components";
@@ -17,8 +17,6 @@ export interface ExpandableContentWrapperProps {
 
 export interface ContentComponentProps {
   fileDescriptor: FileDescriptor;
-  isLoading: boolean;
-  fadeIn: boolean;
   expanded?: boolean;
 }
 
@@ -28,23 +26,8 @@ export default function ExpandableContentWrapper({
   ContentComponent,
 }: ExpandableContentWrapperProps) {
   const [expanded, setExpanded] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [fadeIn, setFadeIn] = useState(false);
 
   const toggleExpand = () => setExpanded((prev) => !prev);
-
-  // Prevent a jarring fade in
-  useEffect(() => {
-    setTimeout(() => setIsLoading(false), 300);
-  }, []);
-
-  useEffect(() => {
-    if (!isLoading) {
-      setTimeout(() => setFadeIn(true), 50);
-    } else {
-      setFadeIn(false);
-    }
-  }, [isLoading]);
 
   const downloadFile = () => {
     const a = document.createElement("a");
@@ -103,8 +86,6 @@ export default function ExpandableContentWrapper({
           {!expanded && (
             <ContentComponent
               fileDescriptor={fileDescriptor}
-              isLoading={isLoading}
-              fadeIn={fadeIn}
               expanded={expanded}
             />
           )}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead loading/fade-in logic from ExpandableContentWrapper and updated CSVContent to match. This simplifies props and loading behavior with no UI change.

- **Refactors**
  - Removed isLoading/fadeIn state and effects from ExpandableContentWrapper and stopped passing them to children.
  - Updated ContentComponentProps and CSVContent to rely only on isFetching for loading.
  - Cleaned up ~20 lines of unused code.

<sup>Written for commit eaa159ab32744908d7963ec75ffb477570f9f2d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

