### PR TITLE
fix(ci): Add secrets inheritance to nightly LLM provider chat workflow

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   provider-chat-test:
     uses: ./.github/workflows/reusable-nightly-llm-provider-chat.yml
+    secrets: inherit
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Description

Added `secrets: inherit` to the nightly LLM provider chat workflow to ensure secrets are properly passed to the reusable workflow.

## How Has This Been Tested?

This change enables the reusable workflow to access necessary secrets for LLM provider authentication during nightly testing.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added secrets: inherit to the nightly LLM provider chat workflow so the reusable workflow receives required secrets. This restores access to AWS OIDC and LLM provider credentials during nightly runs and prevents auth failures.

<sup>Written for commit 41661f27012f9138dcec145eeb11284475c2bb0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

