### PR TITLE
fix(fe): dont align center modals on small screens

### DIFF
--- a/web/src/hooks/useContainerCenter.ts
+++ b/web/src/hooks/useContainerCenter.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
+import useScreenSize from "@/hooks/useScreenSize";
 
 const SELECTOR = "[data-main-container]";
 
@@ -37,6 +38,7 @@ function measure(el: HTMLElement): { x: number; y: number } | null {
  */
 export default function useContainerCenter(): ContainerCenter {
   const pathname = usePathname();
+  const { isSmallScreen } = useScreenSize();
   const [center, setCenter] = useState<{ x: number | null; y: number | null }>(
     () => {
       if (typeof document === "undefined") return NULL_CENTER;
@@ -66,8 +68,10 @@ export default function useContainerCenter(): ContainerCenter {
   }, [pathname]);
 
   return {
-    centerX: center.x,
-    centerY: center.y,
-    hasContainerCenter: center.x !== null && center.y !== null,
+    centerX: isSmallScreen ? null : center.x,
+    centerY: isSmallScreen ? null : center.y,
+    hasContainerCenter: isSmallScreen
+      ? false
+      : center.x !== null && center.y !== null,
   };
 }

--- a/web/src/hooks/useScreenSize.ts
+++ b/web/src/hooks/useScreenSize.ts
@@ -1,6 +1,9 @@
 "use client";
 
-import { MOBILE_SIDEBAR_BREAKPOINT_PX } from "@/lib/constants";
+import {
+  DESKTOP_SMALL_BREAKPOINT_PX,
+  MOBILE_SIDEBAR_BREAKPOINT_PX,
+} from "@/lib/constants";
 import { useState, useCallback } from "react";
 import useOnMount from "@/hooks/useOnMount";
 
@@ -8,6 +11,7 @@ export interface ScreenSize {
   height: number;
   width: number;
   isMobile: boolean;
+  isSmallScreen: boolean;
 }
 
 export default function useScreenSize(): ScreenSize {
@@ -29,10 +33,12 @@ export default function useScreenSize(): ScreenSize {
   });
 
   const isMobile = sizes.width <= MOBILE_SIDEBAR_BREAKPOINT_PX;
+  const isSmall = sizes.width <= DESKTOP_SMALL_BREAKPOINT_PX;
 
   return {
     height: sizes.height,
     width: sizes.width,
-    isMobile: isMounted ? isMobile : false,
+    isMobile: isMounted && isMobile,
+    isSmallScreen: isMounted && isSmall,
   };
 }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -122,6 +122,7 @@ export const MAX_FILES_TO_SHOW = 3;
 
 // SIZES
 export const MOBILE_SIDEBAR_BREAKPOINT_PX = 640;
+export const DESKTOP_SMALL_BREAKPOINT_PX = 912;
 export const DEFAULT_AGENT_AVATAR_SIZE_PX = 18;
 export const HORIZON_DISTANCE_PX = 800;
 export const LOGO_FOLDED_SIZE_PX = 24;


### PR DESCRIPTION
## Description

Introduces a `isSmallScreen` window size (as defined by https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools) to disable centering modals relative to the main container on small screens.

In the 912px > x > 640px range, these modals are commonly clipped or drastically offset (particularly on admin pages since the sidebar does not collapse).

## How Has This Been Tested?

**before**
<img width="1317" height="2047" alt="20260303_12h11m04s_grim" src="https://github.com/user-attachments/assets/480ab851-d3bf-42a8-9ae6-668a94c27557" />

**after**
<img width="1317" height="2047" alt="20260303_12h11m22s_grim" src="https://github.com/user-attachments/assets/3e96bc8b-38a7-4915-9381-e3df91513d80" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop centering modals relative to the main container on small screens (≤912px) to avoid clipping and offsets. On small screens, modals now center to the viewport instead.

- **Bug Fixes**
  - Added DESKTOP_SMALL_BREAKPOINT_PX (912) and isSmallScreen to useScreenSize.
  - useContainerCenter returns null center and hasContainerCenter=false on small screens to disable container-based centering.

<sup>Written for commit 2c03e9486529a212a99be693efca6b2ded102106. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

