### PR TITLE
chore(devtools): `npm run test:diff` on changed files

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "test:verbose": "jest --verbose",
     "test:ci": "jest --ci --maxWorkers=2 --silent --bail",
     "test:changed": "jest --onlyChanged",
+    "test:diff": "jest --changedSince=main",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

This is similar to `test:changed` except it calculates the diff between `main...HEAD` which is convenient for me as I like to commit liberally and follow up with test fixes as separate commits.

## How Has This Been Tested?

`ods web test:diff`

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm script test:diff that runs Jest with --changedSince=main to test only files changed from main to HEAD. Speeds up local testing for PRs with multiple commits by focusing on the diff from main.

<sup>Written for commit c55fca522999e202228e864fb80912f218b97e77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

