### PR TITLE
chore: use abort controller to properly manage oauth requests

### DIFF
--- a/web/src/components/oauth/OAuthCallbackPage.tsx
+++ b/web/src/components/oauth/OAuthCallbackPage.tsx
@@ -86,6 +86,8 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
   ]);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const handleOAuthCallback = async () => {
       // Handle OAuth error from provider
       if (error) {
@@ -122,6 +124,7 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
             "Content-Type": "application/json",
           },
           credentials: "include",
+          signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -181,6 +184,7 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
         setIsError(false);
         setIsLoading(false);
       } catch (error) {
+        if (controller.signal.aborted) return;
         console.error("OAuth callback error:", error);
         setStatusMessage(config.errorMessage || "Something Went Wrong");
         setStatusDetails(
@@ -194,6 +198,7 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
     };
 
     handleOAuthCallback();
+    return () => controller.abort();
   }, [code, state, error, errorDescription, searchParams, config]);
 
   const getStatusIcon = () => {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use AbortController in OAuthCallbackPage to cancel in-flight OAuth requests on unmount or dependency changes. This prevents state updates after unmount and reduces noisy error logs during fast navigation.

- **Bug Fixes**
  - Pass controller.signal to the OAuth fetch and abort it in effect cleanup.
  - Skip error handling if the request was aborted.
  - Avoids race conditions and flaky error messages during redirects.

<sup>Written for commit cdb5a649366ddc3ddca310f8e8b55539464b1323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

