### PR TITLE
feat(slack): convert markdown tables to Slack-friendly format

### DIFF
--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -241,7 +241,7 @@ class SlackRenderer(HTMLRenderer):
     def table_row(self, text: str) -> str:  # noqa: ARG002
         cells = self._current_row_cells
         self._current_row_cells = []
-        # First column becomes the bold title, remaining columns are key-value lines
+        # First column becomes the bold title, remaining columns are bulleted fields
         lines: list[str] = []
         if cells:
             title = cells[0]
@@ -253,10 +253,10 @@ class SlackRenderer(HTMLRenderer):
                     lines.append(f"*{title}*")
             for i, cell in enumerate(cells[1:], start=1):
                 if i < len(self._table_headers):
-                    lines.append(f"  {self._table_headers[i]}: {cell}")
+                    lines.append(f"  • {self._table_headers[i]}: {cell}")
                 else:
-                    lines.append(f"  {cell}")
-        return "\n".join(lines) + "\n"
+                    lines.append(f"  • {cell}")
+        return "\n".join(lines) + "\n\n"
 
     def table_body(self, text: str) -> str:
         return text

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -119,8 +119,10 @@ def test_table_renders_as_vertical_cards() -> None:
 
     formatted = format_slack_message(message)
 
-    assert "*Auth*\n  Status: Done\n  Owner: Alice" in formatted
-    assert "*Search*\n  Status: In Progress\n  Owner: Bob" in formatted
+    assert "*Auth*\n  • Status: Done\n  • Owner: Alice" in formatted
+    assert "*Search*\n  • Status: In Progress\n  • Owner: Bob" in formatted
+    # Cards separated by blank line
+    assert "Owner: Alice\n\n*Search*" in formatted
     # No raw pipe-and-dash table syntax
     assert "---|" not in formatted
 
@@ -147,7 +149,7 @@ def test_table_embedded_in_text() -> None:
     formatted = format_slack_message(message)
 
     assert "Here are the results:" in formatted
-    assert "*Apples*\n  Count: 5" in formatted
+    assert "*Apples*\n  • Count: 5" in formatted
     assert "That's all." in formatted
 
 
@@ -173,7 +175,7 @@ def test_table_with_alignment_specifiers() -> None:
 
     formatted = format_slack_message(message)
 
-    assert "*a*\n  Center: b\n  Right: c" in formatted
+    assert "*a*\n  • Center: b\n  • Right: c" in formatted
 
 
 def test_two_tables_in_same_message_use_independent_headers() -> None:
@@ -189,8 +191,8 @@ def test_two_tables_in_same_message_use_independent_headers() -> None:
 
     formatted = format_slack_message(message)
 
-    assert "*1*\n  B: 2" in formatted
-    assert "*p*\n  Y: q\n  Z: r" in formatted
+    assert "*1*\n  • B: 2" in formatted
+    assert "*p*\n  • Y: q\n  • Z: r" in formatted
 
 
 def test_table_empty_first_column_no_bare_asterisks() -> None:
@@ -200,4 +202,4 @@ def test_table_empty_first_column_no_bare_asterisks() -> None:
 
     # Empty title should not produce "**" (bare asterisks)
     assert "**" not in formatted
-    assert "  Status: Done" in formatted
+    assert "  • Status: Done" in formatted


### PR DESCRIPTION
## Description

Slack doesn't render markdown tables — pipe-and-dash syntax passes through as ugly plaintext. This enables mistune's `table` plugin in the `SlackRenderer` and adds rendering methods that convert each table row into a vertical card: the first column becomes a bold title, remaining columns become bulleted key-value fields underneath, with blank lines separating each card.

**Before (raw markdown in Slack):**
```
| Feature | Status      | Owner |
|---------|-------------|-------|
| Auth    | Done        | Alice |
| Search  | In Progress | Bob   |
```

**After (Slack mrkdwn):**
> **Auth**
>   • Status: Done
>   • Owner: Alice
>
> **Search**
>   • Status: In Progress
>   • Owner: Bob

Edge cases handled:
- Empty first column (skips title to avoid bare `**`)
- Pre-formatted bold cells (avoids double-wrapping `**text**`)
- Multiple tables in one message (state reset between tables)
- Alignment specifiers (`:---`, `:---:`, `---:`)

## How Has This Been Tested?

https://onyx-company.slack.com/archives/C09ULM10RUG/p1772649489072379

https://onyx-company.slack.com/archives/C09ULM10RUG/p1772649648966939

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check