### PR TITLE
fix(a11y): prevent show password button losing focus on tab

### DIFF
--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
@@ -172,6 +172,7 @@ export default function PasswordInputTypeIn({
 }: PasswordInputTypeInProps) {
   const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
   const [isFocused, setIsFocused] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   // Track selection range before changes occur
   const selectionRef = React.useRef<{ start: number; end: number }>({
@@ -192,9 +193,22 @@ export default function PasswordInputTypeIn({
     return realValue;
   };
 
+  const handleContainerFocus = React.useCallback(() => {
+    setIsFocused(true);
+  }, []);
+
+  const handleContainerBlur = React.useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (containerRef.current?.contains(e.relatedTarget as Node)) {
+        return;
+      }
+      setIsFocused(false);
+    },
+    []
+  );
+
   const handleFocus = React.useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
-      setIsFocused(true);
       onFocus?.(e);
     },
     [onFocus]
@@ -202,7 +216,6 @@ export default function PasswordInputTypeIn({
 
   const handleBlur = React.useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
-      setIsFocused(false);
       onBlur?.(e);
     },
     [onBlur]
@@ -272,35 +285,42 @@ export default function PasswordInputTypeIn({
       : "Show password";
 
   return (
-    <InputTypeIn
-      ref={ref}
-      value={getDisplayValue()}
-      onChange={handleChange}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onSelect={captureSelection}
-      onKeyDown={captureSelection}
-      variant={disabled ? "disabled" : error ? "error" : undefined}
-      showClearButton={showClearButton}
-      autoComplete="off"
-      data-ph-no-capture
-      rightSection={
-        showToggleButton ? (
-          <Button
-            icon={isRevealed ? SvgEye : SvgEyeClosed}
-            disabled={disabled || effectiveNonRevealable}
-            onClick={noProp(() => setIsPasswordVisible((v) => !v))}
-            type="button"
-            variant={isRevealed ? "action" : undefined}
-            prominence="tertiary"
-            size="sm"
-            tooltipSide="left"
-            tooltip={toggleLabel}
-            aria-label={toggleLabel}
-          />
-        ) : undefined
-      }
-      {...props}
-    />
+    <div
+      ref={containerRef}
+      className="contents"
+      onFocus={handleContainerFocus}
+      onBlur={handleContainerBlur}
+    >
+      <InputTypeIn
+        ref={ref}
+        value={getDisplayValue()}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onSelect={captureSelection}
+        onKeyDown={captureSelection}
+        variant={disabled ? "disabled" : error ? "error" : undefined}
+        showClearButton={showClearButton}
+        autoComplete="off"
+        data-ph-no-capture
+        rightSection={
+          showToggleButton ? (
+            <Button
+              icon={isRevealed ? SvgEye : SvgEyeClosed}
+              disabled={disabled || effectiveNonRevealable}
+              onClick={noProp(() => setIsPasswordVisible((v) => !v))}
+              type="button"
+              variant={isRevealed ? "action" : undefined}
+              prominence="tertiary"
+              size="sm"
+              tooltipSide="left"
+              tooltip={toggleLabel}
+              aria-label={toggleLabel}
+            />
+          ) : undefined
+        }
+        {...props}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Description

This show password toggle button is hidden when the input is not in focus which means when a user tabs focus from the input to the button, this button is removed. This in turn resets the tabindex to the input and prevents the user from tabbing out (in my case, to tab to the `Create an Account` link). Now, include if the button is focused in determining whether to show the button.

## How Has This Been Tested?

Tabbed on the login page and confirmed expected tabbing behavior.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an a11y issue where tabbing from the password field hid the “Show password” button and trapped focus. The button now stays visible when focused so users can tab past the field.

- **Bug Fixes**
  - Track focus on a wrapper container so the toggle stays visible when either the input or button is focused.
  - Removed input-level focus toggling that hid the button on tab, restoring normal tab order (e.g., to “Create an Account”).

<sup>Written for commit cb22afc07deb9e40a678123ef52e39c4590d3e7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

