### PR TITLE
chore: port Greptile custom context rules to greptile.json

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -51,20 +51,41 @@
       "other": [
         {
           "scope": [],
-          "content": ""
+          "content": "Use explicit type annotations for variables to enhance code clarity, especially when moving type hints around in the code."
         }
       ],
       "rules": [
         {
           "scope": [],
-          "rule": ""
+          "rule": "Whenever a TODO is added, there must always be an associated name or ticket with that TODO in the style of TODO(name): ... or TODO(1234): ..."
+        },
+        {
+          "scope": ["web/**"],
+          "rule": "For frontend changes (changes that touch the /web directory), make sure to enforce all standards described in the web/STANDARDS.md file."
+        },
+        {
+          "scope": [],
+          "rule": "Remove temporary debugging code before merging to production, especially tenant-specific debugging logs."
+        },
+        {
+          "scope": [],
+          "rule": "When hardcoding a boolean variable to a constant value, remove the variable entirely and clean up all places where it's used rather than just setting it to a constant."
+        },
+        {
+          "scope": ["backend/**/*.py"],
+          "rule": "Never raise HTTPException directly in business code. Use `raise OnyxError(OnyxErrorCode.XXX, \"message\")` from `onyx.error_handling.exceptions`. A global FastAPI exception handler converts OnyxError into structured JSON responses with {\"error_code\": \"...\", \"message\": \"...\"}. Error codes are defined in `onyx.error_handling.error_codes.OnyxErrorCode`. For upstream errors with dynamic HTTP status codes, use `status_code_override`: `raise OnyxError(OnyxErrorCode.BAD_GATEWAY, detail, status_code_override=upstream_status)`."
         }
       ],
       "files": [
         {
           "scope": [],
-          "path": "",
-          "description": ""
+          "path": "contributing_guides/best_practices.md",
+          "description": "Best practices for contributing to the codebase"
+        },
+        {
+          "scope": [],
+          "path": "CLAUDE.md",
+          "description": "Project instructions and coding standards"
         }
       ]
     }


### PR DESCRIPTION
## Description

Ports all existing Greptile custom context rules from the UI dashboard into `greptile.json` so they're version-controlled and reviewable.

Rules added:
- TODO format enforcement (must include name or ticket)
- Frontend standards enforcement (`web/STANDARDS.md`)
- No temporary debugging code in production
- Remove hardcoded boolean variables entirely
- OnyxError over HTTPException in backend

File references: `contributing_guides/best_practices.md`, `CLAUDE.md`

Other context: type annotation guidance

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check