### PR TITLE
feat: Support intermediate code interpreter file generation

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -52,6 +52,7 @@ from onyx.tools.built_in_tools import STOPPING_TOOLS_NAMES
 from onyx.tools.interface import Tool
 from onyx.tools.models import ChatFile
 from onyx.tools.models import MemoryToolResponseSnapshot
+from onyx.tools.models import PythonToolRichResponse
 from onyx.tools.models import ToolCallInfo
 from onyx.tools.models import ToolCallKickoff
 from onyx.tools.models import ToolResponse
@@ -966,6 +967,13 @@ def run_llm_loop(
                 ):
                     generated_images = tool_response.rich_response.generated_images
 
+                # Extract generated_files if this is a code interpreter response
+                generated_files = None
+                if isinstance(tool_response.rich_response, PythonToolRichResponse):
+                    generated_files = (
+                        tool_response.rich_response.generated_files or None
+                    )
+
                 # Persist memory if this is a memory tool response
                 memory_snapshot: MemoryToolResponseSnapshot | None = None
                 if isinstance(tool_response.rich_response, MemoryToolResponse):
@@ -1017,6 +1025,7 @@ def run_llm_loop(
                     tool_call_response=saved_response,
                     search_docs=displayed_docs or search_docs,
                     generated_images=generated_images,
+                    generated_files=generated_files,
                 )
                 # Add to state container for partial save support
                 state_container.add_tool_call(tool_call_info)

--- a/backend/onyx/chat/save_chat.py
+++ b/backend/onyx/chat/save_chat.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 
 from sqlalchemy.orm import Session
 
@@ -12,12 +13,39 @@ from onyx.db.chat import create_db_search_doc
 from onyx.db.models import ChatMessage
 from onyx.db.models import ToolCall
 from onyx.db.tools import create_tool_call_no_commit
+from onyx.file_store.models import FileDescriptor
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import get_tokenizer
+from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
 from onyx.tools.models import ToolCallInfo
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def _extract_referenced_file_descriptors(
+    tool_calls: list[ToolCallInfo],
+    message_text: str,
+) -> list[FileDescriptor]:
+    """Extract FileDescriptors for code interpreter files referenced in the message text."""
+    descriptors: list[FileDescriptor] = []
+    for tool_call_info in tool_calls:
+        if not tool_call_info.generated_files:
+            continue
+        for gen_file in tool_call_info.generated_files:
+            file_id = (
+                gen_file.file_link.rsplit("/", 1)[-1] if gen_file.file_link else ""
+            )
+            if file_id and file_id in message_text:
+                mime_type, _ = mimetypes.guess_type(gen_file.filename)
+                descriptors.append(
+                    FileDescriptor(
+                        id=file_id,
+                        type=mime_type_to_chat_file_type(mime_type),
+                        name=gen_file.filename,
+                    )
+                )
+    return descriptors
 
 
 def _create_and_link_tool_calls(
@@ -296,6 +324,15 @@ def save_chat_turn(
     assistant_message.citations = (
         citation_number_to_search_doc_id if citation_number_to_search_doc_id else None
     )
+
+    # 8. Attach code interpreter generated files that the assistant actually
+    # referenced in its response, so they are available via load_all_chat_files
+    # on subsequent turns. Files not mentioned are intermediate artifacts.
+    if message_text:
+        referenced = _extract_referenced_file_descriptors(tool_calls, message_text)
+        if referenced:
+            existing_files = assistant_message.files or []
+            assistant_message.files = existing_files + referenced
 
     # Finally save the messages, tool calls, and docs
     db_session.commit()

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -93,6 +93,8 @@ class ToolResponse(BaseModel):
         # | WebContentResponse
         # This comes from custom tools, tool result needs to be saved
         | CustomToolCallSummary
+        # This comes from code interpreter, carries generated files
+        | PythonToolRichResponse
         # If the rich response is a string, this is what's saved to the tool call in the DB
         | str
         | None  # If nothing needs to be persisted outside of the string value passed to the LLM
@@ -193,6 +195,12 @@ class ChatFile(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
+class PythonToolRichResponse(BaseModel):
+    """Rich response from the Python tool carrying generated files."""
+
+    generated_files: list[PythonExecutionFile] = []
+
+
 class PythonToolOverrideKwargs(BaseModel):
     """Override kwargs for the Python/Code Interpreter tool."""
 
@@ -245,6 +253,7 @@ class ToolCallInfo(BaseModel):
     tool_call_response: str
     search_docs: list[SearchDoc] | None = None
     generated_images: list[GeneratedImage] | None = None
+    generated_files: list[PythonExecutionFile] | None = None
 
 
 CHAT_SESSION_ID_PLACEHOLDER = "CHAT_SESSION_ID"

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -23,6 +23,7 @@ from onyx.tools.interface import Tool
 from onyx.tools.models import LlmPythonExecutionResult
 from onyx.tools.models import PythonExecutionFile
 from onyx.tools.models import PythonToolOverrideKwargs
+from onyx.tools.models import PythonToolRichResponse
 from onyx.tools.models import ToolCallException
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
@@ -329,7 +330,9 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             llm_response = adapter.dump_json(result).decode()
 
             return ToolResponse(
-                rich_response=None,  # No rich response needed for Python tool
+                rich_response=PythonToolRichResponse(
+                    generated_files=generated_files,
+                ),
                 llm_facing_response=llm_response,
             )
 

--- a/backend/tests/unit/onyx/chat/test_save_chat_files.py
+++ b/backend/tests/unit/onyx/chat/test_save_chat_files.py
@@ -1,0 +1,178 @@
+"""Tests for _extract_referenced_file_descriptors in save_chat.py.
+
+Verifies that only code interpreter generated files actually referenced
+in the assistant's message text are extracted as FileDescriptors for
+cross-turn persistence.
+"""
+
+from onyx.chat.save_chat import _extract_referenced_file_descriptors
+from onyx.file_store.models import ChatFileType
+from onyx.tools.models import PythonExecutionFile
+from onyx.tools.models import ToolCallInfo
+
+
+def _make_tool_call_info(
+    generated_files: list[PythonExecutionFile] | None = None,
+    tool_name: str = "python",
+) -> ToolCallInfo:
+    return ToolCallInfo(
+        parent_tool_call_id=None,
+        turn_index=0,
+        tab_index=0,
+        tool_name=tool_name,
+        tool_call_id="tc_1",
+        tool_id=1,
+        reasoning_tokens=None,
+        tool_call_arguments={"code": "print('hi')"},
+        tool_call_response="{}",
+        generated_files=generated_files,
+    )
+
+
+def test_returns_empty_when_no_generated_files() -> None:
+    tool_call = _make_tool_call_info(generated_files=None)
+    result = _extract_referenced_file_descriptors([tool_call], "some message")
+    assert result == []
+
+
+def test_returns_empty_when_file_not_referenced() -> None:
+    files = [
+        PythonExecutionFile(
+            filename="chart.png",
+            file_link="http://localhost/api/chat/file/abc-123",
+        )
+    ]
+    tool_call = _make_tool_call_info(generated_files=files)
+    result = _extract_referenced_file_descriptors([tool_call], "Here is your answer.")
+    assert result == []
+
+
+def test_extracts_referenced_file() -> None:
+    file_id = "abc-123-def"
+    files = [
+        PythonExecutionFile(
+            filename="chart.png",
+            file_link=f"http://localhost/api/chat/file/{file_id}",
+        )
+    ]
+    tool_call = _make_tool_call_info(generated_files=files)
+    message = (
+        f"Here is the chart: [chart.png](http://localhost/api/chat/file/{file_id})"
+    )
+
+    result = _extract_referenced_file_descriptors([tool_call], message)
+
+    assert len(result) == 1
+    assert result[0]["id"] == file_id
+    assert result[0]["type"] == ChatFileType.IMAGE
+    assert result[0]["name"] == "chart.png"
+
+
+def test_filters_unreferenced_files() -> None:
+    referenced_id = "ref-111"
+    unreferenced_id = "unref-222"
+    files = [
+        PythonExecutionFile(
+            filename="chart.png",
+            file_link=f"http://localhost/api/chat/file/{referenced_id}",
+        ),
+        PythonExecutionFile(
+            filename="data.csv",
+            file_link=f"http://localhost/api/chat/file/{unreferenced_id}",
+        ),
+    ]
+    tool_call = _make_tool_call_info(generated_files=files)
+    message = f"Here is the chart: [chart.png](http://localhost/api/chat/file/{referenced_id})"
+
+    result = _extract_referenced_file_descriptors([tool_call], message)
+
+    assert len(result) == 1
+    assert result[0]["id"] == referenced_id
+    assert result[0]["name"] == "chart.png"
+
+
+def test_extracts_from_multiple_tool_calls() -> None:
+    id_1 = "file-aaa"
+    id_2 = "file-bbb"
+    tc1 = _make_tool_call_info(
+        generated_files=[
+            PythonExecutionFile(
+                filename="plot.png",
+                file_link=f"http://localhost/api/chat/file/{id_1}",
+            )
+        ]
+    )
+    tc2 = _make_tool_call_info(
+        generated_files=[
+            PythonExecutionFile(
+                filename="report.csv",
+                file_link=f"http://localhost/api/chat/file/{id_2}",
+            )
+        ]
+    )
+    message = (
+        f"[plot.png](http://localhost/api/chat/file/{id_1}) "
+        f"and [report.csv](http://localhost/api/chat/file/{id_2})"
+    )
+
+    result = _extract_referenced_file_descriptors([tc1, tc2], message)
+
+    assert len(result) == 2
+    ids = {d["id"] for d in result}
+    assert ids == {id_1, id_2}
+
+
+def test_csv_file_type() -> None:
+    file_id = "csv-123"
+    files = [
+        PythonExecutionFile(
+            filename="data.csv",
+            file_link=f"http://localhost/api/chat/file/{file_id}",
+        )
+    ]
+    tool_call = _make_tool_call_info(generated_files=files)
+    message = f"[data.csv](http://localhost/api/chat/file/{file_id})"
+
+    result = _extract_referenced_file_descriptors([tool_call], message)
+
+    assert len(result) == 1
+    assert result[0]["type"] == ChatFileType.CSV
+
+
+def test_unknown_extension_defaults_to_plain_text() -> None:
+    file_id = "bin-456"
+    files = [
+        PythonExecutionFile(
+            filename="output.xyz",
+            file_link=f"http://localhost/api/chat/file/{file_id}",
+        )
+    ]
+    tool_call = _make_tool_call_info(generated_files=files)
+    message = f"[output.xyz](http://localhost/api/chat/file/{file_id})"
+
+    result = _extract_referenced_file_descriptors([tool_call], message)
+
+    assert len(result) == 1
+    assert result[0]["type"] == ChatFileType.PLAIN_TEXT
+
+
+def test_skips_tool_calls_without_generated_files() -> None:
+    file_id = "img-789"
+    tc_no_files = _make_tool_call_info(generated_files=None)
+    tc_empty = _make_tool_call_info(generated_files=[])
+    tc_with_files = _make_tool_call_info(
+        generated_files=[
+            PythonExecutionFile(
+                filename="result.png",
+                file_link=f"http://localhost/api/chat/file/{file_id}",
+            )
+        ]
+    )
+    message = f"[result.png](http://localhost/api/chat/file/{file_id})"
+
+    result = _extract_referenced_file_descriptors(
+        [tc_no_files, tc_empty, tc_with_files], message
+    )
+
+    assert len(result) == 1
+    assert result[0]["id"] == file_id


### PR DESCRIPTION
## Description
We want to support multistep code interpreter workflows. For example, user creates ci artifact. They then ask for a change or something extra built on top of that artifact. The initial artifact should be uploaded and usable as context / input file.

This PR achieves this by saving code interpreter artifacts in the assistant message. In particular, it only saves artifacts that the assistant chooses to be in the final output. These files will then be apart of the ChatFiles array that is uploaded to code interpreter and be usable.

## How Has This Been Tested?
Manual + Unit tests

## Additional Options
closes https://linear.app/onyx-app/issue/ENG-3792/support-multistep-workflows

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist code interpreter outputs that are linked in the assistant’s reply, so they are reloaded as ChatFiles in later turns. This enables multi-step Python workflows and aligns with ENG-3792.

- **New Features**
  - Python tool returns PythonToolRichResponse with generated_files; LLM loop stores them on ToolCallInfo.
  - On save, only files referenced in the assistant message are extracted, typed via MIME, and appended to assistant_message.files for future runs.
  - Added unit tests covering selective persistence, multiple tool calls, and file-type mapping.

<sup>Written for commit 7647dfa3fba062a96222a7aee915e3d294e19fc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

