### PR TITLE
fix: Markdown does not show all texts

### DIFF
--- a/web/src/sections/modals/PreviewModal/variants/markdownVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/markdownVariant.tsx
@@ -30,7 +30,7 @@ export const markdownVariant: PreviewVariant = {
     <ScrollIndicatorDiv className="flex-1 min-h-0 p-4" variant="shadow">
       <MinimalMarkdown
         content={ctx.fileContent}
-        className="w-full pb-4 h-full text-lg break-words"
+        className="w-full pb-4 text-lg break-words"
       />
     </ScrollIndicatorDiv>
   ),


### PR DESCRIPTION
## Description
The very bottom of the text is currently hidden. With this it is now shown

<img width="1664" height="906" alt="Screenshot 2026-03-03 at 5 56 19 PM" src="https://github.com/user-attachments/assets/d9575f29-bbf2-4887-a72a-fc11f27c109f" />


## How Has This Been Tested?
Manual

## Additional Options
closes https://linear.app/onyx-app/issue/ENG-3793/rendered-md-possibly-other-text-files-do-not-show-all-the-text

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hidden bottom content in the Markdown preview so all text is visible and scrolls correctly. Addresses Linear ENG-3793.

- **Bug Fixes**
  - Removed the h-full class from MinimalMarkdown in PreviewModal’s markdown variant to prevent bottom clipping.

<sup>Written for commit 188ec9362e2860908948537f3e4f8343c5868aaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

