### PR TITLE
chore(fe): "Share Chat"->"Share"

### DIFF
--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -399,7 +399,7 @@ function Header() {
                 onClick={() => setShowShareModal(true)}
                 aria-label="share-chat-button"
               >
-                Share Chat
+                Share
               </Button>
               <SimplePopover
                 trigger={


### PR DESCRIPTION
## Description

I think Duo mentioned offline to me this button should only contain the action text, `Share`.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the header button label from "Share Chat" to "Share" to match UX guidance and keep the action text concise. Button behavior and the share modal remain unchanged.

<sup>Written for commit 90cec81951e046867cdb0323853bd7d8eba2e188. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

