### PR TITLE
fix(ui): InputComboBox search for users/groups (#8928) to release v2.11

### DIFF
--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
@@ -195,12 +195,11 @@ describe("InputComboBox", () => {
 
       await user.type(input, "app");
 
-      // Get all options and check the first one contains Apple
+      // Search should only show matching options by default
       const options = screen.getAllByRole("option");
-      expect(options.length).toBeGreaterThan(0);
+      expect(options.length).toBe(1);
       expect(options[0]!.textContent).toBe("Apple");
-      // Banana and Cherry should be in "Other options" section
-      expect(screen.getByText("Banana")).toBeInTheDocument();
+      expect(screen.queryByText("Banana")).not.toBeInTheDocument();
     });
 
     test("shows 'No options found' when no matches and strict mode", async () => {
@@ -217,12 +216,10 @@ describe("InputComboBox", () => {
 
       await user.type(input, "xyz");
 
-      // In strict mode with no matches, all options go to "Other options" section
-      // which shows all options (not "No options found")
-      expect(screen.getByText("Other options")).toBeInTheDocument();
+      expect(screen.getByText("No options found")).toBeInTheDocument();
     });
 
-    test("shows separator between matched and unmatched options", async () => {
+    test("shows separator between matched and unmatched options when enabled", async () => {
       const user = setupUser();
       render(
         <InputComboBox
@@ -230,6 +227,7 @@ describe("InputComboBox", () => {
           value=""
           options={mockOptions}
           separatorLabel="Other fruits"
+          showOtherOptions
         />
       );
       const input = screen.getByPlaceholderText("Select");

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
@@ -129,6 +129,7 @@ const InputComboBox = ({
   leftSearchIcon = false,
   rightSection,
   separatorLabel = "Other options",
+  showOtherOptions = false,
   ...rest
 }: WithoutStyles<InputComboBoxProps>) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -152,6 +153,8 @@ const InputComboBox = ({
   // Filtering Hook
   const { matchedOptions, unmatchedOptions, hasSearchTerm } =
     useOptionFiltering({ options, inputValue });
+  const visibleUnmatchedOptions =
+    hasSearchTerm && showOtherOptions ? unmatchedOptions : [];
 
   // Whether to show the create option (only when no partial matches)
   const showCreateOption =
@@ -162,13 +165,13 @@ const InputComboBox = ({
 
   // Combined list for keyboard navigation (includes create option when shown)
   const allVisibleOptions = useMemo(() => {
-    const baseOptions = [...matchedOptions, ...unmatchedOptions];
+    const baseOptions = [...matchedOptions, ...visibleUnmatchedOptions];
     if (showCreateOption) {
       // Prepend a synthetic option for the "create new" item
       return [{ value: inputValue, label: inputValue }, ...baseOptions];
     }
     return baseOptions;
-  }, [matchedOptions, unmatchedOptions, showCreateOption, inputValue]);
+  }, [matchedOptions, visibleUnmatchedOptions, showCreateOption, inputValue]);
 
   // Floating UI for dropdown positioning
   const { refs, floatingStyles } = useFloating({
@@ -417,7 +420,7 @@ const InputComboBox = ({
           fieldId={fieldId}
           placeholder={placeholder}
           matchedOptions={matchedOptions}
-          unmatchedOptions={unmatchedOptions}
+          unmatchedOptions={visibleUnmatchedOptions}
           hasSearchTerm={hasSearchTerm}
           separatorLabel={separatorLabel}
           value={value}

--- a/web/src/refresh-components/inputs/InputComboBox/types.ts
+++ b/web/src/refresh-components/inputs/InputComboBox/types.ts
@@ -40,4 +40,9 @@ export interface InputComboBoxProps
   rightSection?: React.ReactNode;
   /** Label for the separator between matched and unmatched options */
   separatorLabel?: string;
+  /**
+   * When true, keep non-matching options visible under a separator while searching.
+   * Defaults to false so search results are strictly filtered.
+   */
+  showOtherOptions?: boolean;
 }


### PR DESCRIPTION
Cherry-pick of commit 28332fa24b3ac54b7f50d0d2278cdce325cf53ed to release/v2.11 branch.

Original PR: #8928

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes InputComboBox search so only matching users/groups show by default and shows “No options found” when there are no matches. Adds an opt-in prop to display other options under a separator when needed.

- **Bug Fixes**
  - Hide non-matching options while typing.
  - Show “No options found” when there are zero matches.

- **New Features**
  - Added showOtherOptions (default false) to keep non-matching options visible under separatorLabel during search.

<sup>Written for commit cab51131f3927ae5cfd1a96a625331780884d9fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

