### PR TITLE
fix(ci): Add fallback environment variables for nightly LLM provider inputs

### DIFF
--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -285,14 +285,43 @@ jobs:
             OLLAMA_API_KEY, test/ollama-api-key
             OPENROUTER_API_KEY, test/openrouter-api-key
 
+      - name: Resolve nightly provider inputs
+        id: resolve-nightly-inputs
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          MODELS_INPUT: ${{ matrix.models }}
+          AZURE_API_BASE_INPUT: ${{ matrix.api_base }}
+        run: |
+          models="$MODELS_INPUT"
+          if [ -z "$models" ]; then
+            case "$PROVIDER" in
+              openai) models="${NIGHTLY_LLM_OPENAI_MODELS:-}" ;;
+              anthropic) models="${NIGHTLY_LLM_ANTHROPIC_MODELS:-}" ;;
+              bedrock) models="${NIGHTLY_LLM_BEDROCK_MODELS:-}" ;;
+              vertex_ai) models="${NIGHTLY_LLM_VERTEX_AI_MODELS:-}" ;;
+              azure) models="${NIGHTLY_LLM_AZURE_MODELS:-}" ;;
+              ollama_chat) models="${NIGHTLY_LLM_OLLAMA_MODELS:-}" ;;
+              openrouter) models="${NIGHTLY_LLM_OPENROUTER_MODELS:-}" ;;
+            esac
+          fi
+
+          api_base="$AZURE_API_BASE_INPUT"
+          if [ -z "$api_base" ] && [ "$PROVIDER" = "azure" ]; then
+            api_base="${NIGHTLY_LLM_AZURE_API_BASE:-}"
+          fi
+
+          echo "models=$models" >> "$GITHUB_OUTPUT"
+          echo "api_base=$api_base" >> "$GITHUB_OUTPUT"
+
       - name: Run nightly provider chat test
         uses: ./.github/actions/run-nightly-provider-chat-test
         with:
           provider: ${{ matrix.provider }}
-          models: ${{ matrix.models }}
+          models: ${{ steps.resolve-nightly-inputs.outputs.models }}
           provider-api-key: ${{ matrix.api_key_env && env[matrix.api_key_env] || '' }}
           strict: ${{ inputs.strict && 'true' || 'false' }}
-          api-base: ${{ matrix.api_base }}
+          api-base: ${{ steps.resolve-nightly-inputs.outputs.api_base }}
           api-version: ${{ matrix.api_version }}
           deployment-name: ${{ matrix.deployment_name }}
           custom-config-json: ${{ matrix.custom_config_env && env[matrix.custom_config_env] || '' }}


### PR DESCRIPTION
## Description

Added fallback logic for nightly LLM provider tests to use environment variables when matrix inputs are not provided. The workflow now includes a new step that resolves models and API base configurations by checking provider-specific environment variables (e.g., `NIGHTLY_LLM_OPENAI_MODELS`, `NIGHTLY_LLM_AZURE_API_BASE`) when the corresponding matrix values are empty.

## How Has This Been Tested?

The changes affect the GitHub Actions workflow for nightly LLM provider chat tests. Testing should verify that the workflow correctly falls back to environment variables when matrix inputs are not specified for each supported provider (OpenAI, Anthropic, Bedrock, Vertex AI, Azure, Ollama, and OpenRouter).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fallback logic in the nightly LLM provider workflow to read models and Azure API base from environment variables when matrix inputs are missing. Prevents nightly chat tests from failing when inputs aren’t set.

- **Bug Fixes**
  - Added a “Resolve nightly provider inputs” step to set models per provider from env vars (e.g., NIGHTLY_LLM_OPENAI_MODELS) and Azure API base from NIGHTLY_LLM_AZURE_API_BASE.
  - Passed the resolved values to the run-nightly-provider-chat-test action.
  - Covers OpenAI, Anthropic, Bedrock, Vertex AI, Azure, Ollama, and OpenRouter.

<sup>Written for commit dff01cc63f6c5e350529de6d8a165694f02bf5e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

