### PR TITLE
fix(ui): Persist agent sharing changes immediately for existing agents (#9024) to release v3.0

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -83,13 +83,18 @@ import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import useFilter from "@/hooks/useFilter";
 import EnabledCount from "@/refresh-components/EnabledCount";
 import { useAppRouter } from "@/hooks/appNavigation";
-import { deleteAgent } from "@/lib/agents";
+import {
+  deleteAgent,
+  updateAgentFeaturedStatus,
+  updateAgentSharedStatus,
+} from "@/lib/agents";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import ShareAgentModal from "@/sections/modals/ShareAgentModal";
 import AgentKnowledgePane from "@/sections/knowledge/AgentKnowledgePane";
 import { ValidSources } from "@/lib/types";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { useUser } from "@/providers/UserProvider";
+import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 
 interface AgentIconEditorProps {
   existingAgent?: FullPersona | null;
@@ -457,6 +462,7 @@ export default function AgentEditorPage({
   const { isAdmin, isCurator } = useUser();
   const canUpdateFeaturedStatus = isAdmin || isCurator;
   const vectorDbEnabled = settings?.settings.vector_db_enabled !== false;
+  const isPaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
 
   // LLM Model Selection
   const getCurrentLlm = useCallback(
@@ -1082,19 +1088,111 @@ export default function AgentEditorPage({
                     isPublic={values.is_public}
                     isFeatured={values.is_default_persona}
                     labelIds={values.label_ids}
-                    onShare={(
+                    onShare={async (
                       userIds,
                       groupIds,
                       isPublic,
                       isFeatured,
                       labelIds
                     ) => {
-                      setFieldValue("shared_user_ids", userIds);
-                      setFieldValue("shared_group_ids", groupIds);
-                      setFieldValue("is_public", isPublic);
-                      setFieldValue("is_default_persona", isFeatured);
-                      setFieldValue("label_ids", labelIds);
+                      if (!existingAgent) {
+                        // New agents are not persisted until the main Create action.
+                        setFieldValue("shared_user_ids", userIds);
+                        setFieldValue("shared_group_ids", groupIds);
+                        setFieldValue("is_public", isPublic);
+                        setFieldValue("featured", isFeatured);
+                        setFieldValue("label_ids", labelIds);
+                        shareAgentModal.toggle(false);
+                        return;
+                      }
+
+                      const applySharingFields = () => {
+                        setFieldValue("shared_user_ids", userIds);
+                        setFieldValue("shared_group_ids", groupIds);
+                        setFieldValue("is_public", isPublic);
+                        setFieldValue("label_ids", labelIds);
+                      };
+
+                      const refreshSharedUi = async () => {
+                        try {
+                          await refreshAgents();
+                          refreshAgent?.();
+                        } catch (error) {
+                          console.error(
+                            "Refresh failed after successful share:",
+                            error
+                          );
+                          toast.error(
+                            "Agent sharing was saved, but failed to refresh. Please reload."
+                          );
+                        }
+                      };
+
+                      let shareError: string | null;
+                      try {
+                        shareError = await updateAgentSharedStatus(
+                          existingAgent.id,
+                          userIds,
+                          groupIds,
+                          isPublic,
+                          isPaidEnterpriseFeaturesEnabled,
+                          labelIds
+                        );
+                      } catch (error) {
+                        console.error(
+                          "Share agent mutation failed unexpectedly:",
+                          error
+                        );
+                        toast.error("Failed to share agent. Please try again.");
+                        return;
+                      }
+
+                      if (shareError) {
+                        toast.error(`Failed to share agent: ${shareError}`);
+                        return;
+                      }
+
+                      if (canUpdateFeaturedStatus) {
+                        let featuredError: string | null;
+                        try {
+                          featuredError = await updateAgentFeaturedStatus(
+                            existingAgent.id,
+                            isFeatured
+                          );
+                        } catch (error) {
+                          console.error(
+                            "Featured mutation failed unexpectedly:",
+                            error
+                          );
+                          // Share succeeded; sync form and UI before returning.
+                          applySharingFields();
+                          await refreshSharedUi();
+                          toast.error(
+                            "Failed to update featured status. Please try again."
+                          );
+                          return;
+                        }
+
+                        if (featuredError) {
+                          // Share succeeded, featured failed: keep modal open for retry.
+                          applySharingFields();
+                          await refreshSharedUi();
+                          toast.error(
+                            `Failed to update featured status: ${featuredError}`
+                          );
+                          return;
+                        }
+
+                        applySharingFields();
+                        setFieldValue("featured", isFeatured);
+                        shareAgentModal.toggle(false);
+                        await refreshSharedUi();
+                        return;
+                      }
+
+                      applySharingFields();
                       shareAgentModal.toggle(false);
+                      await refreshSharedUi();
                     }}
                   />
                 </shareAgentModal.Provider>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import {
@@ -56,7 +56,7 @@ interface ShareAgentFormContentProps {
 }
 
 function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
-  const { values, setFieldValue, handleSubmit, dirty } =
+  const { values, setFieldValue, handleSubmit, dirty, isSubmitting } =
     useFormikContext<ShareAgentFormValues>();
   const { data: usersData } = useShareableUsers({ includeApiKeys: true });
   const { data: groupsData } = useShareableGroups();
@@ -349,12 +349,15 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
             ) : undefined
           }
           cancel={
-            <Button secondary onClick={handleClose}>
+            <Button secondary onClick={handleClose} disabled={isSubmitting}>
               Cancel
             </Button>
           }
           submit={
-            <Button onClick={() => handleSubmit()} disabled={!dirty}>
+            <Button
+              onClick={() => handleSubmit()}
+              disabled={!dirty || isSubmitting}
+            >
               Save
             </Button>
           }
@@ -381,7 +384,7 @@ export interface ShareAgentModalProps {
     isPublic: boolean,
     isFeatured: boolean,
     labelIds: number[]
-  ) => void;
+  ) => Promise<void> | void;
 }
 
 export default function ShareAgentModal({
@@ -395,16 +398,31 @@ export default function ShareAgentModal({
 }: ShareAgentModalProps) {
   const shareAgentModal = useModal();
 
-  const initialValues: ShareAgentFormValues = {
-    selectedUserIds: userIds,
-    selectedGroupIds: groupIds,
-    isPublic: isPublic,
-    isFeatured: isFeatured,
-    labelIds: labelIds,
-  };
+  const initialValues = useMemo(
+    (): ShareAgentFormValues => ({
+      selectedUserIds: userIds,
+      selectedGroupIds: groupIds,
+      isPublic: isPublic,
+      isFeatured: isFeatured,
+      labelIds: labelIds,
+    }),
+    [userIds, groupIds, isPublic, isFeatured, labelIds]
+  );
+  const [modalInitialValues, setModalInitialValues] =
+    useState<ShareAgentFormValues>(initialValues);
+  const wasOpenRef = useRef(false);
 
-  function handleSubmit(values: ShareAgentFormValues) {
-    onShare?.(
+  useEffect(() => {
+    // Capture fresh props exactly when the modal opens, then keep them stable
+    // while open so in-flight parent updates don't reset form state.
+    if (shareAgentModal.isOpen && !wasOpenRef.current) {
+      setModalInitialValues(initialValues);
+    }
+    wasOpenRef.current = shareAgentModal.isOpen;
+  }, [shareAgentModal.isOpen, initialValues]);
+
+  async function handleSubmit(values: ShareAgentFormValues) {
+    await onShare?.(
       values.selectedUserIds,
       values.selectedGroupIds,
       values.isPublic,
@@ -416,7 +434,7 @@ export default function ShareAgentModal({
   return (
     <Modal open={shareAgentModal.isOpen} onOpenChange={shareAgentModal.toggle}>
       <Formik
-        initialValues={initialValues}
+        initialValues={modalInitialValues}
         onSubmit={handleSubmit}
         enableReinitialize
       >


### PR DESCRIPTION
Cherry-pick of commit 8193aa4fd04b04258f7373dcf119f793243bbdc2 to release/v3.0 branch.

Original PR: #9024

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately persist agent sharing changes for existing agents and refresh the UI to prevent lost updates and inconsistent states after sharing from the editor.

- **Bug Fixes**
  - Save sharing and featured status right away for existing agents; new agents still persist on create.
  - Refresh agent lists and the current agent after successful updates; show clear error toasts and keep the modal open for featured update retries.
  - Disable Save/Cancel while submitting and lock initial form values while the modal is open to avoid mid-submit resets.
  - Update featured status only for admins/curators; pass enterprise feature flag when updating shared status.

<sup>Written for commit bdc8a8196223544c2e0eb36c455264c28f6da644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

