### PR TITLE
fix(llm): Final LLM Cleanup for Nightly Tests

### DIFF
--- a/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
+++ b/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
@@ -50,9 +50,44 @@ def _stringify_custom_config_value(value: object) -> str:
     return str(value)
 
 
+def _looks_like_vertex_credentials_payload(
+    raw_custom_config: dict[object, object],
+) -> bool:
+    normalized_keys = {str(key).strip().lower() for key in raw_custom_config}
+    provider_specific_keys = {
+        "vertex_credentials",
+        "credentials_file",
+        "vertex_credentials_file",
+        "google_application_credentials",
+        "vertex_location",
+        "location",
+        "vertex_region",
+        "region",
+    }
+    if normalized_keys & provider_specific_keys:
+        return False
+
+    normalized_type = str(raw_custom_config.get("type", "")).strip().lower()
+    if normalized_type not in {"service_account", "external_account"}:
+        return False
+
+    # Service account JSON usually includes private_key/client_email, while external
+    # account JSON includes credential_source. Either shape should be accepted.
+    has_service_account_markers = any(
+        key in normalized_keys for key in {"private_key", "client_email"}
+    )
+    has_external_account_markers = "credential_source" in normalized_keys
+    return has_service_account_markers or has_external_account_markers
+
+
 def _normalize_custom_config(
     provider: str, raw_custom_config: dict[object, object]
 ) -> dict[str, str]:
+    if provider == "vertex_ai" and _looks_like_vertex_credentials_payload(
+        raw_custom_config
+    ):
+        return {"vertex_credentials": json.dumps(raw_custom_config)}
+
     normalized: dict[str, str] = {}
     for raw_key, raw_value in raw_custom_config.items():
         key = str(raw_key).strip()
@@ -192,11 +227,15 @@ def _validate_provider_config(config: NightlyProviderConfig) -> None:
             config.custom_config and config.custom_config.get("vertex_credentials")
         )
         if not has_vertex_credentials:
+            configured_keys = (
+                sorted(config.custom_config.keys()) if config.custom_config else []
+            )
             _skip_or_fail(
                 strict=config.strict,
                 message=(
                     f"{_ENV_CUSTOM_CONFIG_JSON} must include 'vertex_credentials' "
-                    f"for provider '{config.provider}'"
+                    f"for provider '{config.provider}'. "
+                    f"Found keys: {configured_keys}"
                 ),
             )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There were a number of syntax related fixes required to get all of the tests to properly run and pass and they have all be addressed and tested.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested this in the github actions to validate all of the changes
https://github.com/onyx-dot-app/onyx/actions/runs/22694638258

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the model field to the provider payload and sets defaults via /admin/llm/default with provider_id and model_name. Updates tests to assert default_text provider_id and model_name, and expands Vertex AI custom_config normalization (alias mapping, stringifying, and auto-wrapping raw service/external account JSON as vertex_credentials), with validation requiring vertex_credentials.

<sup>Written for commit 8155aa2f52ade4313efb9c6947a87b104d7f03bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

