### PR TITLE
fix: Correct file_id for docs

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 from collections.abc import Generator
 from datetime import timedelta
 from uuid import UUID
@@ -61,7 +60,6 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.usage import increment_usage
 from onyx.db.usage import UsageType
 from onyx.db.user_file import get_file_id_by_user_file_id
-from onyx.file_processing.extract_file_text import docx_to_txt_filename
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.factory import get_default_llm
@@ -811,18 +809,6 @@ def fetch_chat_file(
     file_record = file_store.read_file_record(file_id)
     if not file_record:
         raise HTTPException(status_code=404, detail="File not found")
-
-    original_file_name = file_record.display_name
-    if file_record.file_type.startswith(
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    ):
-        # Check if a converted text file exists for .docx files
-        txt_file_name = docx_to_txt_filename(original_file_name)
-        txt_file_id = os.path.join(os.path.dirname(file_id), txt_file_name)
-        txt_file_record = file_store.read_file_record(txt_file_id)
-        if txt_file_record:
-            file_record = txt_file_record
-            file_id = txt_file_id
 
     media_type = file_record.file_type
     file_io = file_store.read_file(file_id, mode="b")


### PR DESCRIPTION
## Description
Legacy code was converting the file_id for word docs and other various types to the title. This drops that and looks up by the actual file id in the database.

## How Has This Been Tested?
Manual.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopped rewriting file_id for Word docs and now fetch files by the real file_id. Fixes failed docx loads and incorrect lookups.

- **Bug Fixes**
  - Removed legacy .docx-to-.txt fallback based on display_name.
  - Read files directly by file_id for consistent retrieval across types.

<sup>Written for commit 47bb69c3ea0921998f751beb66ec53f6f5e1e8a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

