### PR TITLE
chore: Add docx preview depend

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -48,6 +48,7 @@
         "cmdk": "^1.0.0",
         "cookies-next": "^5.1.0",
         "date-fns": "^3.6.0",
+        "docx-preview": "^0.3.7",
         "favicon-fetch": "^1.0.0",
         "formik": "^2.2.9",
         "highlight.js": "^11.11.1",
@@ -7956,6 +7957,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docx-preview": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.3.7.tgz",
+      "integrity": "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": ">=3.0.0"
       }
     },
     "node_modules/dom-accessibility-api": {

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,7 @@
     "cmdk": "^1.0.0",
     "cookies-next": "^5.1.0",
     "date-fns": "^3.6.0",
+    "docx-preview": "^0.3.7",
     "favicon-fetch": "^1.0.0",
     "formik": "^2.2.9",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Description
This adds a preview variant for docs

<img width="1916" height="1076" alt="Screenshot 2026-03-04 at 3 44 20 PM" src="https://github.com/user-attachments/assets/b44a4b9b-779b-477d-9d12-267af79e8c5f" />


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docx-preview to enable in-browser DOCX previews in the web app.

- **Dependencies**
  - Added docx-preview ^0.3.7.
  - Pulls in jszip as a transitive dependency.

<sup>Written for commit 52b56ad1f1b9809c2ea114ec211493fceee290e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

