### PR TITLE
fix(ui): Improve text truncation and overflow handling in FileCard layout

### DIFF
--- a/web/src/layouts/general-layouts.tsx
+++ b/web/src/layouts/general-layouts.tsx
@@ -190,14 +190,17 @@ function AttachmentItemLayout({
         alignItems="center"
         gap={1.5}
       >
-        <Content
-          title={title}
-          description={description}
-          sizePreset="main-ui"
-          variant="section"
-        />
+        <div className="flex-1 min-w-0">
+          <Content
+            title={title}
+            description={description}
+            sizePreset="main-ui"
+            variant="section"
+            widthVariant="full"
+          />
+        </div>
         {middleText && (
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <Truncated text03 secondaryBody>
               {middleText}
             </Truncated>

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -173,19 +173,21 @@ export function FileCard({
         removeFile && doneUploading ? () => removeFile(file.id) : undefined
       }
     >
-      <div className="max-w-[12rem]">
+      <div className="min-w-0 max-w-[12rem]">
         <Interactive.Container border heightVariant="fit">
-          <AttachmentItemLayout
-            icon={isProcessing ? SimpleLoader : SvgFileText}
-            title={file.name}
-            description={
-              isProcessing
-                ? file.status === UserFileStatus.UPLOADING
-                  ? "Uploading..."
-                  : "Processing..."
-                : typeLabel
-            }
-          />
+          <div className="[&_.opal-content-md-body]:min-w-0 [&_.opal-content-md-title]:break-all">
+            <AttachmentItemLayout
+              icon={isProcessing ? SimpleLoader : SvgFileText}
+              title={file.name}
+              description={
+                isProcessing
+                  ? file.status === UserFileStatus.UPLOADING
+                    ? "Uploading..."
+                    : "Processing..."
+                  : typeLabel
+              }
+            />
+          </div>
           <Spacer horizontal rem={0.5} />
         </Interactive.Container>
       </div>


### PR DESCRIPTION
## Description

Fixed text overflow issues in file attachment components by adding proper text truncation and width constraints. Added `min-w-0` classes to prevent flex items from overflowing their containers, set `widthVariant="full"` on the Content component, and applied `break-all` styling to file titles to ensure long filenames wrap properly within their allocated space.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

Before:
<img width="401" height="324" alt="Screenshot 2026-03-04 at 5 11 58 PM" src="https://github.com/user-attachments/assets/36a95361-4f7c-46c2-8e6c-4db96e04e298" />

After:
<img width="414" height="321" alt="Screenshot 2026-03-04 at 5 11 10 PM" src="https://github.com/user-attachments/assets/23336c6c-0603-4590-ba29-8a184c433120" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text overflow in FileCard and attachment layouts. Long filenames now wrap and content truncates correctly without breaking the UI.

- **Bug Fixes**
  - Added min-w-0 wrappers to flex children to prevent overflow.
  - Set Content widthVariant="full" for proper truncation.
  - Applied break-all to file titles to wrap very long names.

<sup>Written for commit a03a4cd20794fae311783c2985a5011d98280f38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

