### PR TITLE
fix(vertex): Vision support

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -59,6 +59,32 @@ CUSTOM_LITELLM_MODEL_OVERRIDES: dict[str, dict[str, Any]] = {
     for model_name in _TWELVE_LABS_PEGASUS_MODEL_NAMES
 }
 
+# Known vision-capable model name patterns for fallback when LiteLLM's
+# model_cost data is missing the supports_vision field.
+VISION_CAPABLE_MODEL_PATTERNS = frozenset(
+    {
+        "claude-3",
+        "claude-sonnet",
+        "claude-opus",
+        "claude-haiku",
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-4.1",
+        "gpt-5",
+        "gemini",
+    }
+)
+
+
+def _infer_vision_support(model_name: str) -> bool:
+    """Infer vision support from model name patterns.
+
+    Used as a fallback when LiteLLM's model_cost data doesn't include
+    the supports_vision field for a known model.
+    """
+    model_lower = model_name.lower()
+    return any(pattern in model_lower for pattern in VISION_CAPABLE_MODEL_PATTERNS)
+
 
 def truncate_litellm_user_id(user_id: str) -> str:
     """Truncate the LiteLLM `user` field maximum length."""
@@ -715,11 +741,17 @@ def litellm_thinks_model_supports_image_input(
         if not model_obj:
             logger.warning(
                 f"No litellm entry found for {model_provider}/{model_name}, "
-                "this model may or may not support image input."
+                "falling back to pattern-based vision inference."
             )
-            return False
-        # The or False here is because sometimes the dict contains the key but the value is None
-        return model_obj.get("supports_vision", False) or False
+            return _infer_vision_support(model_name)
+
+        supports_vision = model_obj.get("supports_vision")
+        if supports_vision is not None:
+            return bool(supports_vision)
+
+        # supports_vision not set in LiteLLM data — fall back to pattern matching
+        # (e.g. vertex_ai/claude-3-5-haiku is missing this field)
+        return _infer_vision_support(model_name)
     except Exception:
         logger.exception(
             f"Failed to get model object for {model_provider}/{model_name}"

--- a/backend/tests/unit/onyx/llm/test_vision_support.py
+++ b/backend/tests/unit/onyx/llm/test_vision_support.py
@@ -1,0 +1,174 @@
+from unittest.mock import patch
+
+import litellm
+
+from onyx.llm.utils import _infer_vision_support
+from onyx.llm.utils import get_model_map
+from onyx.llm.utils import litellm_thinks_model_supports_image_input
+
+
+class TestInferVisionSupport:
+    """Tests for the pattern-based vision support fallback."""
+
+    def test_claude_3_models(self) -> None:
+        assert _infer_vision_support("claude-3-5-haiku") is True
+        assert _infer_vision_support("claude-3-5-haiku@20241022") is True
+        assert _infer_vision_support("claude-3-5-sonnet-v2@20241022") is True
+        assert _infer_vision_support("claude-3-opus@20240229") is True
+        assert _infer_vision_support("claude-3-7-sonnet@20250219") is True
+
+    def test_claude_named_models(self) -> None:
+        assert _infer_vision_support("claude-sonnet-4-6") is True
+        assert _infer_vision_support("claude-opus-4-5") is True
+        assert _infer_vision_support("claude-haiku-4-5@20251001") is True
+        assert _infer_vision_support("claude-sonnet-4-6@default") is True
+
+    def test_openai_models(self) -> None:
+        assert _infer_vision_support("gpt-4o") is True
+        assert _infer_vision_support("gpt-4o-mini") is True
+        assert _infer_vision_support("gpt-4-turbo") is True
+        assert _infer_vision_support("gpt-4.1") is True
+        assert _infer_vision_support("gpt-5") is True
+        assert _infer_vision_support("gpt-5-mini") is True
+
+    def test_gemini_models(self) -> None:
+        assert _infer_vision_support("gemini-2.5-flash") is True
+        assert _infer_vision_support("gemini-2.5-pro") is True
+        assert _infer_vision_support("gemini-3-pro-preview") is True
+
+    def test_non_vision_models(self) -> None:
+        assert _infer_vision_support("text-embedding-3-small") is False
+        assert _infer_vision_support("mistral-large-latest") is False
+        assert _infer_vision_support("deepseek-v3") is False
+        assert _infer_vision_support("llama-3.1-70b") is False
+
+    def test_case_insensitive(self) -> None:
+        assert _infer_vision_support("Claude-3-5-Haiku") is True
+        assert _infer_vision_support("GPT-4O") is True
+        assert _infer_vision_support("GEMINI-2.5-PRO") is True
+
+
+class TestLitellmVisionSupport:
+    """Tests for litellm_thinks_model_supports_image_input with fallback behavior."""
+
+    def test_vertex_ai_claude_haiku_missing_supports_vision(self) -> None:
+        """claude-3-5-haiku on vertex_ai is missing supports_vision in litellm.
+        The pattern fallback should detect it as vision-capable."""
+        get_model_map.cache_clear()
+        try:
+            assert (
+                litellm_thinks_model_supports_image_input(
+                    "claude-3-5-haiku", "vertex_ai"
+                )
+                is True
+            )
+            assert (
+                litellm_thinks_model_supports_image_input(
+                    "claude-3-5-haiku@20241022", "vertex_ai"
+                )
+                is True
+            )
+        finally:
+            get_model_map.cache_clear()
+
+    def test_vertex_ai_claude_with_supports_vision_set(self) -> None:
+        """Models that already have supports_vision=True in litellm should still work."""
+        get_model_map.cache_clear()
+        try:
+            assert (
+                litellm_thinks_model_supports_image_input(
+                    "claude-3-5-sonnet-v2@20241022", "vertex_ai"
+                )
+                is True
+            )
+            assert (
+                litellm_thinks_model_supports_image_input(
+                    "claude-sonnet-4-6", "vertex_ai"
+                )
+                is True
+            )
+        finally:
+            get_model_map.cache_clear()
+
+    def test_model_not_in_litellm_uses_pattern_fallback(self) -> None:
+        """A model not in litellm at all should fall back to pattern matching."""
+        mock_model_cost: dict[str, dict] = {}
+        with patch.object(litellm, "model_cost", mock_model_cost):
+            get_model_map.cache_clear()
+            try:
+                # Known vision pattern → True
+                assert (
+                    litellm_thinks_model_supports_image_input(
+                        "claude-3-future-model", "vertex_ai"
+                    )
+                    is True
+                )
+                # Unknown model → False
+                assert (
+                    litellm_thinks_model_supports_image_input(
+                        "some-unknown-model", "some_provider"
+                    )
+                    is False
+                )
+            finally:
+                get_model_map.cache_clear()
+
+    def test_explicit_false_is_respected(self) -> None:
+        """If litellm explicitly sets supports_vision=False, respect it."""
+        mock_model_cost = {
+            "test_provider/no-vision-model": {
+                "supports_vision": False,
+                "max_tokens": 4096,
+            }
+        }
+        with patch.object(litellm, "model_cost", mock_model_cost):
+            get_model_map.cache_clear()
+            try:
+                assert (
+                    litellm_thinks_model_supports_image_input(
+                        "no-vision-model", "test_provider"
+                    )
+                    is False
+                )
+            finally:
+                get_model_map.cache_clear()
+
+    def test_supports_vision_none_uses_fallback(self) -> None:
+        """If supports_vision is explicitly None, fall back to pattern matching."""
+        mock_model_cost = {
+            "vertex_ai/claude-3-new-model": {
+                "supports_vision": None,
+                "max_tokens": 4096,
+            }
+        }
+        with patch.object(litellm, "model_cost", mock_model_cost):
+            get_model_map.cache_clear()
+            try:
+                assert (
+                    litellm_thinks_model_supports_image_input(
+                        "claude-3-new-model", "vertex_ai"
+                    )
+                    is True
+                )
+            finally:
+                get_model_map.cache_clear()
+
+    def test_supports_vision_missing_uses_fallback(self) -> None:
+        """If supports_vision key is missing entirely, fall back to pattern matching."""
+        mock_model_cost = {
+            "vertex_ai/claude-3-5-haiku": {
+                "max_tokens": 4096,
+                # no supports_vision key
+            }
+        }
+        with patch.object(litellm, "model_cost", mock_model_cost):
+            get_model_map.cache_clear()
+            try:
+                assert (
+                    litellm_thinks_model_supports_image_input(
+                        "claude-3-5-haiku", "vertex_ai"
+                    )
+                    is True
+                )
+            finally:
+                get_model_map.cache_clear()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix vision detection on Vertex AI by adding a pattern-based fallback when LiteLLM lacks supports_vision. Vision-capable models like Claude 3, GPT-4o, and Gemini are now correctly treated as supporting image input.

- **Bug Fixes**
  - Added VISION_CAPABLE_MODEL_PATTERNS and _infer_vision_support for name-based vision inference.
  - Updated litellm_thinks_model_supports_image_input to use the fallback when data is missing or None, and to respect explicit False.
  - Added unit tests covering Vertex AI Claude models and fallback scenarios.

<sup>Written for commit 59f44c205ce1802ca5ea8fc67d5755438a298d61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

