### PR TITLE
chore(fe): rm redundant `alignBubble`

### DIFF
--- a/web/src/app/app/message/FileDisplay.tsx
+++ b/web/src/app/app/message/FileDisplay.tsx
@@ -7,15 +7,13 @@ import { InMessageImage } from "@/app/app/components/files/images/InMessageImage
 import CsvContent from "@/components/tools/CSVContent";
 import TextViewModal from "@/sections/modals/TextViewModal";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
-import { cn } from "@/lib/utils";
 import ExpandableContentWrapper from "@/components/tools/ExpandableContentWrapper";
 
 interface FileDisplayProps {
   files: FileDescriptor[];
-  alignBubble?: boolean;
 }
 
-export default function FileDisplay({ files, alignBubble }: FileDisplayProps) {
+export default function FileDisplay({ files }: FileDisplayProps) {
   const [close, setClose] = useState(true);
   const [previewingFile, setPreviewingFile] = useState<FileDescriptor | null>(
     null
@@ -43,59 +41,47 @@ export default function FileDisplay({ files, alignBubble }: FileDisplayProps) {
       )}
 
       {textFiles.length > 0 && (
-        <div
-          id="onyx-file"
-          className={cn("m-2 auto", alignBubble && "ml-auto")}
-        >
-          <div className="flex flex-col items-end gap-2">
-            {textFiles.map((file) => (
-              <Attachment
-                key={file.id}
-                fileName={file.name || file.id}
-                open={() => setPreviewingFile(file)}
-              />
-            ))}
-          </div>
+        <div id="onyx-file" className="flex flex-col items-end gap-2 py-2">
+          {textFiles.map((file) => (
+            <Attachment
+              key={file.id}
+              fileName={file.name || file.id}
+              open={() => setPreviewingFile(file)}
+            />
+          ))}
         </div>
       )}
 
       {imageFiles.length > 0 && (
-        <div
-          id="onyx-image"
-          className={cn("m-2 auto", alignBubble && "ml-auto")}
-        >
-          <div className="flex flex-col items-end gap-2">
-            {imageFiles.map((file) => (
-              <InMessageImage key={file.id} fileId={file.id} />
-            ))}
-          </div>
+        <div id="onyx-image" className="flex flex-col items-end gap-2 py-2">
+          {imageFiles.map((file) => (
+            <InMessageImage key={file.id} fileId={file.id} />
+          ))}
         </div>
       )}
 
       {csvFiles.length > 0 && (
-        <div className={cn("m-2 auto", alignBubble && "ml-auto")}>
-          <div className="flex flex-col items-end gap-2">
-            {csvFiles.map((file) => {
-              return (
-                <div key={file.id} className="w-fit">
-                  {close ? (
-                    <>
-                      <ExpandableContentWrapper
-                        fileDescriptor={file}
-                        close={() => setClose(false)}
-                        ContentComponent={CsvContent}
-                      />
-                    </>
-                  ) : (
-                    <Attachment
-                      open={() => setClose(true)}
-                      fileName={file.name || file.id}
+        <div className="flex flex-col items-end gap-2 py-2">
+          {csvFiles.map((file) => {
+            return (
+              <div key={file.id} className="w-fit">
+                {close ? (
+                  <>
+                    <ExpandableContentWrapper
+                      fileDescriptor={file}
+                      close={() => setClose(false)}
+                      ContentComponent={CsvContent}
                     />
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                  </>
+                ) : (
+                  <Attachment
+                    open={() => setClose(true)}
+                    fileName={file.name || file.id}
+                  />
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </>

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -195,7 +195,7 @@ const HumanMessage = React.memo(function HumanMessage({
       id="onyx-human-message"
       className="group flex flex-col justify-end w-full relative"
     >
-      <FileDisplay alignBubble files={files || []} />
+      <FileDisplay files={files || []} />
       {isEditing ? (
         <MessageEditing
           content={content}


### PR DESCRIPTION
## Description

This is only ever set to `true` and it's redundant with the the parent container's `justify-end`.

small visual change to remove the `mx-2` on the images since that is not defined in the mocks.

## How Has This Been Tested?

Expecting minimal behavioral change

<img width="2880" height="1920" alt="20260304_19h43m27s_grim" src="https://github.com/user-attachments/assets/ccd20e98-906c-4852-b895-c1812461a623" />


## Additional Options

- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant alignBubble prop and standardized file, image, and CSV wrappers. Alignment now relies on the parent container’s justify-end with no expected behavior change.

- **Refactors**
  - Removed alignBubble and cn usage in FileDisplay; unified wrappers to flex-col items-end with gap-2 and py-2.
  - Updated HumanMessage to stop passing alignBubble; removed extra margins to match mocks.

<sup>Written for commit 7535c3593ff7c532f775d027d5053855d461a7db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





