### PR TITLE
fix(fe): properly wrap copy and edit buttons on mobile

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FileDescriptor } from "@/app/app/interfaces";
 import "katex/dist/katex.min.css";
 import MessageSwitcher from "@/app/app/message/MessageSwitcher";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
+import useScreenSize from "@/hooks/useScreenSize";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Button } from "@opal/components";
 import { SvgEdit } from "@opal/icons";
@@ -137,6 +138,7 @@ const HumanMessage = React.memo(function HumanMessage({
   const [content, setContent] = useState(initialContent);
 
   const [isEditing, setIsEditing] = useState(false);
+  const { isMobile } = useScreenSize();
 
   // Use nodeId for switching (finding position in siblings)
   const indexInSiblings = otherMessagesCanSwitchTo?.indexOf(nodeId);
@@ -168,100 +170,104 @@ const HumanMessage = React.memo(function HumanMessage({
     return undefined;
   };
 
+  const copyEditButton = useMemo(
+    () => (
+      <div className="flex flex-row flex-shrink px-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <CopyIconButton
+          getCopyText={() => content}
+          prominence="tertiary"
+          data-testid="HumanMessage/copy-button"
+        />
+        <Button
+          icon={SvgEdit}
+          prominence="tertiary"
+          tooltip="Edit"
+          onClick={() => setIsEditing(true)}
+          data-testid="HumanMessage/edit-button"
+        />
+      </div>
+    ),
+    [content]
+  );
+
   return (
     <div
       id="onyx-human-message"
       className="group flex flex-col justify-end w-full relative"
     >
       <FileDisplay alignBubble files={files || []} />
-      <div className="md:flex md:flex-wrap relative justify-end break-words">
-        {isEditing ? (
-          <MessageEditing
-            content={content}
-            onSubmitEdit={(editedContent) => {
-              // Don't update UI for edits that can't be persisted
-              if (messageId === undefined || messageId === null) {
-                setIsEditing(false);
-                return;
-              }
-              onEdit?.(editedContent, messageId);
-              setContent(editedContent);
+      {isEditing ? (
+        <MessageEditing
+          content={content}
+          onSubmitEdit={(editedContent) => {
+            // Don't update UI for edits that can't be persisted
+            if (messageId === undefined || messageId === null) {
               setIsEditing(false);
-            }}
-            onCancelEdit={() => setIsEditing(false)}
-          />
-        ) : (
-          <>
-            <div className="md:max-w-[37.5rem] flex basis-[100%] md:basis-auto justify-end md:order-1">
-              <div
-                className={
-                  "max-w-[30rem] md:max-w-[37.5rem] whitespace-break-spaces break-anywhere rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
+              return;
+            }
+            onEdit?.(editedContent, messageId);
+            setContent(editedContent);
+            setIsEditing(false);
+          }}
+          onCancelEdit={() => setIsEditing(false)}
+        />
+      ) : (
+        <div className="flex justify-end">
+          {onEdit && !isMobile && copyEditButton}
+          <div className="md:max-w-[37.5rem]">
+            <div
+              className={
+                "max-w-[30rem] md:max-w-[37.5rem] whitespace-break-spaces break-anywhere rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
+              }
+              onCopy={(e) => {
+                const selection = window.getSelection();
+                if (selection) {
+                  e.preventDefault();
+                  const text = selection
+                    .toString()
+                    .replace(/\n{2,}/g, "\n")
+                    .trim();
+                  e.clipboardData.setData("text/plain", text);
                 }
-                onCopy={(e) => {
-                  const selection = window.getSelection();
-                  if (selection) {
-                    e.preventDefault();
-                    const text = selection
-                      .toString()
-                      .replace(/\n{2,}/g, "\n")
-                      .trim();
-                    e.clipboardData.setData("text/plain", text);
-                  }
-                }}
+              }}
+            >
+              <Text
+                as="p"
+                className="inline-block align-middle"
+                mainContentBody
               >
-                <Text
-                  as="p"
-                  className="inline-block align-middle"
-                  mainContentBody
-                >
-                  {content}
-                </Text>
-              </div>
+                {content}
+              </Text>
             </div>
-            {onEdit && (
-              <div className="absolute md:relative right-0 z-content flex flex-row p-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <CopyIconButton
-                  getCopyText={() => content}
-                  prominence="tertiary"
-                  data-testid="HumanMessage/copy-button"
-                />
-                <Button
-                  icon={SvgEdit}
-                  prominence="tertiary"
-                  tooltip="Edit"
-                  onClick={() => setIsEditing(true)}
-                  data-testid="HumanMessage/edit-button"
-                />
-              </div>
-            )}
-          </>
-        )}
-        <div className="md:min-w-[100%] flex justify-end order-1 mt-1">
-          {currentMessageInd !== undefined &&
-            onMessageSelection &&
-            otherMessagesCanSwitchTo &&
-            otherMessagesCanSwitchTo.length > 1 && (
-              <MessageSwitcher
-                disableForStreaming={disableSwitchingForStreaming}
-                currentPage={currentMessageInd + 1}
-                totalPages={otherMessagesCanSwitchTo.length}
-                handlePrevious={() => {
-                  stopGenerating();
-                  const prevMessage = getPreviousMessage();
-                  if (prevMessage !== undefined) {
-                    onMessageSelection(prevMessage);
-                  }
-                }}
-                handleNext={() => {
-                  stopGenerating();
-                  const nextMessage = getNextMessage();
-                  if (nextMessage !== undefined) {
-                    onMessageSelection(nextMessage);
-                  }
-                }}
-              />
-            )}
+          </div>
         </div>
+      )}
+      <div className="flex justify-end pt-1">
+        {!isEditing && onEdit && isMobile && copyEditButton}
+        {currentMessageInd !== undefined &&
+          onMessageSelection &&
+          otherMessagesCanSwitchTo &&
+          otherMessagesCanSwitchTo.length > 1 && (
+            <MessageSwitcher
+              disableForStreaming={disableSwitchingForStreaming}
+              currentPage={currentMessageInd + 1}
+              totalPages={otherMessagesCanSwitchTo.length}
+              handlePrevious={() => {
+                stopGenerating();
+                const prevMessage = getPreviousMessage();
+                if (prevMessage !== undefined) {
+                  onMessageSelection(prevMessage);
+                }
+              }}
+              handleNext={() => {
+                stopGenerating();
+                const nextMessage = getNextMessage();
+                if (nextMessage !== undefined) {
+                  onMessageSelection(nextMessage);
+                }
+              }}
+            />
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

https://github.com/onyx-dot-app/onyx/pull/8696 introduced a bug on small screens on chat messages with forked conversations where the copy and edit buttons overlap the conversation switcher,

<img width="1256" height="330" alt="20260304_20h04m29s_grim" src="https://github.com/user-attachments/assets/636f57c6-bd9f-47e0-b382-12f4b4adde04" />

This previous styling was also relatively complex, alternating between `flex-wrap`ing and `order`ing for responsive behavior (which is also less accessible since the DOM flow does not match visual flow), and this is much simpler. 

## How Has This Been Tested?

Expecting purely visual change

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile layout where the copy and edit buttons overlapped the conversation switcher on forked chat messages. Buttons now render inline on desktop, move below and next to the switcher on mobile, and hide while editing.

- **Bug Fixes**
  - Place copy/edit inline with the message on desktop; move them below and next to the switcher on mobile.
  - Hide copy/edit during editing and prevent overlap with MessageSwitcher.

- **Refactors**
  - Replace flex-wrap/order-based layout with a simpler DOM flow for better accessibility.
  - Use useScreenSize to conditionally place buttons by screen size.

<sup>Written for commit bb6ec2030e1b7c978204a0c5c6226a26cf860045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

