### PR TITLE
chore(playwright): screenshot tests for user settings pages

### DIFF
--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -30,7 +30,10 @@ export default function Layout({ children }: LayoutProps) {
         <SettingsLayouts.Body>
           <div className="grid grid-cols-[auto_1fr]">
             {/* Left: Tab Navigation */}
-            <div className="flex flex-col px-2 w-[12.5rem]">
+            <div
+              data-testid="settings-left-tab-navigation"
+              className="flex flex-col px-2 w-[12.5rem]"
+            >
               <SidebarTab
                 href="/app/settings/general"
                 selected={pathname === "/app/settings/general"}

--- a/web/tests/e2e/settings/settings_pages.spec.ts
+++ b/web/tests/e2e/settings/settings_pages.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+test.use({ storageState: "admin_auth.json" });
+
+for (const theme of THEMES) {
+  test.describe(`Settings pages (${theme} mode)`, () => {
+    test.beforeEach(async ({ page }) => {
+      await setThemeBeforeNavigation(page, theme);
+    });
+
+    test("should screenshot each settings tab", async ({ page }) => {
+      await page.goto("/app/settings");
+      await page.waitForLoadState("networkidle");
+
+      const nav = page.getByTestId("settings-left-tab-navigation");
+      const tabs = nav.locator("a");
+      const count = await tabs.count();
+
+      expect(count).toBeGreaterThan(0);
+      for (let i = 0; i < count; i++) {
+        const tab = tabs.nth(i);
+        const href = await tab.getAttribute("href");
+        const slug = href ? href.replace("/app/settings/", "") : `tab-${i}`;
+
+        await tab.click();
+        await page.waitForLoadState("networkidle");
+
+        await expectScreenshot(page, {
+          name: `settings-${theme}-${slug}`,
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description


## How Has This Been Tested?

ran locally and confirmed screenshots look stable

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Playwright visual regression tests for user settings pages. Screenshots every settings tab in light and dark mode to catch UI regressions.

- **New Features**
  - Screenshot test iterates all left-nav settings tabs and snapshots each page per theme.
  - Adds data-testid="settings-left-tab-navigation" for a stable selector in tests.

<sup>Written for commit ca4c72b225fbb15b2f54f5c10313d2160647d21a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

