### PR TITLE
fix(chrome-extension): open login in new tab when session expires

### DIFF
--- a/web/src/sections/AppHealthBanner.tsx
+++ b/web/src/sections/AppHealthBanner.tsx
@@ -44,7 +44,11 @@ export default function AppHealthBanner() {
     if (isExtension) {
       // In the Chrome extension, open login in a new tab so OAuth popups
       // work correctly (the extension iframe has no navigable URL origin).
-      window.open(window.location.origin + "/auth/login", "_blank", "noopener,noreferrer");
+      window.open(
+        window.location.origin + "/auth/login",
+        "_blank",
+        "noopener,noreferrer"
+      );
     } else {
       router.push("/auth/login");
     }


### PR DESCRIPTION
## Description

In the Chrome extension, the app runs inside an iframe with a chrome-extension:// origin. When the session expires and the user clicks "Log In", navigating within the iframe breaks OAuth popups because there's no proper URL origin. Now opens login in a new browser tab when running in the extension context.

## How Has This Been Tested?

Locally

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login flow in the Chrome extension. On session expiry, clicking Log In opens /auth/login in a new tab in the extension context and uses normal routing elsewhere so OAuth popups work.

<sup>Written for commit 020c4716de3bf2fe0b089d40ced5424252264162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

