### PR TITLE
fix(fe): disable projects modal button unless project is named

### DIFF
--- a/web/src/components/modals/CreateProjectModal.tsx
+++ b/web/src/components/modals/CreateProjectModal.tsx
@@ -68,7 +68,9 @@ export default function CreateProjectModal({
             <Button prominence="secondary" onClick={() => modal.toggle(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSubmit}>Create Project</Button>
+            <Button disabled={!projectName.trim()} onClick={handleSubmit}>
+              Create Project
+            </Button>
           </Modal.Footer>
         </Modal.Content>
       </Modal>


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3731/desktop-app-cant-create-project

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Create Project button in the modal until a trimmed project name is entered. Prevents empty submissions and fixes the desktop app project creation issue (Linear ENG-3731).

<sup>Written for commit 72ca6571570d5df0726422c57dcb9997c4a53d09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

