### PR TITLE
fix(permissions): Add file connector access control for global curators (#8990) to release v2.12

### DIFF
--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -92,6 +92,7 @@ from onyx.db.connector_credential_pair import get_connector_credential_pairs_for
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pairs_for_user_parallel,
 )
+from onyx.db.connector_credential_pair import verify_user_has_access_to_cc_pair
 from onyx.db.credentials import cleanup_gmail_credentials
 from onyx.db.credentials import cleanup_google_drive_credentials
 from onyx.db.credentials import create_credential
@@ -556,6 +557,43 @@ def _normalize_file_names_for_backwards_compatibility(
     return file_names + file_locations[len(file_names) :]
 
 
+def _fetch_and_check_file_connector_cc_pair_permissions(
+    connector_id: int,
+    user: User,
+    db_session: Session,
+    require_editable: bool,
+) -> ConnectorCredentialPair:
+    cc_pair = fetch_connector_credential_pair_for_connector(db_session, connector_id)
+    if cc_pair is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No Connector-Credential Pair found for this connector",
+        )
+
+    has_requested_access = verify_user_has_access_to_cc_pair(
+        cc_pair_id=cc_pair.id,
+        db_session=db_session,
+        user=user,
+        get_editable=require_editable,
+    )
+    if has_requested_access:
+        return cc_pair
+
+    # Special case: global curators should be able to manage files
+    # for public file connectors even when they are not the creator.
+    if (
+        require_editable
+        and user.role == UserRole.GLOBAL_CURATOR
+        and cc_pair.access_type == AccessType.PUBLIC
+    ):
+        return cc_pair
+
+    raise HTTPException(
+        status_code=403,
+        detail="Access denied. User cannot manage files for this connector.",
+    )
+
+
 @router.post("/admin/connector/file/upload", tags=PUBLIC_API_TAGS)
 def upload_files_api(
     files: list[UploadFile],
@@ -567,7 +605,7 @@ def upload_files_api(
 @router.get("/admin/connector/{connector_id}/files", tags=PUBLIC_API_TAGS)
 def list_connector_files(
     connector_id: int,
-    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> ConnectorFilesResponse:
     """List all files in a file connector."""
@@ -579,6 +617,13 @@ def list_connector_files(
         raise HTTPException(
             status_code=400, detail="This endpoint only works with file connectors"
         )
+
+    _ = _fetch_and_check_file_connector_cc_pair_permissions(
+        connector_id=connector_id,
+        user=user,
+        db_session=db_session,
+        require_editable=False,
+    )
 
     file_locations = connector.connector_specific_config.get("file_locations", [])
     file_names = connector.connector_specific_config.get("file_names", [])
@@ -629,7 +674,7 @@ def update_connector_files(
     connector_id: int,
     files: list[UploadFile] | None = File(None),
     file_ids_to_remove: str = Form("[]"),
-    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> FileUploadResponse:
     """
@@ -647,12 +692,13 @@ def update_connector_files(
         )
 
     # Get the connector-credential pair for indexing/pruning triggers
-    cc_pair = fetch_connector_credential_pair_for_connector(db_session, connector_id)
-    if cc_pair is None:
-        raise HTTPException(
-            status_code=404,
-            detail="No Connector-Credential Pair found for this connector",
-        )
+    # and validate user permissions for file management.
+    cc_pair = _fetch_and_check_file_connector_cc_pair_permissions(
+        connector_id=connector_id,
+        user=user,
+        db_session=db_session,
+        require_editable=True,
+    )
 
     # Parse file IDs to remove
     try:

--- a/backend/tests/integration/tests/permissions/test_file_connector_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_file_connector_permissions.py
@@ -1,0 +1,234 @@
+import io
+import json
+import os
+
+import pytest
+import requests
+
+from onyx.db.enums import AccessType
+from onyx.db.models import UserRole
+from onyx.server.documents.models import DocumentSource
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.connector import ConnectorManager
+from tests.integration.common_utils.managers.credential import CredentialManager
+from tests.integration.common_utils.managers.user import DATestUser
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+
+
+def _upload_connector_file(
+    *,
+    user_performing_action: DATestUser,
+    file_name: str,
+    content: bytes,
+) -> tuple[str, str]:
+    headers = user_performing_action.headers.copy()
+    headers.pop("Content-Type", None)
+
+    response = requests.post(
+        f"{API_SERVER_URL}/manage/admin/connector/file/upload",
+        files=[("files", (file_name, io.BytesIO(content), "text/plain"))],
+        headers=headers,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload["file_paths"][0], payload["file_names"][0]
+
+
+def _update_connector_files(
+    *,
+    connector_id: int,
+    user_performing_action: DATestUser,
+    file_ids_to_remove: list[str],
+    new_file_name: str,
+    new_file_content: bytes,
+) -> requests.Response:
+    headers = user_performing_action.headers.copy()
+    headers.pop("Content-Type", None)
+
+    return requests.post(
+        f"{API_SERVER_URL}/manage/admin/connector/{connector_id}/files/update",
+        data={"file_ids_to_remove": json.dumps(file_ids_to_remove)},
+        files=[("files", (new_file_name, io.BytesIO(new_file_content), "text/plain"))],
+        headers=headers,
+    )
+
+
+def _list_connector_files(
+    *,
+    connector_id: int,
+    user_performing_action: DATestUser,
+) -> requests.Response:
+    return requests.get(
+        f"{API_SERVER_URL}/manage/admin/connector/{connector_id}/files",
+        headers=user_performing_action.headers,
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Curator and user group tests are enterprise only",
+)
+@pytest.mark.usefixtures("reset")
+def test_only_global_curator_can_update_public_file_connector_files() -> None:
+    admin_user = UserManager.create(name="admin_user")
+
+    global_curator_creator = UserManager.create(name="global_curator_creator")
+    global_curator_creator = UserManager.set_role(
+        user_to_set=global_curator_creator,
+        target_role=UserRole.GLOBAL_CURATOR,
+        user_performing_action=admin_user,
+    )
+
+    global_curator_editor = UserManager.create(name="global_curator_editor")
+    global_curator_editor = UserManager.set_role(
+        user_to_set=global_curator_editor,
+        target_role=UserRole.GLOBAL_CURATOR,
+        user_performing_action=admin_user,
+    )
+
+    curator_user = UserManager.create(name="curator_user")
+    curator_group = UserGroupManager.create(
+        name="curator_group",
+        user_ids=[curator_user.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[curator_group],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.set_curator_status(
+        test_user_group=curator_group,
+        user_to_set_as_curator=curator_user,
+        user_performing_action=admin_user,
+    )
+
+    initial_file_id, initial_file_name = _upload_connector_file(
+        user_performing_action=global_curator_creator,
+        file_name="initial-file.txt",
+        content=b"initial file content",
+    )
+
+    connector = ConnectorManager.create(
+        user_performing_action=global_curator_creator,
+        name="public_file_connector",
+        source=DocumentSource.FILE,
+        connector_specific_config={
+            "file_locations": [initial_file_id],
+            "file_names": [initial_file_name],
+            "zip_metadata_file_id": None,
+        },
+        access_type=AccessType.PUBLIC,
+        groups=[],
+    )
+    credential = CredentialManager.create(
+        user_performing_action=global_curator_creator,
+        source=DocumentSource.FILE,
+        curator_public=True,
+        groups=[],
+        name="public_file_connector_credential",
+    )
+    CCPairManager.create(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        user_performing_action=global_curator_creator,
+        access_type=AccessType.PUBLIC,
+        groups=[],
+        name="public_file_connector_cc_pair",
+    )
+
+    curator_list_response = _list_connector_files(
+        connector_id=connector.id,
+        user_performing_action=curator_user,
+    )
+    curator_list_response.raise_for_status()
+    curator_list_payload = curator_list_response.json()
+    assert any(f["file_id"] == initial_file_id for f in curator_list_payload["files"])
+
+    global_curator_list_response = _list_connector_files(
+        connector_id=connector.id,
+        user_performing_action=global_curator_editor,
+    )
+    global_curator_list_response.raise_for_status()
+    global_curator_list_payload = global_curator_list_response.json()
+    assert any(
+        f["file_id"] == initial_file_id for f in global_curator_list_payload["files"]
+    )
+
+    denied_response = _update_connector_files(
+        connector_id=connector.id,
+        user_performing_action=curator_user,
+        file_ids_to_remove=[initial_file_id],
+        new_file_name="curator-file.txt",
+        new_file_content=b"curator updated file",
+    )
+    assert denied_response.status_code == 403
+
+    allowed_response = _update_connector_files(
+        connector_id=connector.id,
+        user_performing_action=global_curator_editor,
+        file_ids_to_remove=[initial_file_id],
+        new_file_name="global-curator-file.txt",
+        new_file_content=b"global curator updated file",
+    )
+    allowed_response.raise_for_status()
+
+    payload = allowed_response.json()
+    assert initial_file_id not in payload["file_paths"]
+    assert "global-curator-file.txt" in payload["file_names"]
+
+    creator_group = UserGroupManager.create(
+        name="creator_group",
+        user_ids=[global_curator_creator.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[creator_group],
+        user_performing_action=admin_user,
+    )
+
+    private_file_id, private_file_name = _upload_connector_file(
+        user_performing_action=global_curator_creator,
+        file_name="private-initial-file.txt",
+        content=b"private initial file content",
+    )
+
+    private_connector = ConnectorManager.create(
+        user_performing_action=global_curator_creator,
+        name="private_file_connector",
+        source=DocumentSource.FILE,
+        connector_specific_config={
+            "file_locations": [private_file_id],
+            "file_names": [private_file_name],
+            "zip_metadata_file_id": None,
+        },
+        access_type=AccessType.PRIVATE,
+        groups=[creator_group.id],
+    )
+    private_credential = CredentialManager.create(
+        user_performing_action=global_curator_creator,
+        source=DocumentSource.FILE,
+        curator_public=False,
+        groups=[creator_group.id],
+        name="private_file_connector_credential",
+    )
+    CCPairManager.create(
+        connector_id=private_connector.id,
+        credential_id=private_credential.id,
+        user_performing_action=global_curator_creator,
+        access_type=AccessType.PRIVATE,
+        groups=[creator_group.id],
+        name="private_file_connector_cc_pair",
+    )
+
+    private_denied_response = _update_connector_files(
+        connector_id=private_connector.id,
+        user_performing_action=global_curator_editor,
+        file_ids_to_remove=[private_file_id],
+        new_file_name="global-curator-private-file.txt",
+        new_file_content=b"global curator private update",
+    )
+    assert private_denied_response.status_code == 403

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -64,6 +64,8 @@ import { useStatusChange } from "./useStatusChange";
 import { useReIndexModal } from "./ReIndexModal";
 import Button from "@/refresh-components/buttons/Button";
 import { SvgSettings } from "@opal/icons";
+import { UserRole } from "@/lib/types";
+import { useUser } from "@/providers/UserProvider";
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -90,6 +92,7 @@ const PAGES_PER_BATCH = 8;
 function Main({ ccPairId }: { ccPairId: number }) {
   const router = useRouter();
   const { popup, setPopup } = usePopup();
+  const { user } = useUser();
 
   const {
     data: ccPair,
@@ -181,6 +184,12 @@ function Main({ ccPairId }: { ccPairId: number }) {
   }, [ccPair, refresh, setPopup]);
 
   const latestIndexAttempt = indexAttempts?.[0];
+  const canManageInlineFileConnectorFiles =
+    ccPair?.connector.source === "file" &&
+    (ccPair.is_editable_for_current_user ||
+      (user?.role === UserRole.GLOBAL_CURATOR &&
+        ccPair.access_type === "public"));
+
   const isResolvingErrors =
     (latestIndexAttempt?.status === "in_progress" ||
       latestIndexAttempt?.status === "not_started") &&
@@ -727,15 +736,14 @@ function Main({ ccPairId }: { ccPairId: number }) {
               />
 
               {/* Inline file management for file connectors */}
-              {ccPair.connector.source === "file" &&
-                ccPair.is_editable_for_current_user && (
-                  <div className="mt-6">
-                    <InlineFileManagement
-                      connectorId={ccPair.connector.id}
-                      onRefresh={refresh}
-                    />
-                  </div>
-                )}
+              {canManageInlineFileConnectorFiles && (
+                <div className="mt-6">
+                  <InlineFileManagement
+                    connectorId={ccPair.connector.id}
+                    onRefresh={refresh}
+                  />
+                </div>
+              )}
             </Card>
           </>
         )}


### PR DESCRIPTION
Cherry-pick of commit 49b509a0a741f976e5acc0a38777f5f80f2869a1 to release/v2.12 branch.

Original PR: #8990

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix file connector permissions so global curators can manage files on public file connectors they didn’t create, while private connectors remain restricted. Adds strict backend checks and updates the admin UI to reflect access.

- **Bug Fixes**
  - Enforce connector-credential pair permission checks on file list and update endpoints; return 403 when unauthorized.
  - Allow global curators to edit files for public file connectors; no edit access for private connectors.
  - Show inline file management in Admin when editable or when a global curator is viewing a public file connector.
  - Add integration tests covering allow/deny cases for curators vs global curators.

<sup>Written for commit 2cf19d1fc33314835ac9bb354a8afdfe9cd2edf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

