### PR TITLE
chore: upgrade golangci-lint to v2.10.1 for Go 1.26 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,6 +122,7 @@ repos:
     rev: 5d1e709b7be35cb2025444e19de266b056b7b7ee # frozen: v2.10.1
     hooks:
       - id: golangci-lint
+        language_version: "1.26.0"
         entry: bash -c "find tools/ -name go.mod -print0 | xargs -0 -I{} bash -c 'cd \"$(dirname {})\" && golangci-lint run ./...'"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Description

Upgrade golangci-lint from v2.7.2 (built with Go 1.24) to v2.10.1 (built with Go 1.26) in `.pre-commit-config.yaml`. The old version fails with:

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.0)
```

This is needed after Go modules are upgraded to Go 1.26 (e.g. `jamison/upgrade-ods`).

## How Has This Been Tested?

Pre-commit hook installs and runs successfully with the new version locally.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade golangci-lint to v2.10.1 and set the hook language_version to Go 1.26 so pre-commit installs and runs with our Go 1.26 toolchain. Fixes CI/local failures from the older linter and default Go 1.24.

- **Dependencies**
  - Bump golangci-lint to v2.10.1 and set language_version: "1.26.0" in .pre-commit-config.yaml.

- **Migration**
  - No manual steps. Pre-commit will install using Go 1.26.

<sup>Written for commit 43e42cd12cadf290f69e4c2d96b8f4e2283edd46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

