### PR TITLE
fix(safari): chat background blur ignores text

### DIFF
--- a/web/src/hooks/useBrowserInfo.ts
+++ b/web/src/hooks/useBrowserInfo.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export interface BrowserInfo {
   isSafari: boolean;
@@ -14,51 +14,51 @@ export interface BrowserInfo {
   isWindows: boolean;
 }
 
-function detectBrowserInfo(): BrowserInfo {
-  if (typeof window === "undefined") {
-    return {
-      isSafari: false,
-      isFirefox: false,
-      isChrome: false,
-      isChromium: false,
-      isEdge: false,
-      isOpera: false,
-      isIOS: false,
-      isMac: false,
-      isWindows: false,
-    };
-  }
-
-  const userAgent = window.navigator.userAgent;
-  const isEdge = /Edg/i.test(userAgent);
-  const isOpera = /OPR|Opera/i.test(userAgent);
-  const isFirefox = /Firefox|FxiOS/i.test(userAgent);
-  const isChrome = /Chrome|CriOS/i.test(userAgent) && !isEdge && !isOpera;
-  const isChromium = /Chromium/i.test(userAgent) || isChrome;
-  const isSafari =
-    /Safari/i.test(userAgent) &&
-    !isChromium &&
-    !isEdge &&
-    !isOpera &&
-    !isFirefox;
-  const isIOS = /iPhone|iPad|iPod/i.test(userAgent);
-  const isMac = /Macintosh|Mac OS X/i.test(userAgent);
-  const isWindows = /Win/i.test(userAgent);
-
-  return {
-    isSafari,
-    isFirefox,
-    isChrome,
-    isChromium,
-    isEdge,
-    isOpera,
-    isIOS,
-    isMac,
-    isWindows,
-  };
-}
+const DEFAULT_BROWSER_INFO: BrowserInfo = {
+  isSafari: false,
+  isFirefox: false,
+  isChrome: false,
+  isChromium: false,
+  isEdge: false,
+  isOpera: false,
+  isIOS: false,
+  isMac: false,
+  isWindows: false,
+};
 
 export default function useBrowserInfo(): BrowserInfo {
-  const [browserInfo] = useState<BrowserInfo>(detectBrowserInfo);
+  const [browserInfo, setBrowserInfo] =
+    useState<BrowserInfo>(DEFAULT_BROWSER_INFO);
+  useEffect(() => {
+    const userAgent = window.navigator.userAgent;
+
+    const isEdge = /Edg/i.test(userAgent);
+    const isOpera = /OPR|Opera/i.test(userAgent);
+    const isFirefox = /Firefox|FxiOS/i.test(userAgent);
+    const isChrome = /Chrome|CriOS/i.test(userAgent) && !isEdge && !isOpera;
+    const isChromium = /Chromium/i.test(userAgent) || isChrome;
+    const isSafari =
+      /Safari/i.test(userAgent) &&
+      !isChromium &&
+      !isEdge &&
+      !isOpera &&
+      !isFirefox;
+    const isIOS = /iPhone|iPad|iPod/i.test(userAgent);
+    const isMac = /Macintosh|Mac OS X/i.test(userAgent);
+    const isWindows = /Win/i.test(userAgent);
+
+    setBrowserInfo({
+      isSafari,
+      isFirefox,
+      isChrome,
+      isChromium,
+      isEdge,
+      isOpera,
+      isIOS,
+      isMac,
+      isWindows,
+    });
+  }, []);
+
   return browserInfo;
 }

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -579,7 +579,7 @@ function Root({ children, enableBackground }: AppRootProps) {
           <div className="absolute inset-0 backdrop-blur-[1px] pointer-events-none" />
           {isSafari ? (
             <div
-              className="absolute z-0 inset-0 bg-cover bg-center bg-fixed pointer-events-none overflow-hidden"
+              className="absolute z-0 inset-0 bg-cover bg-center bg-fixed pointer-events-none"
               style={{
                 backgroundImage: `url(${appBackgroundUrl})`,
                 filter: "blur(16px)",


### PR DESCRIPTION
## Description

Safari (and therefore the desktop app) has issues with applying the blur via `mask-image` causing descendant text to blur (causing a glow or halo).

For Safari, don't apply the blur and instead duplicate the background image with a blur effect applied to it. This is computationally heavier, but ensures the blur is only applied to the background image instead of descendant elements.

## How Has This Been Tested?

**before**
<img width="1665" height="2047" alt="20260305_14h04m56s_grim" src="https://github.com/user-attachments/assets/ade5121b-16d1-45cf-957c-d61031ae52e3" />

**after**
<img width="1665" height="2047" alt="20260305_14h04m45s_grim" src="https://github.com/user-attachments/assets/e6ee9872-b16c-424c-a9ee-d742f22daeee" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat background blur on Safari and the desktop app so text stays sharp by switching to a blurred background image with a mask. Other browsers keep the existing masked backdrop blur, with a subtle 1px layer to smooth the effect.

- **Bug Fixes**
  - Added a useBrowserInfo hook to detect Safari and include OS flags.
  - On Safari, render a fixed background image (filter: blur(16px)) with a horizontal mask instead of backdrop-blur.
  - Keep masked backdrop-blur for non-Safari browsers.
  - Reused a single horizontal blur mask value for both maskImage and WebkitMaskImage.

<sup>Written for commit 706314e334d91dc03ced9071ba368522bf7066a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

