### PR TITLE
chore(playwright): tighten how elements are hidden

### DIFF
--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -165,11 +165,6 @@ export async function expectScreenshot(
     threshold,
   } = options;
 
-  // Wait for any in-flight CSS animations / transitions to settle so that
-  // screenshots are deterministic (e.g. slide-in card animations on the
-  // onboarding flow).
-  await waitForAnimations(page);
-
   // Merge default hide selectors with per-call selectors
   const allHideSelectors = [...DEFAULT_HIDE_SELECTORS, ...hide];
 
@@ -178,7 +173,10 @@ export async function expectScreenshot(
   if (allHideSelectors.length > 0) {
     styleHandle = await page.addStyleTag({
       content: allHideSelectors
-        .map((selector) => `${selector} { visibility: hidden !important; }`)
+        .map(
+          (selector) =>
+            `${selector} { visibility: hidden !important; opacity: 0 !important; pointer-events: none !important; }`
+        )
         .join("\n"),
     });
   }
@@ -189,6 +187,11 @@ export async function expectScreenshot(
     const maskLocators = allMaskSelectors.map((selector) =>
       page.locator(selector)
     );
+
+    // Wait for any in-flight CSS animations / transitions to settle so that
+    // screenshots are deterministic (e.g. slide-in card animations on the
+    // onboarding flow).
+    await waitForAnimations(page);
 
     // Build the screenshot name array (Playwright expects string[])
     const nameArg = name ? [name + ".png"] : undefined;
@@ -253,10 +256,6 @@ export async function expectElementScreenshot(
 
   const page = locator.page();
 
-  // Wait for any in-flight CSS animations / transitions to settle so that
-  // element screenshots are deterministic (same reasoning as expectScreenshot).
-  await waitForAnimations(page);
-
   // Merge default hide selectors with per-call selectors
   const allHideSelectors = [...DEFAULT_HIDE_SELECTORS, ...hide];
 
@@ -265,7 +264,10 @@ export async function expectElementScreenshot(
   if (allHideSelectors.length > 0) {
     styleHandle = await page.addStyleTag({
       content: allHideSelectors
-        .map((selector) => `${selector} { visibility: hidden !important; }`)
+        .map(
+          (selector) =>
+            `${selector} { visibility: hidden !important; opacity: 0 !important; pointer-events: none !important; }`
+        )
         .join("\n"),
     });
   }
@@ -276,6 +278,10 @@ export async function expectElementScreenshot(
     const maskLocators = allMaskSelectors.map((selector) =>
       page.locator(selector)
     );
+
+    // Wait for any in-flight CSS animations / transitions to settle so that
+    // element screenshots are deterministic (same reasoning as expectScreenshot).
+    await waitForAnimations(page);
 
     // Build the screenshot name array (Playwright expects string[])
     const nameArg = name ? [name + ".png"] : undefined;


### PR DESCRIPTION
## Description

Also disable opacity when hiding elements in screenshots.

## How Has This Been Tested?

Ran `tests/e2e/chat/chat_message_rendering.spec.ts` tests locally and none of the screenshots had the actions-buttons

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened element hiding in Playwright visual regression to make screenshots more deterministic and reduce flakiness, especially with overlays and transitions. We now wait for animations after applying hides.

- **Bug Fixes**
  - Hide selectors now set visibility: hidden, opacity: 0, and pointer-events: none.
  - Moved waitForAnimations to run after hides and locator resolution before taking screenshots.

<sup>Written for commit 98aa8d9fa53e8dee7ab1dd2701c62fe70a89be1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

