### PR TITLE
chore(tests): run golang tests in CI

### DIFF
--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   detect-modules:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:


### PR DESCRIPTION
## Description

Soon we'll have a user-facing golang application, so we should test it.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow that auto-detects Go modules and runs tests for each in CI. It also checks for dependency drift by running go mod tidy and failing on diffs.

- **New Features**
  - Scans for go.mod and runs go test ./... per module via a matrix.
  - Runs go mod tidy and fails on go.mod/go.sum changes.
  - Triggers on PRs to main and release/**, merge_group, and v*.*.* tags.
  - Uses Go 1.26, pins actions to SHAs, disables checkout credentials, caches via **/go.sum, and cancels in-progress runs.

<sup>Written for commit 30647570e0062aac3c47a502dd44a51db315fc0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



