### PR TITLE
fix(fe): make BlinkingBar smaller

### DIFF
--- a/web/src/app/app/message/BlinkingBar.tsx
+++ b/web/src/app/app/message/BlinkingBar.tsx
@@ -4,7 +4,7 @@ export function BlinkingBar({ addMargin = false }: { addMargin?: boolean }) {
   return (
     <span
       className={cn(
-        "animate-pulse flex-none bg-theme-primary-05 relative top-[0.15rem] inline-block w-[0.5em] h-[1rem]",
+        "animate-pulse flex-none bg-theme-primary-05 relative top-[0.15rem] inline-block w-[0.5rem] h-[1rem]",
         addMargin && "ml-1"
       )}
     ></span>


### PR DESCRIPTION
## Description

Makes the bar `1rem` instead of `1.25rem` and updates positioning to roughly 50% of `align-middle` and `align-baseline`.

Closes https://linear.app/onyx-app/issue/ENG-3496/new-cursor-style

## How Has This Been Tested?

<img width="2880" height="1920" alt="20260305_19h11m30s_grim" src="https://github.com/user-attachments/assets/a48f8290-68c7-42dc-b8be-fc1cf03e14e6" />
<img width="2880" height="1920" alt="20260305_19h11m17s_grim" src="https://github.com/user-attachments/assets/2fbae386-bff4-4f36-8e1b-9ec3d6b3186e" />
<img width="2880" height="1920" alt="20260305_19h11m02s_grim" src="https://github.com/user-attachments/assets/e717f037-d2ea-4b97-9e00-bba128619d05" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks the BlinkingBar and adjusts its position to match the new cursor style. Height is now 1rem (was 1.25em), width is 0.5rem (was 0.5em), and top offset is 0.15rem; addresses Linear ENG-3496.

<sup>Written for commit cd56ea065ad758d70d59559c9bb55be462f393df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

