### PR TITLE
chore(llm): Adding Integration test for Model state cache 2/2

### DIFF
--- a/web/tests/e2e/admin/llm_provider_setup.spec.ts
+++ b/web/tests/e2e/admin/llm_provider_setup.spec.ts
@@ -30,8 +30,36 @@ function uniqueName(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function normalizeAlphaNum(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function modelTokenVariants(modelName: string): string[][] {
+  return modelName
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0)
+    .map((token) => {
+      // Display names may shorten long numeric segments to suffixes.
+      if (/^\d+$/.test(token) && token.length > 5) {
+        return [token, token.slice(-5)];
+      }
+      return [token];
+    });
+}
+
+function textMatchesModel(modelName: string, candidateText: string): boolean {
+  const normalizedCandidate = normalizeAlphaNum(candidateText);
+  if (!normalizedCandidate) {
+    return false;
+  }
+
+  const tokenVariants = modelTokenVariants(modelName);
+  return tokenVariants.every((variants) =>
+    variants.some((variant) =>
+      normalizedCandidate.includes(normalizeAlphaNum(variant))
+    )
+  );
 }
 
 async function getAdminLLMProviderResponse(page: Page) {
@@ -155,10 +183,14 @@ async function getModelCountInChatSelector(
   await dialog.waitFor({ state: "visible", timeout: 10000 });
 
   await dialog.getByPlaceholder("Search models...").fill(modelName);
-  const matchingModelOptions = dialog
-    .locator("[data-selected]")
-    .filter({ hasText: new RegExp(`^${escapeRegex(modelName)}$`) });
-  const count = await matchingModelOptions.count();
+  const optionButtons = dialog.getByRole("button");
+  const optionTexts = await optionButtons.allTextContents();
+  const uniqueOptionTexts = Array.from(
+    new Set(optionTexts.map((text) => text.trim()))
+  );
+  const count = uniqueOptionTexts.filter((text) =>
+    textMatchesModel(modelName, text)
+  ).length;
 
   await page.keyboard.press("Escape");
   await dialog.waitFor({ state: "hidden", timeout: 10000 });


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding additional integration test to fix this issue but keeping separate in order to make the cherry-picking of the first PR easier

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran locally

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Playwright integration tests ensuring the chat model selector reflects visibility changes after a single save (enable hidden, disable visible), validating the model state cache. Adds helpers for creating providers with multiple models, navigating admin↔chat, polling API visibility, and robust selector counting with tokenized/normalized matching and clean popover handling.

<sup>Written for commit 7aef16f9b7468cdee9829776b3446b0f3084dcc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

