### PR TITLE
chore(playwright): hide flaky AppInputBar/llm-popover-trigger

### DIFF
--- a/web/tests/e2e/agents/create_and_edit_agent.spec.ts
+++ b/web/tests/e2e/agents/create_and_edit_agent.spec.ts
@@ -292,7 +292,10 @@ test.describe("Assistant Creation and Edit Verification", () => {
       expect(agentIdMatch).toBeTruthy();
       const agentId = agentIdMatch ? agentIdMatch[1] : null;
       expect(agentId).not.toBeNull();
-      await expectScreenshot(page, { name: "welcome-page-with-assistant" });
+      await expectScreenshot(page, {
+        name: "welcome-page-with-assistant",
+        hide: ["[data-testid='AppInputBar/llm-popover-trigger']"],
+      });
 
       // Store assistant ID for cleanup
       knowledgeAssistantId = Number(agentId);


### PR DESCRIPTION
## Description

Caused a flake here: https://onyx-playwright-artifacts.s3.us-east-2.amazonaws.com/reports/pr-9050/22776067697/admin/index.html

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "[data-testid='AppInputBar/llm-popover-trigger']" element during expectScreenshot("welcome-page-with-assistant") in create_and_edit_agent.spec.ts to remove flaky diffs. This stabilizes the assistant creation/edit e2e test by masking a dynamic UI element.

<sup>Written for commit f627aee160059f5738dfb36a768bc8f90ae95219. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

