### PR TITLE
chore: rm dead llm provider code and bump claude recs

### DIFF
--- a/backend/onyx/llm/model_metadata_enrichments.json
+++ b/backend/onyx/llm/model_metadata_enrichments.json
@@ -1512,6 +1512,10 @@
     "display_name": "Claude Opus 4.5",
     "model_vendor": "anthropic"
   },
+  "claude-opus-4-6": {
+    "display_name": "Claude Opus 4.6",
+    "model_vendor": "anthropic"
+  },
   "claude-opus-4-5-20251101": {
     "display_name": "Claude Opus 4.5",
     "model_vendor": "anthropic",
@@ -1524,6 +1528,10 @@
   },
   "claude-sonnet-4-5": {
     "display_name": "Claude Sonnet 4.5",
+    "model_vendor": "anthropic"
+  },
+  "claude-sonnet-4-6": {
+    "display_name": "Claude Sonnet 4.6",
     "model_vendor": "anthropic"
   },
   "claude-sonnet-4-5-20250929": {

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -1,37 +1,8 @@
 from onyx.llm.constants import LlmProviderNames
 
 OPENAI_PROVIDER_NAME = "openai"
-# Curated list of OpenAI models to show by default in the UI
-OPENAI_VISIBLE_MODEL_NAMES = {
-    "gpt-5",
-    "gpt-5-mini",
-    "o1",
-    "o3-mini",
-    "gpt-4o",
-    "gpt-4o-mini",
-}
 
 BEDROCK_PROVIDER_NAME = "bedrock"
-BEDROCK_DEFAULT_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
-
-
-def _fallback_bedrock_regions() -> list[str]:
-    # Fall back to a conservative set of well-known Bedrock regions if boto3 data isn't available.
-    return [
-        "us-east-1",
-        "us-east-2",
-        "us-gov-east-1",
-        "us-gov-west-1",
-        "us-west-2",
-        "ap-northeast-1",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-east-1",
-        "ca-central-1",
-        "eu-central-1",
-        "eu-west-2",
-    ]
 
 
 OLLAMA_PROVIDER_NAME = "ollama_chat"
@@ -51,13 +22,6 @@ OPENROUTER_PROVIDER_NAME = "openrouter"
 
 ANTHROPIC_PROVIDER_NAME = "anthropic"
 
-# Curated list of Anthropic models to show by default in the UI
-ANTHROPIC_VISIBLE_MODEL_NAMES = {
-    "claude-opus-4-5",
-    "claude-sonnet-4-5",
-    "claude-haiku-4-5",
-}
-
 AZURE_PROVIDER_NAME = "azure"
 
 
@@ -65,13 +29,6 @@ VERTEXAI_PROVIDER_NAME = "vertex_ai"
 VERTEX_CREDENTIALS_FILE_KWARG = "vertex_credentials"
 VERTEX_CREDENTIALS_FILE_KWARG_ENV_VAR_FORMAT = "CREDENTIALS_FILE"
 VERTEX_LOCATION_KWARG = "vertex_location"
-VERTEXAI_DEFAULT_MODEL = "gemini-2.5-flash"
-# Curated list of Vertex AI models to show by default in the UI
-VERTEXAI_VISIBLE_MODEL_NAMES = {
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini-2.5-pro",
-}
 
 AWS_REGION_NAME_KWARG = "aws_region_name"
 AWS_REGION_NAME_KWARG_ENV_VAR_FORMAT = "AWS_REGION_NAME"

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -17,6 +17,10 @@
           "display_name": "Claude Opus 4.6"
         },
         {
+          "name": "claude-sonnet-4-6",
+          "display_name": "Claude Sonnet 4.6"
+        },
+        {
           "name": "claude-opus-4-5",
           "display_name": "Claude Opus 4.5"
         },

--- a/web/src/app/craft/components/ToggleWarningModal.tsx
+++ b/web/src/app/craft/components/ToggleWarningModal.tsx
@@ -39,7 +39,7 @@ export function ToggleWarningModal({
           {/* Message */}
           <div className="flex justify-center">
             <Text mainUiBody text04 className="text-center">
-              We recommend using <strong>Claude Opus 4.5</strong> for Crafting.
+              We recommend using <strong>Claude Opus 4.6</strong> for Crafting.
               <br />
               Other models may have reduced capabilities for code creation,
               <br />

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -34,8 +34,8 @@ export const PROVIDERS: ProviderConfig[] = [
     providerName: LLMProviderName.ANTHROPIC,
     recommended: true,
     models: [
-      { name: "claude-opus-4-5", label: "Claude Opus 4.5", recommended: true },
-      { name: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+      { name: "claude-opus-4-6", label: "Claude Opus 4.6", recommended: true },
+      { name: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
     ],
     apiKeyPlaceholder: "sk-ant-...",
     apiKeyUrl: "https://console.anthropic.com/dashboard",

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -5,12 +5,12 @@
 export interface BuildLlmSelection {
   providerName: string; // e.g., "build-mode-anthropic" (LLMProviderDescriptor.name)
   provider: string; // e.g., "anthropic"
-  modelName: string; // e.g., "claude-opus-4-5"
+  modelName: string; // e.g., "claude-opus-4-6"
 }
 
 // Priority order for smart default LLM selection
 const LLM_SELECTION_PRIORITY = [
-  { provider: "anthropic", modelName: "claude-opus-4-5" },
+  { provider: "anthropic", modelName: "claude-opus-4-6" },
   { provider: "openai", modelName: "gpt-5.2" },
   { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
 ] as const;
@@ -63,11 +63,11 @@ export function getDefaultLlmSelection(
 export const RECOMMENDED_BUILD_MODELS = {
   preferred: {
     provider: "anthropic",
-    modelName: "claude-opus-4-5",
-    displayName: "Claude Opus 4.5",
+    modelName: "claude-opus-4-6",
+    displayName: "Claude Opus 4.6",
   },
   alternatives: [
-    { provider: "anthropic", modelName: "claude-sonnet-4-5" },
+    { provider: "anthropic", modelName: "claude-sonnet-4-6" },
     { provider: "openai", modelName: "gpt-5.2" },
     { provider: "openai", modelName: "gpt-5.1-codex" },
     { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
@@ -148,8 +148,8 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     providerName: "anthropic",
     recommended: true,
     models: [
-      { name: "claude-opus-4-5", label: "Claude Opus 4.5", recommended: true },
-      { name: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+      { name: "claude-opus-4-6", label: "Claude Opus 4.6", recommended: true },
+      { name: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
     ],
     apiKeyPlaceholder: "sk-ant-...",
     apiKeyUrl: "https://console.anthropic.com/dashboard",

--- a/web/src/sections/onboarding/forms/__tests__/AnthropicOnboardingForm.test.tsx
+++ b/web/src/sections/onboarding/forms/__tests__/AnthropicOnboardingForm.test.tsx
@@ -10,7 +10,6 @@ import {
   createMockOnboardingActions,
   createMockFetchResponses,
   MOCK_PROVIDERS,
-  ANTHROPIC_DEFAULT_VISIBLE_MODELS,
 } from "./testHelpers";
 
 // Mock fetch
@@ -51,8 +50,6 @@ jest.mock("@/components/modals/ProviderModal", () => ({
   },
 }));
 
-// Mock fetchModels utility - returns the curated Anthropic visible models
-// that match ANTHROPIC_VISIBLE_MODEL_NAMES from backend
 const mockFetchModels = jest.fn().mockResolvedValue({
   models: [
     {
@@ -149,71 +146,6 @@ describe("AnthropicOnboardingForm", () => {
       render(<AnthropicOnboardingForm {...defaultProps} open={false} />);
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Default Available Models", () => {
-    /**
-     * This test verifies that the exact curated list of Anthropic visible models
-     * matches what's returned from /api/admin/llm/built-in/options.
-     * The expected models are defined in ANTHROPIC_VISIBLE_MODEL_NAMES in
-     * backend/onyx/llm/llm_provider_options.py
-     */
-    test("llmDescriptor contains the correct default visible models from built-in options", () => {
-      const expectedModelNames = [
-        "claude-opus-4-5",
-        "claude-sonnet-4-5",
-        "claude-haiku-4-5",
-      ];
-
-      // Verify MOCK_PROVIDERS.anthropic has the correct model configurations
-      const actualModelNames = MOCK_PROVIDERS.anthropic.known_models.map(
-        (config) => config.name
-      );
-
-      // Check that all expected models are present
-      expect(actualModelNames).toEqual(
-        expect.arrayContaining(expectedModelNames)
-      );
-
-      // Check that only the expected models are present (no extras)
-      expect(actualModelNames).toHaveLength(expectedModelNames.length);
-
-      // Verify each model has is_visible set to true
-      MOCK_PROVIDERS.anthropic.known_models.forEach((config) => {
-        expect(config.is_visible).toBe(true);
-      });
-    });
-
-    test("ANTHROPIC_DEFAULT_VISIBLE_MODELS matches backend ANTHROPIC_VISIBLE_MODEL_NAMES", () => {
-      // These are the exact model names from backend/onyx/llm/llm_provider_options.py
-      // ANTHROPIC_VISIBLE_MODEL_NAMES = {"claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"}
-      const backendVisibleModelNames = new Set([
-        "claude-opus-4-5",
-        "claude-sonnet-4-5",
-        "claude-haiku-4-5",
-      ]);
-
-      const testHelperModelNames = new Set(
-        ANTHROPIC_DEFAULT_VISIBLE_MODELS.map((m) => m.name)
-      );
-
-      expect(testHelperModelNames).toEqual(backendVisibleModelNames);
-    });
-
-    test("all default models are marked as visible", () => {
-      ANTHROPIC_DEFAULT_VISIBLE_MODELS.forEach((model) => {
-        expect(model.is_visible).toBe(true);
-      });
-    });
-
-    test("default model claude-sonnet-4-5 is set correctly in component", () => {
-      // The AnthropicOnboardingForm sets DEFAULT_DEFAULT_MODEL_NAME = "claude-sonnet-4-5"
-      // Verify this model exists in the default visible models
-      const defaultModelExists = ANTHROPIC_DEFAULT_VISIBLE_MODELS.some(
-        (m) => m.name === "claude-sonnet-4-5"
-      );
-      expect(defaultModelExists).toBe(true);
     });
   });
 

--- a/web/src/sections/onboarding/forms/__tests__/OpenAIOnboardingForm.test.tsx
+++ b/web/src/sections/onboarding/forms/__tests__/OpenAIOnboardingForm.test.tsx
@@ -10,7 +10,6 @@ import {
   createMockOnboardingActions,
   createMockFetchResponses,
   MOCK_PROVIDERS,
-  OPENAI_DEFAULT_VISIBLE_MODELS,
 } from "./testHelpers";
 
 // Mock fetch
@@ -54,8 +53,6 @@ jest.mock("@/components/modals/ProviderModal", () => ({
   },
 }));
 
-// Mock fetchModels utility - returns the curated OpenAI visible models
-// that match OPENAI_VISIBLE_MODEL_NAMES from backend
 const mockFetchModels = jest.fn().mockResolvedValue({
   models: [
     {
@@ -170,77 +167,6 @@ describe("OpenAIOnboardingForm", () => {
       render(<OpenAIOnboardingForm {...defaultProps} open={false} />);
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Default Available Models", () => {
-    /**
-     * This test verifies that the exact curated list of OpenAI visible models
-     * matches what's returned from /api/admin/llm/built-in/options.
-     * The expected models are defined in OPENAI_VISIBLE_MODEL_NAMES in
-     * backend/onyx/llm/llm_provider_options.py
-     */
-    test("llmDescriptor contains the correct default visible models from built-in options", () => {
-      const expectedModelNames = [
-        "gpt-5.2",
-        "gpt-5-mini",
-        "o1",
-        "o3-mini",
-        "gpt-4o",
-        "gpt-4o-mini",
-      ];
-
-      // Verify MOCK_PROVIDERS.openai has the correct model configurations
-      const actualModelNames = MOCK_PROVIDERS.openai.known_models.map(
-        (config) => config.name
-      );
-
-      // Check that all expected models are present
-      expect(actualModelNames).toEqual(
-        expect.arrayContaining(expectedModelNames)
-      );
-
-      // Check that only the expected models are present (no extras)
-      expect(actualModelNames).toHaveLength(expectedModelNames.length);
-
-      // Verify each model has is_visible set to true
-      MOCK_PROVIDERS.openai.known_models.forEach((config) => {
-        expect(config.is_visible).toBe(true);
-      });
-    });
-
-    test("OPENAI_DEFAULT_VISIBLE_MODELS matches backend OPENAI_VISIBLE_MODEL_NAMES", () => {
-      // These are the exact model names from backend/onyx/llm/llm_provider_options.py
-      // OPENAI_VISIBLE_MODEL_NAMES = {"gpt-5.2", "gpt-5-mini", "o1", "o3-mini", "gpt-4o", "gpt-4o-mini"}
-      const backendVisibleModelNames = new Set([
-        "gpt-5.2",
-        "gpt-5-mini",
-        "o1",
-        "o3-mini",
-        "gpt-4o",
-        "gpt-4o-mini",
-      ]);
-
-      const testHelperModelNames = new Set(
-        OPENAI_DEFAULT_VISIBLE_MODELS.map((m) => m.name)
-      );
-
-      expect(testHelperModelNames).toEqual(backendVisibleModelNames);
-    });
-
-    test("all default models are marked as visible", () => {
-      OPENAI_DEFAULT_VISIBLE_MODELS.forEach((model) => {
-        expect(model.is_visible).toBe(true);
-      });
-    });
-
-    test("default model gpt-5.2 is set correctly in component", () => {
-      // The OpenAIOnboardingForm sets DEFAULT_DEFAULT_MODEL_NAME = "gpt-5.2"
-      // Verify this model exists in the default visible models
-      const defaultModelExists = OPENAI_DEFAULT_VISIBLE_MODELS.some(
-        (m) => m.name === "gpt-5.2"
-      );
-      expect(defaultModelExists).toBe(true);
     });
   });
 

--- a/web/src/sections/onboarding/forms/__tests__/VertexAIOnboardingForm.test.tsx
+++ b/web/src/sections/onboarding/forms/__tests__/VertexAIOnboardingForm.test.tsx
@@ -10,7 +10,6 @@ import {
   createMockOnboardingActions,
   createMockFetchResponses,
   MOCK_PROVIDERS,
-  VERTEXAI_DEFAULT_VISIBLE_MODELS,
 } from "./testHelpers";
 
 // Mock fetch
@@ -51,8 +50,6 @@ jest.mock("@/components/modals/ProviderModal", () => ({
   },
 }));
 
-// Mock fetchModels utility - returns the curated Vertex AI visible models
-// that match VERTEXAI_VISIBLE_MODEL_NAMES from backend
 jest.mock("@/app/admin/configuration/llm/utils", () => ({
   canProviderFetchModels: jest.fn().mockReturnValue(true),
   fetchModels: jest.fn().mockResolvedValue({
@@ -151,71 +148,6 @@ describe("VertexAIOnboardingForm", () => {
       render(<VertexAIOnboardingForm {...defaultProps} open={false} />);
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Default Available Models", () => {
-    /**
-     * This test verifies that the exact curated list of Vertex AI visible models
-     * matches what's returned from /api/admin/llm/built-in/options.
-     * The expected models are defined in VERTEXAI_VISIBLE_MODEL_NAMES in
-     * backend/onyx/llm/llm_provider_options.py
-     */
-    test("llmDescriptor contains the correct default visible models from built-in options", () => {
-      const expectedModelNames = [
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
-        "gemini-2.5-pro",
-      ];
-
-      // Verify MOCK_PROVIDERS.vertexAi has the correct model configurations
-      const actualModelNames = MOCK_PROVIDERS.vertexAi.known_models.map(
-        (config) => config.name
-      );
-
-      // Check that all expected models are present
-      expect(actualModelNames).toEqual(
-        expect.arrayContaining(expectedModelNames)
-      );
-
-      // Check that only the expected models are present (no extras)
-      expect(actualModelNames).toHaveLength(expectedModelNames.length);
-
-      // Verify each model has is_visible set to true
-      MOCK_PROVIDERS.vertexAi.known_models.forEach((config) => {
-        expect(config.is_visible).toBe(true);
-      });
-    });
-
-    test("VERTEXAI_DEFAULT_VISIBLE_MODELS matches backend VERTEXAI_VISIBLE_MODEL_NAMES", () => {
-      // These are the exact model names from backend/onyx/llm/llm_provider_options.py
-      // VERTEXAI_VISIBLE_MODEL_NAMES = {"gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro"}
-      const backendVisibleModelNames = new Set([
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
-        "gemini-2.5-pro",
-      ]);
-
-      const testHelperModelNames = new Set(
-        VERTEXAI_DEFAULT_VISIBLE_MODELS.map((m) => m.name)
-      );
-
-      expect(testHelperModelNames).toEqual(backendVisibleModelNames);
-    });
-
-    test("all default models are marked as visible", () => {
-      VERTEXAI_DEFAULT_VISIBLE_MODELS.forEach((model) => {
-        expect(model.is_visible).toBe(true);
-      });
-    });
-
-    test("default model gemini-2.5-pro is set correctly in component", () => {
-      // The VertexAIOnboardingForm sets DEFAULT_DEFAULT_MODEL_NAME = "gemini-2.5-pro"
-      // Verify this model exists in the default visible models
-      const defaultModelExists = VERTEXAI_DEFAULT_VISIBLE_MODELS.some(
-        (m) => m.name === "gemini-2.5-pro"
-      );
-      expect(defaultModelExists).toBe(true);
     });
   });
 

--- a/web/src/sections/onboarding/forms/__tests__/testHelpers.tsx
+++ b/web/src/sections/onboarding/forms/__tests__/testHelpers.tsx
@@ -1,7 +1,6 @@
 /**
  * Shared test helpers and mocks for onboarding form tests
  */
-import React from "react";
 
 // Mock Element.prototype.scrollIntoView for JSDOM (not implemented in jsdom)
 Element.prototype.scrollIntoView = jest.fn();
@@ -161,11 +160,6 @@ export async function waitForModalOpen(screen: any, waitFor: any) {
 /**
  * Common provider descriptors for testing
  */
-/**
- * The curated list of OpenAI visible models that are returned by
- * /api/admin/llm/built-in/options. This must match OPENAI_VISIBLE_MODEL_NAMES
- * in backend/onyx/llm/llm_provider_options.py
- */
 export const OPENAI_DEFAULT_VISIBLE_MODELS = [
   {
     name: "gpt-5.2",
@@ -211,11 +205,6 @@ export const OPENAI_DEFAULT_VISIBLE_MODELS = [
   },
 ];
 
-/**
- * The curated list of Anthropic visible models that are returned by
- * /api/admin/llm/built-in/options. This must match ANTHROPIC_VISIBLE_MODEL_NAMES
- * in backend/onyx/llm/llm_provider_options.py
- */
 export const ANTHROPIC_DEFAULT_VISIBLE_MODELS = [
   {
     name: "claude-opus-4-5",
@@ -240,11 +229,6 @@ export const ANTHROPIC_DEFAULT_VISIBLE_MODELS = [
   },
 ];
 
-/**
- * The curated list of Vertex AI visible models that are returned by
- * /api/admin/llm/built-in/options. This must match VERTEXAI_VISIBLE_MODEL_NAMES
- * in backend/onyx/llm/llm_provider_options.py
- */
 export const VERTEXAI_DEFAULT_VISIBLE_MODELS = [
   {
     name: "gemini-2.5-flash",


### PR DESCRIPTION
## Description

Removed unused LLM provider configuration and updated Anthropic recommendations to Claude Opus 4.6 and Sonnet 4.6 across backend and UI. This simplifies provider setup and surfaces the latest models in onboarding and Craft.



## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused LLM provider configuration and updated Anthropic recommendations to Claude Opus 4.6 and Sonnet 4.6 across backend and UI. This simplifies provider setup and surfaces the latest models in onboarding and Craft.

- **Refactors**
  - Removed curated visible model sets and defaults from backend constants (OpenAI, Anthropic, Vertex AI; Bedrock fallback regions).
  - Deleted tests and helpers that depended on curated model visibility lists.

- **New Features**
  - Added metadata for claude-opus-4-6 and claude-sonnet-4-6; updated recommended-models.json.
  - Updated onboarding defaults and labels to prefer Claude Opus 4.6, with Sonnet 4.6 as an alternative.
  - Updated Craft modal copy to recommend Claude Opus 4.6.

<sup>Written for commit f92b4dbb49ed43b9a6c19459a02f936c3111e313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

