### PR TITLE
fix(fe): add horizontal padding to chat page

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -709,7 +709,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
             >
               {/* Main content grid — 3 rows, animated */}
               <div
-                className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out"
+                className="flex-1 w-full grid min-h-0 px-4 transition-[grid-template-rows] duration-150 ease-in-out"
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}


### PR DESCRIPTION
## Description

There's no padding on small screens and it bothers me a bit.

## How Has This Been Tested?

**before**
<img width="1512" height="2085" alt="20260306_11h44m54s_grim" src="https://github.com/user-attachments/assets/1620e3db-fead-44db-b22a-3488d9163139" />

**after**
<img width="1512" height="2085" alt="20260306_11h44m47s_grim" src="https://github.com/user-attachments/assets/c8194039-9b9f-4c0b-abc4-54cb14dad069" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added horizontal padding to the chat page so content doesn’t touch the screen edges on small displays. Applies px-4 to the main grid container for better readability.

<sup>Written for commit 9071eef04bd8290746c5a5550b07725df5b0e28a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

