### PR TITLE
feat(cli): add PyPI and release workflow badges to README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,8 @@
 # Onyx CLI
 
+[![Release CLI](https://github.com/onyx-dot-app/onyx/actions/workflows/release-cli.yml/badge.svg)](https://github.com/onyx-dot-app/onyx/actions/workflows/release-cli.yml)
+[![PyPI](https://img.shields.io/pypi/v/onyx-cli.svg)](https://pypi.org/project/onyx-cli/)
+
 A terminal interface for chatting with your [Onyx](https://github.com/onyx-dot-app/onyx) agent. Built with Go using [Bubble Tea](https://github.com/charmbracelet/bubbletea) for the TUI framework.
 
 ## Installation


### PR DESCRIPTION
## Description

Adds PyPI version and release workflow status badges to the CLI README, matching the pattern already used in `tools/ods/README.md`.

## How Has This Been Tested?

Visual Inspection of README

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check