### PR TITLE
fix(fe): account for wrapper padding in textarea auto-resize

### DIFF
--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -204,8 +204,9 @@ const AppInputBar = React.memo(
       wrapper.style.height = `${MIN_INPUT_HEIGHT}px`;
 
       // scrollHeight doesn't include the wrapper's padding, so add it back
-      const paddingTop = parseFloat(getComputedStyle(wrapper).paddingTop);
-      const paddingBottom = parseFloat(getComputedStyle(wrapper).paddingBottom);
+      const wrapperStyle = getComputedStyle(wrapper);
+      const paddingTop = parseFloat(wrapperStyle.paddingTop);
+      const paddingBottom = parseFloat(wrapperStyle.paddingBottom);
       const contentHeight = textarea.scrollHeight + paddingTop + paddingBottom;
 
       wrapper.style.height = `${Math.min(


### PR DESCRIPTION
## Description

The textarea wrapper in `AppInputBar` has `py-2` (16px vertical padding), but the auto-resize logic was setting the wrapper's height directly to `textarea.scrollHeight`, which doesn't include the wrapper's own padding. This caused the top line to get clipped (~half a line) when text wrapped to multiple lines.

## Video
 
https://github.com/user-attachments/assets/fc9053c6-2dda-4519-a6d4-8acdf62bcafb

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed AppInputBar textarea auto-resize to include wrapper padding, preventing top-line clipping on multi-line input. Cached getComputedStyle to avoid extra reflows.

<sup>Written for commit e05f3b629c50a8b8168577ded6abf54fdc90bd3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

