### PR TITLE
chore(zizmor): fix rust-toolchain commit

### DIFF
--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: ./desktop/package-lock.json
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Description

Upgrades action to HEAD

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Rust toolchain setup in the PR desktop build workflow by pinning dtolnay/rust-toolchain to a valid commit. This unblocks CI and ensures consistent toolchain installation.

<sup>Written for commit 9547b5cda5b919be7bd3d64aaee3867ecf881347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

