### PR TITLE
fix(fe): fix API Key Role dropdown options (#9154) to release v3.0

### DIFF
--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -5,7 +5,7 @@ import Modal from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { FormikField } from "@/refresh-components/form/FormikField";
 import { FormField } from "@/refresh-components/form/FormField";
 import { USER_ROLE_LABELS, UserRole } from "@/lib/types";
@@ -106,26 +106,25 @@ export default function OnyxApiKeyForm({
                     <FormField name="role" state={state} className="w-full">
                       <FormField.Label>Role:</FormField.Label>
                       <FormField.Control>
-                        <InputComboBox
+                        <InputSelect
                           value={field.value}
                           onValueChange={(value) => helper.setValue(value)}
-                          options={[
-                            {
-                              label: USER_ROLE_LABELS[UserRole.LIMITED],
-                              value: UserRole.LIMITED.toString(),
-                            },
-                            {
-                              label: USER_ROLE_LABELS[UserRole.BASIC],
-                              value: UserRole.BASIC.toString(),
-                            },
-                            {
-                              label: USER_ROLE_LABELS[UserRole.ADMIN],
-                              value: UserRole.ADMIN.toString(),
-                            },
-                          ]}
-                          placeholder="Select a role"
-                          strict
-                        />
+                        >
+                          <InputSelect.Trigger placeholder="Select a role" />
+                          <InputSelect.Content>
+                            <InputSelect.Item
+                              value={UserRole.LIMITED.toString()}
+                            >
+                              {USER_ROLE_LABELS[UserRole.LIMITED]}
+                            </InputSelect.Item>
+                            <InputSelect.Item value={UserRole.BASIC.toString()}>
+                              {USER_ROLE_LABELS[UserRole.BASIC]}
+                            </InputSelect.Item>
+                            <InputSelect.Item value={UserRole.ADMIN.toString()}>
+                              {USER_ROLE_LABELS[UserRole.ADMIN]}
+                            </InputSelect.Item>
+                          </InputSelect.Content>
+                        </InputSelect>
                       </FormField.Control>
                       <FormField.Description>
                         Select the role for this API key. Limited has access to


### PR DESCRIPTION
Cherry-pick of commit 48802618db6aa0ece2d1a9d82ebd0dace3b7c176 to release/v3.0 branch.

Original PR: #9154

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API Key Role dropdown so only valid roles (Limited, Basic, Admin) are shown and saved correctly.

- **Bug Fixes**
  - Replaced InputComboBox with InputSelect and defined explicit role items.
  - Aligned labels/values with USER_ROLE_LABELS and UserRole enums; added “Select a role” placeholder.

<sup>Written for commit 2532b06e0db50a3c62ab0baee65d03ae8194727d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

