### PR TITLE
feat: add Novita as an optional LLM provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -25,6 +25,7 @@ class LlmProviderNames(str, Enum):
     LM_STUDIO = "lm_studio"
     MISTRAL = "mistral"
     LITELLM_PROXY = "litellm_proxy"
+    NOVITA = "novita"
 
     def __str__(self) -> str:
         """Needed so things like:
@@ -43,6 +44,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.AZURE,
     LlmProviderNames.OLLAMA_CHAT,
     LlmProviderNames.LM_STUDIO,
+    LlmProviderNames.NOVITA,
 ]
 
 
@@ -59,6 +61,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "ollama": "Ollama",
     LlmProviderNames.OLLAMA_CHAT: "Ollama",
     LlmProviderNames.LM_STUDIO: "LM Studio",
+    LlmProviderNames.NOVITA: "Novita",
     "groq": "Groq",
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -43,6 +43,7 @@ from onyx.llm.well_known_providers.constants import (
     AWS_SECRET_ACCESS_KEY_KWARG_ENV_VAR_FORMAT,
 )
 from onyx.llm.well_known_providers.constants import LM_STUDIO_API_KEY_CONFIG_KEY
+from onyx.llm.well_known_providers.constants import NOVITA_API_KEY_CONFIG_KEY
 from onyx.llm.well_known_providers.constants import OLLAMA_API_KEY_CONFIG_KEY
 from onyx.llm.well_known_providers.constants import VERTEX_CREDENTIALS_FILE_KWARG
 from onyx.llm.well_known_providers.constants import (
@@ -253,6 +254,9 @@ class LitellmLLM(LLM):
                 elif model_provider == LlmProviderNames.LM_STUDIO:
                     if k == LM_STUDIO_API_KEY_CONFIG_KEY:
                         model_kwargs["api_key"] = v
+                elif model_provider == LlmProviderNames.NOVITA:
+                    if k == NOVITA_API_KEY_CONFIG_KEY:
+                        model_kwargs["api_key"] = v
                 elif model_provider == LlmProviderNames.BEDROCK:
                     if k == AWS_REGION_NAME_KWARG:
                         model_kwargs[k] = v
@@ -281,6 +285,16 @@ class LitellmLLM(LLM):
                 base = self._api_base.rstrip("/")
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
                 model_kwargs["api_base"] = self._api_base
+
+        if model_provider == LlmProviderNames.NOVITA:
+            if self._api_base is None:
+                self._api_base = "https://api.novita.ai/openai"
+
+            # Check for API key in environment if not provided
+            if not self._api_key and not model_kwargs.get("api_key"):
+                self._api_key = os.environ.get("NOVITA_API_KEY")
+
+            self._custom_llm_provider = "openai"
 
         # Default vertex_location to "global" if not provided for Vertex AI
         # Latest gemini models are only available through the global region

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -2,6 +2,8 @@ from onyx.llm.constants import LlmProviderNames
 
 OPENAI_PROVIDER_NAME = "openai"
 
+NOVITA_PROVIDER_NAME = "novita"
+
 BEDROCK_PROVIDER_NAME = "bedrock"
 
 
@@ -11,10 +13,13 @@ OLLAMA_API_KEY_CONFIG_KEY = "OLLAMA_API_KEY"
 LM_STUDIO_PROVIDER_NAME = "lm_studio"
 LM_STUDIO_API_KEY_CONFIG_KEY = "LM_STUDIO_API_KEY"
 
+NOVITA_API_KEY_CONFIG_KEY = "NOVITA_API_KEY"
+
 # Providers that use optional Bearer auth from custom_config
 PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
     LlmProviderNames.OLLAMA_CHAT: OLLAMA_API_KEY_CONFIG_KEY,
     LlmProviderNames.LM_STUDIO: LM_STUDIO_API_KEY_CONFIG_KEY,
+    LlmProviderNames.NOVITA: NOVITA_API_KEY_CONFIG_KEY,
 }
 
 # OpenRouter

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -18,6 +18,7 @@ from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LM_STUDIO_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OLLAMA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import NOVITA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENROUTER_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import VERTEXAI_PROVIDER_NAME
 from onyx.llm.well_known_providers.models import WellKnownLLMProviderDescriptor
@@ -41,6 +42,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
     """
     return {
         OPENAI_PROVIDER_NAME: get_openai_model_names(),
+        NOVITA_PROVIDER_NAME: get_novita_model_names(),
         BEDROCK_PROVIDER_NAME: [],  # Dynamic - fetched from AWS API
         ANTHROPIC_PROVIDER_NAME: get_anthropic_model_names(),
         VERTEXAI_PROVIDER_NAME: get_vertexai_model_names(),
@@ -170,6 +172,19 @@ def get_openai_model_names() -> list[str]:
         ),
         reverse=True,
     )
+
+
+def get_novita_model_names() -> list[str]:
+    """Get Novita model names.
+    Since Novita is OpenAI-compatible, we can list some popular models here.
+    Novita also supports many other models; users can always enter them manually."""
+    return [
+        "deepseek/deepseek-v3",
+        "deepseek/deepseek-r1",
+        "meta-llama/llama-3.3-70b-instruct",
+        "meta-llama/llama-3.1-70b-instruct",
+        "meta-llama/llama-3.1-8b-instruct",
+    ]
 
 
 def get_anthropic_model_names() -> list[str]:
@@ -330,6 +345,7 @@ def get_provider_display_name(provider_name: str) -> str:
         AZURE_PROVIDER_NAME: "Azure OpenAI",
         BEDROCK_PROVIDER_NAME: "Amazon Bedrock",
         VERTEXAI_PROVIDER_NAME: "Google Vertex AI",
+        NOVITA_PROVIDER_NAME: "Novita",
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
     }
 

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -63,6 +63,15 @@
           "display_name": "Kimi K2 0905"
         }
       ]
+    },
+    "novita": {
+      "default_model": { "name": "deepseek/deepseek-v3" },
+      "additional_visible_models": [
+        { "name": "deepseek/deepseek-v3" },
+        { "name": "deepseek/deepseek-r1" },
+        { "name": "meta-llama/llama-3.3-70b-instruct" },
+        { "name": "meta-llama/llama-3.1-70b-instruct" }
+      ]
     }
   }
 }

--- a/backend/tests/unit/onyx/llm/test_novita.py
+++ b/backend/tests/unit/onyx/llm/test_novita.py
@@ -1,0 +1,65 @@
+import os
+from unittest.mock import patch
+import litellm
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.models import UserMessage
+
+def test_novita_llm_init() -> None:
+    # Test that Novita provider sets the correct base URL and custom_llm_provider
+    llm = LitellmLLM(
+        api_key="test_novita_key",
+        model_provider=LlmProviderNames.NOVITA,
+        model_name="deepseek/deepseek-v3",
+        max_input_tokens=4096,
+    )
+    
+    assert llm._api_base == "https://api.novita.ai/openai"
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_key == "test_novita_key"
+
+def test_novita_llm_init_from_env(monkeypatch) -> None:
+    # Test that Novita provider picks up the API key from environment
+    monkeypatch.setenv("NOVITA_API_KEY", "env_novita_key")
+    
+    llm = LitellmLLM(
+        api_key=None,
+        model_provider=LlmProviderNames.NOVITA,
+        model_name="deepseek/deepseek-v3",
+        max_input_tokens=4096,
+    )
+    
+    assert llm._api_key == "env_novita_key"
+
+def test_novita_completion_call() -> None:
+    # Test that Novita completion calls litellm with correct arguments
+    llm = LitellmLLM(
+        api_key="test_novita_key",
+        model_provider=LlmProviderNames.NOVITA,
+        model_name="deepseek/deepseek-v3",
+        max_input_tokens=4096,
+    )
+    
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = [
+            litellm.ModelResponse(
+                id="chatcmpl-123",
+                choices=[
+                    litellm.Choices(
+                        delta={"role": "assistant", "content": "Hello"},
+                        finish_reason="stop",
+                        index=0,
+                    )
+                ],
+                model="deepseek/deepseek-v3",
+            )
+        ]
+        
+        messages = [UserMessage(content="Hi")]
+        llm.invoke(messages)
+        
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["model"] == "novita/deepseek/deepseek-v3"
+        assert kwargs["base_url"] == "https://api.novita.ai/openai"
+        assert kwargs["custom_llm_provider"] == "openai"
+        assert kwargs["api_key"] == "test_novita_key"

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -38,6 +38,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   "ollama_chat",
   "lm_studio",
   "vertex_ai",
+  "novita",
 ]);
 
 export const getProviderIcon = (

--- a/web/src/interfaces/llm.ts
+++ b/web/src/interfaces/llm.ts
@@ -7,6 +7,7 @@ export enum LLMProviderName {
   OPENROUTER = "openrouter",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
+  NOVITA = "novita",
   CUSTOM = "custom",
 }
 


### PR DESCRIPTION
### Summary
This PR adds Novita as an optional, well-known LLM provider.

### Changes
- Added Novita to LLM provider lists in backend and frontend.
- Added default Novita base URL (`https://api.novita.ai/openai`).
- Added support for `NOVITA_API_KEY` environment variable.
- Added recommended Novita models (DeepSeek V3/R1, Llama 3.3/3.1).
- Updated frontend to correctly display vendor icons for Novita models.

### Testing
- Added a new unit test `backend/tests/unit/onyx/llm/test_novita.py` to verify the integration logic in `LitellmLLM`.
- Verified the configuration and defaults in the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Novita as an optional LLM provider with an OpenAI‑compatible endpoint. This lets users pick Novita in the admin UI and run DeepSeek and Llama models.

- **New Features**
  - Backend: added Novita provider, default base URL (https://api.novita.ai/openai), NOVITA_API_KEY support, and OpenAI-compatible routing.
  - Frontend: added Novita to provider enums/config, marked as an aggregator, and displays vendor icons.
  - Recommended models: deepseek/deepseek-v3 (default), deepseek/deepseek-r1, meta-llama/llama-3.3-70b-instruct, meta-llama/llama-3.1-70b-instruct.

- **Migration**
  - Set NOVITA_API_KEY in the environment or provider config.
  - Optionally override the API base URL.
  - In Admin → Configuration → LLM, choose Novita and select a model.

<sup>Written for commit 1fecf7f684559f5b382799d2c4778ec0dcd0887e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

