### PR TITLE
fix: remove unnecessary multitenant check in migration

### DIFF
--- a/backend/alembic_tenants/versions/3b9f09038764_add_read_only_kg_user.py
+++ b/backend/alembic_tenants/versions/3b9f09038764_add_read_only_kg_user.py
@@ -24,8 +24,7 @@ def upgrade() -> None:
     # Enable pg_trgm extension if not already enabled
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
 
-    # Create read-only db user here only in multi-tenant mode. For single-tenant mode,
-    # the user is created in the standard migration.
+    # Create the read-only db user if it does not already exist.
     if not (DB_READONLY_USER and DB_READONLY_PASSWORD):
         raise Exception("DB_READONLY_USER or DB_READONLY_PASSWORD is not set")
 


### PR DESCRIPTION
## Description

- The kg read only user migration in `alembic_tenants` performs an unnecessary check for `MULTI_TENANT`
- No other migrations in schema_private do this check and it's a footgun for local development as the local multi tenant guide advises to run migrations without setting the env var
- These migrations would only ever be run in multi-tenant mode, so there's no need to check

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `MULTI_TENANT` check in the tenants Alembic migration so the read-only DB user and `pg_trgm` extension are managed consistently across upgrade and downgrade. This prevents the migration from silently skipping user setup when the flag isn’t set.

- **Bug Fixes**
  - Enable `pg_trgm` on upgrade; drop it on downgrade.
  - Create the read-only user when missing; revoke all privileges and grant only CONNECT; revoke and drop on downgrade.
  - Remove the `shared_configs.configs.MULTI_TENANT` import and conditional logic; validate `DB_READONLY_USER` and `DB_READONLY_PASSWORD` and error if missing.

<sup>Written for commit 81710c01880f78deb396a896f4c77b3fe8ab6159. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



