### PR TITLE
fix: don't fetch mcp tools when no llms are configured

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -182,7 +182,7 @@ export default function ActionsPopover({
   const { llmProviders, isLoading: isLLMLoading } = useLLMProviders(
     selectedAgent.id
   );
-  const hasAnyProvider = isLLMLoading || (llmProviders?.length ?? 0) > 0;
+  const hasAnyProvider = !isLLMLoading && (llmProviders?.length ?? 0) > 0;
 
   // Use the OAuth hook
   const { getToolAuthStatus, authenticateTool } = useToolOAuthStatus(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only fetch MCP servers in `ActionsPopover` after LLM providers finish loading and at least one is configured. Prevents unnecessary requests and errors on fresh or unconfigured setups.

- **Bug Fixes**
  - Use `useLLMProviders(selectedAgent.id)` and gate the fetch until providers load and exist via `hasAnyProvider`; added `hasAnyProvider` to effect deps.

<sup>Written for commit 0fa794dcf6b4aa6d98d95d423d8e483362a56602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

