### PR TITLE
fix: ph ssl upgrade on redirect for local development

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -8,7 +8,8 @@ const cspHeader = `
     base-uri 'self';
     form-action 'self';
     ${
-      process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true"
+      process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" &&
+      process.env.NODE_ENV !== "development"
         ? "upgrade-insecure-requests;"
         : ""
     }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing HTTPS upgrades in local development by gating the CSP `upgrade-insecure-requests` directive. The CSP in `next.config.js` now only adds it when `NEXT_PUBLIC_CLOUD_ENABLED` is true and `NODE_ENV` is not `development`, fixing local redirects and mixed-content issues.

<sup>Written for commit 7b06455bf9003db33f033c99cd88188f6e368da4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

