### PR TITLE
chore: update decryption utility

### DIFF
--- a/backend/scripts/decrypt.py
+++ b/backend/scripts/decrypt.py
@@ -1,48 +1,93 @@
+"""Decrypt a raw hex-encoded credential value.
+
+Usage:
+    python -m scripts.decrypt <hex_value>
+    python -m scripts.decrypt <hex_value> --key "my-encryption-key"
+    python -m scripts.decrypt <hex_value> --key ""
+
+Pass --key "" to skip decryption and just decode the raw bytes as UTF-8.
+Omit --key to use the current ENCRYPTION_KEY_SECRET from the environment.
+"""
+
+import argparse
 import binascii
 import json
+import os
 import sys
 
-from onyx.utils.encryption import decrypt_bytes_to_string
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+from onyx.utils.encryption import decrypt_bytes_to_string  # noqa: E402
+from onyx.utils.variable_functionality import global_version  # noqa: E402
 
 
-def decrypt_raw_credential(encrypted_value: str) -> None:
-    """Decrypt and display a raw encrypted credential value
+def decrypt_raw_credential(encrypted_value: str, key: str | None = None) -> None:
+    """Decrypt and display a raw encrypted credential value.
 
     Args:
-        encrypted_value: The hex encoded encrypted credential value
+        encrypted_value: The hex-encoded encrypted credential value.
+        key: Encryption key to use. None means use ENCRYPTION_KEY_SECRET,
+             empty string means just decode as UTF-8.
     """
+    # Strip common hex prefixes
+    if encrypted_value.startswith("\\x"):
+        encrypted_value = encrypted_value[2:]
+    elif encrypted_value.startswith("x"):
+        encrypted_value = encrypted_value[1:]
+    print(encrypted_value)
+
     try:
-        # If string starts with 'x', remove it as it's just a prefix indicating hex
-        if encrypted_value.startswith("x"):
-            encrypted_value = encrypted_value[1:]
-        elif encrypted_value.startswith("\\x"):
-            encrypted_value = encrypted_value[2:]
-
-        # Convert hex string to bytes
-        encrypted_bytes = binascii.unhexlify(encrypted_value)
-
-        # Decrypt the bytes
-        decrypted_str = decrypt_bytes_to_string(encrypted_bytes)
-
-        # Parse and pretty print the decrypted JSON
-        decrypted_json = json.loads(decrypted_str)
-        print("Decrypted credential value:")
-        print(json.dumps(decrypted_json, indent=2))
-
+        raw_bytes = binascii.unhexlify(encrypted_value)
     except binascii.Error:
-        print("Error: Invalid hex encoded string")
+        print("Error: Invalid hex-encoded string")
+        sys.exit(1)
 
-    except json.JSONDecodeError as e:
-        print(f"Decrypted raw value (not JSON): {e}")
+    if key == "":
+        # Empty key → just decode as UTF-8, no decryption
+        try:
+            decrypted_str = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as e:
+            print(f"Error decoding bytes as UTF-8: {e}")
+            sys.exit(1)
+    else:
+        print(key)
+        try:
+            decrypted_str = decrypt_bytes_to_string(raw_bytes, key=key)
+        except Exception as e:
+            print(f"Error decrypting value: {e}")
+            sys.exit(1)
 
-    except Exception as e:
-        print(f"Error decrypting value: {e}")
+    # Try to pretty-print as JSON, otherwise print raw
+    try:
+        parsed = json.loads(decrypted_str)
+        print(json.dumps(parsed, indent=2))
+    except json.JSONDecodeError:
+        print(decrypted_str)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Decrypt a hex-encoded credential value."
+    )
+    parser.add_argument(
+        "value",
+        help="Hex-encoded encrypted value to decrypt.",
+    )
+    parser.add_argument(
+        "--key",
+        default=None,
+        help=(
+            "Encryption key. Omit to use ENCRYPTION_KEY_SECRET from env. "
+            'Pass "" (empty) to just decode as UTF-8 without decryption.'
+        ),
+    )
+    args = parser.parse_args()
+
+    global_version.set_ee()
+    decrypt_raw_credential(args.value, key=args.key)
+    global_version.unset_ee()
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python decrypt.py <hex_encoded_encrypted_value>")
-        sys.exit(1)
-
-    encrypted_value = sys.argv[1]
-    decrypt_raw_credential(encrypted_value)
+    main()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `backend/scripts/decrypt.py` to a proper CLI for decrypting hex-encoded credentials. Adds `--key` support, better errors, and JSON pretty-print with a raw fallback.

- **New Features**
  - New CLI with `argparse`: `python -m scripts.decrypt <hex> [--key "..."]`. Uses `ENCRYPTION_KEY_SECRET` by default; pass `--key ""` to UTF-8 decode without decryption.
  - Handles `\x` and `x` prefixes and validates hex input.
  - Pretty-prints JSON output; falls back to raw string when not JSON.
  - Runs in EE context via `global_version.set_ee()`/`unset_ee()` and fixes imports by adjusting `sys.path`.
  - Adds `main()` entrypoint and clearer usage/help text.

<sup>Written for commit 26ecc4967ce1d53774e8c83eaebcf62eb6aea0b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

