### PR TITLE
fix(mcp): use CE-compatible chat endpoint for search_indexed_documents

### DIFF
--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -26,6 +26,10 @@ async def search_indexed_documents(
     Use this tool for information that is not public knowledge and specific to the user,
     their team, their work, or their organization/company.
 
+    Note: This tool uses the chat endpoint internally which invokes an LLM on every
+    call, consuming tokens and adding latency. To be replaced when a CE-compatible
+    pure-search endpoint is available.
+
     To find a list of available sources, use the `indexed_sources` resource.
     Returns chunks of text as search results with snippets, scores, and metadata.
 


### PR DESCRIPTION
## Description
`search_indexed_documents` MCP tool was calling `/search/send-search-message` which is 
only available in EE, causing a 404 for all Community Edition users — making the MCP 
server completely non-functional in CE.

Fixed by switching to `/chat/send-chat-message` which is available in all editions.
Response parsing updated to use `top_documents` (ChatFullResponse field) instead of 
`search_docs`, and results are now capped to the requested `limit`.

Known limitation: each search call creates a ChatSession row. 
A dedicated CE search endpoint would be the proper fix

## How Has This Been Tested?
Verified by code inspection:
- `/search/send-search-message` only exists in `backend/ee/onyx/server/query_and_chat/search_backend.py`
- `/chat/send-chat-message` exists in CE `backend/onyx/server/query_and_chat/chat_backend.py`
- `ChatFullResponse` uses `top_documents` field (confirmed in `backend/onyx/chat/models.py`)

Fixes #9187

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 404 in Community Edition by switching the MCP `search_indexed_documents` tool to the CE-compatible `/chat/send-chat-message` endpoint, restoring search functionality. Also updates parsing to use `top_documents`, caps results to `limit`, and fixes error handling.

- **Bug Fixes**
  - Replaced EE-only `/search/send-search-message` with `/chat/send-chat-message`.
  - Request uses `message`, `stream: false`, `chat_session_info: {}`, with optional `internal_search_filters`.
  - Parse `top_documents`; map `blurb` to `content`; cap results to `limit` (backend controls retrieval depth).
  - Use `error_msg` and remove `executed_queries`; PEP 8: add missing blank line between top-level functions.
  - Add docstring note: this path invokes an LLM on each call, consuming tokens and adding latency until a CE pure-search endpoint exists.

<sup>Written for commit 974b175a9d64c72ca0686b5b66ebe9b33275ffd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



