### PR TITLE
fix(mcp): use CE-compatible chat endpoint for search_indexed_documents

### DIFF
--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -124,9 +124,10 @@ async def search_indexed_documents(
     base_url = build_api_server_url_for_http_requests(respect_env_override_if_set=True)
     auth_headers = {"Authorization": f"Bearer {access_token.token}"}
 
+    search_request: dict[str, Any]
     if is_ee:
         # EE: use the dedicated search endpoint (no LLM invocation)
-        search_request: dict[str, Any] = {
+        search_request = {
             "search_query": query,
             "filters": filters,
             "num_docs_fed_to_llm_selection": limit,
@@ -140,7 +141,7 @@ async def search_indexed_documents(
         content_field = "content"
     else:
         # CE: fall back to the chat endpoint (invokes LLM, consumes tokens)
-        search_request: dict[str, Any] = {
+        search_request = {
             "message": query,
             "stream": False,
             "chat_session_info": {},


### PR DESCRIPTION
This PR runs GitHub Actions CI for #9192.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches MCP search to use the EE search endpoint with a CE chat fallback, and fixes response parsing for both paths. This improves compatibility and avoids LLM token use on EE while documenting CE side effects.

- **Bug Fixes**
  - Split by edition: EE → `/search/send-search-message`; CE → `/chat/send-chat-message`.
  - EE request uses `search_query`, `filters`, `include_content`, `num_docs_fed_to_llm_selection`, `stream: false`; CE uses `message`, `stream: false`, empty `chat_session_info`, optional `internal_search_filters`.
  - Parse docs from `search_docs` (EE, `content`) and `top_documents` (CE, `blurb`); cap returned results to `limit`.
  - Handle errors via `error` (EE) and `error_msg` (CE); remove `executed_queries`.
  - Add edition check with `global_version.is_ee_version()`, reuse `base_url` and auth headers; explicit `dict[str, Any]` typing to satisfy mypy.
  - Docstring and comments clarify CE token/latency and `limit` behavior; minor PEP 8 spacing fix.

<sup>Written for commit d2c6e1380758bf296d1b6c47ff99ac50beb6b944. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

