### PR TITLE
fix(api memory): replace glibc with jemalloc for memory allocating

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,12 +52,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-# Use jemalloc instead of glibc malloc to reduce memory fragmentation
-# in long-running Python processes (API server, Celery workers).
-# The soname is architecture-independent; the dynamic linker resolves
-# the correct path from standard library directories.
-ENV LD_PRELOAD=libjemalloc.so.2
-
 # Conditionally install Node.js 20 for Craft (required for Next.js)
 # Only installed when ENABLE_CRAFT=true
 RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
@@ -172,6 +166,13 @@ ENV PYTHONPATH=/app
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
+
+# Use jemalloc instead of glibc malloc to reduce memory fragmentation
+# in long-running Python processes (API server, Celery workers).
+# The soname is architecture-independent; the dynamic linker resolves
+# the correct path from standard library directories.
+# Placed after all RUN steps so build-time processes are unaffected.
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
During a DR, the API server allocates large buffers — LLM streaming chunks, 100K+ token conversation history strings, and URL fetch content — peaking at ~400–500 MB above baseline. Python frees all of it, but glibc does not return those pages to the OS due to poor fragmentation handling. This PR replacing glibc with jemalloc for memory allocation.

linear: https://linear.app/onyx-app/project/memory-leaks-and-api-pods-crashing-88fcbf1510b0/overview
doc: https://docs.google.com/document/d/1_RfH2WzME73Bw4PaRcbEIPkNtdpVrvJpz6uaZ4XViyE/edit?tab=t.4564xw4az5tj

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Before the fix:
<img width="1684" height="963" alt="Screenshot 2026-03-06 at 5 20 25 PM" src="https://github.com/user-attachments/assets/d178dd60-8445-4f35-a8e0-e6263afc4a4c" />
After the fix:
<img width="1517" height="851" alt="Screenshot 2026-03-07 at 5 56 35 PM" src="https://github.com/user-attachments/assets/0adcc238-94b7-4772-833d-03e6fa8c8b08" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch API server and workers to `jemalloc` so freed memory returns to the OS and RSS drops back to baseline after large requests. Addresses the Linear issue on memory leaks and pod crashes under DR-scale loads.

- **Bug Fixes**
  - Install `libjemalloc2` and set `LD_PRELOAD=libjemalloc.so.2` in `backend/Dockerfile`, placed after all RUN steps so only runtime processes use it.
  - Load tests show peak memory is released after requests; no sustained 400–500 MB RSS growth.

<sup>Written for commit 8a1461739dc0293cbeb03ab77f3e3fee67109b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

