### PR TITLE
ci: add Storybook production deploy workflow - 3/3

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -3,6 +3,12 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: prj_sG49mVsA25UsxIPhN2pmBJlikJZM
   VERCEL_CLI: vercel@50.14.1
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+concurrency:
+  group: storybook-deploy-production
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -32,10 +38,10 @@ jobs:
           cache-dependency-path: ./web/package-lock.json
 
       - name: Pull Vercel Environment Information
-        run: npx --yes ${{ env.VERCEL_CLI }} pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes ${{ env.VERCEL_CLI }} pull --yes --environment=production --token=${{ env.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: npx --yes ${{ env.VERCEL_CLI }} build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes ${{ env.VERCEL_CLI }} build --prod --token=${{ env.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel (Production)
-        run: npx --yes ${{ env.VERCEL_CLI }} deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes ${{ env.VERCEL_CLI }} deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }}


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that deploys Storybook to Vercel on merge to `main`. Triggers when any of these paths change:
- `web/lib/opal/**` — all opal source and config
- `web/src/refresh-components/**` — app-level components
- `web/.storybook/**` — storybook config
- `web/package.json` / `web/package-lock.json` — dependency changes

Production deploys only — no preview builds. Uses the existing `VERCEL_ORG_ID` and `VERCEL_TOKEN` secrets with the Storybook project ID hardcoded in the workflow.

**Linear:** [ENG-3092](https://linear.app/onyx-app/issue/ENG-3092/create-qa-storybook-site-to-be-deployed-on-fe-dev)

## How Has This Been Tested?

Workflow syntax validated by `actionlint` pre-commit hook.

## Additional Options

- [ ] This PR should be cherry-picked into a release branch
- [x] Override Linear Check