### PR TITLE
fix: discord connector async resource cleanup

### DIFF
--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterable
 from collections.abc import Iterable
 from datetime import datetime
@@ -204,7 +205,7 @@ def _manage_async_retrieval(
 
     end_time: datetime | None = end
 
-    async def _async_fetch() -> AsyncIterable[Document]:
+    async def _async_fetch() -> AsyncGenerator[Document, None]:
         intents = Intents.default()
         intents.message_content = True
         async with Client(intents=intents) as discord_client:
@@ -229,10 +230,9 @@ def _manage_async_retrieval(
         loop = asyncio.new_event_loop()
         async_gen = _async_fetch()
         try:
-            async_iter = async_gen.__aiter__()
             while True:
                 try:
-                    doc = loop.run_until_complete(anext(async_iter))
+                    doc = loop.run_until_complete(anext(async_gen))
                     yield doc
                 except StopAsyncIteration:
                     break


### PR DESCRIPTION
## Description

- Fix async resource cleanup in the Discord connector that caused RuntimeError: no running event loop warnings during garbage collection
- Previously, run_and_yield() closed the event loop without first closing the async generator. When Python later GC'd the generator, the Discord client's async with block tried to await client.close(), but the loop was already gone.
- Now we explicitly aclose() the async generator before closing the loop, so the Discord client shuts down cleanly while the loop is still available.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes async shutdown in the Discord connector by closing the async generator before the event loop. This lets the Discord client finish cleanup and avoids pending-task/loop warnings.

- **Bug Fixes**
  - Close the async generator with `loop.run_until_complete(async_gen.aclose())` before `loop.close()`.
  - Create `async_gen` outside the try block and use a nested try/finally so the loop always closes even if cleanup fails.
  - Type `_async_fetch` as `AsyncGenerator` and iterate with `anext(async_gen)` for clarity.

<sup>Written for commit 904c71ab7cfdafeaa92edbe964f558e046ad3a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



