### PR TITLE
ci: add Storybook deploy workflow - 3/3

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -49,3 +49,21 @@ jobs:
       - name: Deploy to Vercel (Production)
         working-directory: web
         run: npx --yes "$VERCEL_CLI" deploy storybook-static/ --prod --yes
+
+  notify-slack-on-failure:
+    needs: Deploy-Storybook
+    if: always() && needs.Deploy-Storybook.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/slack-notify
+
+      - name: Send Slack notification
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          failed-jobs: "• Deploy-Storybook"
+          title: "🚨 Storybook Deploy Failed"


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that deploys Storybook to Vercel on merge to `main`. Triggers when any of these paths change:
- `web/lib/opal/**` — all opal source and config
- `web/src/refresh-components/**` — app-level components
- `web/.storybook/**` — storybook config
- `web/package.json` / `web/package-lock.json` — dependency changes

Production deploys only — no preview builds. Uses the existing `VERCEL_ORG_ID` and `VERCEL_TOKEN` secrets with the Storybook project ID hardcoded in the workflow.

**Linear:** [ENG-3092](https://linear.app/onyx-app/issue/ENG-3092/create-qa-storybook-site-to-be-deployed-on-fe-dev)

## How Has This Been Tested?

Workflow syntax validated by `actionlint` pre-commit hook.

## Additional Options

- [ ] This PR should be cherry-picked into a release branch
- [x] Override Linear Check