### PR TITLE
fix(fe): move app padding inside overflow container

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -676,7 +676,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
             >
               {/* Main content grid — 3 rows, animated */}
               <div
-                className="flex-1 w-full grid min-h-0 px-4 transition-[grid-template-rows] duration-150 ease-in-out"
+                className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out"
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
@@ -741,7 +741,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
 
                 {/* ── Middle-center: AppInputBar ── */}
-                <div className="row-start-2 flex flex-col items-center">
+                <div className="row-start-2 flex flex-col items-center px-4">
                   <div className="relative w-full max-w-[var(--app-page-main-content-width)] flex flex-col">
                     {/* Scroll to bottom button - positioned absolutely above AppInputBar */}
                     {appFocus.isChat() && showScrollButton && (
@@ -841,7 +841,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
 
                 {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
-                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full">
+                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-4">
                   {/* Agent description below input */}
                   {(appFocus.isNewSession() || appFocus.isAgent()) &&
                     !isDefaultAgent && (

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -115,7 +115,7 @@ const ChatUI = React.memo(
 
     return (
       <>
-        <div className="flex flex-col w-full max-w-[var(--app-page-main-content-width)] h-full pt-4 pb-8 pr-1 gap-12">
+        <div className="flex flex-col w-full max-w-[var(--app-page-main-content-width)] h-full p-4 pb-8 pr-5 gap-12">
           {messages.map((message, i) => {
             const messageReactComponentKey = `message-${message.nodeId}`;
             const parentMessage = message.parentNodeId


### PR DESCRIPTION
## Description
[fix(fe): add horizontal padding to chat page](https://github.com/onyx-dot-app/onyx/pull/9147) unintentionally changed visual behavior of non-responsive sizes namely that app scrollbar now has a 1rem gap with the viewport,

<img width="1557" height="1036" alt="20260309_13h18m41s_grim" src="https://github.com/user-attachments/assets/9189ae95-c363-40ac-99cb-45895053e4d8" />

This fixes it by moving the padding inside the element which is applying `overflow`.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 1rem gap between the app scrollbar and the viewport on fixed-width layouts by moving horizontal padding inside the scroll/overflow containers. Keeps chat page spacing consistent.

- **Bug Fixes**
  - Moved `px-4` off the outer grid in `AppPage.tsx` and applied it to the middle and bottom rows (the overflow areas) so the scrollbar sits flush with the viewport.
  - Updated `ChatUI` container padding to `p-4 pb-8 pr-5` to preserve content spacing without affecting the outer scroll.

<sup>Written for commit 9e8185fc8fa412ceadbb5c5c9d9293466d60c00b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

