### PR TITLE
fix(safari): Search results dont shrink (#9126) to release v3.0

### DIFF
--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -198,16 +198,15 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
   const showEmpty = !error && results.length === 0;
 
   return (
-    <>
-      <div
-        className="flex-1 min-h-0 w-full grid gap-x-4"
-        style={{
-          gridTemplateColumns: showEmpty ? "1fr" : "3fr 1fr",
-          gridTemplateRows: "auto 1fr auto",
-        }}
-      >
-        {/* Top-left: Search filters */}
-        <div className="row-start-1 col-start-1 flex flex-col justify-end gap-3">
+    <div className="flex-1 min-h-0 w-full flex flex-col gap-3">
+      {/* ── Top row: Filters + Result count ── */}
+      <div className="flex-shrink-0 flex flex-row gap-x-4">
+        <div
+          className={cn(
+            "flex flex-col justify-end gap-3",
+            showEmpty ? "flex-1" : "flex-[3]"
+          )}
+        >
           <div className="flex flex-row gap-2">
             {/* Time filter */}
             <Popover open={timeFilterOpen} onOpenChange={setTimeFilterOpen}>
@@ -307,9 +306,8 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           <Separator noPadding />
         </div>
 
-        {/* Top-right: Number of results */}
         {!showEmpty && (
-          <div className="row-start-1 col-start-2 flex flex-col justify-end gap-3">
+          <div className="flex-1 flex flex-col justify-end gap-3">
             <Section alignItems="start">
               <Text text03 mainUiMuted>
                 {results.length} Results
@@ -319,12 +317,14 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
             <Separator noPadding />
           </div>
         )}
+      </div>
 
-        {/* Bottom-left: Search results */}
+      {/* ── Middle row: Results + Source filter ── */}
+      <div className="flex-1 min-h-0 flex flex-row gap-x-4">
         <div
           className={cn(
-            "row-start-2 col-start-1 min-h-0 overflow-y-scroll py-3 flex flex-col gap-2",
-            showEmpty && "justify-center"
+            "min-h-0 overflow-y-scroll flex flex-col gap-2",
+            showEmpty ? "flex-1 justify-center" : "flex-[3]"
           )}
         >
           {error ? (
@@ -332,12 +332,16 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           ) : paginatedResults.length > 0 ? (
             <>
               {paginatedResults.map((doc) => (
-                <SearchCard
+                <div
                   key={`${doc.document_id}-${doc.chunk_ind}`}
-                  document={doc}
-                  isLlmSelected={llmSelectedSet.has(doc.document_id)}
-                  onDocumentClick={onDocumentClick}
-                />
+                  className="flex-shrink-0"
+                >
+                  <SearchCard
+                    document={doc}
+                    isLlmSelected={llmSelectedSet.has(doc.document_id)}
+                    onDocumentClick={onDocumentClick}
+                  />
+                </div>
               ))}
             </>
           ) : (
@@ -349,20 +353,8 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           )}
         </div>
 
-        {/* Pagination */}
         {!showEmpty && (
-          <div className="row-start-3 col-start-1 col-span-2 pt-3">
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
-            />
-          </div>
-        )}
-
-        {/* Bottom-right: Source filter */}
-        {!showEmpty && (
-          <div className="row-start-2 col-start-2 min-h-0 overflow-y-auto flex flex-col gap-4 px-1 py-3">
+          <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 px-1">
             <Section gap={0.25} height="fit">
               {sourcesWithMeta.map(({ source, meta, count }) => (
                 <LineItem
@@ -386,6 +378,15 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           </div>
         )}
       </div>
-    </>
+
+      {/* ── Bottom row: Pagination ── */}
+      {!showEmpty && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
+    </div>
   );
 }

--- a/web/src/refresh-components/Pagination.tsx
+++ b/web/src/refresh-components/Pagination.tsx
@@ -66,7 +66,7 @@ export default function Pagination({
   const pageNumbers = getPageNumbers();
 
   return (
-    <Section flexDirection="row" gap={0.25}>
+    <Section flexDirection="row" height="auto" gap={0.25}>
       {/* Previous button */}
       <Disabled disabled={currentPage === 1}>
         <Button
@@ -77,7 +77,7 @@ export default function Pagination({
       </Disabled>
 
       {/* Page numbers */}
-      <Section flexDirection="row" gap={0} width="fit">
+      <Section flexDirection="row" height="auto" gap={0} width="fit">
         {pageNumbers.map((page, index) => {
           if (page === "...") {
             return (


### PR DESCRIPTION
Cherry-pick of commit fe593a15da2f79096ffa48723d436fc686c22427 to release/v3.0 branch.

Original PR: #9126

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Safari layout bug where search results wouldn’t shrink, causing overflow. Reworks the search UI layout so filters, results, and pagination behave correctly across browsers.

- **Bug Fixes**
  - Replaced the grid with a flex layout so the top (filters/results count), middle (results + source filter), and bottom (pagination) sections shrink and grow properly in Safari.
  - Ensured the results list can scroll by enforcing `min-h-0`, and wrapped each result in a non-shrinking container to prevent height expansion.
  - Moved pagination to the bottom and set its container height to `auto` to avoid layout issues in Safari.

<sup>Written for commit 062fb53e009f23eab67e82d76b07aadfb2a55e05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

