### PR TITLE
fix: impropoer kv store strings

### DIFF
--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -44,6 +44,7 @@ from onyx.connectors.google_utils.shared_constants import (
 from onyx.db.credentials import update_credential_json
 from onyx.db.models import User
 from onyx.key_value_store.factory import get_kv_store
+from onyx.key_value_store.interface import unwrap_str
 from onyx.server.documents.models import CredentialBase
 from onyx.server.documents.models import GoogleAppCredentials
 from onyx.server.documents.models import GoogleServiceAccountKey
@@ -89,8 +90,7 @@ def _get_current_oauth_user(creds: OAuthCredentials, source: DocumentSource) -> 
 
 
 def verify_csrf(credential_id: int, state: str) -> None:
-    loaded = get_kv_store().load(KV_CRED_KEY.format(str(credential_id)))
-    csrf = loaded["value"] if isinstance(loaded, dict) else loaded
+    csrf = unwrap_str(get_kv_store().load(KV_CRED_KEY.format(str(credential_id))))
     if csrf != state:
         raise PermissionError(
             "State from Google Drive Connector callback does not match expected"

--- a/backend/onyx/key_value_store/interface.py
+++ b/backend/onyx/key_value_store/interface.py
@@ -1,10 +1,24 @@
 import abc
+from typing import cast
 
 from onyx.utils.special_types import JSON_ro
 
 
 class KvKeyNotFoundError(Exception):
     pass
+
+
+def unwrap_str(val: JSON_ro) -> str:
+    """Unwrap a string stored as {"value": str} in the encrypted KV store.
+    Also handles legacy plain-string values cached in Redis."""
+    if isinstance(val, dict):
+        try:
+            return cast(str, val["value"])
+        except KeyError:
+            raise ValueError(
+                f"Expected dict with 'value' key, got keys: {list(val.keys())}"
+            )
+    return cast(str, val)
 
 
 class KeyValueStore:

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -2,7 +2,6 @@ import contextvars
 import threading
 import uuid
 from enum import Enum
-from typing import cast
 
 import requests
 
@@ -15,8 +14,8 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import User
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
+from onyx.key_value_store.interface import unwrap_str
 from onyx.utils.logger import setup_logger
-from onyx.utils.special_types import JSON_ro
 from onyx.utils.variable_functionality import (
     fetch_versioned_implementation_with_fallback,
 )
@@ -25,14 +24,6 @@ from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
-
-
-def _unwrap_str(val: JSON_ro) -> str:
-    """Unwrap a string stored as {"value": str} in the KV store.
-    Also handles legacy plain-string values cached in Redis."""
-    if isinstance(val, dict):
-        return cast(str, val["value"])
-    return cast(str, val)
 
 
 _DANSWER_TELEMETRY_ENDPOINT = "https://telemetry.onyx.app/anonymous_telemetry"
@@ -72,7 +63,7 @@ def get_or_generate_uuid() -> str:
     kv_store = get_kv_store()
 
     try:
-        _CACHED_UUID = _unwrap_str(kv_store.load(KV_CUSTOMER_UUID_KEY))
+        _CACHED_UUID = unwrap_str(kv_store.load(KV_CUSTOMER_UUID_KEY))
     except KvKeyNotFoundError:
         _CACHED_UUID = str(uuid.uuid4())
         kv_store.store(KV_CUSTOMER_UUID_KEY, {"value": _CACHED_UUID}, encrypt=True)
@@ -89,7 +80,7 @@ def _get_or_generate_instance_domain() -> str | None:  #
     kv_store = get_kv_store()
 
     try:
-        _CACHED_INSTANCE_DOMAIN = _unwrap_str(kv_store.load(KV_INSTANCE_DOMAIN_KEY))
+        _CACHED_INSTANCE_DOMAIN = unwrap_str(kv_store.load(KV_INSTANCE_DOMAIN_KEY))
     except KvKeyNotFoundError:
         with get_session_with_current_tenant() as db_session:
             first_user = db_session.query(User).first()


### PR DESCRIPTION
## Description

- KVStore encrypted_value column is typed as `EncryptedJson`, but never enforced dict/str type mismatches
- The column would silently accept strings and do `json.dumps('"foo"')` and `json.loads('"foo"')`, both of which just return the string
- #9177 added a type check that then caused these instances to fail

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized KV store string values to `{"value": str}` and added a shared `unwrap_str` for backward compatibility with legacy plain strings. Fixes CSRF state verification and telemetry ID/domain loading by eliminating Redis type mismatches.

- **Bug Fixes**
  - Google OAuth: save `state` as `{"value": ...}` in `get_auth_url` and unwrap on read in `verify_csrf`.
  - Telemetry: use `unwrap_str` when reading UUID and instance domain; store both as wrapped values.

<sup>Written for commit 543be5a5a69a8ed3b6f692f53ed0861e9001c640. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



