### PR TITLE
fix(fe): fix chat content padding

### DIFF
--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -366,7 +366,7 @@ const ChatScrollContainer = React.memo(
           >
             <div
               ref={contentWrapperRef}
-              className="w-full flex-1 flex flex-col items-center"
+              className="w-full flex-1 flex flex-col items-center px-4"
               data-scroll-ready={isScrollReady}
               style={{
                 visibility: isScrollReady ? "visible" : "hidden",

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -115,7 +115,7 @@ const ChatUI = React.memo(
 
     return (
       <>
-        <div className="flex flex-col w-full max-w-[var(--app-page-main-content-width)] h-full p-4 pb-8 pr-5 gap-12">
+        <div className="flex flex-col w-full max-w-[var(--app-page-main-content-width)] h-full pt-4 pb-8 pr-1 gap-12">
           {messages.map((message, i) => {
             const messageReactComponentKey = `message-${message.nodeId}`;
             const parentMessage = message.parentNodeId


### PR DESCRIPTION
## Description

This element is setting a width of `max-w-[var(--app-page-main-content-width)]` which takes into account its padding making it now smaller which was not intended.

I think it's semantically not supposed to be in the ChatSrollContainer, but it's not really a big deal I think.

## How Has This Been Tested?

Captured by visual regression

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat content padding so the chat area no longer shrinks when `max-w-[var(--app-page-main-content-width)]` includes padding. Moves horizontal padding into the scroll container and tweaks the chat wrapper spacing for consistent alignment.

- **Bug Fixes**
  - Added `px-4` to `ChatScrollContainer` content wrapper.
  - Adjusted `ChatUI` wrapper from `p-4 pb-8 pr-5` to `pt-4 pb-8 pr-1` to avoid affecting max width.

<sup>Written for commit c1a91661d2dfade6f3114b47f5a0344a4dc449fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

