### PR TITLE
fix: use `detail` instead of `message` in OnyxError response shape (#9214) to release v3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,7 +598,7 @@ Before writing your plan, make sure to do research. Explore the relevant section
 Never hardcode status codes or use `starlette.status` / `fastapi.status` constants directly.**
 
 A global FastAPI exception handler converts `OnyxError` into a JSON response with the standard
-`{"error_code": "...", "message": "..."}` shape. This eliminates boilerplate and keeps error
+`{"error_code": "...", "detail": "..."}` shape. This eliminates boilerplate and keeps error
 handling consistent across the entire backend.
 
 ```python

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -91,11 +91,11 @@ class OnyxErrorCode(Enum):
         """Build a structured error detail dict.
 
         Returns a dict like:
-            {"error_code": "UNAUTHENTICATED", "message": "Token expired"}
+            {"error_code": "UNAUTHENTICATED", "detail": "Token expired"}
 
-        If no message is supplied, the error code itself is used as the message.
+        If no message is supplied, the error code itself is used as the detail.
         """
         return {
             "error_code": self.code,
-            "message": message or self.code,
+            "detail": message or self.code,
         }

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -3,7 +3,7 @@
 Raise ``OnyxError`` instead of ``HTTPException`` in business code.  A global
 FastAPI exception handler (registered via ``register_onyx_exception_handlers``)
 converts it into a JSON response with the standard
-``{"error_code": "...", "message": "..."}`` shape.
+``{"error_code": "...", "detail": "..."}`` shape.
 
 Usage::
 
@@ -37,21 +37,21 @@ class OnyxError(Exception):
 
     Attributes:
         error_code: The ``OnyxErrorCode`` enum member.
-        message: Human-readable message (defaults to the error code string).
+        detail: Human-readable detail (defaults to the error code string).
         status_code: HTTP status — either overridden or from the error code.
     """
 
     def __init__(
         self,
         error_code: OnyxErrorCode,
-        message: str | None = None,
+        detail: str | None = None,
         *,
         status_code_override: int | None = None,
     ) -> None:
-        resolved_message = message or error_code.code
-        super().__init__(resolved_message)
+        resolved_detail = detail or error_code.code
+        super().__init__(resolved_detail)
         self.error_code = error_code
-        self.message = resolved_message
+        self.detail = resolved_detail
         self._status_code_override = status_code_override
 
     @property
@@ -73,11 +73,11 @@ def register_onyx_exception_handlers(app: FastAPI) -> None:
     ) -> JSONResponse:
         status_code = exc.status_code
         if status_code >= 500:
-            logger.error(f"OnyxError {exc.error_code.code}: {exc.message}")
+            logger.error(f"OnyxError {exc.error_code.code}: {exc.detail}")
         elif status_code >= 400:
-            logger.warning(f"OnyxError {exc.error_code.code}: {exc.message}")
+            logger.warning(f"OnyxError {exc.error_code.code}: {exc.detail}")
 
         return JSONResponse(
             status_code=status_code,
-            content=exc.error_code.detail(exc.message),
+            content=exc.error_code.detail(exc.detail),
         )

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider.py
@@ -158,7 +158,7 @@ class TestLLMConfigurationEndpoint:
                     )
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
-                assert exc_info.value.message == error_message
+                assert exc_info.value.detail == error_message
 
         finally:
             db_session.rollback()
@@ -540,7 +540,7 @@ class TestDefaultProviderEndpoint:
                 run_test_default_provider(_=_create_mock_admin())
 
             assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
-            assert "No LLM Provider setup" in exc_info.value.message
+            assert "No LLM Provider setup" in exc_info.value.detail
 
         finally:
             db_session.rollback()
@@ -585,7 +585,7 @@ class TestDefaultProviderEndpoint:
                     run_test_default_provider(_=_create_mock_admin())
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
-                assert exc_info.value.message == error_message
+                assert exc_info.value.detail == error_message
 
         finally:
             db_session.rollback()

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
@@ -111,7 +111,7 @@ class TestLLMProviderChanges:
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
                 assert "cannot be changed without changing the API key" in str(
-                    exc_info.value.message
+                    exc_info.value.detail
                 )
         finally:
             _cleanup_provider(db_session, provider_name)
@@ -247,7 +247,7 @@ class TestLLMProviderChanges:
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
                 assert "cannot be changed without changing the API key" in str(
-                    exc_info.value.message
+                    exc_info.value.detail
                 )
         finally:
             _cleanup_provider(db_session, provider_name)
@@ -350,7 +350,7 @@ class TestLLMProviderChanges:
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
                 assert "cannot be changed without changing the API key" in str(
-                    exc_info.value.message
+                    exc_info.value.detail
                 )
         finally:
             _cleanup_provider(db_session, provider_name)
@@ -386,7 +386,7 @@ class TestLLMProviderChanges:
 
                 assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
                 assert "cannot be changed without changing the API key" in str(
-                    exc_info.value.message
+                    exc_info.value.detail
                 )
         finally:
             _cleanup_provider(db_session, provider_name)

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -427,7 +427,7 @@ def test_delete_default_llm_provider_rejected(reset: None) -> None:  # noqa: ARG
         headers=admin_user.headers,
     )
     assert delete_response.status_code == 400
-    assert "Cannot delete the default LLM provider" in delete_response.json()["message"]
+    assert "Cannot delete the default LLM provider" in delete_response.json()["detail"]
 
     # Verify provider still exists
     provider_data = _get_provider_by_id(admin_user, created_provider["id"])
@@ -674,7 +674,7 @@ def test_duplicate_provider_name_rejected(reset: None) -> None:  # noqa: ARG001
         json=base_payload,
     )
     assert response.status_code == 409
-    assert "already exists" in response.json()["message"]
+    assert "already exists" in response.json()["detail"]
 
 
 def test_rename_provider_rejected(reset: None) -> None:  # noqa: ARG001
@@ -711,7 +711,7 @@ def test_rename_provider_rejected(reset: None) -> None:  # noqa: ARG001
         json=update_payload,
     )
     assert response.status_code == 400
-    assert "not currently supported" in response.json()["message"]
+    assert "not currently supported" in response.json()["detail"]
 
     # Verify no duplicate was created — only the original provider should exist
     provider = _get_provider_by_id(admin_user, provider_id)

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider_persona_access.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider_persona_access.py
@@ -69,7 +69,7 @@ def test_unauthorized_persona_access_returns_403(
 
     # Should return 403 Forbidden
     assert response.status_code == 403
-    assert "don't have access to this assistant" in response.json()["message"]
+    assert "don't have access to this assistant" in response.json()["detail"]
 
 
 def test_authorized_persona_access_returns_filtered_providers(
@@ -245,4 +245,4 @@ def test_nonexistent_persona_returns_404(
 
     # Should return 404
     assert response.status_code == 404
-    assert "Persona not found" in response.json()["message"]
+    assert "Persona not found" in response.json()["detail"]

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_api.py
@@ -107,7 +107,7 @@ class TestCreateCheckoutSession:
 
         assert exc_info.value.status_code == 502
         assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
-        assert exc_info.value.message == "Stripe error"
+        assert exc_info.value.detail == "Stripe error"
 
 
 class TestCreateCustomerPortalSession:
@@ -137,7 +137,7 @@ class TestCreateCustomerPortalSession:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code is OnyxErrorCode.VALIDATION_ERROR
-        assert exc_info.value.message == "No license found"
+        assert exc_info.value.detail == "No license found"
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.billing.api.create_portal_service")
@@ -243,7 +243,7 @@ class TestUpdateSeats:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code is OnyxErrorCode.VALIDATION_ERROR
-        assert exc_info.value.message == "No license found"
+        assert exc_info.value.detail == "No license found"
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.billing.api.get_used_seats")
@@ -317,7 +317,7 @@ class TestUpdateSeats:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
-        assert exc_info.value.message == "Cannot reduce below 10 seats"
+        assert exc_info.value.detail == "Cannot reduce below 10 seats"
 
 
 class TestCircuitBreaker:
@@ -346,7 +346,7 @@ class TestCircuitBreaker:
 
         assert exc_info.value.status_code == 503
         assert exc_info.value.error_code is OnyxErrorCode.SERVICE_UNAVAILABLE
-        assert "Connect to Stripe" in exc_info.value.message
+        assert "Connect to Stripe" in exc_info.value.detail
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.billing.api.MULTI_TENANT", False)

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
@@ -101,7 +101,7 @@ class TestMakeBillingRequest:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
-        assert "Bad request" in exc_info.value.message
+        assert "Bad request" in exc_info.value.detail
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.billing.service._get_headers")
@@ -152,7 +152,7 @@ class TestMakeBillingRequest:
 
         assert exc_info.value.status_code == 502
         assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
-        assert "Failed to connect" in exc_info.value.message
+        assert "Failed to connect" in exc_info.value.detail
 
 
 class TestCreateCheckoutSession:

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
@@ -72,7 +72,7 @@ class TestGetStripePublishableKey:
 
         assert exc_info.value.status_code == 500
         assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
-        assert exc_info.value.message == "Invalid Stripe publishable key format"
+        assert exc_info.value.detail == "Invalid Stripe publishable key format"
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.tenants.billing_api.STRIPE_PUBLISHABLE_KEY_OVERRIDE", None)
@@ -97,7 +97,7 @@ class TestGetStripePublishableKey:
 
         assert exc_info.value.status_code == 500
         assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
-        assert exc_info.value.message == "Invalid Stripe publishable key format"
+        assert exc_info.value.detail == "Invalid Stripe publishable key format"
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.tenants.billing_api.STRIPE_PUBLISHABLE_KEY_OVERRIDE", None)
@@ -118,7 +118,7 @@ class TestGetStripePublishableKey:
 
         assert exc_info.value.status_code == 500
         assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
-        assert exc_info.value.message == "Failed to fetch Stripe publishable key"
+        assert exc_info.value.detail == "Failed to fetch Stripe publishable key"
 
     @pytest.mark.asyncio
     @patch("ee.onyx.server.tenants.billing_api.STRIPE_PUBLISHABLE_KEY_OVERRIDE", None)
@@ -132,7 +132,7 @@ class TestGetStripePublishableKey:
 
         assert exc_info.value.status_code == 500
         assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
-        assert "not configured" in exc_info.value.message
+        assert "not configured" in exc_info.value.detail
 
     @pytest.mark.asyncio
     @patch(

--- a/backend/tests/unit/onyx/error_handling/test_exceptions.py
+++ b/backend/tests/unit/onyx/error_handling/test_exceptions.py
@@ -15,12 +15,12 @@ class TestOnyxError:
     def test_basic_construction(self) -> None:
         err = OnyxError(OnyxErrorCode.NOT_FOUND, "Session not found")
         assert err.error_code is OnyxErrorCode.NOT_FOUND
-        assert err.message == "Session not found"
+        assert err.detail == "Session not found"
         assert err.status_code == 404
 
     def test_message_defaults_to_code(self) -> None:
         err = OnyxError(OnyxErrorCode.UNAUTHENTICATED)
-        assert err.message == "UNAUTHENTICATED"
+        assert err.detail == "UNAUTHENTICATED"
         assert str(err) == "UNAUTHENTICATED"
 
     def test_status_code_override(self) -> None:
@@ -73,18 +73,18 @@ class TestExceptionHandler:
         assert resp.status_code == 404
         body = resp.json()
         assert body["error_code"] == "NOT_FOUND"
-        assert body["message"] == "Thing not found"
+        assert body["detail"] == "Thing not found"
 
     def test_status_code_override_in_response(self, client: TestClient) -> None:
         resp = client.get("/boom-override")
         assert resp.status_code == 503
         body = resp.json()
         assert body["error_code"] == "BAD_GATEWAY"
-        assert body["message"] == "upstream 503"
+        assert body["detail"] == "upstream 503"
 
     def test_default_message(self, client: TestClient) -> None:
         resp = client.get("/boom-default-msg")
         assert resp.status_code == 401
         body = resp.json()
         assert body["error_code"] == "UNAUTHENTICATED"
-        assert body["message"] == "UNAUTHENTICATED"
+        assert body["detail"] == "UNAUTHENTICATED"

--- a/web/src/app/admin/configuration/llm/utils.ts
+++ b/web/src/app/admin/configuration/llm/utils.ts
@@ -145,7 +145,7 @@ export const fetchBedrockModels = async (
       let errorMessage = "Failed to fetch models";
       try {
         const errorData = await response.json();
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
       }
@@ -199,7 +199,7 @@ export const fetchOllamaModels = async (
       let errorMessage = "Failed to fetch models";
       try {
         const errorData = await response.json();
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
       }
@@ -257,7 +257,7 @@ export const fetchOpenRouterModels = async (
       let errorMessage = "Failed to fetch models";
       try {
         const errorData = await response.json();
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
       }
@@ -313,7 +313,7 @@ export const fetchLMStudioModels = async (
       let errorMessage = "Failed to fetch models";
       try {
         const errorData = await response.json();
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
       }

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -240,7 +240,7 @@ export default function AddConnector({
       toast.success("Credential deleted successfully!");
     } else {
       const errorData = await response.json();
-      toast.error(errorData.message);
+      toast.error(errorData.detail || errorData.message);
     }
   };
 
@@ -444,7 +444,7 @@ export default function AddConnector({
 
                 if (!timeoutErrorHappenedRef.current) {
                   // Only show error if timeout didn't happen
-                  toast.error(errorData.message || errorData.detail);
+                  toast.error(errorData.detail || errorData.message);
                 }
               }
             } else if (isSuccess) {

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -368,8 +368,8 @@ function Main() {
       <ErrorCallout
         errorTitle="Error loading standard answers"
         errorMsg={
-          standardAnswersError.info?.message ||
-          standardAnswersError.message.info?.detail
+          standardAnswersError.info?.detail ||
+          standardAnswersError.info?.message
         }
       />
     );
@@ -380,8 +380,8 @@ function Main() {
       <ErrorCallout
         errorTitle="Error loading standard answer categories"
         errorMsg={
-          standardAnswerCategoriesError.info?.message ||
-          standardAnswerCategoriesError.message.info?.detail
+          standardAnswerCategoriesError.info?.detail ||
+          standardAnswerCategoriesError.info?.message
         }
       />
     );

--- a/web/src/components/modals/NewTeamModal.tsx
+++ b/web/src/components/modals/NewTeamModal.tsx
@@ -96,7 +96,9 @@ export default function NewTeamModal() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || "Failed to request invite");
+        throw new Error(
+          errorData.detail || errorData.message || "Failed to request invite"
+        );
       }
 
       setHasRequestedInvite(true);

--- a/web/src/sections/modals/NewTenantModal.tsx
+++ b/web/src/sections/modals/NewTenantModal.tsx
@@ -49,7 +49,11 @@ export default function NewTenantModal({
 
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
-          throw new Error(errorData.message || "Failed to accept invitation");
+          throw new Error(
+            errorData.detail ||
+              errorData.message ||
+              "Failed to accept invitation"
+          );
         }
 
         toast.success("You have accepted the invitation.");
@@ -93,7 +97,11 @@ export default function NewTenantModal({
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || "Failed to decline invitation");
+        throw new Error(
+          errorData.detail ||
+            errorData.message ||
+            "Failed to decline invitation"
+        );
       }
 
       toast.info("You have declined the invitation.");

--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -261,7 +261,7 @@ export function CustomModal({
                                     <ErrorMessage
                                       name={`custom_config_list[${index}][0]`}
                                       component="div"
-                                      className="text-error text-sm mt-1"
+                                      className="text-status-text-error-05 text-sm mt-1"
                                     />
                                   </div>
                                   <div className="mt-3">
@@ -276,7 +276,7 @@ export function CustomModal({
                                     <ErrorMessage
                                       name={`custom_config_list[${index}][1]`}
                                       component="div"
-                                      className="text-error text-sm mt-1"
+                                      className="text-status-text-error-05 text-sm mt-1"
                                     />
                                   </div>
                                 </div>

--- a/web/src/sections/modals/llmConfig/components/FormActionButtons.tsx
+++ b/web/src/sections/modals/llmConfig/components/FormActionButtons.tsx
@@ -41,7 +41,7 @@ export function FormActionButtons({
   return (
     <>
       {testError && (
-        <Text as="p" className="text-error mt-2">
+        <Text as="p" className="text-status-text-error-05 mt-2">
           {testError}
         </Text>
       )}


### PR DESCRIPTION
Cherry-pick of commit f71fab580c5dd598af712f699ae045044981b2d7 to release/v3.0 branch.

Original PR: #9214

- [x] [Optional] Override Linear Check
