### PR TITLE
fix(fe): preview modal fade matches code bg color

### DIFF
--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -1,7 +1,7 @@
 /* Light mode syntax highlighting (Atom One Light) */
 .hljs {
   color: #383a42 !important;
-  background: #fafafa !important;
+  background: var(--background-code-01) !important;
 }
 
 .hljs-comment,
@@ -77,7 +77,7 @@
 /* Dark mode syntax highlighting (Atom One Dark) */
 .dark .hljs {
   color: #e2e6eb !important;
-  background: #151617 !important;
+  background: var(--background-code-01) !important;
 }
 
 .dark .hljs-comment,

--- a/web/src/app/css/colors.css
+++ b/web/src/app/css/colors.css
@@ -438,6 +438,9 @@
   --action-text-link-05: var(--blue-50);
   --action-text-danger-05: var(--red-50);
 
+  /* Background / Code */
+  --background-code-01: var(--grey-02);
+
   /* Code */
   --code-code: var(--alpha-grey-100-85);
   --code-comment: var(--alpha-grey-100-35);
@@ -638,6 +641,9 @@
   /* Action / Text */
   --action-text-link-05: var(--blue-45);
   --action-text-danger-05: var(--red-45);
+
+  /* Background / Code */
+  --background-code-01: #151617;
 
   /* Code */
   --code-code: var(--alpha-grey-00-85);

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -195,7 +195,7 @@ export default function PreviewModal({
             )}
             style={{
               background:
-                "linear-gradient(to top, var(--background-tint-01) 40%, transparent)",
+                "linear-gradient(to top, var(--background-code-01) 40%, transparent)",
             }}
           >
             {/* Left slot */}


### PR DESCRIPTION
## Description

Now that all `PreviewModal` variants render a `CodeBlock`, we can use a now centrally defined `--background-code-01` to apply the correct background color fade.

## How Has This Been Tested?
**before**
<img width="1216" height="1820" alt="20260309_21h10m55s_grim" src="https://github.com/user-attachments/assets/3fbab002-2bb7-4f73-bb9b-d6e70c47c2a5" />

**after**
<img width="1216" height="1820" alt="20260309_21h10m43s_grim" src="https://github.com/user-attachments/assets/204eccd6-e25e-405b-9cce-676ad481f8e0" />

## Additional Options

- [X] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the PreviewModal’s bottom fade match the code block background for a seamless look in light and dark mode by using a shared `--background-code-01` variable.

- **Bug Fixes**
  - Added `--background-code-01` in `colors.css` for light and dark themes.
  - Updated `.hljs` backgrounds to use `var(--background-code-01)`.
  - Changed `PreviewModal` gradient to fade from `var(--background-code-01)`.

<sup>Written for commit b6c26f5a3411c43d6ce9798334798f57f78ac940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

