### PR TITLE
feat(custom-tools): enhance custom tool error handling and timeline UI (#9189) to release v3.0

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -50,6 +50,7 @@ from onyx.tools.built_in_tools import CITEABLE_TOOLS_NAMES
 from onyx.tools.built_in_tools import STOPPING_TOOLS_NAMES
 from onyx.tools.interface import Tool
 from onyx.tools.models import ChatFile
+from onyx.tools.models import CustomToolCallSummary
 from onyx.tools.models import MemoryToolResponseSnapshot
 from onyx.tools.models import PythonToolRichResponse
 from onyx.tools.models import ToolCallInfo
@@ -980,6 +981,10 @@ def run_llm_loop(
 
                 if memory_snapshot:
                     saved_response = json.dumps(memory_snapshot.model_dump())
+                elif isinstance(tool_response.rich_response, CustomToolCallSummary):
+                    saved_response = json.dumps(
+                        tool_response.rich_response.model_dump()
+                    )
                 elif isinstance(tool_response.rich_response, str):
                     saved_response = tool_response.rich_response
                 else:

--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from typing import cast
 from typing import Literal
 
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.chat.citation_utils import extract_citation_order_from_text
@@ -20,7 +22,9 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
 from onyx.server.query_and_chat.streaming_models import AgentResponseStart
 from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.server.query_and_chat.streaming_models import CustomToolArgs
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import FileReaderResult
 from onyx.server.query_and_chat.streaming_models import FileReaderStart
@@ -180,24 +184,37 @@ def create_custom_tool_packets(
     tab_index: int = 0,
     data: dict | list | str | int | float | bool | None = None,
     file_ids: list[str] | None = None,
+    error: CustomToolErrorInfo | None = None,
+    tool_args: dict[str, Any] | None = None,
+    tool_id: int | None = None,
 ) -> list[Packet]:
     packets: list[Packet] = []
 
     packets.append(
         Packet(
             placement=Placement(turn_index=turn_index, tab_index=tab_index),
-            obj=CustomToolStart(tool_name=tool_name),
+            obj=CustomToolStart(tool_name=tool_name, tool_id=tool_id),
         )
     )
+
+    if tool_args:
+        packets.append(
+            Packet(
+                placement=Placement(turn_index=turn_index, tab_index=tab_index),
+                obj=CustomToolArgs(tool_name=tool_name, tool_args=tool_args),
+            )
+        )
 
     packets.append(
         Packet(
             placement=Placement(turn_index=turn_index, tab_index=tab_index),
             obj=CustomToolDelta(
                 tool_name=tool_name,
+                tool_id=tool_id,
                 response_type=response_type,
                 data=data,
                 file_ids=file_ids,
+                error=error,
             ),
         ),
     )
@@ -657,13 +674,55 @@ def translate_assistant_message_to_packets(
 
                     else:
                         # Custom tool or unknown tool
+                        # Try to parse as structured CustomToolCallSummary JSON
+                        custom_data: dict | list | str | int | float | bool | None = (
+                            tool_call.tool_call_response
+                        )
+                        custom_error: CustomToolErrorInfo | None = None
+                        custom_response_type = "text"
+
+                        try:
+                            parsed = json.loads(tool_call.tool_call_response)
+                            if isinstance(parsed, dict) and "tool_name" in parsed:
+                                custom_data = parsed.get("tool_result")
+                                custom_response_type = parsed.get(
+                                    "response_type", "text"
+                                )
+                                if parsed.get("error"):
+                                    custom_error = CustomToolErrorInfo(
+                                        **parsed["error"]
+                                    )
+                        except (
+                            json.JSONDecodeError,
+                            KeyError,
+                            TypeError,
+                            ValidationError,
+                        ):
+                            pass
+
+                        custom_file_ids: list[str] | None = None
+                        if custom_response_type in ("image", "csv") and isinstance(
+                            custom_data, dict
+                        ):
+                            custom_file_ids = custom_data.get("file_ids")
+                            custom_data = None
+
+                        custom_args = {
+                            k: v
+                            for k, v in (tool_call.tool_call_arguments or {}).items()
+                            if k != "requestBody"
+                        }
                         turn_tool_packets.extend(
                             create_custom_tool_packets(
                                 tool_name=tool.display_name or tool.name,
-                                response_type="text",
+                                response_type=custom_response_type,
                                 turn_index=turn_num,
                                 tab_index=tool_call.tab_index,
-                                data=tool_call.tool_call_response,
+                                data=custom_data,
+                                file_ids=custom_file_ids,
+                                error=custom_error,
+                                tool_args=custom_args if custom_args else None,
+                                tool_id=tool_call.tool_id,
                             )
                         )
 

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -33,6 +33,7 @@ class StreamingType(Enum):
     PYTHON_TOOL_START = "python_tool_start"
     PYTHON_TOOL_DELTA = "python_tool_delta"
     CUSTOM_TOOL_START = "custom_tool_start"
+    CUSTOM_TOOL_ARGS = "custom_tool_args"
     CUSTOM_TOOL_DELTA = "custom_tool_delta"
     FILE_READER_START = "file_reader_start"
     FILE_READER_RESULT = "file_reader_result"
@@ -245,6 +246,20 @@ class CustomToolStart(BaseObj):
     type: Literal["custom_tool_start"] = StreamingType.CUSTOM_TOOL_START.value
 
     tool_name: str
+    tool_id: int | None = None
+
+
+class CustomToolArgs(BaseObj):
+    type: Literal["custom_tool_args"] = StreamingType.CUSTOM_TOOL_ARGS.value
+
+    tool_name: str
+    tool_args: dict[str, Any]
+
+
+class CustomToolErrorInfo(BaseModel):
+    is_auth_error: bool = False
+    status_code: int
+    message: str
 
 
 # The allowed streamed packets for a custom tool
@@ -252,11 +267,13 @@ class CustomToolDelta(BaseObj):
     type: Literal["custom_tool_delta"] = StreamingType.CUSTOM_TOOL_DELTA.value
 
     tool_name: str
+    tool_id: int | None = None
     response_type: str
     # For non-file responses
     data: dict | list | str | int | float | bool | None = None
     # For file-based responses like image/csv
     file_ids: list[str] | None = None
+    error: CustomToolErrorInfo | None = None
 
 
 ################################################
@@ -366,6 +383,7 @@ PacketObj = Union[
     PythonToolStart,
     PythonToolDelta,
     CustomToolStart,
+    CustomToolArgs,
     CustomToolDelta,
     FileReaderStart,
     FileReaderResult,

--- a/backend/onyx/server/query_and_chat/streaming_utils.py
+++ b/backend/onyx/server/query_and_chat/streaming_utils.py
@@ -8,8 +8,6 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
 from onyx.server.query_and_chat.streaming_models import AgentResponseStart
 from onyx.server.query_and_chat.streaming_models import CitationInfo
-from onyx.server.query_and_chat.streaming_models import CustomToolDelta
-from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import GeneratedImage
 from onyx.server.query_and_chat.streaming_models import ImageGenerationFinal
 from onyx.server.query_and_chat.streaming_models import ImageGenerationToolStart
@@ -157,39 +155,6 @@ def create_image_generation_packets(
         Packet(
             placement=Placement(turn_index=turn_index),
             obj=ImageGenerationFinal(images=images),
-        ),
-    )
-
-    packets.append(Packet(placement=Placement(turn_index=turn_index), obj=SectionEnd()))
-
-    return packets
-
-
-def create_custom_tool_packets(
-    tool_name: str,
-    response_type: str,
-    turn_index: int,
-    data: dict | list | str | int | float | bool | None = None,
-    file_ids: list[str] | None = None,
-) -> list[Packet]:
-    packets: list[Packet] = []
-
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index),
-            obj=CustomToolStart(tool_name=tool_name),
-        )
-    )
-
-    packets.append(
-        Packet(
-            placement=Placement(turn_index=turn_index),
-            obj=CustomToolDelta(
-                tool_name=tool_name,
-                response_type=response_type,
-                data=data,
-                file_ids=file_ids,
-            ),
         ),
     )
 

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -18,6 +18,7 @@ from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.db.memory import UserMemoryContext
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import GeneratedImage
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
 from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
@@ -61,6 +62,7 @@ class CustomToolCallSummary(BaseModel):
     tool_name: str
     response_type: str  # e.g., 'json', 'image', 'csv', 'graph'
     tool_result: Any  # The response data
+    error: CustomToolErrorInfo | None = None
 
 
 class ToolCallKickoff(BaseModel):

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -15,7 +15,9 @@ from onyx.chat.emitter import get_default_emitter
 from onyx.configs.constants import FileOrigin
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolArgs
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.interface import Tool
@@ -139,7 +141,7 @@ class CustomTool(Tool[None]):
         self.emitter.emit(
             Packet(
                 placement=placement,
-                obj=CustomToolStart(tool_name=self._name),
+                obj=CustomToolStart(tool_name=self._name, tool_id=self._id),
             )
         )
 
@@ -149,10 +151,8 @@ class CustomTool(Tool[None]):
         override_kwargs: None = None,  # noqa: ARG002
         **llm_kwargs: Any,
     ) -> ToolResponse:
-        request_body = llm_kwargs.get(REQUEST_BODY)
-
+        # Build path params
         path_params = {}
-
         for path_param_schema in self._method_spec.get_path_param_schemas():
             param_name = path_param_schema["name"]
             if param_name not in llm_kwargs:
@@ -165,6 +165,7 @@ class CustomTool(Tool[None]):
                 )
             path_params[param_name] = llm_kwargs[param_name]
 
+        # Build query params
         query_params = {}
         for query_param_schema in self._method_spec.get_query_param_schemas():
             if query_param_schema["name"] in llm_kwargs:
@@ -172,6 +173,20 @@ class CustomTool(Tool[None]):
                     query_param_schema["name"]
                 ]
 
+        # Emit args packet (path + query params only, no request body)
+        tool_args = {**path_params, **query_params}
+        if tool_args:
+            self.emitter.emit(
+                Packet(
+                    placement=placement,
+                    obj=CustomToolArgs(
+                        tool_name=self._name,
+                        tool_args=tool_args,
+                    ),
+                )
+            )
+
+        request_body = llm_kwargs.get(REQUEST_BODY)
         url = self._method_spec.build_url(self._base_url, path_params, query_params)
         method = self._method_spec.method
 
@@ -179,6 +194,18 @@ class CustomTool(Tool[None]):
             method, url, json=request_body, headers=self.headers
         )
         content_type = response.headers.get("Content-Type", "")
+
+        # Detect HTTP errors — only 401/403 are flagged as auth errors
+        error_info: CustomToolErrorInfo | None = None
+        if response.status_code in (401, 403):
+            error_info = CustomToolErrorInfo(
+                is_auth_error=True,
+                status_code=response.status_code,
+                message=f"{self._name} action failed because of authentication error",
+            )
+            logger.warning(
+                f"Auth error from custom tool '{self._name}': HTTP {response.status_code}"
+            )
 
         tool_result: Any
         response_type: str
@@ -222,9 +249,11 @@ class CustomTool(Tool[None]):
                 placement=placement,
                 obj=CustomToolDelta(
                     tool_name=self._name,
+                    tool_id=self._id,
                     response_type=response_type,
                     data=data,
                     file_ids=file_ids,
+                    error=error_info,
                 ),
             )
         )
@@ -236,6 +265,7 @@ class CustomTool(Tool[None]):
                 tool_name=self._name,
                 response_type=response_type,
                 tool_result=tool_result,
+                error=error_info,
             ),
             llm_facing_response=llm_facing_response,
         )

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -7,6 +7,8 @@ interface CodeBlockProps {
   className?: string;
   children?: ReactNode;
   codeText: string;
+  showHeader?: boolean;
+  noPadding?: boolean;
 }
 
 const MemoizedCodeLine = memo(({ content }: { content: ReactNode }) => (
@@ -17,6 +19,8 @@ export const CodeBlock = memo(function CodeBlock({
   className = "",
   children,
   codeText,
+  showHeader = true,
+  noPadding = false,
 }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
 
@@ -111,22 +115,32 @@ export const CodeBlock = memo(function CodeBlock({
   };
 
   return (
-    <div className="bg-background-tint-00 px-1 pb-1 rounded-12 max-w-full min-w-0">
-      {language && (
-        <div className="flex items-center px-2 py-1 text-sm text-text-04 gap-x-2">
-          <SvgCode
-            height={12}
-            width={12}
-            stroke="currentColor"
-            className="my-auto"
-          />
-          <Text secondaryMono>{language}</Text>
-          {codeText && <CopyButton />}
+    <>
+      {showHeader ? (
+        <div
+          className={cn(
+            "bg-background-tint-00 rounded-12 max-w-full min-w-0",
+            !noPadding && "px-1 pb-1"
+          )}
+        >
+          {language && (
+            <div className="flex items-center px-2 py-1 text-sm text-text-04 gap-x-2">
+              <SvgCode
+                height={12}
+                width={12}
+                stroke="currentColor"
+                className="my-auto"
+              />
+              <Text secondaryMono>{language}</Text>
+              {codeText && <CopyButton />}
+            </div>
+          )}
+          <CodeContent />
         </div>
+      ) : (
+        <CodeContent />
       )}
-
-      <CodeContent />
-    </div>
+    </>
   );
 });
 

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -2,9 +2,11 @@
 
 import React, { useRef, RefObject, useMemo } from "react";
 import { Packet, StopReason } from "@/app/app/services/streamingModels";
+import CustomToolAuthCard from "@/app/app/message/messageComponents/CustomToolAuthCard";
 import { FullChatState } from "@/app/app/message/messageComponents/interfaces";
 import { FeedbackType } from "@/app/app/interfaces";
 import { handleCopy } from "@/app/app/message/copyingUtils";
+import { useAuthErrors } from "@/app/app/message/messageComponents/hooks/useAuthErrors";
 import { useMessageSwitching } from "@/app/app/message/messageComponents/hooks/useMessageSwitching";
 import { RendererComponent } from "@/app/app/message/messageComponents/renderMessageComponent";
 import { usePacketProcessor } from "@/app/app/message/messageComponents/timeline/hooks/usePacketProcessor";
@@ -146,6 +148,8 @@ const AgentMessage = React.memo(function AgentMessage({
     ]
   );
 
+  const authErrors = useAuthErrors(rawPackets);
+
   // Message switching logic
   const {
     currentMessageInd,
@@ -189,7 +193,16 @@ const AgentMessage = React.memo(function AgentMessage({
         }}
       >
         {pacedDisplayGroups.length > 0 && (
-          <div ref={finalAnswerRef}>
+          <div ref={finalAnswerRef} className="flex flex-col gap-3">
+            {authErrors.map((authError, i) => (
+              <CustomToolAuthCard
+                key={`auth-error-${i}`}
+                toolName={authError.toolName}
+                toolId={authError.toolId}
+                tools={effectiveChatState.agent.tools}
+                agentId={effectiveChatState.agent.id}
+              />
+            ))}
             {pacedDisplayGroups.map((displayGroup, index) => (
               <RendererComponent
                 key={`${displayGroup.turn_index}-${displayGroup.tab_index}`}

--- a/web/src/app/app/message/messageComponents/CustomToolAuthCard.tsx
+++ b/web/src/app/app/message/messageComponents/CustomToolAuthCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useMemo } from "react";
+import Message from "@/refresh-components/messages/Message";
+import { ToolSnapshot } from "@/lib/tools/interfaces";
+import { initiateOAuthFlow } from "@/lib/oauth/api";
+import { useToolOAuthStatus } from "@/lib/hooks/useToolOAuthStatus";
+import { SvgArrowExchange } from "@opal/icons";
+
+interface CustomToolAuthCardProps {
+  toolName: string;
+  toolId: number | null;
+  tools: ToolSnapshot[];
+  agentId: number;
+}
+
+function CustomToolAuthCard({
+  toolName,
+  toolId,
+  tools,
+  agentId,
+}: CustomToolAuthCardProps) {
+  const { getToolAuthStatus } = useToolOAuthStatus(agentId);
+  const matchedTool = useMemo(() => {
+    if (toolId == null) return null;
+    return tools.find((t) => t.id === toolId) ?? null;
+  }, [toolId, tools]);
+
+  // Hide the card if the user already has a valid token
+  const authStatus = matchedTool ? getToolAuthStatus(matchedTool) : undefined;
+  if (authStatus?.hasToken && !authStatus.isTokenExpired) {
+    return null;
+  }
+
+  const oauthConfigId = matchedTool?.oauth_config_id ?? null;
+
+  // No OAuth config — nothing actionable to show
+  if (!oauthConfigId) {
+    return null;
+  }
+
+  const handleAuthenticate = () => {
+    initiateOAuthFlow(
+      oauthConfigId,
+      window.location.pathname + window.location.search
+    );
+  };
+
+  return (
+    <Message
+      static
+      large
+      icon
+      close={false}
+      text={`${toolName} not connected`}
+      description={`Connect to ${toolName} to enable this tool`}
+      actions="Connect"
+      actionPrimary
+      actionIcon={SvgArrowExchange}
+      onAction={handleAuthenticate}
+      className="w-full"
+    />
+  );
+}
+
+export default CustomToolAuthCard;

--- a/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
+++ b/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
@@ -1,0 +1,53 @@
+import { useRef } from "react";
+import {
+  CustomToolDelta,
+  Packet,
+  PacketType,
+} from "@/app/app/services/streamingModels";
+
+interface AuthError {
+  toolName: string;
+  toolId: number | null;
+}
+
+export function useAuthErrors(rawPackets: Packet[]): AuthError[] {
+  const stateRef = useRef<{ processedCount: number; errors: AuthError[] }>({
+    processedCount: 0,
+    errors: [],
+  });
+
+  // Reset if packets shrunk (e.g. new message)
+  if (rawPackets.length < stateRef.current.processedCount) {
+    stateRef.current = { processedCount: 0, errors: [] };
+  }
+
+  // Process only new packets (incremental, like usePacketProcessor)
+  if (rawPackets.length > stateRef.current.processedCount) {
+    let newErrors = stateRef.current.errors;
+    for (let i = stateRef.current.processedCount; i < rawPackets.length; i++) {
+      const packet = rawPackets[i]!;
+      if (packet.obj.type === PacketType.CUSTOM_TOOL_DELTA) {
+        const delta = packet.obj as CustomToolDelta;
+        if (delta.error?.is_auth_error) {
+          const alreadyPresent = newErrors.some(
+            (e) =>
+              (delta.tool_id != null && e.toolId === delta.tool_id) ||
+              (delta.tool_id == null && e.toolName === delta.tool_name)
+          );
+          if (!alreadyPresent) {
+            newErrors = [
+              ...newErrors,
+              { toolName: delta.tool_name, toolId: delta.tool_id ?? null },
+            ];
+          }
+        }
+      }
+    }
+    stateRef.current = {
+      processedCount: rawPackets.length,
+      errors: newErrors,
+    };
+  }
+
+  return stateRef.current.errors;
+}

--- a/web/src/app/app/message/messageComponents/interfaces.ts
+++ b/web/src/app/app/message/messageComponents/interfaces.ts
@@ -7,6 +7,7 @@ import { LlmDescriptor } from "@/lib/hooks";
 import { IconType } from "react-icons";
 import { OnyxIconType } from "@/components/icons/icons";
 import { CitationMap } from "../../interfaces";
+import { TimelineSurfaceBackground } from "@/app/app/message/messageComponents/timeline/primitives/TimelineSurface";
 
 export enum RenderType {
   HIGHLIGHT = "highlight",
@@ -51,6 +52,10 @@ export interface RendererResult {
   alwaysCollapsible?: boolean;
   /** Whether the result should be wrapped by timeline UI or rendered as-is */
   timelineLayout?: TimelineLayout;
+  /** Remove right padding for long-form content (reasoning, deep research, memory). */
+  noPaddingRight?: boolean;
+  /** Override the surface background (e.g. "error" for auth failures). */
+  surfaceBackground?: TimelineSurfaceBackground;
 }
 
 // All renderers return an array of results (even single-step renderers return a 1-element array)

--- a/web/src/app/app/message/messageComponents/renderers/CustomToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/CustomToolRenderer.tsx
@@ -1,14 +1,58 @@
 import React, { useEffect, useMemo } from "react";
-import { FiExternalLink, FiDownload, FiTool } from "react-icons/fi";
 import {
   PacketType,
   CustomToolPacket,
   CustomToolStart,
+  CustomToolArgs,
   CustomToolDelta,
+  CustomToolErrorInfo,
   SectionEnd,
 } from "../../../services/streamingModels";
 import { MessageRenderer, RenderType } from "../interfaces";
 import { buildImgUrl } from "../../../components/files/images/utils";
+import Text from "@/refresh-components/texts/Text";
+import {
+  SvgActions,
+  SvgArrowExchange,
+  SvgDownload,
+  SvgExternalLink,
+} from "@opal/icons";
+import { CodeBlock } from "@/app/app/message/CodeBlock";
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+import FadingEdgeContainer from "@/refresh-components/FadingEdgeContainer";
+
+// Lazy registration for hljs JSON language
+function ensureHljsRegistered() {
+  if (!hljs.listLanguages().includes("json")) {
+    hljs.registerLanguage("json", json);
+  }
+}
+
+// Component to render syntax-highlighted JSON
+interface HighlightedJsonCodeProps {
+  code: string;
+}
+function HighlightedJsonCode({ code }: HighlightedJsonCodeProps) {
+  const highlightedHtml = useMemo(() => {
+    ensureHljsRegistered();
+    try {
+      return hljs.highlight(code, { language: "json" }).value;
+    } catch {
+      return code
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+    }
+  }, [code]);
+
+  return (
+    <span
+      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+      className="hljs"
+    />
+  );
+}
 
 function constructCustomToolState(packets: CustomToolPacket[]) {
   const toolStart = packets.find(
@@ -23,19 +67,26 @@ function constructCustomToolState(packets: CustomToolPacket[]) {
   )?.obj as SectionEnd | null;
 
   const toolName = toolStart?.tool_name || toolDeltas[0]?.tool_name || "Tool";
+  const toolArgsPacket = packets.find(
+    (p) => p.obj.type === PacketType.CUSTOM_TOOL_ARGS
+  )?.obj as CustomToolArgs | null;
+  const toolArgs = toolArgsPacket?.tool_args ?? null;
   const latestDelta = toolDeltas[toolDeltas.length - 1] || null;
   const responseType = latestDelta?.response_type || null;
   const data = latestDelta?.data;
   const fileIds = latestDelta?.file_ids || null;
+  const error = latestDelta?.error || null;
 
   const isRunning = Boolean(toolStart && !toolEnd);
   const isComplete = Boolean(toolStart && toolEnd);
 
   return {
     toolName,
+    toolArgs,
     responseType,
     data,
     fileIds,
+    error,
     isRunning,
     isComplete,
   };
@@ -47,8 +98,16 @@ export const CustomToolRenderer: MessageRenderer<CustomToolPacket, {}> = ({
   renderType,
   children,
 }) => {
-  const { toolName, responseType, data, fileIds, isRunning, isComplete } =
-    constructCustomToolState(packets);
+  const {
+    toolName,
+    toolArgs,
+    responseType,
+    data,
+    fileIds,
+    error,
+    isRunning,
+    isComplete,
+  } = constructCustomToolState(packets);
 
   useEffect(() => {
     if (isComplete) {
@@ -58,76 +117,192 @@ export const CustomToolRenderer: MessageRenderer<CustomToolPacket, {}> = ({
 
   const status = useMemo(() => {
     if (isComplete) {
+      if (error) {
+        return error.is_auth_error
+          ? `${toolName} authentication failed (HTTP ${error.status_code})`
+          : `${toolName} failed (HTTP ${error.status_code})`;
+      }
       if (responseType === "image") return `${toolName} returned images`;
       if (responseType === "csv") return `${toolName} returned a file`;
       return `${toolName} completed`;
     }
     if (isRunning) return `${toolName} running...`;
     return null;
-  }, [toolName, responseType, isComplete, isRunning]);
+  }, [toolName, responseType, error, isComplete, isRunning]);
 
-  const icon = FiTool;
+  const icon = SvgActions;
 
-  if (renderType === RenderType.COMPACT) {
+  const toolArgsJson = useMemo(
+    () => (toolArgs ? JSON.stringify(toolArgs, null, 2) : null),
+    [toolArgs]
+  );
+  const dataJson = useMemo(
+    () =>
+      data !== undefined && data !== null && typeof data === "object"
+        ? JSON.stringify(data, null, 2)
+        : null,
+    [data]
+  );
+
+  const content = useMemo(
+    () => (
+      <div className="flex flex-col gap-3">
+        {/* Loading indicator */}
+        {isRunning &&
+          !error &&
+          !fileIds &&
+          (data === undefined || data === null) && (
+            <div className="flex items-center gap-2 text-sm text-text-03">
+              <div className="flex gap-0.5">
+                <div className="w-1 h-1 bg-current rounded-full animate-pulse"></div>
+                <div
+                  className="w-1 h-1 bg-current rounded-full animate-pulse"
+                  style={{ animationDelay: "0.1s" }}
+                ></div>
+                <div
+                  className="w-1 h-1 bg-current rounded-full animate-pulse"
+                  style={{ animationDelay: "0.2s" }}
+                ></div>
+              </div>
+              <Text text03 secondaryBody>
+                Waiting for response...
+              </Text>
+            </div>
+          )}
+
+        {/* Tool arguments */}
+        {toolArgsJson && (
+          <div>
+            <div className="flex items-center gap-1">
+              <SvgArrowExchange className="w-3 h-3 text-text-02" />
+              <Text text04 secondaryBody>
+                Request
+              </Text>
+            </div>
+            <div className="prose max-w-full">
+              <CodeBlock
+                className="font-secondary-mono"
+                codeText={toolArgsJson}
+                noPadding
+              >
+                <HighlightedJsonCode code={toolArgsJson} />
+              </CodeBlock>
+            </div>
+          </div>
+        )}
+
+        {/* Error display */}
+        {error && (
+          <div className="pl-[var(--timeline-common-text-padding)]">
+            <Text text03 mainUiMuted>
+              {error.message}
+            </Text>
+          </div>
+        )}
+
+        {/* File responses */}
+        {!error && fileIds && fileIds.length > 0 && (
+          <div className="text-sm text-text-03 flex flex-col gap-2">
+            {fileIds.map((fid, idx) => (
+              <div key={fid} className="flex items-center gap-2 flex-wrap">
+                <Text text03 secondaryBody className="whitespace-nowrap">
+                  File {idx + 1}
+                </Text>
+                <a
+                  href={buildImgUrl(fid)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-action-link-01 hover:underline whitespace-nowrap"
+                >
+                  <SvgExternalLink className="w-3 h-3" /> Open
+                </a>
+                <a
+                  href={buildImgUrl(fid)}
+                  download
+                  className="inline-flex items-center gap-1 text-xs text-action-link-01 hover:underline whitespace-nowrap"
+                >
+                  <SvgDownload className="w-3 h-3" /> Download
+                </a>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* JSON/Text responses */}
+        {!error && data !== undefined && data !== null && (
+          <div>
+            <div className="flex items-center gap-1">
+              <SvgArrowExchange className="w-3 h-3 text-text-02" />
+              <Text text04 secondaryBody>
+                Response
+              </Text>
+            </div>
+            <div className="prose max-w-full">
+              {dataJson ? (
+                <CodeBlock
+                  className="font-secondary-mono"
+                  codeText={dataJson}
+                  noPadding
+                >
+                  <HighlightedJsonCode code={dataJson} />
+                </CodeBlock>
+              ) : (
+                <CodeBlock
+                  className="font-secondary-mono"
+                  codeText={String(data)}
+                  noPadding
+                >
+                  {String(data)}
+                </CodeBlock>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    ),
+    [toolArgsJson, dataJson, data, fileIds, error, isRunning]
+  );
+
+  // Auth error: always render FULL with error surface
+  if (error?.is_auth_error) {
     return children([
       {
         icon,
-        status: status,
-        supportsCollapsible: true,
-        // Status is already shown in the step header in compact mode.
-        // Avoid duplicating the same line in the content body.
-        content: <></>,
+        status,
+        supportsCollapsible: false,
+        noPaddingRight: true,
+        surfaceBackground: "error" as const,
+        content,
       },
     ]);
   }
 
+  // FULL mode
+  if (renderType === RenderType.FULL) {
+    return children([
+      {
+        icon,
+        status,
+        supportsCollapsible: true,
+        noPaddingRight: true,
+        content,
+      },
+    ]);
+  }
+
+  // COMPACT mode: wrap in fading container
   return children([
     {
       icon,
       status,
       supportsCollapsible: true,
       content: (
-        <div className="flex flex-col gap-3">
-          {/* File responses */}
-          {fileIds && fileIds.length > 0 && (
-            <div className="text-sm text-muted-foreground flex flex-col gap-2">
-              {fileIds.map((fid, idx) => (
-                <div key={fid} className="flex items-center gap-2 flex-wrap">
-                  <span className="whitespace-nowrap">File {idx + 1}</span>
-                  <a
-                    href={buildImgUrl(fid)}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline whitespace-nowrap"
-                  >
-                    <FiExternalLink className="w-3 h-3" /> Open
-                  </a>
-                  <a
-                    href={buildImgUrl(fid)}
-                    download
-                    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline whitespace-nowrap"
-                  >
-                    <FiDownload className="w-3 h-3" /> Download
-                  </a>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* JSON/Text responses */}
-          {data !== undefined && data !== null && (
-            <div className="text-xs bg-gray-50 dark:bg-gray-800 p-3 rounded border max-h-96 overflow-y-auto font-mono whitespace-pre-wrap break-all">
-              {typeof data === "string" ? data : JSON.stringify(data, null, 2)}
-            </div>
-          )}
-
-          {/* Show placeholder if no response data yet */}
-          {!fileIds && (data === undefined || data === null) && isRunning && (
-            <div className="text-xs text-gray-500 italic">
-              Waiting for response...
-            </div>
-          )}
-        </div>
+        <FadingEdgeContainer
+          direction="bottom"
+          className="max-h-24 overflow-hidden"
+        >
+          {content}
+        </FadingEdgeContainer>
       ),
     },
   ]);

--- a/web/src/app/app/message/messageComponents/timeline/ExpandedTimelineContent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/ExpandedTimelineContent.tsx
@@ -17,9 +17,6 @@ import { TimelineStepComposer } from "./TimelineStepComposer";
 import {
   isSearchToolPackets,
   isPythonToolPackets,
-  isReasoningPackets,
-  isDeepResearchPlanPackets,
-  isMemoryToolPackets,
 } from "@/app/app/message/messageComponents/timeline/packetHelpers";
 
 // =============================================================================
@@ -51,24 +48,10 @@ const TimelineStep = React.memo(function TimelineStep({
     () => isSearchToolPackets(step.packets),
     [step.packets]
   );
-  const isReasoning = useMemo(
-    () => isReasoningPackets(step.packets),
-    [step.packets]
-  );
   const isPythonTool = useMemo(
     () => isPythonToolPackets(step.packets),
     [step.packets]
   );
-  const isDeepResearchPlan = useMemo(
-    () => isDeepResearchPlanPackets(step.packets),
-    [step.packets]
-  );
-
-  const isMemoryTool = useMemo(
-    () => isMemoryToolPackets(step.packets),
-    [step.packets]
-  );
-
   const getCollapsedIcon = useCallback(
     (result: TimelineRendererResult) =>
       isSearchTool ? (result.icon as FunctionComponent<IconProps>) : undefined,
@@ -83,19 +66,10 @@ const TimelineStep = React.memo(function TimelineStep({
         isFirstStep={isFirstStep}
         isSingleStep={isSingleStep}
         collapsible={true}
-        noPaddingRight={isReasoning || isDeepResearchPlan || isMemoryTool}
         getCollapsedIcon={getCollapsedIcon}
       />
     ),
-    [
-      isFirstStep,
-      isLastStep,
-      isSingleStep,
-      isReasoning,
-      isDeepResearchPlan,
-      isMemoryTool,
-      getCollapsedIcon,
-    ]
+    [isFirstStep, isLastStep, isSingleStep, getCollapsedIcon]
   );
 
   return (

--- a/web/src/app/app/message/messageComponents/timeline/ParallelTimelineTabs.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/ParallelTimelineTabs.tsx
@@ -14,11 +14,6 @@ import {
   TimelineRendererComponent,
   TimelineRendererOutput,
 } from "./TimelineRendererComponent";
-import {
-  isReasoningPackets,
-  isDeepResearchPlanPackets,
-  isMemoryToolPackets,
-} from "./packetHelpers";
 import Tabs from "@/refresh-components/Tabs";
 import { SvgBranch, SvgFold, SvgExpand } from "@opal/icons";
 import { Button } from "@opal/components";
@@ -65,13 +60,6 @@ export function ParallelTimelineTabs({
     [turnGroup.steps, activeTab]
   );
 
-  // Determine if the active step needs full-width content (no right padding)
-  const noPaddingRight = activeStep
-    ? isReasoningPackets(activeStep.packets) ||
-      isDeepResearchPlanPackets(activeStep.packets) ||
-      isMemoryToolPackets(activeStep.packets)
-    : false;
-
   // Memoized loading states for each step
   const loadingStates = useMemo(
     () =>
@@ -94,10 +82,9 @@ export function ParallelTimelineTabs({
         isFirstStep={false}
         isSingleStep={false}
         collapsible={true}
-        noPaddingRight={noPaddingRight}
       />
     ),
-    [isLastTurnGroup, noPaddingRight]
+    [isLastTurnGroup]
   );
 
   const hasActivePackets = Boolean(activeStep && activeStep.packets.length > 0);

--- a/web/src/app/app/message/messageComponents/timeline/StepContainer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/StepContainer.tsx
@@ -2,7 +2,10 @@ import React, { FunctionComponent } from "react";
 import { cn } from "@/lib/utils";
 import { IconProps } from "@opal/types";
 import { TimelineRow } from "@/app/app/message/messageComponents/timeline/primitives/TimelineRow";
-import { TimelineSurface } from "@/app/app/message/messageComponents/timeline/primitives/TimelineSurface";
+import {
+  TimelineSurface,
+  TimelineSurfaceBackground,
+} from "@/app/app/message/messageComponents/timeline/primitives/TimelineSurface";
 import { TimelineStepContent } from "@/app/app/message/messageComponents/timeline/primitives/TimelineStepContent";
 
 export interface StepContainerProps {
@@ -36,6 +39,8 @@ export interface StepContainerProps {
   noPaddingRight?: boolean;
   /** Render without rail (for nested/parallel content) */
   withRail?: boolean;
+  /** Override the surface background variant */
+  surfaceBackground?: TimelineSurfaceBackground;
 }
 
 /** Visual wrapper for timeline steps - icon, connector line, header, and content */
@@ -55,6 +60,7 @@ export function StepContainer({
   collapsedIcon: CollapsedIconComponent,
   noPaddingRight = false,
   withRail = true,
+  surfaceBackground,
 }: StepContainerProps) {
   const iconNode = StepIconComponent ? (
     <StepIconComponent
@@ -70,6 +76,7 @@ export function StepContainer({
       className="flex-1 flex flex-col"
       isHover={isHover}
       roundedBottom={isLastStep}
+      background={surfaceBackground}
     >
       <TimelineStepContent
         header={header}
@@ -81,6 +88,7 @@ export function StepContainer({
         hideHeader={hideHeader}
         collapsedIcon={CollapsedIconComponent}
         noPaddingRight={noPaddingRight}
+        surfaceBackground={surfaceBackground}
       >
         {children}
       </TimelineStepContent>

--- a/web/src/app/app/message/messageComponents/timeline/TimelineStepComposer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/TimelineStepComposer.tsx
@@ -17,8 +17,6 @@ export interface TimelineStepComposerProps {
   isSingleStep?: boolean;
   /** Whether StepContainer should show collapse controls. */
   collapsible?: boolean;
-  /** Remove right padding for long-form content (reasoning, deep research). */
-  noPaddingRight?: boolean;
   /** Optional resolver for custom collapsed icon per result. */
   getCollapsedIcon?: (
     result: TimelineRendererResult
@@ -35,7 +33,6 @@ export function TimelineStepComposer({
   isFirstStep,
   isSingleStep = false,
   collapsible = true,
-  noPaddingRight = false,
   getCollapsedIcon,
 }: TimelineStepComposerProps) {
   return (
@@ -64,8 +61,9 @@ export function TimelineStepComposer({
             collapsedIcon={
               getCollapsedIcon ? getCollapsedIcon(result) : undefined
             }
-            noPaddingRight={noPaddingRight}
+            noPaddingRight={result.noPaddingRight ?? false}
             isHover={result.isHover}
+            surfaceBackground={result.surfaceBackground}
           >
             {result.content}
           </StepContainer>

--- a/web/src/app/app/message/messageComponents/timeline/primitives/TimelineStepContent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/primitives/TimelineStepContent.tsx
@@ -1,9 +1,10 @@
 import React, { FunctionComponent } from "react";
 import { cn } from "@/lib/utils";
-import { SvgFold, SvgExpand } from "@opal/icons";
+import { SvgFold, SvgExpand, SvgXOctagon } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import { Button } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
+import { TimelineSurfaceBackground } from "@/app/app/message/messageComponents/timeline/primitives/TimelineSurface";
 
 export interface TimelineStepContentProps {
   children?: React.ReactNode;
@@ -16,6 +17,7 @@ export interface TimelineStepContentProps {
   hideHeader?: boolean;
   collapsedIcon?: FunctionComponent<IconProps>;
   noPaddingRight?: boolean;
+  surfaceBackground?: TimelineSurfaceBackground;
 }
 
 /**
@@ -33,6 +35,7 @@ export function TimelineStepContent({
   hideHeader = false,
   collapsedIcon: CollapsedIconComponent,
   noPaddingRight = false,
+  surfaceBackground,
 }: TimelineStepContentProps) {
   const showCollapseControls = collapsible && supportsCollapsible && onToggle;
 
@@ -47,8 +50,8 @@ export function TimelineStepContent({
           </div>
 
           <div className="h-full w-[var(--timeline-step-header-right-section-width)] flex items-center justify-end">
-            {showCollapseControls &&
-              (buttonTitle ? (
+            {showCollapseControls ? (
+              buttonTitle ? (
                 <Button
                   prominence="tertiary"
                   size="md"
@@ -68,7 +71,12 @@ export function TimelineStepContent({
                     isExpanded ? SvgFold : CollapsedIconComponent || SvgExpand
                   }
                 />
-              ))}
+              )
+            ) : surfaceBackground === "error" ? (
+              <div className="p-1.5">
+                <SvgXOctagon className="h-4 w-4 text-status-error-05" />
+              </div>
+            ) : null}
           </div>
         </div>
       )}

--- a/web/src/app/app/message/messageComponents/timeline/primitives/TimelineSurface.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/primitives/TimelineSurface.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 
-export type TimelineSurfaceBackground = "tint" | "transparent";
+export type TimelineSurfaceBackground = "tint" | "transparent" | "error";
 
 export interface TimelineSurfaceProps {
   children: React.ReactNode;
@@ -28,9 +28,16 @@ export function TimelineSurface({
     return null;
   }
 
-  const baseBackground = background === "tint" ? "bg-background-tint-00" : "";
+  const baseBackground =
+    background === "tint"
+      ? "bg-background-tint-00"
+      : background === "error"
+        ? "bg-status-error-00"
+        : "";
   const hoverBackground =
-    background === "tint" && isHover ? "bg-background-tint-02" : "";
+    (background === "tint" || background === "error") && isHover
+      ? "bg-background-tint-02"
+      : "";
 
   return (
     <div

--- a/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/DeepResearchPlanRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/DeepResearchPlanRenderer.tsx
@@ -69,6 +69,7 @@ export const DeepResearchPlanRenderer: MessageRenderer<
       icon: SvgCircle,
       status: statusText,
       content: planContent,
+      noPaddingRight: true,
     },
   ]);
 };

--- a/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
@@ -27,7 +27,6 @@ import {
   useMarkdownComponents,
   renderMarkdown,
 } from "@/app/app/message/messageComponents/markdownUtils";
-import { isReasoningPackets } from "../../packetHelpers";
 
 interface NestedToolGroup {
   sub_turn_index: number;
@@ -317,8 +316,6 @@ export const ResearchAgentRenderer: MessageRenderer<
             !fullReportContent &&
             !isComplete;
 
-          const isReasoning = isReasoningPackets(group.packets);
-
           return (
             <TimelineRendererComponent
               key={group.sub_turn_index}
@@ -337,7 +334,6 @@ export const ResearchAgentRenderer: MessageRenderer<
                   isFirstStep={!researchTask && index === 0}
                   isSingleStep={false}
                   collapsible={true}
-                  noPaddingRight={isReasoning}
                 />
               )}
             </TimelineRendererComponent>

--- a/web/src/app/app/message/messageComponents/timeline/renderers/memory/MemoryToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/memory/MemoryToolRenderer.tsx
@@ -50,6 +50,7 @@ export const MemoryToolRenderer: MessageRenderer<MemoryToolPacket, {}> = ({
         content: <div />,
         supportsCollapsible: false,
         timelineLayout: "timeline",
+        noPaddingRight: true,
       },
     ]);
   }
@@ -87,6 +88,7 @@ export const MemoryToolRenderer: MessageRenderer<MemoryToolPacket, {}> = ({
         status: "Memory",
         supportsCollapsible: false,
         timelineLayout: "timeline",
+        noPaddingRight: true,
         content,
       },
     ]);
@@ -156,6 +158,7 @@ export const MemoryToolRenderer: MessageRenderer<MemoryToolPacket, {}> = ({
       status: statusLabel,
       supportsCollapsible: false,
       timelineLayout: "timeline",
+      noPaddingRight: true,
       content: memoryContent,
     },
   ]);

--- a/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
@@ -170,7 +170,12 @@ export const ReasoningRenderer: MessageRenderer<
 
   if (!hasStart && !hasEnd && content.length === 0) {
     return children([
-      { icon: SvgCircle, status: THINKING_STATUS, content: <></> },
+      {
+        icon: SvgCircle,
+        status: THINKING_STATUS,
+        content: <></>,
+        noPaddingRight: true,
+      },
     ]);
   }
 
@@ -192,6 +197,7 @@ export const ReasoningRenderer: MessageRenderer<
       status: displayStatus,
       content: reasoningContent,
       expandedText: reasoningContent,
+      noPaddingRight: true,
     },
   ]);
 };

--- a/web/src/app/app/services/packetUtils.ts
+++ b/web/src/app/app/services/packetUtils.ts
@@ -17,6 +17,7 @@ export function isToolPacket(
     PacketType.PYTHON_TOOL_START,
     PacketType.PYTHON_TOOL_DELTA,
     PacketType.CUSTOM_TOOL_START,
+    PacketType.CUSTOM_TOOL_ARGS,
     PacketType.CUSTOM_TOOL_DELTA,
     PacketType.FILE_READER_START,
     PacketType.FILE_READER_RESULT,

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -29,6 +29,7 @@ export enum PacketType {
 
   // Custom tool packets
   CUSTOM_TOOL_START = "custom_tool_start",
+  CUSTOM_TOOL_ARGS = "custom_tool_args",
   CUSTOM_TOOL_DELTA = "custom_tool_delta",
 
   // File reader tool packets
@@ -164,17 +165,32 @@ export interface FetchToolDocuments extends BaseObj {
 }
 
 // Custom Tool Packets
+export interface CustomToolErrorInfo {
+  is_auth_error: boolean;
+  status_code: number;
+  message: string;
+}
+
 export interface CustomToolStart extends BaseObj {
   type: "custom_tool_start";
   tool_name: string;
+  tool_id?: number | null;
+}
+
+export interface CustomToolArgs extends BaseObj {
+  type: "custom_tool_args";
+  tool_name: string;
+  tool_args: Record<string, any>;
 }
 
 export interface CustomToolDelta extends BaseObj {
   type: "custom_tool_delta";
   tool_name: string;
+  tool_id?: number | null;
   response_type: string;
   data?: any;
   file_ids?: string[] | null;
+  error?: CustomToolErrorInfo | null;
 }
 
 // File Reader Packets
@@ -304,6 +320,7 @@ export type FetchToolObj =
   | PacketError;
 export type CustomToolObj =
   | CustomToolStart
+  | CustomToolArgs
   | CustomToolDelta
   | SectionEnd
   | PacketError;

--- a/web/src/components/oauth/OAuthCallbackPage.tsx
+++ b/web/src/components/oauth/OAuthCallbackPage.tsx
@@ -162,12 +162,19 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
 
         setServiceName(result.serviceName || "");
         // Respect backend-provided redirect path (from state.return_path)
-        setRedirectPath(
+        // Sanitize to prevent open redirects (e.g. "//evil.com")
+        const rawPath =
           responseData.redirect_url ||
-            searchParams?.get("return_path") ||
-            config.defaultRedirectPath ||
-            "/app"
-        );
+          searchParams?.get("return_path") ||
+          config.defaultRedirectPath ||
+          "/app";
+        const sanitizedPath =
+          rawPath.startsWith("http://") || rawPath.startsWith("https://")
+            ? "/app"
+            : "/" + rawPath.replace(/^\/+/, "");
+        const redirectUrl = new URL(sanitizedPath, window.location.origin);
+        redirectUrl.searchParams.set("message", "oauth_connected");
+        setRedirectPath(redirectUrl.pathname + redirectUrl.search);
         setStatusMessage(config.successMessage || "Success!");
 
         const successDetails = config.successDetailsTemplate

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -1,6 +1,4 @@
 import { useEffect, useSyncExternalStore } from "react";
-import { useRouter } from "next/navigation";
-import type { Route } from "next";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -174,15 +172,21 @@ interface ToastFromQueryMessages {
  * and strips the param from the URL.
  */
 export function useToastFromQuery(messages: ToastFromQueryMessages) {
-  const router = useRouter();
-
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
     const messageValue = searchParams?.get("message");
 
     if (messageValue && messageValue in messages) {
+      searchParams.delete("message");
+      const newSearch = searchParams.toString()
+        ? "?" + searchParams.toString()
+        : "";
+      window.history.replaceState(
+        null,
+        "",
+        window.location.pathname + newSearch
+      );
       const spec = messages[messageValue];
-      router.replace(window.location.pathname as Route);
       if (spec !== undefined) {
         toast({
           message: spec.message,

--- a/web/src/refresh-components/messages/Message.tsx
+++ b/web/src/refresh-components/messages/Message.tsx
@@ -3,8 +3,7 @@
 import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import Text from "@/refresh-components/texts/Text";
-import IconButton from "@/refresh-components/buttons/IconButton";
-import Button from "@/refresh-components/buttons/Button";
+import { Button } from "@opal/components";
 import {
   SvgAlertCircle,
   SvgAlertTriangle,
@@ -224,6 +223,10 @@ export interface MessageProps extends React.HTMLAttributes<HTMLDivElement> {
   actions?: boolean | string;
   close?: boolean;
 
+  // Action button customization:
+  actionIcon?: IconFunctionComponent;
+  actionPrimary?: boolean;
+
   // Callbacks:
   onClose?: () => void;
   onAction?: () => void;
@@ -250,6 +253,9 @@ function MessageInner(
     iconComponent,
     actions,
     close = true,
+
+    actionIcon,
+    actionPrimary,
 
     onClose,
     onAction,
@@ -337,11 +343,11 @@ function MessageInner(
       {/* Actions */}
       {actions && (
         <div className="flex items-center justify-end shrink-0 self-center pr-2">
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
           <Button
-            secondary
+            prominence={actionPrimary ? "primary" : "secondary"}
+            icon={actionIcon}
             onClick={onAction}
-            className={size === "large" ? "p-2" : "p-1"}
+            size={size === "large" ? "lg" : "md"}
           >
             {typeof actions === "string" ? actions : "Cancel"}
           </Button>
@@ -352,13 +358,12 @@ function MessageInner(
       {close && (
         <div className="flex items-center justify-center shrink-0">
           <div className={cn("flex items-start", closeButtonSize)}>
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <IconButton
-              internal
+            <Button
+              prominence="internal"
               icon={SvgX}
               onClick={onClose}
               aria-label="Close"
-              className={size === "large" ? "p-2 rounded-12" : "p-1 rounded-08"}
+              size={size === "large" ? "lg" : "sm"}
             />
           </div>
         </div>

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -6,7 +6,7 @@ import {
   getAvailableContextTokens,
 } from "@/app/app/services/lib";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "@/hooks/useToast";
+import { toast, useToastFromQuery } from "@/hooks/useToast";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { useFederatedConnectors, useFilters, useLlmManager } from "@/lib/hooks";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
@@ -129,6 +129,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const router = useRouter();
   const appFocus = useAppFocus();
+
+  useToastFromQuery({
+    oauth_connected: {
+      message: "Authentication successful",
+      type: "success",
+    },
+  });
   const { setAppMode } = useAppMode();
   const searchParams = useSearchParams();
 


### PR DESCRIPTION
Cherry-pick of commit 5cdeb8416489ebe0c712cfb463a38c5a09dff88c to release/v3.0 branch.

Original PR: #9189

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved custom tool runs with structured streaming and a clearer timeline: shows request/response details, surfaces auth errors with an inline “Connect” prompt, and better renders JSON and files. Also hardens OAuth callback redirects and adds a success toast after connecting.

- **New Features**
  - Backend: emit `custom_tool_args` packets; add `tool_id` and `error` (incl. `is_auth_error`) to `custom_tool_delta`; persist `CustomToolCallSummary` and parse structured tool results (text/image/csv + errors).
  - Custom tool runner: flags 401/403 as auth errors and streams them; includes `tool_id` in start/delta packets.
  - Frontend: timeline shows request and response blocks with JSON highlighting, file open/download links, and an auth card to connect tools on failure; supports error surfaces and no-right-padding for long content.
  - OAuth: sanitize redirect URLs on callback and trigger a “Authentication successful” toast via query param.

- **Migration**
  - Streaming clients must handle `custom_tool_args` and the new `error` and `tool_id` fields in `custom_tool_delta`.
  - `CustomToolCallSummary` may now include an `error`; handle when present.
  - Timeline renderers can optionally use `noPaddingRight` and `surfaceBackground="error"` when adapting custom UIs.

<sup>Written for commit 876d237cca2dc2b6445e17944e65b9c6bd63d8f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

