### PR TITLE
chore(release): run playwright on release pushes

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -12,6 +12,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+    # TODO: Remove this if we enable merge-queues for release branches.
+    branches:
+      - "release/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Runs playwright on release postsubmits. This enables visual regression reports with the release branch as the baseline.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Playwright tests on release branch pushes (in addition to version tags) so visual regression reports use the release branch as the baseline.

<sup>Written for commit 0a678765e8690b6f5c4cb7fa39e0cd7c1057d074. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

