### PR TITLE
chore(tests): fix nightly model-server tests

### DIFF
--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -3,7 +3,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from httpx_oauth.clients.google import GoogleOAuth2
-from starlette.types import Lifespan
 
 from ee.onyx.server.analytics.api import router as analytics_router
 from ee.onyx.server.auth_check import check_ee_router_auth
@@ -78,14 +77,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         yield
 
 
-def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
+def get_application() -> FastAPI:
     # Anything that happens at import time is not guaranteed to be running ee-version
     # Anything after the server startup will be running ee version
     global_version.set_ee()
 
     test_encryption()
 
-    application = get_application_base(lifespan_override=lifespan_override or lifespan)
+    application = get_application_base(lifespan_override=lifespan)
 
     if MULTI_TENANT:
         add_api_server_tenant_id_middleware(application, logger)

--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 from onyx.auth.users import current_admin_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import UserRole
-from onyx.main import fetch_versioned_implementation
+from onyx.main import get_application
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -51,11 +51,8 @@ def client() -> Generator[TestClient, None, None]:
     # Patch out prometheus metrics setup to avoid "Duplicated timeseries in
     # CollectorRegistry" errors when multiple tests each create a new app
     # (prometheus registers metrics globally and rejects duplicate names).
-    get_app = fetch_versioned_implementation(
-        module="onyx.main", attribute="get_application"
-    )
     with patch("onyx.main.setup_prometheus_metrics"):
-        app: FastAPI = get_app(lifespan_override=test_lifespan)
+        app: FastAPI = get_application(lifespan_override=test_lifespan)
 
     # Override the database session dependency with a mock
     # (these tests don't actually need DB access)


### PR DESCRIPTION
## Description

Fixes https://onyx-company.slack.com/archives/C07K8KBMGKF/p1773159789930279

## How Has This Been Tested?

Captured by existing?

https://github.com/onyx-dot-app/onyx/actions/runs/22915415140

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `get_application` to accept an optional `lifespan_override` so tests can bypass EE startup tasks. Simplified nightly model-server tests by importing `get_application` directly (replacing `fetch_versioned_implementation`) and passing the no-op lifespan for stability.

<sup>Written for commit 3a74624d2de4aee0d0f8210a9879be1d1099d7d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



