### PR TITLE
chore(release): run playwright on release pushes (#9233) to release v3.0

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -12,6 +12,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+    # TODO: Remove this if we enable merge-queues for release branches.
+    branches:
+      - "release/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Cherry-pick of commit e56fa57c21a8b5d7cfa3be070e13803fee88e602 to release/v3.0 branch.

Original PR: #9233

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Playwright tests on pushes to `release/**` branches for v3.0, not just on tags. This catches regressions before tagging and can be removed once merge queues are enabled.

<sup>Written for commit 6969e5d369cc976541ffcc43b85e81940d90ae5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

