### PR TITLE
fix(opensearch): Allow configuring the page size of chunks we get from Vespa during migration

### DIFF
--- a/backend/onyx/background/celery/tasks/opensearch_migration/constants.py
+++ b/backend/onyx/background/celery/tasks/opensearch_migration/constants.py
@@ -11,6 +11,9 @@
 # lock after its cleanup which happens at most after its soft timeout.
 
 # Constants corresponding to migrate_documents_from_vespa_to_opensearch_task.
+from onyx.configs.app_configs import OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE
+
+
 MIGRATION_TASK_SOFT_TIME_LIMIT_S = 60 * 5  # 5 minutes.
 MIGRATION_TASK_TIME_LIMIT_S = 60 * 6  # 6 minutes.
 # The maximum time the lock can be held for. Will automatically be released
@@ -44,7 +47,7 @@ TOTAL_ALLOWABLE_DOC_MIGRATION_ATTEMPTS_BEFORE_PERMANENT_FAILURE = 15
 
 # WARNING: Do not change these values without knowing what changes also need to
 # be made to OpenSearchTenantMigrationRecord.
-GET_VESPA_CHUNKS_PAGE_SIZE = 500
+GET_VESPA_CHUNKS_PAGE_SIZE = OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE
 GET_VESPA_CHUNKS_SLICE_COUNT = 4
 
 # String used to indicate in the vespa_visit_continuation_token mapping that the

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -311,6 +311,9 @@ VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT = (
     os.environ.get("VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT", "true").lower()
     == "true"
 )
+OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE = int(
+    os.environ.get("OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE") or 500
+)
 
 VESPA_HOST = os.environ.get("VESPA_HOST") or "localhost"
 # NOTE: this is used if and only if the vespa config server is accessible via a

--- a/backend/tests/external_dependency_unit/opensearch_migration/test_opensearch_migration_tasks.py
+++ b/backend/tests/external_dependency_unit/opensearch_migration/test_opensearch_migration_tasks.py
@@ -17,6 +17,9 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.background.celery.tasks.opensearch_migration.constants import (
+    GET_VESPA_CHUNKS_SLICE_COUNT,
+)
 from onyx.background.celery.tasks.opensearch_migration.tasks import (
     is_continuation_token_done_for_all_slices,
 )
@@ -320,9 +323,15 @@ def test_embedding_dimension(db_session: Session) -> Generator[int, None, None]:
 @pytest.fixture(scope="function")
 def patch_get_vespa_chunks_page_size() -> Generator[int, None, None]:
     test_page_size = 5
-    with patch(
-        "onyx.background.celery.tasks.opensearch_migration.tasks.GET_VESPA_CHUNKS_PAGE_SIZE",
-        test_page_size,
+    with (
+        patch(
+            "onyx.background.celery.tasks.opensearch_migration.tasks.GET_VESPA_CHUNKS_PAGE_SIZE",
+            test_page_size,
+        ),
+        patch(
+            "onyx.background.celery.tasks.opensearch_migration.constants.GET_VESPA_CHUNKS_PAGE_SIZE",
+            test_page_size,
+        ),
     ):
         yield test_page_size  # Test runs here.
 
@@ -560,6 +569,175 @@ class TestMigrateChunksFromVespaToOpenSearchTask:
         tenant_record = db_session.query(OpenSearchTenantMigrationRecord).first()
         assert tenant_record is not None
         assert tenant_record.total_chunks_migrated > partial_chunks_migrated
+        assert tenant_record.total_chunks_migrated == len(all_chunks)
+        # Visit is complete so continuation token should be None.
+        assert tenant_record.vespa_visit_continuation_token is not None
+        assert is_continuation_token_done_for_all_slices(
+            json.loads(tenant_record.vespa_visit_continuation_token)
+        )
+        assert tenant_record.migration_completed_at is not None
+        assert tenant_record.approx_chunk_count_in_vespa == len(all_chunks)
+
+        # Verify chunks were indexed in OpenSearch.
+        for document in test_documents:
+            opensearch_chunks = _get_document_chunks_from_opensearch(
+                opensearch_client, document.id, get_current_tenant_id()
+            )
+            assert len(opensearch_chunks) == CHUNK_COUNT
+            opensearch_chunks.sort(key=lambda x: x.chunk_index)
+            for opensearch_chunk in opensearch_chunks:
+                _assert_chunk_matches_vespa_chunk(
+                    opensearch_chunk,
+                    document_chunks[document.id][opensearch_chunk.chunk_index],
+                )
+
+    def test_chunk_migration_visits_all_chunks_even_when_batch_size_varies(
+        self,
+        db_session: Session,
+        test_documents: list[Document],
+        vespa_document_index: VespaDocumentIndex,
+        opensearch_client: OpenSearchIndexClient,
+        test_embedding_dimension: int,
+        clean_migration_tables: None,  # noqa: ARG002
+        enable_opensearch_indexing_for_onyx: None,  # noqa: ARG002
+    ) -> None:
+        """
+        Tests that chunk migration works correctly even when the batch size
+        changes halfway through a migration.
+
+        Simulates task time running out my mocking the locking behavior.
+        """
+        # Precondition.
+        # Index chunks into Vespa.
+        document_chunks: dict[str, list[dict[str, Any]]] = {
+            document.id: [
+                _create_raw_document_chunk(
+                    document_id=document.id,
+                    chunk_index=i,
+                    content=f"Test content {i} for {document.id}",
+                    embedding=_generate_test_vector(test_embedding_dimension),
+                    now=datetime.now(),
+                    title=f"Test title {document.id}",
+                    title_embedding=_generate_test_vector(test_embedding_dimension),
+                )
+                for i in range(CHUNK_COUNT)
+            ]
+            for document in test_documents
+        }
+        all_chunks: list[dict[str, Any]] = []
+        for chunks in document_chunks.values():
+            all_chunks.extend(chunks)
+        vespa_document_index.index_raw_chunks(all_chunks)
+
+        # Run the initial batch. To simulate partial progress we will mock the
+        # redis lock to return True for the first invocation of .owned() and
+        # False subsequently.
+        # NOTE: The batch size is currently set to 5 in
+        # patch_get_vespa_chunks_page_size.
+        mock_redis_client = Mock()
+        mock_lock = Mock()
+        mock_lock.owned.side_effect = [True, False, False]
+        mock_lock.acquire.return_value = True
+        mock_redis_client.lock.return_value = mock_lock
+        with patch(
+            "onyx.background.celery.tasks.opensearch_migration.tasks.get_redis_client",
+            return_value=mock_redis_client,
+        ):
+            result_1 = migrate_chunks_from_vespa_to_opensearch_task(
+                tenant_id=get_current_tenant_id()
+            )
+
+        assert result_1 is True
+        # Expire the session cache to see the committed changes from the task.
+        db_session.expire_all()
+
+        # Verify partial progress was saved.
+        tenant_record = db_session.query(OpenSearchTenantMigrationRecord).first()
+        assert tenant_record is not None
+        partial_chunks_migrated = tenant_record.total_chunks_migrated
+        assert partial_chunks_migrated > 0
+        # page_size applies per slice, so one iteration can fetch up to
+        # page_size * GET_VESPA_CHUNKS_SLICE_COUNT chunks total.
+        assert partial_chunks_migrated <= 5 * GET_VESPA_CHUNKS_SLICE_COUNT
+        assert tenant_record.vespa_visit_continuation_token is not None
+        # Slices are not necessarily evenly distributed across all document
+        # chunks so we can't test that every token is non-None, but certainly at
+        # least one must be.
+        assert any(json.loads(tenant_record.vespa_visit_continuation_token).values())
+        assert tenant_record.migration_completed_at is None
+        assert tenant_record.approx_chunk_count_in_vespa is not None
+
+        # Under test.
+        # Now patch the batch size to be some other number, like 2.
+        mock_redis_client = Mock()
+        mock_lock = Mock()
+        mock_lock.owned.side_effect = [True, False, False]
+        mock_lock.acquire.return_value = True
+        mock_redis_client.lock.return_value = mock_lock
+        with (
+            patch(
+                "onyx.background.celery.tasks.opensearch_migration.tasks.GET_VESPA_CHUNKS_PAGE_SIZE",
+                2,
+            ),
+            patch(
+                "onyx.background.celery.tasks.opensearch_migration.constants.GET_VESPA_CHUNKS_PAGE_SIZE",
+                2,
+            ),
+            patch(
+                "onyx.background.celery.tasks.opensearch_migration.tasks.get_redis_client",
+                return_value=mock_redis_client,
+            ),
+        ):
+            result_2 = migrate_chunks_from_vespa_to_opensearch_task(
+                tenant_id=get_current_tenant_id()
+            )
+
+        # Postcondition.
+        assert result_2 is True
+        # Expire the session cache to see the committed changes from the task.
+        db_session.expire_all()
+
+        # Verify next partial progress was saved.
+        tenant_record = db_session.query(OpenSearchTenantMigrationRecord).first()
+        assert tenant_record is not None
+        new_partial_chunks_migrated = tenant_record.total_chunks_migrated
+        assert new_partial_chunks_migrated > partial_chunks_migrated
+        # page_size applies per slice, so one iteration can fetch up to
+        # page_size * GET_VESPA_CHUNKS_SLICE_COUNT chunks total.
+        assert new_partial_chunks_migrated <= (5 + 2) * GET_VESPA_CHUNKS_SLICE_COUNT
+        assert tenant_record.vespa_visit_continuation_token is not None
+        # Slices are not necessarily evenly distributed across all document
+        # chunks so we can't test that every token is non-None, but certainly at
+        # least one must be.
+        assert any(json.loads(tenant_record.vespa_visit_continuation_token).values())
+        assert tenant_record.migration_completed_at is None
+        assert tenant_record.approx_chunk_count_in_vespa is not None
+
+        # Under test.
+        # Run the remainder of the migration.
+        with (
+            patch(
+                "onyx.background.celery.tasks.opensearch_migration.tasks.GET_VESPA_CHUNKS_PAGE_SIZE",
+                2,
+            ),
+            patch(
+                "onyx.background.celery.tasks.opensearch_migration.constants.GET_VESPA_CHUNKS_PAGE_SIZE",
+                2,
+            ),
+        ):
+            result_3 = migrate_chunks_from_vespa_to_opensearch_task(
+                tenant_id=get_current_tenant_id()
+            )
+
+        # Postcondition.
+        assert result_3 is True
+        # Expire the session cache to see the committed changes from the task.
+        db_session.expire_all()
+
+        # Verify completion.
+        tenant_record = db_session.query(OpenSearchTenantMigrationRecord).first()
+        assert tenant_record is not None
+        assert tenant_record.total_chunks_migrated > new_partial_chunks_migrated
         assert tenant_record.total_chunks_migrated == len(all_chunks)
         # Visit is complete so continuation token should be None.
         assert tenant_record.vespa_visit_continuation_token is not None


### PR DESCRIPTION
## Description
Previously the page size of chunks we get from Vespa during migration was just hard-coded to 500. This number seems fine for all deployment types except for mt cloud, where fetching a single page of 500 from Vespa can take minutes.

This PR allows configuring this value via env var, with a default of 500 as before if the value is not set.

We will set the value to something much smaller for mt cloud, like 50.

One concern of doing this is that an in-progress traversal of Vespa using continuation tokens which were produced with a page size of 500 gets messed up when we change page size for the next batch. I've added a test case which tests this exact flow, and the test shows that we still visit all document chunks in Vespa as expected even after changing the page size between batches.

## How Has This Been Tested?
See description; added a test for changing page size in the middle of a migration.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Vespa chunk fetch page size during OpenSearch migration configurable via `OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE`. Default stays 500 and it’s safe to change mid-migration.

- **New Features**
  - Add env var `OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE` to control Vespa visit page size.
  - Add test verifying continuation tokens still visit all chunks when the page size changes mid-run.

- **Migration**
  - For MT Cloud, set `OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE=50` (or similar).
  - No action needed elsewhere; default is 500.

<sup>Written for commit 69c5653ace7ca5ca3752b27411f07536b61d7602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

