### PR TITLE
fix: update jira group sync endpoint

### DIFF
--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -78,7 +78,10 @@ def _get_group_member_emails(
 
         members: list[dict[str, Any]] = page.get("values", [])
         for member in members:
-            if member.get("accountType") != _ATLASSIAN_ACCOUNT_TYPE:
+            account_type = member.get("accountType")
+            # On Jira DC < 9.0, accountType is absent; include those users.
+            # On Cloud / DC 9.0+, filter to real user accounts only.
+            if account_type is not None and account_type != _ATLASSIAN_ACCOUNT_TYPE:
                 continue
 
             email = member.get("emailAddress")


### PR DESCRIPTION
## Description

We were using the old group member endpoint /rest/api/{ver}/group which has been deprecated since sometime last year. The client library has an open PR https://github.com/pycontribs/jira/pull/2356 for updating to use the non-deprecated path, also since last year. So for the moment, we just have to manually call the /group/member non-deprecated path for group syncing. There's not much regression risk as far as I can tell, this endpoint was available at most 2 minor versions after the original deprecated one started being available.


## How Has This Been Tested?

We have CI tests for this, hooray!

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Jira group sync to the non-deprecated GET `/group/member` endpoint to restore compatibility with Jira 10.3+ and reduce extra API calls. Streams one group at a time and filters to real Atlassian user accounts only.

- **Bug Fixes**
  - Replaced deprecated `jira_client.group_members()` with GET `/group/member` via `jira` client `_get_json`.
  - Paginated with `startAt`/`isLast`, `maxResults=50`, and `includeInactiveUsers=false`.
  - Filtered to `accountType == "atlassian"` (and included users when `accountType` is absent on older DC); used `emailAddress`.
  - Clear 404 with Jira 6.0+ upgrade guidance.

- **Refactors**
  - Stream groups in `jira_group_sync` and yield per group name; skip groups with no members.
  - Removed per-user `user()` lookups to avoid extra requests.

<sup>Written for commit 715ae715284f67aec5a46e3bed49ad9573eb93fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

