### PR TITLE
chore(opensearch): Allow configuring num hits from hybrid subquery from env var

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -314,6 +314,9 @@ VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT = (
 OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE = int(
     os.environ.get("OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE") or 500
 )
+OPENSEARCH_OVERRIDE_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES = int(
+    os.environ.get("OPENSEARCH_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES") or 0
+)
 
 VESPA_HOST = os.environ.get("VESPA_HOST") or "localhost"
 # NOTE: this is used if and only if the vespa config server is accessible via a

--- a/backend/onyx/document_index/opensearch/constants.py
+++ b/backend/onyx/document_index/opensearch/constants.py
@@ -1,5 +1,10 @@
 # Default value for the maximum number of tokens a chunk can hold, if none is
 # specified when creating an index.
+from onyx.configs.app_configs import (
+    OPENSEARCH_OVERRIDE_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES,
+)
+
+
 DEFAULT_MAX_CHUNK_SIZE = 512
 
 # Size of the dynamic list used to consider elements during kNN graph creation.
@@ -10,27 +15,43 @@ EF_CONSTRUCTION = 256
 # quality but increase memory footprint. Values typically range between 12 - 48.
 M = 32  # Set relatively high for better accuracy.
 
-# When performing hybrid search, we need to consider more candidates than the number of results to be returned.
-# This is because the scoring is hybrid and the results are reordered due to the hybrid scoring.
-# Higher = more candidates for hybrid fusion = better retrieval accuracy, but results in more computation per query.
-# Imagine a simple case with a single keyword query and a single vector query and we want 10 final docs.
-# If we only fetch 10 candidates from each of keyword and vector, they would have to have perfect overlap to get a good hybrid
-# ranking for the 10 results. If we fetch 1000 candidates from each, we have a much higher chance of all 10 of the final desired
-# docs showing up and getting scored. In worse situations, the final 10 docs don't even show up as the final 10 (worse than just
-# a miss at the reranking step).
-DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES = 750
+# When performing hybrid search, we need to consider more candidates than the
+# number of results to be returned. This is because the scoring is hybrid and
+# the results are reordered due to the hybrid scoring. Higher = more candidates
+# for hybrid fusion = better retrieval accuracy, but results in more computation
+# per query. Imagine a simple case with a single keyword query and a single
+# vector query and we want 10 final docs. If we only fetch 10 candidates from
+# each of keyword and vector, they would have to have perfect overlap to get a
+# good hybrid ranking for the 10 results. If we fetch 1000 candidates from each,
+# we have a much higher chance of all 10 of the final desired docs showing up
+# and getting scored. In worse situations, the final 10 docs don't even show up
+# as the final 10 (worse than just a miss at the reranking step).
+DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES = (
+    OPENSEARCH_OVERRIDE_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES
+    if OPENSEARCH_OVERRIDE_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES > 0
+    else 750
+)
 
-# Number of vectors to examine for top k neighbors for the HNSW method.
+# Number of vectors to examine to decide the top k neighbors for the HNSW
+# method.
+# NOTE: "When creating a search query, you must specify k. If you provide both k
+# and ef_search, then the larger value is passed to the engine. If ef_search is
+# larger than k, you can provide the size parameter to limit the final number of
+# results to k." from
+# https://docs.opensearch.org/latest/query-dsl/specialized/k-nn/index/#ef_search
 EF_SEARCH = DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES
 
-# Since the titles are included in the contents, they are heavily downweighted as they act as a boost
-# rather than an independent scoring component.
+# Since the titles are included in the contents, the embedding matches are
+# heavily downweighted as they act as a boost rather than an independent scoring
+# component.
 SEARCH_TITLE_VECTOR_WEIGHT = 0.1
 SEARCH_CONTENT_VECTOR_WEIGHT = 0.45
-# Single keyword weight for both title and content (merged from former title keyword + content keyword).
+# Single keyword weight for both title and content (merged from former title
+# keyword + content keyword).
 SEARCH_KEYWORD_WEIGHT = 0.45
 
-# NOTE: it is critical that the order of these weights matches the order of the sub-queries in the hybrid search.
+# NOTE: It is critical that the order of these weights matches the order of the
+# sub-queries in the hybrid search.
 HYBRID_SEARCH_NORMALIZATION_WEIGHTS = [
     SEARCH_TITLE_VECTOR_WEIGHT,
     SEARCH_CONTENT_VECTOR_WEIGHT,

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -285,13 +285,16 @@ class DocumentQuery:
         hybrid_search_query: dict[str, Any] = {
             "hybrid": {
                 "queries": hybrid_search_subqueries,
-                # Max results per subquery per shard before aggregation. Ensures keyword and vector
-                # subqueries contribute equally to the candidate pool for hybrid fusion.
+                # Max results per subquery per shard before aggregation. Ensures
+                # keyword and vector subqueries contribute equally to the
+                # candidate pool for hybrid fusion.
                 # Sources:
                 # https://docs.opensearch.org/latest/vector-search/ai-search/hybrid-search/pagination/
                 # https://opensearch.org/blog/navigating-pagination-in-hybrid-queries-with-the-pagination_depth-parameter/
                 "pagination_depth": DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES,
-                # Applied to all the sub-queries independently (this avoids having subqueries having a lot of results thrown out).
+                # Applied to all the sub-queries independently (this avoids
+                # subqueries having a lot of results thrown out during
+                # aggregation).
                 # Sources:
                 # https://docs.opensearch.org/latest/query-dsl/compound/hybrid/
                 # https://opensearch.org/blog/introducing-common-filter-support-for-hybrid-search-queries
@@ -374,9 +377,10 @@ class DocumentQuery:
     def _get_hybrid_search_subqueries(
         query_text: str,
         query_vector: list[float],
-        # The default number of neighbors to consider for knn vector similarity search.
-        # This is higher than the number of results because the scoring is hybrid.
-        # for a detailed breakdown, see where the default value is set.
+        # The default number of neighbors to consider for knn vector similarity
+        # search. This is higher than the number of results because the scoring
+        # is hybrid. For a detailed breakdown, see where the default value is
+        # set.
         vector_candidates: int = DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES,
     ) -> list[dict[str, Any]]:
         """Returns subqueries for hybrid search.
@@ -400,20 +404,27 @@ class DocumentQuery:
         in a single hybrid query. Source:
         https://docs.opensearch.org/latest/query-dsl/compound/hybrid/
 
-        NOTE: Each query is independent during the search phase, there is no backfilling of scores for missing query components.
-        What this means is that if a document was a good vector match but did not show up for keyword, it gets a score of 0 for
-        the keyword component of the hybrid scoring. This is not as bad as just disregarding a score though as there is
-        normalization applied after. So really it is "increasing" the missing score compared to if it was included and the range
-        was renormalized. This does however mean that between docs that have high scores for say the vector field, the keyword
-        scores between them are completely ignored unless they also showed up in the keyword query as a reasonably high match.
-        TLDR, this is a bit of unique funky behavior but it seems ok.
+        NOTE: Each query is independent during the search phase, there is no
+        backfilling of scores for missing query components. What this means is
+        that if a document was a good vector match but did not show up for
+        keyword, it gets a score of 0 for the keyword component of the hybrid
+        scoring. This is not as bad as just disregarding a score though as there
+        is normalization applied after. So really it is "increasing" the missing
+        score compared to if it was included and the range was renormalized.
+        This does however mean that between docs that have high scores for say
+        the vector field, the keyword scores between them are completely ignored
+        unless they also showed up in the keyword query as a reasonably high
+        match. TLDR, this is a bit of unique funky behavior but it seems ok.
 
         NOTE: Options considered and rejected:
-        - minimum_should_match: Since it's hybrid search and users often provide semantic queries, there is often a lot of terms,
-          and very low number of meaningful keywords (and a low ratio of keywords).
-        - fuzziness AUTO: typo tolerance (0/1/2 edit distance by term length). It's mostly for typos as the analyzer ("english by
-          default") already does some stemming and tokenization. In testing datasets, this makes recall slightly worse. It also is
-          less performant so not really any reason to do it.
+        - minimum_should_match: Since it's hybrid search and users often provide
+          semantic queries, there is often a lot of terms, and very low number
+          of meaningful keywords (and a low ratio of keywords).
+        - fuzziness AUTO: Typo tolerance (0/1/2 edit distance by term length).
+          It's mostly for typos as the analyzer ("english" by default) already
+          does some stemming and tokenization. In testing datasets, this makes
+          recall slightly worse. It also is less performant so not really any
+          reason to do it.
 
         Args:
             query_text: The text of the query to search for.


### PR DESCRIPTION
## Description
Title. We want to try tuning this to see if it can make queries faster.

## How Has This Been Tested?
'twas not.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the hybrid search candidate pool size configurable via an env var to tune recall vs. latency without code changes. Defaults to 750 when unset; applied to hybrid `pagination_depth`, k-NN `ef_search`, and vector subquery candidates.

- **New Features**
  - Add `OPENSEARCH_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES` env var to override the default candidate count for hybrid search.
  - The value is used for `pagination_depth`, `ef_search`, and vector neighbor candidates to keep behavior consistent.
  - Updated comments for clarity around hybrid scoring and pagination.

- **Migration**
  - Optional: set `OPENSEARCH_DEFAULT_NUM_HYBRID_SEARCH_CANDIDATES` to a positive integer to tune speed/recall. Leave unset or 0 to keep current behavior.

<sup>Written for commit 6f36ee4f76f00bf3fcf69736480b41f9db62e990. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

