### PR TITLE
chore: add cache_okay to EncryptedJson

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -189,7 +189,9 @@ class EncryptedString(_EncryptedBase):
 
 
 class EncryptedJson(_EncryptedBase):
-    cache_ok = True  # have to re-declare because we set is_json (different than parent)
+    cache_ok = (
+        True  # have to re-declare because _is_json value is different from parent
+    )
     _is_json: bool = True
 
     def process_bind_param(


### PR DESCRIPTION
## Description

Set `cache_ok = True` on `EncryptedJson` to enable safe `SQLAlchemy` type caching for this subclass. This suppresses cache warnings and restores compiled statement caching, since `EncryptedJson` sets `_is_json` differently from its parent.

<sup>Written for commit e3ea6467ecfee7a59c9065c6ec4f3292fe34fa5d. Summary will update on new commits.</sup>

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `cache_ok = True` on `EncryptedJson` to enable safe `SQLAlchemy` type caching for this subclass. This suppresses cache warnings and restores compiled statement caching, since `EncryptedJson` sets `_is_json` differently from its parent.

<sup>Written for commit e3ea6467ecfee7a59c9065c6ec4f3292fe34fa5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

