### PR TITLE
chore: redeclare cache_okay for EncryptedBase children

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -163,7 +163,7 @@ class _EncryptedBase(TypeDecorator):
 
 
 class EncryptedString(_EncryptedBase):
-    # Have to redeclare for children since we explicitly re-declare _is_json
+    # Must redeclare cache_ok in this child class since we explicitly redeclare _is_json
     cache_ok = True
     _is_json: bool = False
 


### PR DESCRIPTION
## Description

see cubic summary

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-declare `cache_ok = True` on `EncryptedString` and `EncryptedJson` (children of `_EncryptedBase`) since they override `_is_json`. This silences `SQLAlchemy` cache warnings and enables safe statement caching for these types.

<sup>Written for commit 1f980351d7f85ce6205810e033fd437486a0af56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



