### PR TITLE
chore: sharepoint dedupe

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1561,6 +1561,7 @@ class SharepointConnector(
         checkpoint.current_drive_id = None
         checkpoint.current_drive_web_url = None
         checkpoint.current_drive_delta_next_link = None
+        checkpoint.seen_document_ids.clear()
 
     def _fetch_slim_documents_from_sharepoint(self) -> GenerateSlimDocumentOutput:
         site_descriptors = self.site_descriptors or self.fetch_sites()

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
@@ -637,3 +637,49 @@ class TestDeltaDuplicateDocumentDedup:
         )
         yielded, _ = _consume_generator(gen)
         assert len(_docs_from(yielded)) == 1
+
+    def test_same_id_across_drives_not_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Graph item IDs are only unique within a drive.  An item in drive B
+        that happens to share an ID with an item already seen in drive A must
+        NOT be skipped."""
+        connector = _setup_connector(monkeypatch)
+        _mock_convert(monkeypatch)
+
+        def fake_fetch_page(
+            self: SharepointConnector,  # noqa: ARG001
+            page_url: str,  # noqa: ARG001
+            drive_id: str,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+            page_size: int = 200,  # noqa: ARG001
+        ) -> tuple[list[DriveItemData], str | None]:
+            return [_make_item("shared-id")], None
+
+        monkeypatch.setattr(
+            SharepointConnector, "_fetch_one_delta_page", fake_fetch_page
+        )
+
+        checkpoint = _build_ready_checkpoint(drive_names=["DriveA", "DriveB"])
+
+        # Drive A: yields the item
+        gen = connector._load_from_checkpoint(
+            _START_TS, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, checkpoint = _consume_generator(gen)
+        docs = _docs_from(yielded)
+        assert len(docs) == 1
+        assert docs[0].id == "shared-id"
+
+        # seen_document_ids should have been cleared when drive A finished
+        assert len(checkpoint.seen_document_ids) == 0
+
+        # Drive B: same ID must be yielded again (different drive)
+        gen = connector._load_from_checkpoint(
+            _START_TS, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, checkpoint = _consume_generator(gen)
+        docs = _docs_from(yielded)
+        assert len(docs) == 1
+        assert docs[0].id == "shared-id"


### PR DESCRIPTION
## Description

the sharepoint connector was yielding duplicate docs across batches, which is a documented thing the Delta API sometimes does. This was causing db lock contention across batches for the same document. Now we save these ids to dedupe.

## How Has This Been Tested?

changed tests to reflect this

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicate SharePoint documents by tracking seen document IDs during delta crawls so items repeated by the Microsoft Graph delta API are yielded only once. Dedup applies within and across pages in a single run, and resets when switching drives.

- **Bug Fixes**
  - Added `seen_document_ids` to the checkpoint and skip already-seen items (with debug log).
  - Persisted the set in checkpoint JSON to survive crash/resume; cleared on fresh runs and when a drive finishes (IDs are drive-scoped).
  - Added tests for cross-page and same-page duplicates, checkpoint round-trip, fresh-run behavior, and allowing same IDs in different drives.

<sup>Written for commit 9e9b3f0b7008c742be505fee59be2f5fe38f9919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



