### PR TITLE
chore(opensearch): unset container ulimits in dev

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -41,6 +41,8 @@ services:
     # Rootless Docker can reject the base OpenSearch ulimit settings, so clear
     # the inherited block entirely in the dev override.
     ulimits: !reset null
+    environment:
+      - bootstrap.memory_lock=false
 
   inference_model_server:
     ports:


### PR DESCRIPTION
## Description

I use [rootless docker](https://docs.docker.com/engine/security/rootless/) which cannot set the hard ulimits,

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting rlimits for ready process: error setting rlimit type 8: operation not permitted
```

## How Has This Been Tested?

`ods compose dev`

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unset OpenSearch container ulimits in the dev Docker Compose override and disable memory locking to support rootless Docker. This clears inherited limits with `ulimits: !reset null` and sets `bootstrap.memory_lock=false`, so `ods compose dev` starts without OCI rlimit failures.

<sup>Written for commit ad1d0961f54931e9949f33df3c191bbaccec6a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

