### PR TITLE
fix(tests): remove deprecated o1-preview and o1-mini model tests

### DIFF
--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -26,14 +26,6 @@ class TestIsTrueOpenAIModel:
         """Test that real OpenAI GPT-4o-mini model is correctly identified."""
         assert is_true_openai_model(LlmProviderNames.OPENAI, "gpt-4o-mini") is True
 
-    def test_real_openai_o1_preview(self) -> None:
-        """Test that real OpenAI o1-preview reasoning model is correctly identified."""
-        assert is_true_openai_model(LlmProviderNames.OPENAI, "o1-preview") is True
-
-    def test_real_openai_o1_mini(self) -> None:
-        """Test that real OpenAI o1-mini reasoning model is correctly identified."""
-        assert is_true_openai_model(LlmProviderNames.OPENAI, "o1-mini") is True
-
     def test_openai_with_provider_prefix(self) -> None:
         """Test that OpenAI model with provider prefix is correctly identified."""
         assert is_true_openai_model(LlmProviderNames.OPENAI, "openai/gpt-4") is False


### PR DESCRIPTION
## Description

Remove `test_real_openai_o1_preview` and `test_real_openai_o1_mini` from `test_true_openai_model.py`. OpenAI deprecated `o1-preview` (July 2025) and `o1-mini` (Oct 2025), and LiteLLM's model registry now maps them to Azure instead of OpenAI. This causes `is_true_openai_model` to correctly return `False`, breaking the tests that asserted `True`.

## How Has This Been Tested?

## Additional Options
- [x] This PR should be considered for cherry-picking into the release branch
- [x] Override Linear Check