### PR TITLE
fix(tests): remove deprecated o1-preview and o1-mini model tests (#9280) to release v3.0

### DIFF
--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -26,14 +26,6 @@ class TestIsTrueOpenAIModel:
         """Test that real OpenAI GPT-4o-mini model is correctly identified."""
         assert is_true_openai_model(LlmProviderNames.OPENAI, "gpt-4o-mini") is True
 
-    def test_real_openai_o1_preview(self) -> None:
-        """Test that real OpenAI o1-preview reasoning model is correctly identified."""
-        assert is_true_openai_model(LlmProviderNames.OPENAI, "o1-preview") is True
-
-    def test_real_openai_o1_mini(self) -> None:
-        """Test that real OpenAI o1-mini reasoning model is correctly identified."""
-        assert is_true_openai_model(LlmProviderNames.OPENAI, "o1-mini") is True
-
     def test_openai_with_provider_prefix(self) -> None:
         """Test that OpenAI model with provider prefix is correctly identified."""
         assert is_true_openai_model(LlmProviderNames.OPENAI, "openai/gpt-4") is False


### PR DESCRIPTION
Cherry-pick of commit ffe04ab91fcfb14d238f9146517b7f6a44277c44 to release/v3.0 branch.

Original PR: #9280

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed tests for deprecated OpenAI o1-preview and o1-mini models to prevent false failures and keep the v3.0 test suite aligned with supported models.

<sup>Written for commit fd05d6dc2bd61f56c11de23bde7bcfed93d38771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

