### PR TITLE
chore(models): rm `claude-3-5-sonnet-v2` metadata

### DIFF
--- a/backend/onyx/llm/model_metadata_enrichments.json
+++ b/backend/onyx/llm/model_metadata_enrichments.json
@@ -3782,16 +3782,6 @@
     "display_name": "Claude Sonnet 3.5",
     "model_vendor": "anthropic"
   },
-  "vertex_ai/claude-3-5-sonnet-v2": {
-    "display_name": "Claude Sonnet 3.5",
-    "model_vendor": "anthropic",
-    "model_version": "v2"
-  },
-  "vertex_ai/claude-3-5-sonnet-v2@20241022": {
-    "display_name": "Claude Sonnet 3.5 v2",
-    "model_vendor": "anthropic",
-    "model_version": "20241022"
-  },
   "vertex_ai/claude-3-5-sonnet@20240620": {
     "display_name": "Claude Sonnet 3.5",
     "model_vendor": "anthropic",


### PR DESCRIPTION
## Description

Referenced by these warnings from the api-server,

```
WARNING:  03/11/2026 03:54:54 PM                       utils.py  519: [API:Lhfw4R_Y] Model 'claude-3-5-sonnet-v2' not found in LiteLLM. Falling back to 32000 tokens.
WARNING:  03/11/2026 03:54:54 PM                       utils.py  716: [API:Lhfw4R_Y] No litellm entry found for vertex_ai/claude-3-5-sonnet-v2, this model may or may not support image input.
WARNING:  03/11/2026 03:54:54 PM                       utils.py  519: [API:Lhfw4R_Y] Model 'claude-3-5-sonnet-v2@20241022' not found in LiteLLM. Falling back to 32000 tokens.
WARNING:  03/11/2026 03:54:54 PM                       utils.py  716: [API:Lhfw4R_Y] No litellm entry found for vertex_ai/claude-3-5-sonnet-v2@20241022, this model may or may not support image input.
```

## How Has This Been Tested?



## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsupported Claude Sonnet 3.5 v2 model metadata to match LiteLLM and silence noisy api-server warnings.

- **Bug Fixes**
  - Deleted `vertex_ai/claude-3-5-sonnet-v2` and `vertex_ai/claude-3-5-sonnet-v2@20241022` from `backend/onyx/llm/model_metadata_enrichments.json`.
  - Eliminates "Model not found in LiteLLM" and "No litellm entry found" warnings; avoids misleading 32k-token fallback logs.

<sup>Written for commit 4372f0783e34287fa7633e6f607dc1f68bf86f60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

