### PR TITLE
fix(fe): `InputComboBox` resets filter value on open (#9287) to release v3.0

### DIFF
--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
@@ -118,6 +118,21 @@ describe("InputComboBox", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
+    test("shows all options on focus when a value is already selected", () => {
+      render(
+        <InputComboBox
+          placeholder="Select"
+          value="apple"
+          options={mockOptions}
+        />
+      );
+      const input = screen.getByDisplayValue("Apple");
+      fireEvent.focus(input);
+
+      const options = screen.getAllByRole("option");
+      expect(options.length).toBe(3);
+    });
+
     test("closes dropdown on tab", async () => {
       const user = setupUser();
       render(

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
@@ -322,24 +322,32 @@ const InputComboBox = ({
 
   const handleFocus = useCallback(() => {
     if (hasOptions) {
+      setInputValue("");
       setIsOpen(true);
-      setHighlightedIndex(-1); // Start with no highlight on focus
-      setIsKeyboardNav(false); // Start with mouse mode
+      setHighlightedIndex(-1);
+      setIsKeyboardNav(false);
     }
-  }, [hasOptions, setIsOpen, setHighlightedIndex, setIsKeyboardNav]);
+  }, [
+    hasOptions,
+    setInputValue,
+    setIsOpen,
+    setHighlightedIndex,
+    setIsKeyboardNav,
+  ]);
 
   const toggleDropdown = useCallback(() => {
     if (!disabled && hasOptions) {
       setIsOpen((prev) => {
         const newOpen = !prev;
         if (newOpen) {
-          setHighlightedIndex(-1); // Reset highlight when opening
+          setInputValue("");
+          setHighlightedIndex(-1);
         }
         return newOpen;
       });
       inputRef.current?.focus();
     }
-  }, [disabled, hasOptions, setIsOpen, setHighlightedIndex]);
+  }, [disabled, hasOptions, setIsOpen, setInputValue, setHighlightedIndex]);
 
   const autoId = useId();
   const fieldId = fieldContext?.baseId || name || `combo-box-${autoId}`;

--- a/web/src/refresh-components/inputs/InputComboBox/hooks.ts
+++ b/web/src/refresh-components/inputs/InputComboBox/hooks.ts
@@ -20,21 +20,26 @@ export function useComboBoxState({ value, options }: UseComboBoxStateProps) {
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [isKeyboardNav, setIsKeyboardNav] = useState(false);
 
-  // State synchronization logic
-  // Only sync when the dropdown is closed or when value changes significantly
+  // Sync inputValue with the external value prop.
+  // When the dropdown is closed, always reflect the controlled value.
+  // When the dropdown is open, only sync if the *value prop itself* changes
+  // (e.g. parent programmatically updates it), not when inputValue changes
+  // (e.g. user clears the field on focus to browse all options).
   useEffect(() => {
-    // If dropdown is closed, always sync with prop value
     if (!isOpen) {
       setInputValue(value);
-    } else {
-      // If dropdown is open, only sync if the new value is an exact match with an option
-      // This prevents interference when user is typing
+    }
+  }, [value, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
       const isExactOptionMatch = options.some((opt) => opt.value === value);
-      if (isExactOptionMatch && inputValue !== value) {
+      if (isExactOptionMatch) {
         setInputValue(value);
       }
     }
-  }, [value, isOpen, options, inputValue]);
+    // Only react to value prop changes while open, not inputValue changes
+  }, [value]);
 
   // Reset highlight and keyboard nav when closing dropdown
   useEffect(() => {


### PR DESCRIPTION
Cherry-pick of commit a78607f1b59fe6901f46638fc19695ad4912662e to release/v3.0 branch.

Original PR: #9287

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `InputComboBox` so opening the dropdown clears the filter and shows all options, even when a value is selected. Prevents the selected label from auto-filtering the list on open.

- **Bug Fixes**
  - Clear `inputValue` on focus/open and when toggling the dropdown to display all options.
  - Adjust state sync: mirror `value` when closed; while open, only sync if the `value` prop changes (not on user input).
  - Add test to verify all options appear on focus when a value is already selected.

<sup>Written for commit f1b523e30b4c44917092d04b96c42ac6435585f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

