### PR TITLE
fix(fe): prevent clicking `InputSelect` from selecting text

### DIFF
--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { cn, noProp } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import LineItem, { LineItemProps } from "@/refresh-components/buttons/LineItem";
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
@@ -298,7 +298,10 @@ function InputSelectContent({
         )}
         sideOffset={4}
         position="popper"
-        onMouseDown={noProp()}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
         {...props}
       >
         <SelectPrimitive.Viewport className="flex flex-col gap-1">


### PR DESCRIPTION
## Description

When an `InputSelect` is used inside a modal (e.g. the API key form from the `/admin/api-key` page), clicking on a dropdown item causes all text in the modal to become selected. This fixes it by preventing the default selection behavior on mouse down events.

## How Has This Been Tested?

Not really. Maybe captured by existing i guess

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop text selection when clicking `InputSelect` items in modals (e.g., `/admin/api-key`) by canceling selection on mouse down. Replaces `noProp()` with an `onMouseDown` handler that calls `e.stopPropagation()` and `e.preventDefault()`, and removes the unused `noProp` import.

<sup>Written for commit ea0249461981e949996fdf1ec3689c696ab92e48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

