### PR TITLE
fix(slackbot): resolve channel references and filter search by channel tags (#9256) to release v2.12

### DIFF
--- a/backend/onyx/onyxbot/slack/constants.py
+++ b/backend/onyx/onyxbot/slack/constants.py
@@ -1,4 +1,8 @@
+import re
 from enum import Enum
+
+# Matches Slack channel references like <#C097NBWMY8Y> or <#C097NBWMY8Y|channel-name>
+SLACK_CHANNEL_REF_PATTERN = re.compile(r"<#([A-Z0-9]+)(?:\|([^>]+))?>")
 
 LIKE_BLOCK_ACTION_ID = "feedback-like"
 DISLIKE_BLOCK_ACTION_ID = "feedback-dislike"

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -18,15 +18,18 @@ from onyx.configs.onyxbot_configs import ONYX_BOT_DISPLAY_ERROR_MSGS
 from onyx.configs.onyxbot_configs import ONYX_BOT_NUM_RETRIES
 from onyx.configs.onyxbot_configs import ONYX_BOT_REACT_EMOJI
 from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import Tag
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import SlackChannelConfig
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
 from onyx.db.users import get_user_by_email
 from onyx.onyxbot.slack.blocks import build_slack_response_blocks
+from onyx.onyxbot.slack.constants import SLACK_CHANNEL_REF_PATTERN
 from onyx.onyxbot.slack.handlers.utils import send_team_member_message
 from onyx.onyxbot.slack.models import SlackMessageInfo
 from onyx.onyxbot.slack.models import ThreadMessage
+from onyx.onyxbot.slack.utils import get_channel_from_id
 from onyx.onyxbot.slack.utils import get_channel_name_from_id
 from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
 from onyx.onyxbot.slack.utils import SlackRateLimiter
@@ -39,6 +42,51 @@ from onyx.utils.logger import OnyxLoggingAdapter
 srl = SlackRateLimiter()
 
 RT = TypeVar("RT")  # return type
+
+
+def resolve_channel_references(
+    message: str,
+    client: WebClient,
+    logger: OnyxLoggingAdapter,
+) -> tuple[str, list[Tag]]:
+    """Parse Slack channel references from a message, resolve IDs to names,
+    replace the raw markup with readable #channel-name, and return channel tags
+    for search filtering."""
+    tags: list[Tag] = []
+    channel_matches = SLACK_CHANNEL_REF_PATTERN.findall(message)
+    seen_channel_ids: set[str] = set()
+
+    for channel_id, channel_name_from_markup in channel_matches:
+        if channel_id in seen_channel_ids:
+            continue
+        seen_channel_ids.add(channel_id)
+
+        channel_name = channel_name_from_markup or None
+
+        if not channel_name:
+            try:
+                channel_info = get_channel_from_id(client=client, channel_id=channel_id)
+                channel_name = channel_info.get("name") or None
+            except Exception:
+                logger.warning(f"Failed to resolve channel name for ID: {channel_id}")
+
+            if not channel_name:
+                continue
+
+        # Replace raw Slack markup with readable channel name
+        if channel_name_from_markup:
+            message = message.replace(
+                f"<#{channel_id}|{channel_name_from_markup}>",
+                f"#{channel_name}",
+            )
+        else:
+            message = message.replace(
+                f"<#{channel_id}>",
+                f"#{channel_name}",
+            )
+        tags.append(Tag(tag_key="Channel", tag_value=channel_name))
+
+    return message, tags
 
 
 def rate_limits(
@@ -157,6 +205,20 @@ def handle_regular_answer(
     user_message = messages[-1]
     history_messages = messages[:-1]
 
+    # Resolve any <#CHANNEL_ID> references in the user message to readable
+    # channel names and extract channel tags for search filtering
+    resolved_message, channel_tags = resolve_channel_references(
+        message=user_message.message,
+        client=client,
+        logger=logger,
+    )
+
+    user_message = ThreadMessage(
+        message=resolved_message,
+        sender=user_message.sender,
+        role=user_message.role,
+    )
+
     channel_name, _ = get_channel_name_from_id(
         client=client,
         channel_id=channel,
@@ -207,6 +269,7 @@ def handle_regular_answer(
             source_type=None,
             document_set=document_set_names,
             time_cutoff=None,
+            tags=channel_tags if channel_tags else None,
         )
 
         new_message_request = SendMessageRequest(
@@ -230,6 +293,16 @@ def handle_regular_answer(
             onyx_user=user if can_search_over_private_docs else get_anonymous_user(),
             slack_context_str=slack_context_str,
         )
+
+        # If a channel filter was applied but no results were found, override
+        # the LLM response to avoid hallucinated answers about unindexed channels
+        if channel_tags and not answer.citation_info and not answer.top_documents:
+            channel_names = ", ".join(f"#{tag.tag_value}" for tag in channel_tags)
+            answer.answer = (
+                f"No indexed data found for {channel_names}. "
+                "This channel may not be indexed, or there may be no messages "
+                "matching your query within it."
+            )
 
     except Exception as e:
         logger.exception(
@@ -285,6 +358,7 @@ def handle_regular_answer(
         only_respond_if_citations
         and not answer.citation_info
         and not message_info.bypass_filters
+        and not channel_tags
     ):
         logger.error(
             f"Unable to find citations to answer: '{answer.answer}' - not answering!"

--- a/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
+++ b/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
@@ -1,0 +1,204 @@
+"""Tests for Slack channel reference resolution and tag filtering
+in handle_regular_answer.py."""
+
+from unittest.mock import MagicMock
+
+from slack_sdk.errors import SlackApiError
+
+from onyx.context.search.models import Tag
+from onyx.onyxbot.slack.constants import SLACK_CHANNEL_REF_PATTERN
+from onyx.onyxbot.slack.handlers.handle_regular_answer import resolve_channel_references
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_client_with_channels(
+    channel_map: dict[str, str],
+) -> MagicMock:
+    """Return a mock WebClient where conversations_info resolves IDs to names."""
+    client = MagicMock()
+
+    def _conversations_info(channel: str) -> MagicMock:
+        if channel in channel_map:
+            resp = MagicMock()
+            resp.validate = MagicMock()
+            resp.__getitem__ = lambda _self, key: {
+                "channel": {
+                    "name": channel_map[channel],
+                    "is_im": False,
+                    "is_mpim": False,
+                }
+            }[key]
+            return resp
+        raise SlackApiError("channel_not_found", response=MagicMock())
+
+    client.conversations_info = _conversations_info
+    return client
+
+
+def _mock_logger() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# SLACK_CHANNEL_REF_PATTERN regex tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlackChannelRefPattern:
+    def test_matches_bare_channel_id(self) -> None:
+        matches = SLACK_CHANNEL_REF_PATTERN.findall("<#C097NBWMY8Y>")
+        assert matches == [("C097NBWMY8Y", "")]
+
+    def test_matches_channel_id_with_name(self) -> None:
+        matches = SLACK_CHANNEL_REF_PATTERN.findall("<#C097NBWMY8Y|eng-infra>")
+        assert matches == [("C097NBWMY8Y", "eng-infra")]
+
+    def test_matches_multiple_channels(self) -> None:
+        msg = "compare <#C111AAA> and <#C222BBB|general>"
+        matches = SLACK_CHANNEL_REF_PATTERN.findall(msg)
+        assert len(matches) == 2
+        assert ("C111AAA", "") in matches
+        assert ("C222BBB", "general") in matches
+
+    def test_no_match_on_plain_text(self) -> None:
+        matches = SLACK_CHANNEL_REF_PATTERN.findall("no channels here")
+        assert matches == []
+
+    def test_no_match_on_user_mention(self) -> None:
+        matches = SLACK_CHANNEL_REF_PATTERN.findall("<@U12345>")
+        assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_channel_references tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChannelReferences:
+    def test_resolves_bare_channel_id_via_api(self) -> None:
+        client = _mock_client_with_channels({"C097NBWMY8Y": "eng-infra"})
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="summary of <#C097NBWMY8Y> this week",
+            client=client,
+            logger=logger,
+        )
+
+        assert message == "summary of #eng-infra this week"
+        assert len(tags) == 1
+        assert tags[0] == Tag(tag_key="Channel", tag_value="eng-infra")
+
+    def test_uses_name_from_pipe_format_without_api_call(self) -> None:
+        client = MagicMock()
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="check <#C097NBWMY8Y|eng-infra> for updates",
+            client=client,
+            logger=logger,
+        )
+
+        assert message == "check #eng-infra for updates"
+        assert tags == [Tag(tag_key="Channel", tag_value="eng-infra")]
+        # Should NOT have called the API since name was in the markup
+        client.conversations_info.assert_not_called()
+
+    def test_multiple_channels(self) -> None:
+        client = _mock_client_with_channels(
+            {
+                "C111AAA": "eng-infra",
+                "C222BBB": "eng-general",
+            }
+        )
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="compare <#C111AAA> and <#C222BBB>",
+            client=client,
+            logger=logger,
+        )
+
+        assert "#eng-infra" in message
+        assert "#eng-general" in message
+        assert "<#" not in message
+        assert len(tags) == 2
+        tag_values = {t.tag_value for t in tags}
+        assert tag_values == {"eng-infra", "eng-general"}
+
+    def test_no_channel_references_returns_unchanged(self) -> None:
+        client = MagicMock()
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="just a normal message with no channels",
+            client=client,
+            logger=logger,
+        )
+
+        assert message == "just a normal message with no channels"
+        assert tags == []
+
+    def test_api_failure_skips_channel_gracefully(self) -> None:
+        # Client that fails for all channel lookups
+        client = _mock_client_with_channels({})
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="check <#CBADID123>",
+            client=client,
+            logger=logger,
+        )
+
+        # Message should remain unchanged for the failed channel
+        assert "<#CBADID123>" in message
+        assert tags == []
+        logger.warning.assert_called_once()
+
+    def test_partial_failure_resolves_what_it_can(self) -> None:
+        # Only one of two channels resolves
+        client = _mock_client_with_channels({"C111AAA": "eng-infra"})
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="compare <#C111AAA> and <#CBADID123>",
+            client=client,
+            logger=logger,
+        )
+
+        assert "#eng-infra" in message
+        assert "<#CBADID123>" in message  # failed one stays raw
+        assert len(tags) == 1
+        assert tags[0].tag_value == "eng-infra"
+
+    def test_duplicate_channel_produces_single_tag(self) -> None:
+        client = _mock_client_with_channels({"C111AAA": "eng-infra"})
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="summarize <#C111AAA> and compare with <#C111AAA>",
+            client=client,
+            logger=logger,
+        )
+
+        assert message == "summarize #eng-infra and compare with #eng-infra"
+        assert len(tags) == 1
+        assert tags[0].tag_value == "eng-infra"
+
+    def test_mixed_pipe_and_bare_formats(self) -> None:
+        client = _mock_client_with_channels({"C222BBB": "random"})
+        logger = _mock_logger()
+
+        message, tags = resolve_channel_references(
+            message="see <#C111AAA|eng-infra> and <#C222BBB>",
+            client=client,
+            logger=logger,
+        )
+
+        assert "#eng-infra" in message
+        assert "#random" in message
+        assert len(tags) == 2


### PR DESCRIPTION
Cherry-pick of commit f01f210af85b959177b390f3a9d43370f4b2f5e7 to release/v2.12 branch.

Original PR: #9256

- [x] [Optional] Override Linear Check
