### PR TITLE
fix(db): avoid SQLAlchemy sentinel mismatch in batch user insert

### DIFF
--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -360,8 +360,8 @@ def batch_add_ext_perm_user_if_not_exists(
     # batch path hits a UUID sentinel mismatch with server_default columns.
     for email in missing_lower_emails:
         user = _generate_ext_permissioned_user(email=email)
+        savepoint = db_session.begin_nested()
         try:
-            savepoint = db_session.begin_nested()
             db_session.add(user)
             savepoint.commit()
         except IntegrityError:


### PR DESCRIPTION
## Description

Fixes failing sharepoint integration tests.

`batch_add_ext_perm_user_if_not_exists` used `add_all()` which triggers SQLAlchemy 2.0's `insertmanyvalues` batch optimization. After `created_at`/`updated_at` columns with `server_default=func.now()` were added to the `User` model (ca39da7), the `RETURNING` clause sentinel matching fails with a UUID type mismatch between psycopg2 and SQLAlchemy, crashing external group sync tasks with `InvalidRequestError: Can't match sentinel values in result set to parameter sets`.

Switches to individual `add()` + `flush()` per user to avoid the batch insert path entirely.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check