### PR TITLE
fix(favicon): prefer relative path to favicon

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -12,7 +12,7 @@ import {
   MODAL_ROOT_ID,
 } from "@/lib/constants";
 import { Metadata } from "next";
-import { buildClientUrl } from "@/lib/utilsSS";
+
 import { Inter } from "next/font/google";
 import { EnterpriseSettings, ApplicationStatus } from "@/interfaces/settings";
 import AppProvider from "@/providers/AppProvider";
@@ -45,14 +45,14 @@ const hankenGrotesk = Hanken_Grotesk({
 });
 
 export async function generateMetadata(): Promise<Metadata> {
-  let logoLocation = buildClientUrl("/onyx.ico");
+  let logoLocation = "/onyx.ico";
   let enterpriseSettings: EnterpriseSettings | null = null;
   if (SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED) {
     enterpriseSettings = await (await fetchEnterpriseSettingsSS()).json();
     logoLocation =
       enterpriseSettings && enterpriseSettings.use_custom_logo
         ? "/api/enterprise-settings/logo"
-        : buildClientUrl("/onyx.ico");
+        : "/onyx.ico";
   }
 
   return {


### PR DESCRIPTION
## Description

Simple, hopefully more reliable way to find the favicon.

<img width="2880" height="1920" alt="20260312_11h09m15s_grim" src="https://github.com/user-attachments/assets/8e20e2ec-e80e-48c5-91c2-3699e8d20a22" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer a relative path for the favicon in app metadata to avoid broken icons across environments. Enterprise instances still use the custom logo endpoint when enabled.

<sup>Written for commit 4c7daa96626aa20d56104b5796f7c973e376b542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

