### PR TITLE
fix(cherry-pick): Improving workflows

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -75,9 +75,9 @@ jobs:
 
           member_state="$(cat "${member_state_file}")"
           if [ "${member_state}" != "active" ]; then
-            echo "should_cherrypick=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::${MERGED_BY} is not an active member of team ${ALLOWED_TEAM}. Skipping cherry-pick."
-            exit 0
+            echo "gate_error=not-team-member" >> "$GITHUB_OUTPUT"
+            echo "::error::${MERGED_BY} is not an active member of team ${ALLOWED_TEAM} (state: ${member_state}). Failing cherry-pick gate."
+            exit 1
           fi
 
           exit 0
@@ -130,7 +130,10 @@ jobs:
           tee_exit="${pipe_statuses[1]:-0}"
           set -e
           if [ "${tee_exit}" -ne 0 ]; then
-            echo "::warning::tee failed to write to output_file; cherry-pick reason/excerpt may be incomplete."
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "reason=output-capture-failed" >> "$GITHUB_OUTPUT"
+            echo "::error::tee failed to capture cherry-pick output (exit ${tee_exit}); cannot classify result."
+            exit 1
           fi
 
           if [ "${exit_code}" -eq 0 ]; then
@@ -198,6 +201,10 @@ jobs:
             reason_text="requested cherry-pick but merge commit SHA was missing"
           elif [ "${GATE_ERROR}" = "team-api-error" ]; then
             reason_text="team membership lookup failed while validating cherry-pick permissions"
+          elif [ "${GATE_ERROR}" = "not-team-member" ]; then
+            reason_text="merger is not an active member of the allowed team"
+          elif [ "${CHERRY_PICK_REASON}" = "output-capture-failed" ]; then
+            reason_text="failed to capture cherry-pick output for classification"
           elif [ "${CHERRY_PICK_REASON}" = "merge-conflict" ]; then
             reason_text="merge conflict during cherry-pick"
           fi


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This PR hardens the post-merge cherry-pick automation so failures are visible instead of silently skipping.

- Switched trigger from push on main to pull_request_target on closed (gated to merged PRs into main) so PR metadata is always available.
- Split workflow logic into:
  - resolve-cherry-pick-request (deterministic PR checkbox + merge SHA resolution)
  - cherry-pick-to-latest-release (actual cherry-pick execution)
- Updated cherry-pick to use pull_request.merge_commit_sha directly instead of GITHUB_SHA.
- Fixed error handling so cherry-pick command failures (including merge conflicts) are captured and explicitly fail the job.
- Updated Slack notification gating so it fires when cherry-pick was requested and either the gate or cherry-pick job fails.
- Added explicit failure if CHERRY_PICK_PRS_WEBHOOK is missing, to avoid silent notification skips.
- Improved Slack failure summary with source PR and merge SHA context.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

- Validated workflow YAML parses correctly: 
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/post-merge-beta-cherry-pick.yml"); puts "yaml-ok"'`
- Audited historical workflow runs/logs with gh to confirm prior silent failure modes were real:
  - “No merged PR associated with commit …; skipping”
  - Merge-conflict runs marked success with no Slack alert
  - Gate-step failures (e.g., GitHub API errors) causing Slack job to skip due to missing outputs
- Confirmed updated conditions/outputs in the modified workflow file align with those failure paths. 
- End-to-end GitHub Actions runtime execution has not been run locally in this branch (needs merge/run in repo Actions).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make post-merge cherry-picks fail loudly and notify Slack when requested picks go wrong. Stops silent skips by using PR event data and stricter gating.

- **Bug Fixes**
  - Trigger on `pull_request_target` closed; gate to merged PRs into `main` from this repo only, require merger to be in `onyx-core-team`, and read checkbox and merge SHA from the event payload.
  - Split into `resolve-cherry-pick-request` and `cherry-pick-to-latest-release`; publish `pr_number`, `merge_commit_sha`, `merged_by`, and `gate_error`; run cherry-pick only when resolve succeeds and opt-in is checked.
  - Use PR `merge_commit_sha` for the cherry-pick and assign the created PR to the merger; checkout locked to `main` for security.
  - Treat gate and cherry-pick errors as failures (missing merge SHA, team API errors, not-team-member, output-capture failure, merge conflicts, command errors); capture output even if `tee` stumbles and fail the job.
  - Slack alerts fire when a cherry-pick was requested and either job fails; include source PR, merge SHA, the failing job, and a clear reason with an excerpt; fail if `CHERRY_PICK_PRS_WEBHOOK` is missing.

<sup>Written for commit 3c6510bd4ab47fb41229c646877767f1b72622cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

