### PR TITLE
chore(greptile): Improving the Custom Context

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -52,6 +52,10 @@
         {
           "scope": [],
           "content": "Use explicit type annotations for variables to enhance code clarity, especially when moving type hints around in the code."
+        },
+        {
+          "scope": [],
+          "content": "Use `contributing_guides/best_practices.md` as core review context. Prefer consistency with existing patterns, fix issues in code you touch, avoid tacking new features onto muddy interfaces, fail loudly instead of silently swallowing errors, keep code strictly typed, preserve clear state boundaries, remove duplicate or dead logic, break up overly long functions, avoid hidden import-time side effects, respect module boundaries, and favor correctness-by-construction over relying on callers to use an API correctly."
         }
       ],
       "rules": [
@@ -72,6 +76,14 @@
           "rule": "When hardcoding a boolean variable to a constant value, remove the variable entirely and clean up all places where it's used rather than just setting it to a constant."
         },
         {
+          "scope": [],
+          "rule": "Code changes must consider both multi-tenant and single-tenant deployments. In multi-tenant mode, preserve tenant isolation, ensure tenant context is propagated correctly, and avoid assumptions that only hold for a single shared schema or globally shared state. In single-tenant mode, avoid introducing unnecessary tenant-specific requirements or cloud-only control-plane dependencies."
+        },
+        {
+          "scope": [],
+          "rule": "Code changes must consider both regular Onyx deployments and Onyx lite deployments. Lite deployments disable the vector DB, Redis, model servers, and background workers by default, use PostgreSQL-backed cache/auth/file storage, and rely on the API server to handle background work. Do not assume those services are available unless the code path is explicitly limited to full deployments."
+        },
+        {
           "scope": ["backend/**/*.py"],
           "rule": "Never raise HTTPException directly in business code. Use `raise OnyxError(OnyxErrorCode.XXX, \"message\")` from `onyx.error_handling.exceptions`. A global FastAPI exception handler converts OnyxError into structured JSON responses with {\"error_code\": \"...\", \"message\": \"...\"}. Error codes are defined in `onyx.error_handling.error_codes.OnyxErrorCode`. For upstream errors with dynamic HTTP status codes, use `status_code_override`: `raise OnyxError(OnyxErrorCode.BAD_GATEWAY, detail, status_code_override=upstream_status)`."
         }
@@ -86,6 +98,21 @@
           "scope": [],
           "path": "CLAUDE.md",
           "description": "Project instructions and coding standards"
+        },
+        {
+          "scope": [],
+          "path": "backend/alembic/README.md",
+          "description": "Migration guidance, including multi-tenant migration behavior"
+        },
+        {
+          "scope": [],
+          "path": "deployment/helm/charts/onyx/values-lite.yaml",
+          "description": "Lite deployment Helm values and service assumptions"
+        },
+        {
+          "scope": [],
+          "path": "deployment/docker_compose/docker-compose.onyx-lite.yml",
+          "description": "Lite deployment Docker Compose overlay and disabled service behavior"
         }
       ]
     }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Updating the context to cover other cases like Multi-Tenant vs. Single-Tenant & Regular deployment vs. Onyx Lite deployment 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `greptile.json` to strengthen code review context with best practices and deployment-mode rules, covering multi-tenant vs single-tenant and Onyx vs Onyx Lite. This helps reviewers catch invalid assumptions and align changes with our deployment constraints.

- **New Features**
  - Add `contributing_guides/best_practices.md` as core review context.
  - Add rules to consider both multi-tenant/single-tenant and full/Lite deployments; avoid assumptions about shared state or unavailable services in Lite.
  - Link key references: `backend/alembic/README.md`, `deployment/helm/charts/onyx/values-lite.yaml`, `deployment/docker_compose/docker-compose.onyx-lite.yml`.

<sup>Written for commit 7894bb63b2c46c3b28e316a4155262b8381b8119. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

