### PR TITLE
fix: sharepoint pages 400 list expand

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1275,6 +1275,7 @@ class SharepointConnector(
         page_url: str | None = site_pages_base
         params: dict[str, str] | None = {"$expand": "canvasLayout"}
         total_yielded = 0
+        yielded_ids: set[str] = set()
 
         while page_url:
             try:
@@ -1294,7 +1295,7 @@ class SharepointConnector(
                         f"per-page expansion."
                     )
                     yield from self._fetch_site_pages_individually(
-                        site_pages_base, start, end
+                        site_pages_base, start, end, skip_ids=yielded_ids
                     )
                     return
                 raise
@@ -1305,6 +1306,9 @@ class SharepointConnector(
                 if not _site_page_in_time_window(page, start, end):
                     continue
                 total_yielded += 1
+                page_id = page.get("id")
+                if page_id:
+                    yielded_ids.add(page_id)
                 yield page
 
             page_url = data.get("@odata.nextLink")
@@ -1316,6 +1320,7 @@ class SharepointConnector(
         site_pages_base: str,
         start: datetime | None = None,
         end: datetime | None = None,
+        skip_ids: set[str] | None = None,
     ) -> Generator[dict[str, Any], None, None]:
         """Fallback for _fetch_site_pages: list pages without $expand, then
         expand canvasLayout on each page individually.
@@ -1327,9 +1332,13 @@ class SharepointConnector(
         response. This method works around it by fetching metadata first, then
         expanding each page individually so only the broken page loses its
         canvas content.
+
+        ``skip_ids`` contains page IDs already yielded by the caller before the
+        fallback was triggered, preventing duplicates.
         """
         page_url: str | None = site_pages_base
         total_yielded = 0
+        _skip_ids = skip_ids or set()
 
         while page_url:
             try:
@@ -1344,6 +1353,9 @@ class SharepointConnector(
                     continue
 
                 page_id = page.get("id")
+                if page_id and page_id in _skip_ids:
+                    continue
+
                 if not page_id:
                     total_yielded += 1
                     yield page
@@ -1368,7 +1380,8 @@ class SharepointConnector(
         """Try to GET a single page with $expand=canvasLayout. On 400, return
         the metadata-only fallback so the page is still indexed (without canvas
         content)."""
-        single_url = f"{site_pages_base}/{page_id}/microsoft.graph.sitePage"
+        pages_collection = site_pages_base.removesuffix("/microsoft.graph.sitePage")
+        single_url = f"{pages_collection}/{page_id}/microsoft.graph.sitePage"
         try:
             return self._graph_api_get_json(single_url, {"$expand": "canvasLayout"})
         except HTTPError as e:

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -20,10 +20,8 @@ from onyx.connectors.sharepoint.connector import SiteDescriptor
 
 SITE_URL = "https://tenant.sharepoint.com/sites/ClassicSite"
 FAKE_SITE_ID = "tenant.sharepoint.com,abc123,def456"
-SITE_PAGES_BASE = (
-    f"https://graph.microsoft.com/v1.0/sites/{FAKE_SITE_ID}"
-    f"/pages/microsoft.graph.sitePage"
-)
+PAGES_COLLECTION = f"https://graph.microsoft.com/v1.0/sites/{FAKE_SITE_ID}/pages"
+SITE_PAGES_BASE = f"{PAGES_COLLECTION}/microsoft.graph.sitePage"
 
 
 def _site_descriptor() -> SiteDescriptor:
@@ -234,9 +232,12 @@ class TestFetchSitePages400Fallback:
                 )
             if url == SITE_PAGES_BASE and params is None:
                 return {"value": [good_page, bad_page]}
-            if "good-1" in url:
+            expand_params = {"$expand": "canvasLayout"}
+            if url == f"{PAGES_COLLECTION}/good-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
                 return good_page_expanded
-            if "bad-1" in url:
+            if url == f"{PAGES_COLLECTION}/bad-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
                 raise _make_http_error(
                     400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
                 )
@@ -249,6 +250,60 @@ class TestFetchSitePages400Fallback:
         assert pages[0].get("canvasLayout") is not None
         assert pages[1].get("canvasLayout") is None
         assert pages[1]["id"] == "bad-1"
+
+    def test_mid_pagination_400_does_not_duplicate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the first paginated batch succeeds but a later nextLink
+        returns 400, pages from the first batch must not be re-yielded
+        by the fallback."""
+        connector = _setup_connector(monkeypatch)
+        good_page = self.GOOD_PAGE
+        good_page_expanded = self.GOOD_PAGE_EXPANDED
+        bad_page = self.BAD_PAGE
+        second_page = {
+            "id": "page-2",
+            "name": "Second.aspx",
+            "title": "Second Page",
+            "lastModifiedDateTime": "2025-06-01T00:00:00Z",
+        }
+        next_link = "https://graph.microsoft.com/v1.0/next-page-link"
+
+        def fake_get_json(
+            self: SharepointConnector,  # noqa: ARG001
+            url: str,
+            params: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            if url == SITE_PAGES_BASE and params == {"$expand": "canvasLayout"}:
+                return {
+                    "value": [good_page],
+                    "@odata.nextLink": next_link,
+                }
+            if url == next_link:
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            if url == SITE_PAGES_BASE and params is None:
+                return {"value": [good_page, bad_page, second_page]}
+            expand_params = {"$expand": "canvasLayout"}
+            if url == f"{PAGES_COLLECTION}/good-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                return good_page_expanded
+            if url == f"{PAGES_COLLECTION}/bad-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            if url == f"{PAGES_COLLECTION}/page-2/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                return {**second_page, "canvasLayout": {"horizontalSections": []}}
+            raise AssertionError(f"Unexpected call: {url} {params}")
+
+        _patch_graph_api_get_json(monkeypatch, fake_get_json)
+        pages = list(connector._fetch_site_pages(_site_descriptor()))
+
+        ids = [p["id"] for p in pages]
+        assert ids == ["good-1", "bad-1", "page-2"]
 
     def test_non_invalid_request_400_still_raises(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Description

Some pages in sharepoint kick back a 400 with $expand=canvasLayout which we use to get the full page text. This is similar to a known bug in getting sharepoint data via graph API: https://github.com/SharePoint/sp-dev-docs/issues/8822

Whatever the case, the facts are that even a single page that gives back a 400 when you request it with expand=canvasLayout will cause an entire list batch to return a 400. So, when we hit this particular 400 in a list call, we iterate through all the pages to do our best to index as many valid pages as possible, and simply skip the page body for pages where we still get the error when we run an individual GET.

## How Has This Been Tested?

unit tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint page indexing failures caused by 400s from list-level `$expand=canvasLayout`. Falls back to per-page expansion and avoids duplicates if the error happens mid-pagination so valid pages still index.

- **Bug Fixes**
  - Detect Graph `invalidRequest` 400 on the list endpoint; list without `$expand`, then expand each page individually.
  - Index good pages with canvas content; index bad pages metadata-only.
  - Preserve pagination and time-window filtering; prevent duplicates when switching to the fallback mid-pagination.
  - Only fall back on `invalidRequest`; other 400s still raise. Added tests for 404 sites, the 400 fallback, mid-pagination dedupe, and non-`invalidRequest` 400s.

<sup>Written for commit 56ede9feb49b49d72ac59909fdcabb387ec6dad7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

