### PR TITLE
Add crypto payment addresses and retrieval function

### DIFF
--- a/backend/payment;s_crypto_payments.py
+++ b/backend/payment;s_crypto_payments.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.logging_utils import getLogger  # same logger module
+
+logger = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CryptoAddresses:
+    eth_evm: str
+    btc: str
+    solana_like: str
+
+
+CRYPTO_ADDRESSES = CryptoAddresses(
+    eth_evm="0x59e7778EB7c28ea6Eb2fE1a06fF693A04E9535Eb",
+    btc="bc1p6a9de8md64psxdmu6cjstfzqrxr0rxyxgtyj5293aajlrkpua2ns84ggpr",
+    solana_like="BTyjtayJJNguYoBpVDMfrBJgZ25vVZsG96TYwJLf7Wi3",
+)
+
+
+def get_crypto_addresses() -> CryptoAddresses:
+    logger.info("Returning crypto payment addresses")
+    return CRYPTO_ADDRESSES


### PR DESCRIPTION
prices for services.

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized crypto payment addresses with a helper to retrieve them. Provides ETH/EVM, BTC, and Solana-like addresses from one source and logs access.

- **New Features**
  - `CryptoAddresses` frozen dataclass with `eth_evm`, `btc`, `solana_like`.
  - `CRYPTO_ADDRESSES` constant populated with current addresses.
  - `get_crypto_addresses()` returns the addresses and logs the request.

<sup>Written for commit 60705595b186f2c1458c924faec4f9607173cf7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

