### PR TITLE
fix(helm): User Auth Secret off by Default

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.34
+version: 0.4.35
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1184,8 +1184,9 @@ auth:
       opensearch_admin_username: "admin"
       opensearch_admin_password: "OnyxDev1!"
   userauth:
-    # -- Used for signing password reset tokens, email verification tokens, and JWT tokens.
-    enabled: true
+    # -- Used for password reset / verification tokens and OAuth/OIDC state signing.
+    # Disabled by default to preserve upgrade compatibility for existing Helm customers.
+    enabled: false
     # -- Overwrite the default secret name, ignored if existingSecret is defined
     secretName: 'onyx-userauth'
     # -- Use a secret specified elsewhere
@@ -1193,15 +1194,16 @@ auth:
     # -- This defines the env var to secret map
     secretKeys:
       USER_AUTH_SECRET: user_auth_secret
-    # -- Secret value. Required - generate with: openssl rand -hex 32
-    # If not set, helm install/upgrade will fail.
+    # -- Secret value. Required when this secret is enabled - generate with: openssl rand -hex 32
+    # If not set, helm install/upgrade will fail when auth.userauth.enabled=true.
     values:
       user_auth_secret: ""
 
 configMap:
   # Auth type: "basic" (default), "google_oauth", "oidc", or "saml"
   # UPGRADE NOTE: Default changed from "disabled" to "basic" in 0.4.34.
-  # You must also set auth.userauth.values.user_auth_secret.
+  # Set auth.userauth.enabled=true and provide auth.userauth.values.user_auth_secret
+  # before enabling flows that require it.
   AUTH_TYPE: "basic"
   # Enable PKCE for OIDC login flow. Leave empty/false for backward compatibility.
   OIDC_PKCE_ENABLED: ""


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This value was set to default true but this would break all existing customers. Turning this back to default false to ensure that the customers can upgrade and then afterwards we will communicate the proper way to migrate over to using this new setup.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested this locally with our cluster

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `auth.userauth.enabled` by default in the Helm chart to preserve upgrade compatibility and prevent install/upgrade failures; bump chart to version 0.4.35 and clarify values comments.

- **Migration**
  - To opt in: set `auth.userauth.enabled: true`.
  - Provide a secret via `auth.userauth.values.user_auth_secret` (or set `auth.userauth.existingSecret`).
  - If enabling OAuth/OIDC or password reset/verification flows, set `configMap.AUTH_TYPE` accordingly (and `OIDC_PKCE_ENABLED` if needed).

<sup>Written for commit 77311ef1abc0e2f79a6f0de5668042dafee6d395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

