### PR TITLE
fix(voice): sanitized error and fix replay voice on revisit chat

### DIFF
--- a/backend/onyx/server/manage/voice/api.py
+++ b/backend/onyx/server/manage/voice/api.py
@@ -33,6 +33,10 @@ logger = setup_logger()
 
 admin_router = APIRouter(prefix="/admin/voice")
 
+VOICE_PROVIDER_VALIDATION_FAILURE_MESSAGE = (
+    "Connection test failed. Please verify your API key and settings."
+)
+
 
 def _validate_voice_api_base(provider_type: str, api_base: str | None) -> str | None:
     """Validate and normalize provider api_base / target URI."""
@@ -136,7 +140,7 @@ async def upsert_voice_provider_endpoint(
         logger.error(f"Voice provider credential validation failed on save: {e}")
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
-            str(e),
+            VOICE_PROVIDER_VALIDATION_FAILURE_MESSAGE,
         ) from e
 
     db_session.commit()
@@ -263,7 +267,7 @@ async def test_voice_provider(
         logger.error(f"Voice provider connection test failed: {e}")
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
-            str(e),
+            VOICE_PROVIDER_VALIDATION_FAILURE_MESSAGE,
         ) from e
 
     logger.info(f"Voice provider test succeeded for {request.provider_type}.")

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -175,6 +175,9 @@ const AgentMessage = React.memo(function AgentMessage({
   // Streaming TTS integration
   const { streamTTS, resetTTS, stopTTS } = useVoiceMode();
   const ttsCompletedRef = useRef(false);
+  const hasStreamedIncompleteRef = useRef(false);
+  const hasObservedPacketGrowthRef = useRef(false);
+  const lastSeenPacketCountRef = useRef(packetCount ?? rawPackets.length);
   const streamTTSRef = useRef(streamTTS);
 
   // Keep streamTTS ref in sync without triggering effect re-runs
@@ -186,6 +189,12 @@ const AgentMessage = React.memo(function AgentMessage({
   // Uses ref for streamTTS to avoid re-triggering when its identity changes
   // Note: packetCount is used instead of rawPackets because the array is mutated in place
   useLayoutEffect(() => {
+    const effectivePacketCount = packetCount ?? rawPackets.length;
+    if (effectivePacketCount > lastSeenPacketCountRef.current) {
+      hasObservedPacketGrowthRef.current = true;
+    }
+    lastSeenPacketCountRef.current = effectivePacketCount;
+
     // Skip if we've already finished TTS for this message
     if (ttsCompletedRef.current) return;
 
@@ -196,13 +205,22 @@ const AgentMessage = React.memo(function AgentMessage({
     }
 
     const textContent = removeThinkingTokens(getTextContent(rawPackets));
-    if (typeof textContent === "string" && textContent.length > 0) {
-      streamTTSRef.current(textContent, isComplete, nodeId);
+    if (!(typeof textContent === "string" && textContent.length > 0)) return;
 
-      // Mark as completed once the message is done streaming
-      if (isComplete) {
-        ttsCompletedRef.current = true;
+    // Only autoplay messages that were observed streaming in this lifecycle.
+    // Prevents historical, already-complete chats from re-triggering read-aloud on mount.
+    if (!isComplete) {
+      if (!hasObservedPacketGrowthRef.current) {
+        return;
       }
+      hasStreamedIncompleteRef.current = true;
+      streamTTSRef.current(textContent, false, nodeId);
+      return;
+    }
+
+    if (hasStreamedIncompleteRef.current) {
+      streamTTSRef.current(textContent, true, nodeId);
+      ttsCompletedRef.current = true;
     }
   }, [packetCount, isComplete, rawPackets, nodeId, stopPacketSeen, stopReason]); // packetCount triggers on new packets since rawPackets is mutated in place
 
@@ -216,6 +234,9 @@ const AgentMessage = React.memo(function AgentMessage({
   // Reset TTS completed flag when nodeId changes (new message)
   useEffect(() => {
     ttsCompletedRef.current = false;
+    hasStreamedIncompleteRef.current = false;
+    hasObservedPacketGrowthRef.current = false;
+    lastSeenPacketCountRef.current = packetCount ?? rawPackets.length;
   }, [nodeId]);
 
   // Reset TTS when component unmounts or nodeId changes


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Voice Mode fixes

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Local testing for minor bug

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes voice provider errors and fixes voice autoplay so completed messages don’t replay when revisiting a chat. Improves privacy and reduces unexpected audio.

- **Bug Fixes**
  - Backend: Replace raw provider validation errors with a generic message in both save and test endpoints to avoid leaking details.
  - Frontend: Only auto-play TTS for messages that streamed in the current session by tracking packet growth and incomplete streaming; prevents replay on revisit and correctly finalizes TTS state.

<sup>Written for commit 919c90ae35ce71ce117b172e8f2605afc858105b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

