### PR TITLE
chore(cherry-pick): Whitelist for Users who can CP

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -37,10 +37,27 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
-          # GitHub team slug authorized to trigger cherry-picks (e.g. "core-eng").
-          # For private/secret teams the GITHUB_TOKEN may need org:read scope;
-          # visible teams work with the default token.
-          ALLOWED_TEAM: "onyx-core-team"
+          # Explicit merger allowlist used because pull_request_target runs with
+          # the default GITHUB_TOKEN, which cannot reliably read org/team
+          # membership for this repository context.
+          ALLOWED_MERGERS: |
+            acaprau
+            bo-onyx
+            danelegend
+            duo-onyx
+            evan-onyx
+            jessicasingh7
+            jmelahman
+            joachim-danswer
+            justin-tahara
+            nmgarza5
+            raunakab
+            rohoswagger
+            subash-mohan
+            trial2onyx
+            wenxi-onyx
+            weves
+            yuhongsun96
         run: |
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "merged_by=${MERGED_BY}" >> "$GITHUB_OUTPUT"
@@ -64,19 +81,11 @@ jobs:
 
           echo "merge_commit_sha=${MERGE_COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
-          member_state_file="$(mktemp)"
-          member_err_file="$(mktemp)"
-          if ! gh api "orgs/${GITHUB_REPOSITORY_OWNER}/teams/${ALLOWED_TEAM}/memberships/${MERGED_BY}" --jq '.state' >"${member_state_file}" 2>"${member_err_file}"; then
-            api_err="$(tr '\n' ' ' < "${member_err_file}" | sed 's/[[:space:]]\+/ /g' | cut -c1-300)"
-            echo "gate_error=team-api-error" >> "$GITHUB_OUTPUT"
-            echo "::error::Team membership API call failed for ${MERGED_BY} in ${ALLOWED_TEAM}: ${api_err}"
-            exit 1
-          fi
-
-          member_state="$(cat "${member_state_file}")"
-          if [ "${member_state}" != "active" ]; then
-            echo "gate_error=not-team-member" >> "$GITHUB_OUTPUT"
-            echo "::error::${MERGED_BY} is not an active member of team ${ALLOWED_TEAM} (state: ${member_state}). Failing cherry-pick gate."
+          normalized_merged_by="$(printf '%s' "${MERGED_BY}" | tr '[:upper:]' '[:lower:]')"
+          normalized_allowed_mergers="$(printf '%s\n' "${ALLOWED_MERGERS}" | tr '[:upper:]' '[:lower:]')"
+          if ! printf '%s\n' "${normalized_allowed_mergers}" | grep -Fxq "${normalized_merged_by}"; then
+            echo "gate_error=not-allowed-merger" >> "$GITHUB_OUTPUT"
+            echo "::error::${MERGED_BY} is not in the explicit cherry-pick merger allowlist. Failing cherry-pick gate."
             exit 1
           fi
 
@@ -199,10 +208,8 @@ jobs:
           reason_text="cherry-pick command failed"
           if [ "${GATE_ERROR}" = "missing-merge-commit-sha" ]; then
             reason_text="requested cherry-pick but merge commit SHA was missing"
-          elif [ "${GATE_ERROR}" = "team-api-error" ]; then
-            reason_text="team membership lookup failed while validating cherry-pick permissions"
-          elif [ "${GATE_ERROR}" = "not-team-member" ]; then
-            reason_text="merger is not an active member of the allowed team"
+          elif [ "${GATE_ERROR}" = "not-allowed-merger" ]; then
+            reason_text="merger is not in the explicit cherry-pick allowlist"
           elif [ "${CHERRY_PICK_REASON}" = "output-capture-failed" ]; then
             reason_text="failed to capture cherry-pick output for classification"
           elif [ "${CHERRY_PICK_REASON}" = "merge-conflict" ]; then


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Changing the Allowed Team workflow to be Allowed Mergers since the API is not able to hit this API endpoint. 

On top of this also made sure that the error is displayed properly if they aren't able to merge.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch cherry-pick permissions from a team membership check to an explicit allowlist to avoid org/team API limitations in `pull_request_target`. Adds clearer errors when a user isn’t allowed to cherry-pick.

- **Refactors**
  - Replace team check with `ALLOWED_MERGERS` allowlist; remove GitHub team API calls.
  - Compare usernames case-insensitively.
  - Emit `not-allowed-merger` and show a clear failure reason.

<sup>Written for commit eb9da708a7e708bd5070265f8d98c4fc86dc6086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

