### PR TITLE
chore(python): configure `ruff format`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,12 @@ typeCheckingMode = "off"
 line-length = 130
 target-version = "py311"
 
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
 [tool.ruff.lint]
 ignore = []
 select = [


### PR DESCRIPTION
## Description

Two purposes:
1. I want to start moving us off `black` and onto `ruff format`
2. I already use `ruff format` w/ save on edit, so editing files means I almost always have to run pre-commit hooks afterwards

## How Has This Been Tested?

no-op

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `ruff format` in `pyproject.toml` to start migrating from `black` and standardize Python formatting. Improves save-on-edit workflows and reduces post-edit pre-commit runs.

- **Refactors**
  - Added `[tool.ruff.format]` with: double quotes, space indents, magic trailing comma kept, auto line endings.

<sup>Written for commit 6b375c4c1827f4fa9714f2c2165ad54195a8d284. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

