### PR TITLE
fix(opal): move default type=button from Button to InteractiveContainer

### DIFF
--- a/web/lib/opal/src/components/buttons/button/components.tsx
+++ b/web/lib/opal/src/components/buttons/button/components.tsx
@@ -55,7 +55,7 @@ function Button({
   children,
   rightIcon: RightIcon,
   size = "lg",
-  type = "button",
+  type,
   width,
   tooltip,
   tooltipSide = "top",

--- a/web/lib/opal/src/core/interactive/container/components.tsx
+++ b/web/lib/opal/src/core/interactive/container/components.tsx
@@ -97,7 +97,7 @@ interface InteractiveContainerProps
  */
 function InteractiveContainer({
   ref,
-  type,
+  type = "button",
   border,
   roundingVariant = "default",
   heightVariant = "lg",


### PR DESCRIPTION
## Description

Moves the default `type="button"` from the opal `Button` component down to `InteractiveContainer`. This ensures all interactive elements (not just `Button`) get the correct default type, preventing accidental form submissions.

## How Has This Been Tested?

- Type checking passes
- Verified no behavioral change — `InteractiveContainer` is the underlying element for all interactive opal components

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the default type="button" from `Button` to `InteractiveContainer` so all interactive components default to button and don’t accidentally submit forms. Behavior stays the same since `InteractiveContainer` underlies all interactive Opal components.

<sup>Written for commit 51b8ac96d615012ba4519001c287a52191c9fd0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->