### PR TITLE
fix: sharepoint pages 400 list expand (#9321) to release v3.0

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -278,6 +278,23 @@ def _log_and_raise_for_status(response: requests.Response) -> None:
         raise
 
 
+GRAPH_INVALID_REQUEST_CODE = "invalidRequest"
+
+
+def _is_graph_invalid_request(response: requests.Response) -> bool:
+    """Return True if the response body is the generic Graph API
+    ``{"error": {"code": "invalidRequest", "message": "Invalid request"}}``
+    shape. This particular error has no actionable inner error code and is
+    returned by the site-pages endpoint when a page has a corrupt canvas layout
+    (e.g. duplicate web-part IDs — see SharePoint/sp-dev-docs#8822)."""
+    try:
+        body = response.json()
+    except Exception:
+        return False
+    error = body.get("error", {})
+    return error.get("code") == GRAPH_INVALID_REQUEST_CODE
+
+
 def load_certificate_from_pfx(pfx_data: bytes, password: str) -> CertificateData | None:
     """Load certificate from .pfx file for MSAL authentication"""
     try:
@@ -1248,19 +1265,35 @@ class SharepointConnector(
         site.execute_query()
         site_id = site.id
 
-        page_url: str | None = (
-            f"{self.graph_api_base}/sites/{site_id}" f"/pages/microsoft.graph.sitePage"
+        site_pages_base = (
+            f"{self.graph_api_base}/sites/{site_id}/pages/microsoft.graph.sitePage"
         )
+        page_url: str | None = site_pages_base
         params: dict[str, str] | None = {"$expand": "canvasLayout"}
         total_yielded = 0
+        yielded_ids: set[str] = set()
 
         while page_url:
             try:
                 data = self._graph_api_get_json(page_url, params)
             except HTTPError as e:
-                if e.response.status_code == 404:
+                if e.response is not None and e.response.status_code == 404:
                     logger.warning(f"Site page not found: {page_url}")
                     break
+                if (
+                    e.response is not None
+                    and e.response.status_code == 400
+                    and _is_graph_invalid_request(e.response)
+                ):
+                    logger.warning(
+                        f"$expand=canvasLayout on the LIST endpoint returned 400 "
+                        f"for site {site_descriptor.url}. Falling back to "
+                        f"per-page expansion."
+                    )
+                    yield from self._fetch_site_pages_individually(
+                        site_pages_base, start, end, skip_ids=yielded_ids
+                    )
+                    return
                 raise
 
             params = None  # nextLink already embeds query params
@@ -1269,11 +1302,97 @@ class SharepointConnector(
                 if not _site_page_in_time_window(page, start, end):
                     continue
                 total_yielded += 1
+                page_id = page.get("id")
+                if page_id:
+                    yielded_ids.add(page_id)
                 yield page
 
             page_url = data.get("@odata.nextLink")
 
         logger.debug(f"Yielded {total_yielded} site pages for {site_descriptor.url}")
+
+    def _fetch_site_pages_individually(
+        self,
+        site_pages_base: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        skip_ids: set[str] | None = None,
+    ) -> Generator[dict[str, Any], None, None]:
+        """Fallback for _fetch_site_pages: list pages without $expand, then
+        expand canvasLayout on each page individually.
+
+        The Graph API's LIST endpoint can return 400 when $expand=canvasLayout
+        is used and *any* page in the site has a corrupt canvas layout (e.g.
+        duplicate web part IDs — see SharePoint/sp-dev-docs#8822). Since the
+        LIST expansion is all-or-nothing, a single bad page poisons the entire
+        response. This method works around it by fetching metadata first, then
+        expanding each page individually so only the broken page loses its
+        canvas content.
+
+        ``skip_ids`` contains page IDs already yielded by the caller before the
+        fallback was triggered, preventing duplicates.
+        """
+        page_url: str | None = site_pages_base
+        total_yielded = 0
+        _skip_ids = skip_ids or set()
+
+        while page_url:
+            try:
+                data = self._graph_api_get_json(page_url)
+            except HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    break
+                raise
+
+            for page in data.get("value", []):
+                if not _site_page_in_time_window(page, start, end):
+                    continue
+
+                page_id = page.get("id")
+                if page_id and page_id in _skip_ids:
+                    continue
+
+                if not page_id:
+                    total_yielded += 1
+                    yield page
+                    continue
+
+                expanded = self._try_expand_single_page(site_pages_base, page_id, page)
+                total_yielded += 1
+                yield expanded
+
+            page_url = data.get("@odata.nextLink")
+
+        logger.debug(
+            f"Yielded {total_yielded} site pages (per-page expansion fallback)"
+        )
+
+    def _try_expand_single_page(
+        self,
+        site_pages_base: str,
+        page_id: str,
+        fallback_page: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Try to GET a single page with $expand=canvasLayout. On 400, return
+        the metadata-only fallback so the page is still indexed (without canvas
+        content)."""
+        pages_collection = site_pages_base.removesuffix("/microsoft.graph.sitePage")
+        single_url = f"{pages_collection}/{page_id}/microsoft.graph.sitePage"
+        try:
+            return self._graph_api_get_json(single_url, {"$expand": "canvasLayout"})
+        except HTTPError as e:
+            if (
+                e.response is not None
+                and e.response.status_code == 400
+                and _is_graph_invalid_request(e.response)
+            ):
+                page_name = fallback_page.get("name", page_id)
+                logger.warning(
+                    f"$expand=canvasLayout failed for page '{page_name}' "
+                    f"({page_id}). Indexing metadata only."
+                )
+                return fallback_page
+            raise
 
     def _acquire_token(self) -> dict[str, Any]:
         """

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -1,33 +1,43 @@
-"""Unit tests for SharepointConnector._fetch_site_pages 404 handling.
+"""Unit tests for SharepointConnector._fetch_site_pages error handling.
 
-The Graph Pages API returns 404 for classic sites or sites without
-modern pages enabled.  _fetch_site_pages should gracefully skip these
-rather than crashing the entire indexing run.
+Covers 404 handling (classic sites / no modern pages) and 400
+canvasLayout fallback (corrupt pages causing $expand=canvasLayout to
+fail on the LIST endpoint).
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
 from requests import Response
 from requests.exceptions import HTTPError
 
+from onyx.connectors.sharepoint.connector import GRAPH_INVALID_REQUEST_CODE
 from onyx.connectors.sharepoint.connector import SharepointConnector
 from onyx.connectors.sharepoint.connector import SiteDescriptor
 
 SITE_URL = "https://tenant.sharepoint.com/sites/ClassicSite"
 FAKE_SITE_ID = "tenant.sharepoint.com,abc123,def456"
+PAGES_COLLECTION = f"https://graph.microsoft.com/v1.0/sites/{FAKE_SITE_ID}/pages"
+SITE_PAGES_BASE = f"{PAGES_COLLECTION}/microsoft.graph.sitePage"
 
 
 def _site_descriptor() -> SiteDescriptor:
     return SiteDescriptor(url=SITE_URL, drive_name=None, folder_path=None)
 
 
-def _make_http_error(status_code: int) -> HTTPError:
+def _make_http_error(
+    status_code: int,
+    error_code: str = "itemNotFound",
+    message: str = "Item not found",
+) -> HTTPError:
+    body = {"error": {"code": error_code, "message": message}}
     response = Response()
     response.status_code = status_code
-    response._content = b'{"error":{"code":"itemNotFound","message":"Item not found"}}'
+    response._content = json.dumps(body).encode()
+    response.headers["Content-Type"] = "application/json"
     return HTTPError(response=response)
 
 
@@ -177,3 +187,139 @@ class TestFetchSitePages404:
         pages = list(connector._fetch_site_pages(_site_descriptor()))
         assert len(pages) == 1
         assert pages[0]["id"] == "page-1"
+
+
+class TestFetchSitePages400Fallback:
+    """When $expand=canvasLayout on the LIST endpoint returns 400
+    invalidRequest, _fetch_site_pages should fall back to listing
+    without expansion, then expanding each page individually."""
+
+    GOOD_PAGE: dict[str, Any] = {
+        "id": "good-1",
+        "name": "Good.aspx",
+        "title": "Good Page",
+        "lastModifiedDateTime": "2025-06-01T00:00:00Z",
+    }
+    BAD_PAGE: dict[str, Any] = {
+        "id": "bad-1",
+        "name": "Bad.aspx",
+        "title": "Bad Page",
+        "lastModifiedDateTime": "2025-06-01T00:00:00Z",
+    }
+    GOOD_PAGE_EXPANDED: dict[str, Any] = {
+        **GOOD_PAGE,
+        "canvasLayout": {"horizontalSections": []},
+    }
+
+    def test_fallback_expands_good_pages_individually(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On 400 from the LIST expand, the connector should list without
+        expand, then GET each page individually with $expand=canvasLayout."""
+        connector = _setup_connector(monkeypatch)
+        good_page = self.GOOD_PAGE
+        bad_page = self.BAD_PAGE
+        good_page_expanded = self.GOOD_PAGE_EXPANDED
+
+        def fake_get_json(
+            self: SharepointConnector,  # noqa: ARG001
+            url: str,
+            params: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            if url == SITE_PAGES_BASE and params == {"$expand": "canvasLayout"}:
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            if url == SITE_PAGES_BASE and params is None:
+                return {"value": [good_page, bad_page]}
+            expand_params = {"$expand": "canvasLayout"}
+            if url == f"{PAGES_COLLECTION}/good-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                return good_page_expanded
+            if url == f"{PAGES_COLLECTION}/bad-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            raise AssertionError(f"Unexpected call: {url} {params}")
+
+        _patch_graph_api_get_json(monkeypatch, fake_get_json)
+        pages = list(connector._fetch_site_pages(_site_descriptor()))
+
+        assert len(pages) == 2
+        assert pages[0].get("canvasLayout") is not None
+        assert pages[1].get("canvasLayout") is None
+        assert pages[1]["id"] == "bad-1"
+
+    def test_mid_pagination_400_does_not_duplicate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the first paginated batch succeeds but a later nextLink
+        returns 400, pages from the first batch must not be re-yielded
+        by the fallback."""
+        connector = _setup_connector(monkeypatch)
+        good_page = self.GOOD_PAGE
+        good_page_expanded = self.GOOD_PAGE_EXPANDED
+        bad_page = self.BAD_PAGE
+        second_page = {
+            "id": "page-2",
+            "name": "Second.aspx",
+            "title": "Second Page",
+            "lastModifiedDateTime": "2025-06-01T00:00:00Z",
+        }
+        next_link = "https://graph.microsoft.com/v1.0/next-page-link"
+
+        def fake_get_json(
+            self: SharepointConnector,  # noqa: ARG001
+            url: str,
+            params: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            if url == SITE_PAGES_BASE and params == {"$expand": "canvasLayout"}:
+                return {
+                    "value": [good_page],
+                    "@odata.nextLink": next_link,
+                }
+            if url == next_link:
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            if url == SITE_PAGES_BASE and params is None:
+                return {"value": [good_page, bad_page, second_page]}
+            expand_params = {"$expand": "canvasLayout"}
+            if url == f"{PAGES_COLLECTION}/good-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                return good_page_expanded
+            if url == f"{PAGES_COLLECTION}/bad-1/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                raise _make_http_error(
+                    400, GRAPH_INVALID_REQUEST_CODE, "Invalid request"
+                )
+            if url == f"{PAGES_COLLECTION}/page-2/microsoft.graph.sitePage":
+                assert params == expand_params, f"Expected $expand params, got {params}"
+                return {**second_page, "canvasLayout": {"horizontalSections": []}}
+            raise AssertionError(f"Unexpected call: {url} {params}")
+
+        _patch_graph_api_get_json(monkeypatch, fake_get_json)
+        pages = list(connector._fetch_site_pages(_site_descriptor()))
+
+        ids = [p["id"] for p in pages]
+        assert ids == ["good-1", "bad-1", "page-2"]
+
+    def test_non_invalid_request_400_still_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 400 with a different error code (not invalidRequest) should
+        propagate, not trigger the fallback."""
+        connector = _setup_connector(monkeypatch)
+
+        def fake_get_json(
+            self: SharepointConnector,  # noqa: ARG001
+            url: str,  # noqa: ARG001
+            params: dict[str, str] | None = None,  # noqa: ARG001
+        ) -> dict[str, Any]:
+            raise _make_http_error(400, "badRequest", "Something else went wrong")
+
+        _patch_graph_api_get_json(monkeypatch, fake_get_json)
+
+        with pytest.raises(HTTPError):
+            list(connector._fetch_site_pages(_site_descriptor()))


### PR DESCRIPTION
Cherry-pick of commit 613be0de6614e607edefe526522696da83dde050 to release/v3.0 branch.

Original PR: #9321

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors from the SharePoint Graph pages LIST endpoint when using $expand=canvasLayout by falling back to per‑page expansion and indexing metadata for corrupt pages. Prevents indexing failures and duplicates, and continues to gracefully handle 404s for classic sites.

- **Bug Fixes**
  - Detect Graph `invalidRequest` 400s and fall back: list pages without expand, then expand each page individually; on per‑page 400, index metadata only.
  - Track yielded page IDs to avoid duplicates if fallback triggers mid‑pagination.
  - Add targeted logging and unit tests for 404 handling, 400 fallback, and non-`invalidRequest` 400 propagation.

<sup>Written for commit 64b90bd95fd10e4ba5289f7a1b26b3db1e90ab9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

