### PR TITLE
chore(playwright): remove `.only` typo

### DIFF
--- a/web/tests/e2e/chat/chat_message_rendering.spec.ts
+++ b/web/tests/e2e/chat/chat_message_rendering.spec.ts
@@ -459,7 +459,7 @@ for (const theme of THEMES) {
         );
       });
 
-      test.only("AI response with LaTeX math renders correctly", async ({
+      test("AI response with LaTeX math renders correctly", async ({
         page,
       }) => {
         await openChat(page);


### PR DESCRIPTION
## Description

Auto-merge incident

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an accidental `.only` from a chat message rendering e2e test in `@playwright/test` so the full suite runs in CI again.

<sup>Written for commit 7dc920506601ad1e4910aaca0ed9cbf7aacbb1b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

