### PR TITLE
chore(blame): ignore ruff formatting change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,4 @@
 
 3134e5f840c12c8f32613ce520101a047c89dcc2  # refactor(whitespace): rm temporary react fragments (#7161)
 ed3f72bc75f3e3a9ae9e4d8cd38278f9c97e78b4  # refactor(whitespace): rm react fragment #7190
+7b927e79c25f4ddfd18a067f489e122acd2c89de  # chore(format): format files where `ruff` and `black` agree (#9339)


### PR DESCRIPTION
## Description

Ignore purely mechanical, no-op

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `ruff`/`black` formatting-only revision to `.git-blame-ignore-revs` so git blame skips mechanical formatting changes. This keeps blame focused on meaningful code edits.

<sup>Written for commit 0c9ec69017f07e4ead157b558341f64e16d3a7a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

