### PR TITLE
fix(fe): bump flatted to patch CVE-2026-32141

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10309,7 +10309,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Description

Bumps `flatted` from 3.3.3 → 3.4.1 to resolve [CVE-2026-32141](https://nvd.nist.gov/vuln/detail/CVE-2026-32141).

Dev dependency only (`package-lock.json`), no runtime impact.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check