### PR TITLE
perf(backend): set a timeout on billing HTTP calls

### DIFF
--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -32,7 +32,7 @@ def fetch_stripe_checkout_session(
         "billing_period": billing_period,
         "seats": seats,
     }
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload, timeout=10.0)
     if not response.ok:
         try:
             data = response.json()
@@ -57,7 +57,7 @@ def fetch_tenant_stripe_information(tenant_id: str) -> dict:
     }
     url = f"{CONTROL_PLANE_API_BASE_URL}/tenant-stripe-information"
     params = {"tenant_id": tenant_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10.0)
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
Added a mandatory timeout in backend/ee/onyx/server/tenants/billing.py to avoid indefinite network calls.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile backend/ee/onyx/server/tenants/billing.py`.

Context: py-http-timeout at backend/ee/onyx/server/tenants/billing.py:35.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 10s timeout to outbound billing HTTP requests to prevent hanging workers and improve reliability. Applied to `requests.post` in fetch_stripe_checkout_session and `requests.get` in fetch_tenant_stripe_information within backend/ee/onyx/server/tenants/billing.py.

<sup>Written for commit 187b77d95c3036c022598a70504ece471c0d45fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

