### PR TITLE
feat: Add Jira Service Management Connector (Fixes #2281)

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -200,6 +200,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -655,6 +656,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "outline data",
     DocumentSource.CONFLUENCE: "confluence data (pages, spaces, etc.)",
     DocumentSource.JIRA: "jira data (issues, tickets, projects, etc.)",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "jira service management data (service requests, SLAs, approvals, queues, etc.)",
     DocumentSource.SLAB: "slab data",
     DocumentSource.PRODUCTBOARD: "productboard data (boards, etc.)",
     DocumentSource.FILE: "files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -339,6 +339,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    document_source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -427,7 +428,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=document_source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -453,6 +454,10 @@ class JiraConnector(
     CheckpointedConnectorWithPermSync[JiraConnectorCheckpoint],
     SlimConnectorWithPermSync,
 ):
+    @property
+    def document_source(self) -> DocumentSource:
+        return DocumentSource.JIRA
+
     def __init__(
         self,
         jira_base_url: str,
@@ -648,6 +653,30 @@ class JiraConnector(
         )
         return None
 
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None,
+    ) -> Document | None:
+        return process_jira_issue(
+            jira_base_url=self.jira_base,
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            labels_to_skip=self.labels_to_skip,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+            document_source=self.document_source,
+        )
+
+    def _get_document_external_access(
+        self,
+        project_key: str,
+        add_prefix: bool,
+    ) -> Any:
+        return self._get_project_permissions(
+            project_key,
+            add_prefix=add_prefix,
+        )
+
     def _get_jql_query(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> str:
@@ -656,14 +685,7 @@ class JiraConnector(
         If a custom JQL query is provided, it will be used and combined with time constraints.
         Otherwise, the query will be constructed based on project key (if provided).
         """
-        start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M"
-        )
-        end_date_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M"
-        )
-
-        time_jql = f"updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
+        time_jql = self._build_time_jql(start=start, end=end)
 
         # If custom JQL query is provided, use it and combine with time constraints
         if self.jql_query:
@@ -675,6 +697,20 @@ class JiraConnector(
             return f"{base_jql} AND {time_jql}"
 
         return time_jql
+
+    def _build_time_jql(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> str:
+        start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+        end_date_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+
+        return f"updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
 
     def load_from_checkpoint(
         self,
@@ -770,17 +806,14 @@ class JiraConnector(
                     else None
                 )
 
-                if document := process_jira_issue(
-                    jira_base_url=self.jira_base,
+                if document := self._process_issue(
                     issue=issue,
-                    comment_email_blacklist=self.comment_email_blacklist,
-                    labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:
-                        document.external_access = self._get_project_permissions(
-                            project_key,
+                        document.external_access = self._get_document_external_access(
+                            project_key=project_key,
                             add_prefix=True,  # Indexing path - prefix here
                         )
                     yield document
@@ -896,8 +929,9 @@ class JiraConnector(
                     SlimDocument(
                         id=doc_id,
                         # Permission sync path - don't prefix, upsert_document_external_perms handles it
-                        external_access=self._get_project_permissions(
-                            project_key, add_prefix=False
+                        external_access=self._get_document_external_access(
+                            project_key=project_key,
+                            add_prefix=False,
                         ),
                         parent_hierarchy_raw_node_id=(
                             self._get_parent_hierarchy_raw_node_id(issue, project_key)

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,11 @@
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnectorCheckpoint,
+)
+
+__all__ = [
+    "JiraServiceManagementConnector",
+    "JiraServiceManagementConnectorCheckpoint",
+]

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from jira.resources import Issue
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import JIRA_CONNECTOR_MAX_TICKET_SIZE
+from onyx.configs.app_configs import JIRA_CONNECTOR_LABELS_TO_SKIP
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import ConnectorMissingCredentialError
+from onyx.connectors.jira.connector import _perform_jql_search
+from onyx.connectors.jira.connector import JiraConnector
+from onyx.connectors.jira.connector import JiraConnectorCheckpoint
+from onyx.connectors.jira.utils import best_effort_basic_expert_info
+from onyx.connectors.jira.utils import best_effort_get_field_from_issue
+from onyx.connectors.models import BasicExpertInfo
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+from .utils import absolute_jsm_link
+from .utils import append_with_byte_limit
+from .utils import build_queue_membership_map
+from .utils import format_approval_summaries
+from .utils import format_queue_summaries
+from .utils import format_request_field_values
+from .utils import format_sla_summaries
+from .utils import get_approval
+from .utils import get_customer_request
+from .utils import jsm_user_to_basic_expert_info
+from .utils import JSMQueue
+from .utils import JSMRequestType
+from .utils import JSMServiceDesk
+from .utils import list_request_approvals
+from .utils import list_request_participants
+from .utils import list_request_slas
+from .utils import list_request_types
+from .utils import list_service_desks
+from .utils import stringify_jsm_value
+
+logger = setup_logger()
+
+_FIELD_REPORTER = "reporter"
+_FIELD_PROJECT = "project"
+
+_METADATA_SERVICE_DESK = "jsm_service_desk"
+_METADATA_SERVICE_DESK_ID = "jsm_service_desk_id"
+_METADATA_REQUEST_ID = "jsm_request_id"
+_METADATA_REQUEST_STATUS = "jsm_request_status"
+_METADATA_REQUEST_PORTAL_URL = "jsm_request_portal_url"
+_METADATA_REQUEST_TYPE = "jsm_request_type"
+_METADATA_REQUEST_TYPE_ID = "jsm_request_type_id"
+_METADATA_REQUEST_TYPE_GROUPS = "jsm_request_type_group_ids"
+_METADATA_CUSTOMER = "jsm_customer"
+_METADATA_CUSTOMER_EMAIL = "jsm_customer_email"
+_METADATA_CUSTOMER_ACCOUNT_ID = "jsm_customer_account_id"
+_METADATA_PARTICIPANTS = "jsm_participants"
+_METADATA_APPROVALS = "jsm_approvals"
+_METADATA_QUEUES = "jsm_queues"
+_METADATA_SLAS = "jsm_slas"
+
+
+JiraServiceManagementConnectorCheckpoint = JiraConnectorCheckpoint
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str | None = None,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] | None = None,
+        jql_query: str | None = None,
+        scoped_token: bool = False,
+    ) -> None:
+        super().__init__(
+            jira_base_url=jira_base_url,
+            project_key=project_key,
+            comment_email_blacklist=comment_email_blacklist,
+            batch_size=batch_size,
+            labels_to_skip=(
+                JIRA_CONNECTOR_LABELS_TO_SKIP
+                if labels_to_skip is None
+                else labels_to_skip
+            ),
+            jql_query=jql_query,
+            scoped_token=scoped_token,
+        )
+        self._service_desk_by_project_key: dict[str, JSMServiceDesk] | None = None
+        self._request_types_by_service_desk_id: dict[str, dict[str, JSMRequestType]] = (
+            {}
+        )
+        self._queue_membership_by_service_desk_id: dict[
+            str, dict[str, list[JSMQueue]]
+        ] = {}
+        self._warning_cache: set[str] = set()
+
+    @property
+    @override
+    def document_source(self) -> DocumentSource:
+        return DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    @override
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._service_desk_by_project_key = None
+        self._request_types_by_service_desk_id.clear()
+        self._queue_membership_by_service_desk_id.clear()
+        self._warning_cache.clear()
+        return super().load_credentials(credentials)
+
+    @override
+    def _get_document_external_access(
+        self,
+        project_key: str,
+        add_prefix: bool,
+    ) -> Any:
+        del project_key
+        del add_prefix
+        # JSM request visibility can differ from Jira project visibility. Until
+        # request-level permission sync is implemented, do not assign doc-level perms.
+        return None
+
+    @override
+    def _get_jql_query(self, start: float, end: float) -> str:
+        scope_jql = self._get_service_desk_scope_jql()
+        time_jql = self._build_time_jql(start=start, end=end)
+
+        if self.jql_query:
+            return f"({scope_jql}) AND ({self.jql_query}) AND {time_jql}"
+
+        return f"({scope_jql}) AND {time_jql}"
+
+    @override
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        try:
+            service_desk_by_project_key = self._get_service_desk_by_project_key()
+        except Exception as exc:
+            self._handle_jira_connector_settings_error(exc)
+
+        if not service_desk_by_project_key:
+            raise ConnectorValidationError(
+                "No Jira Service Management service desks were accessible with the provided credentials."
+            )
+
+        if self.jira_project and self.jira_project not in service_desk_by_project_key:
+            raise ConnectorValidationError(
+                f"Project '{self.jira_project}' is not an accessible Jira Service Management service desk."
+            )
+
+        if self.jql_query:
+            try:
+                next(
+                    iter(
+                        _perform_jql_search(
+                            jira_client=self.jira_client,
+                            jql=f"({self._get_service_desk_scope_jql()}) AND ({self.jql_query})",
+                            start=0,
+                            max_results=1,
+                            all_issue_ids=[],
+                        )
+                    ),
+                    None,
+                )
+            except Exception as exc:
+                self._handle_jira_connector_settings_error(exc)
+
+    @override
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None,
+    ) -> Document | None:
+        document = super()._process_issue(
+            issue=issue,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        )
+        if document is None:
+            return None
+
+        service_desk = self._get_service_desk_for_issue(issue)
+        if service_desk is None:
+            return None
+
+        request = get_customer_request(
+            jira_client=self.jira_client,
+            issue_id_or_key=issue.key,
+        )
+        if request is None:
+            logger.debug(
+                "Skipping Jira issue %s because it is not accessible as a JSM request",
+                issue.key,
+            )
+            return None
+
+        participants = self._get_request_participants(issue.key)
+        slas = self._get_request_slas(issue.key)
+        approvals = self._get_request_approvals(issue.key)
+        request_type = self._get_request_type(service_desk.service_desk_id, request)
+        queues = self._get_request_queues(service_desk.service_desk_id, issue.key)
+
+        jsm_metadata = self._build_jsm_metadata(
+            issue=issue,
+            service_desk=service_desk,
+            request=request,
+            request_type=request_type,
+            participants=participants,
+            approvals=approvals,
+            slas=slas,
+            queues=queues,
+        )
+        document.metadata.update(jsm_metadata)
+
+        jsm_text = self._build_jsm_text(
+            service_desk=service_desk,
+            request=request,
+            request_type=request_type,
+            participants=participants,
+            approvals=approvals,
+            slas=slas,
+            queues=queues,
+        )
+
+        existing_section = document.sections[0]
+        if isinstance(existing_section, TextSection):
+            existing_section.text = append_with_byte_limit(
+                existing_text=existing_section.text,
+                text_to_append=jsm_text,
+                max_bytes=JIRA_CONNECTOR_MAX_TICKET_SIZE,
+            )
+
+        document.secondary_owners = self._build_secondary_owners(
+            issue=issue,
+            request=request,
+            participants=participants,
+            approvals=approvals,
+        )
+        document.additional_info = {
+            "service_desk_id": service_desk.service_desk_id,
+            "request_id": request.get("issueId"),
+            "request_type_id": request.get("requestTypeId"),
+            "queue_ids": [queue.queue_id for queue in queues],
+        }
+        return document
+
+    def _get_service_desk_by_project_key(self) -> dict[str, JSMServiceDesk]:
+        if self._service_desk_by_project_key is None:
+            service_desk_by_project_key: dict[str, JSMServiceDesk] = {}
+            for service_desk in list_service_desks(self.jira_client):
+                if service_desk.project_key:
+                    service_desk_by_project_key[service_desk.project_key] = service_desk
+            self._service_desk_by_project_key = service_desk_by_project_key
+
+        return self._service_desk_by_project_key
+
+    def _get_service_desk_scope_jql(self) -> str:
+        if self.jira_project:
+            service_desk_by_project_key = self._get_service_desk_by_project_key()
+            if self.jira_project not in service_desk_by_project_key:
+                raise ConnectorValidationError(
+                    f"Project '{self.jira_project}' is not an accessible Jira Service Management service desk."
+                )
+            return f'project = "{self.jira_project}"'
+
+        project_keys = sorted(self._get_service_desk_by_project_key().keys())
+        if not project_keys:
+            raise ConnectorValidationError(
+                "No Jira Service Management service desks were accessible with the provided credentials."
+            )
+
+        if len(project_keys) == 1:
+            return f'project = "{project_keys[0]}"'
+
+        quoted_project_keys = ", ".join(f'"{project_key}"' for project_key in project_keys)
+        return f"project in ({quoted_project_keys})"
+
+    def _get_service_desk_for_issue(self, issue: Issue) -> JSMServiceDesk | None:
+        project = best_effort_get_field_from_issue(issue, _FIELD_PROJECT)
+        project_key = getattr(project, "key", None) if project is not None else None
+        if project_key is None:
+            return None
+
+        return self._get_service_desk_by_project_key().get(project_key)
+
+    def _get_request_type_map(
+        self,
+        service_desk_id: str,
+    ) -> dict[str, JSMRequestType]:
+        if service_desk_id not in self._request_types_by_service_desk_id:
+            try:
+                request_types = list_request_types(
+                    jira_client=self.jira_client,
+                    service_desk_id=service_desk_id,
+                )
+            except requests.HTTPError as exc:
+                self._warn_once(
+                    warning_key=f"request_types:{service_desk_id}",
+                    message=(
+                        "Unable to fetch Jira Service Management request types for "
+                        f"service desk {service_desk_id}: {exc}"
+                    ),
+                )
+                request_types = []
+
+            self._request_types_by_service_desk_id[service_desk_id] = {
+                request_type.request_type_id: request_type for request_type in request_types
+            }
+
+        return self._request_types_by_service_desk_id[service_desk_id]
+
+    def _get_request_type(
+        self,
+        service_desk_id: str,
+        request: dict[str, Any],
+    ) -> JSMRequestType | None:
+        request_type_id = request.get("requestTypeId")
+        if request_type_id is not None:
+            request_type = self._get_request_type_map(service_desk_id).get(
+                str(request_type_id)
+            )
+            if request_type is not None:
+                return request_type
+
+        raw_request_type = request.get("requestType")
+        if not isinstance(raw_request_type, dict):
+            return None
+
+        raw_group_ids = raw_request_type.get("groupIds", [])
+        group_ids = tuple(
+            str(group_id)
+            for group_id in raw_group_ids
+            if group_id is not None and str(group_id).strip()
+        )
+        derived_request_type_id = raw_request_type.get("id") or request_type_id
+        if derived_request_type_id is None:
+            return None
+
+        return JSMRequestType(
+            request_type_id=str(derived_request_type_id),
+            name=_coerce_optional_str(raw_request_type.get("name")),
+            description=_coerce_optional_str(raw_request_type.get("description")),
+            help_text=_coerce_optional_str(raw_request_type.get("helpText")),
+            issue_type_id=_coerce_optional_str(raw_request_type.get("issueTypeId")),
+            group_ids=group_ids,
+        )
+
+    def _get_request_queues(
+        self,
+        service_desk_id: str,
+        issue_key: str,
+    ) -> list[JSMQueue]:
+        if service_desk_id not in self._queue_membership_by_service_desk_id:
+            try:
+                self._queue_membership_by_service_desk_id[service_desk_id] = (
+                    build_queue_membership_map(
+                        jira_client=self.jira_client,
+                        service_desk_id=service_desk_id,
+                    )
+                )
+            except requests.HTTPError as exc:
+                self._warn_once(
+                    warning_key=f"queues:{service_desk_id}",
+                    message=(
+                        "Unable to fetch Jira Service Management queues for "
+                        f"service desk {service_desk_id}: {exc}"
+                    ),
+                )
+                self._queue_membership_by_service_desk_id[service_desk_id] = {}
+
+        return self._queue_membership_by_service_desk_id[service_desk_id].get(
+            issue_key,
+            [],
+        )
+
+    def _get_request_participants(self, issue_key: str) -> list[dict[str, Any]]:
+        try:
+            return list_request_participants(
+                jira_client=self.jira_client,
+                issue_id_or_key=issue_key,
+            )
+        except requests.HTTPError as exc:
+            self._warn_once(
+                warning_key=f"participants:{issue_key}",
+                message=(
+                    f"Unable to fetch Jira Service Management participants for {issue_key}: {exc}"
+                ),
+            )
+            return []
+
+    def _get_request_slas(self, issue_key: str) -> list[dict[str, Any]]:
+        try:
+            return list_request_slas(
+                jira_client=self.jira_client,
+                issue_id_or_key=issue_key,
+            )
+        except requests.HTTPError as exc:
+            self._warn_once(
+                warning_key=f"slas:{issue_key}",
+                message=f"Unable to fetch Jira Service Management SLAs for {issue_key}: {exc}",
+            )
+            return []
+
+    def _get_request_approvals(self, issue_key: str) -> list[dict[str, Any]]:
+        try:
+            approvals = list_request_approvals(
+                jira_client=self.jira_client,
+                issue_id_or_key=issue_key,
+            )
+        except requests.HTTPError as exc:
+            self._warn_once(
+                warning_key=f"approvals:{issue_key}",
+                message=(
+                    f"Unable to fetch Jira Service Management approvals for {issue_key}: {exc}"
+                ),
+            )
+            return []
+
+        detailed_approvals: list[dict[str, Any]] = []
+        for approval in approvals:
+            approval_id = approval.get("id")
+            if approval_id is None:
+                detailed_approvals.append(approval)
+                continue
+
+            if approval.get("approvers") and approval.get("finalDecision") is not None:
+                detailed_approvals.append(approval)
+                continue
+
+            try:
+                approval_detail = get_approval(
+                    jira_client=self.jira_client,
+                    issue_id_or_key=issue_key,
+                    approval_id=str(approval_id),
+                )
+            except requests.HTTPError as exc:
+                self._warn_once(
+                    warning_key=f"approval:{issue_key}:{approval_id}",
+                    message=(
+                        "Unable to fetch Jira Service Management approval detail for "
+                        f"{issue_key}/{approval_id}: {exc}"
+                    ),
+                )
+                approval_detail = None
+
+            detailed_approvals.append(approval_detail or approval)
+
+        return detailed_approvals
+
+    def _build_jsm_metadata(
+        self,
+        issue: Issue,
+        service_desk: JSMServiceDesk,
+        request: dict[str, Any],
+        request_type: JSMRequestType | None,
+        participants: list[dict[str, Any]],
+        approvals: list[dict[str, Any]],
+        slas: list[dict[str, Any]],
+        queues: list[JSMQueue],
+    ) -> dict[str, str | list[str]]:
+        metadata: dict[str, str | list[str]] = {
+            _METADATA_SERVICE_DESK_ID: service_desk.service_desk_id,
+        }
+
+        raw_service_desk = request.get("serviceDesk")
+        service_desk_name = None
+        if isinstance(raw_service_desk, dict):
+            service_desk_name = _coerce_optional_str(
+                raw_service_desk.get("projectName") or raw_service_desk.get("name")
+            )
+        if service_desk_name is None:
+            service_desk_name = service_desk.project_name
+        if service_desk_name:
+            metadata[_METADATA_SERVICE_DESK] = service_desk_name
+
+        request_id = _coerce_optional_str(request.get("issueId"))
+        if request_id:
+            metadata[_METADATA_REQUEST_ID] = request_id
+
+        current_status = request.get("currentStatus")
+        if isinstance(current_status, dict):
+            current_status_str = _coerce_optional_str(
+                current_status.get("status") or current_status.get("statusCategory")
+            )
+            if current_status_str:
+                metadata[_METADATA_REQUEST_STATUS] = current_status_str
+
+        portal_url = absolute_jsm_link(
+            self.jira_base,
+            _extract_portal_link(request),
+        )
+        if portal_url:
+            metadata[_METADATA_REQUEST_PORTAL_URL] = portal_url
+
+        if request_type is not None:
+            if request_type.name:
+                metadata[_METADATA_REQUEST_TYPE] = request_type.name
+            metadata[_METADATA_REQUEST_TYPE_ID] = request_type.request_type_id
+            if request_type.group_ids:
+                metadata[_METADATA_REQUEST_TYPE_GROUPS] = list(request_type.group_ids)
+
+        requester_info = self._get_requester_info(issue, request)
+        if requester_info is not None:
+            if requester_info.display_name:
+                metadata[_METADATA_CUSTOMER] = requester_info.display_name
+            if requester_info.email:
+                metadata[_METADATA_CUSTOMER_EMAIL] = requester_info.email
+            if requester_info.display_name is None and requester_info.email:
+                metadata[_METADATA_CUSTOMER] = requester_info.email
+
+        requester_account_id = _coerce_optional_str(
+            request.get("reporter", {}).get("accountId")
+            if isinstance(request.get("reporter"), dict)
+            else None
+        )
+        if requester_account_id:
+            metadata[_METADATA_CUSTOMER_ACCOUNT_ID] = requester_account_id
+
+        participant_names = self._extract_user_display_values(participants)
+        if participant_names:
+            metadata[_METADATA_PARTICIPANTS] = participant_names
+
+        approval_summaries = format_approval_summaries(approvals)
+        if approval_summaries:
+            metadata[_METADATA_APPROVALS] = approval_summaries
+
+        queue_summaries = format_queue_summaries(queues)
+        if queue_summaries:
+            metadata[_METADATA_QUEUES] = queue_summaries
+
+        sla_summaries = format_sla_summaries(slas)
+        if sla_summaries:
+            metadata[_METADATA_SLAS] = sla_summaries
+
+        return metadata
+
+    def _build_jsm_text(
+        self,
+        service_desk: JSMServiceDesk,
+        request: dict[str, Any],
+        request_type: JSMRequestType | None,
+        participants: list[dict[str, Any]],
+        approvals: list[dict[str, Any]],
+        slas: list[dict[str, Any]],
+        queues: list[JSMQueue],
+    ) -> str:
+        lines = ["Jira Service Management Details:"]
+
+        service_desk_name = service_desk.project_name or service_desk.project_key
+        if service_desk_name:
+            lines.append(f"Service desk: {service_desk_name}")
+
+        if request_type is not None and request_type.name:
+            lines.append(f"Request type: {request_type.name}")
+        elif request.get("requestType"):
+            lines.append(
+                f"Request type: {stringify_jsm_value(request.get('requestType'))}"
+            )
+
+        requester_info = self._get_requester_info(None, request)
+        if requester_info is not None:
+            requester_name = requester_info.get_semantic_name()
+            if requester_info.email:
+                lines.append(f"Customer: {requester_name} ({requester_info.email})")
+            else:
+                lines.append(f"Customer: {requester_name}")
+
+        request_field_values = request.get("requestFieldValues", [])
+        if isinstance(request_field_values, list):
+            formatted_request_fields = format_request_field_values(
+                [
+                    request_field_value
+                    for request_field_value in request_field_values
+                    if isinstance(request_field_value, dict)
+                ]
+            )
+            if formatted_request_fields:
+                lines.append("Request fields:")
+                lines.extend(formatted_request_fields)
+
+        participant_names = self._extract_user_display_values(participants)
+        if participant_names:
+            lines.append(f"Participants: {', '.join(participant_names)}")
+
+        approval_summaries = format_approval_summaries(approvals)
+        if approval_summaries:
+            lines.append("Approvals:")
+            lines.extend(approval_summaries)
+
+        queue_summaries = format_queue_summaries(queues)
+        if queue_summaries:
+            lines.append(f"Queues: {', '.join(queue_summaries)}")
+
+        sla_summaries = format_sla_summaries(slas)
+        if sla_summaries:
+            lines.append("SLAs:")
+            lines.extend(sla_summaries)
+
+        portal_url = absolute_jsm_link(self.jira_base, _extract_portal_link(request))
+        if portal_url:
+            lines.append(f"Portal URL: {portal_url}")
+
+        return "\n".join(lines)
+
+    def _build_secondary_owners(
+        self,
+        issue: Issue,
+        request: dict[str, Any],
+        participants: list[dict[str, Any]],
+        approvals: list[dict[str, Any]],
+    ) -> list[BasicExpertInfo] | None:
+        primary_owners = set()
+        reporter = best_effort_get_field_from_issue(issue, _FIELD_REPORTER)
+        if reporter is not None and (
+            reporter_info := best_effort_basic_expert_info(reporter)
+        ):
+            primary_owners.add(reporter_info)
+
+        additional_people: set[BasicExpertInfo] = set()
+        requester_info = self._get_requester_info(issue, request)
+        if requester_info is not None and requester_info not in primary_owners:
+            additional_people.add(requester_info)
+
+        for participant in participants:
+            participant_info = self._build_basic_expert_info_from_jsm_user(participant)
+            if participant_info is not None and participant_info not in primary_owners:
+                additional_people.add(participant_info)
+
+        for approval in approvals:
+            approvers = approval.get("approvers")
+            if not isinstance(approvers, list):
+                continue
+            for approver in approvers:
+                if not isinstance(approver, dict):
+                    continue
+                approval_user = approver.get("approver")
+                if not isinstance(approval_user, dict):
+                    continue
+                approver_info = self._build_basic_expert_info_from_jsm_user(approval_user)
+                if approver_info is not None and approver_info not in primary_owners:
+                    additional_people.add(approver_info)
+
+        if not additional_people:
+            return None
+
+        return sorted(
+            additional_people,
+            key=lambda info: (
+                info.get_semantic_name().lower(),
+                info.email or "",
+            ),
+        )
+
+    def _build_basic_expert_info_from_jsm_user(
+        self,
+        user: dict[str, Any] | None,
+    ) -> BasicExpertInfo | None:
+        user_info = jsm_user_to_basic_expert_info(user)
+        if user_info is None:
+            return None
+
+        return BasicExpertInfo(
+            display_name=user_info.get("display_name"),
+            email=user_info.get("email"),
+        )
+
+    def _get_requester_info(
+        self,
+        issue: Issue | None,
+        request: dict[str, Any],
+    ) -> BasicExpertInfo | None:
+        raw_reporter = request.get("reporter")
+        if isinstance(raw_reporter, dict):
+            requester_info = self._build_basic_expert_info_from_jsm_user(raw_reporter)
+            if requester_info is not None:
+                return requester_info
+
+        if issue is None:
+            return None
+
+        reporter = best_effort_get_field_from_issue(issue, _FIELD_REPORTER)
+        if reporter is not None:
+            return best_effort_basic_expert_info(reporter)
+
+        return None
+
+    def _extract_user_display_values(
+        self,
+        users: list[dict[str, Any]],
+    ) -> list[str]:
+        display_values: list[str] = []
+        for user in users:
+            user_info = self._build_basic_expert_info_from_jsm_user(user)
+            if user_info is None:
+                continue
+            display_values.append(user_info.get_semantic_name())
+
+        # Stable dedupe preserving order
+        deduped_display_values = list(dict.fromkeys(display_values))
+        return deduped_display_values
+
+    def _warn_once(self, warning_key: str, message: str) -> None:
+        if warning_key in self._warning_cache:
+            return
+
+        self._warning_cache.add(warning_key)
+        logger.warning(message)
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    coerced = str(value).strip()
+    return coerced or None
+
+
+def _extract_portal_link(request: dict[str, Any]) -> str | None:
+    links = request.get("_links")
+    if not isinstance(links, dict):
+        return None
+
+    portal_link = links.get("web") or links.get("agent")
+    return _coerce_optional_str(portal_link)

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,620 @@
+from __future__ import annotations
+
+import html
+import re
+from collections import defaultdict
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+from jira import JIRA
+
+from onyx.connectors.jira.utils import extract_text_from_adf
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+JSM_API_PAGE_SIZE = 50
+JSM_QUEUE_ISSUE_SCAN_LIMIT = 5000
+JSM_REQUEST_EXPAND = "participant,status,requestType,serviceDesk"
+
+
+@dataclass(frozen=True)
+class JSMServiceDesk:
+    service_desk_id: str
+    project_key: str | None
+    project_name: str | None
+    project_id: str | None
+    portal_id: str | None
+
+
+@dataclass(frozen=True)
+class JSMRequestType:
+    request_type_id: str
+    name: str | None
+    description: str | None
+    help_text: str | None
+    issue_type_id: str | None
+    group_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class JSMQueue:
+    queue_id: str
+    name: str | None
+    jql: str | None
+    issue_count: int | None
+
+
+def _build_servicedesk_api_url(jira_client: JIRA, path: str) -> str:
+    server_url = str(jira_client._options["server"]).rstrip("/")
+    normalized_path = path.lstrip("/")
+    return f"{server_url}/rest/servicedeskapi/{normalized_path}"
+
+
+def _raise_for_http_status(response: requests.Response, path: str) -> None:
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        logger.debug(
+            "JSM API request failed. path=%s status=%s body=%s",
+            path,
+            response.status_code,
+            response.text,
+        )
+        raise
+
+
+def jsm_get_json(
+    jira_client: JIRA,
+    path: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = jira_client._session.get(
+        _build_servicedesk_api_url(jira_client, path),
+        params=params,
+        headers=headers,
+    )
+    _raise_for_http_status(response, path)
+    response_json = response.json()
+    if not isinstance(response_json, dict):
+        raise RuntimeError(f"Unexpected JSM payload for path '{path}': {response_json}")
+    return response_json
+
+
+def jsm_get_json_optional(
+    jira_client: JIRA,
+    path: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    allowed_status_codes: tuple[int, ...] = (403, 404),
+) -> dict[str, Any] | None:
+    try:
+        return jsm_get_json(
+            jira_client=jira_client,
+            path=path,
+            params=params,
+            headers=headers,
+        )
+    except requests.HTTPError as exc:
+        response = exc.response
+        status_code = response.status_code if response is not None else None
+        if status_code in allowed_status_codes:
+            return None
+        raise
+
+
+def iter_jsm_paginated_values(
+    jira_client: JIRA,
+    path: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    page_size: int = JSM_API_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    start = 0
+
+    while True:
+        page_params = dict(params or {})
+        page_params["start"] = start
+        page_params["limit"] = page_size
+
+        page = jsm_get_json(
+            jira_client=jira_client,
+            path=path,
+            params=page_params,
+            headers=headers,
+        )
+        raw_values = page.get("values", [])
+        if not isinstance(raw_values, list):
+            raise RuntimeError(f"Unexpected paginated JSM response for path '{path}'")
+
+        values = [value for value in raw_values if isinstance(value, dict)]
+        for value in values:
+            yield value
+
+        if not values:
+            break
+
+        if page.get("isLastPage") is True:
+            break
+
+        size = page.get("size")
+        if isinstance(size, int) and size > 0:
+            start += size
+        else:
+            start += len(values)
+
+
+def list_service_desks(jira_client: JIRA) -> list[JSMServiceDesk]:
+    service_desks: list[JSMServiceDesk] = []
+
+    for raw_service_desk in iter_jsm_paginated_values(
+        jira_client=jira_client,
+        path="servicedesk",
+    ):
+        service_desks.append(
+            JSMServiceDesk(
+                service_desk_id=str(
+                    raw_service_desk.get("id")
+                    or raw_service_desk.get("serviceDeskId")
+                    or ""
+                ),
+                project_key=_coerce_optional_str(raw_service_desk.get("projectKey")),
+                project_name=_coerce_optional_str(raw_service_desk.get("projectName")),
+                project_id=_coerce_optional_str(raw_service_desk.get("projectId")),
+                portal_id=_coerce_optional_str(raw_service_desk.get("portalId")),
+            )
+        )
+
+    return [service_desk for service_desk in service_desks if service_desk.service_desk_id]
+
+
+def list_request_types(
+    jira_client: JIRA,
+    service_desk_id: str,
+) -> list[JSMRequestType]:
+    request_types: list[JSMRequestType] = []
+    path = f"servicedesk/{service_desk_id}/requesttype"
+
+    for raw_request_type in iter_jsm_paginated_values(
+        jira_client=jira_client,
+        path=path,
+    ):
+        raw_group_ids = raw_request_type.get("groupIds", [])
+        group_ids = tuple(
+            str(group_id)
+            for group_id in raw_group_ids
+            if group_id is not None and str(group_id).strip()
+        )
+        request_type_id = _coerce_optional_str(raw_request_type.get("id"))
+        if not request_type_id:
+            continue
+
+        request_types.append(
+            JSMRequestType(
+                request_type_id=request_type_id,
+                name=_coerce_optional_str(raw_request_type.get("name")),
+                description=_coerce_optional_str(raw_request_type.get("description")),
+                help_text=_coerce_optional_str(raw_request_type.get("helpText")),
+                issue_type_id=_coerce_optional_str(raw_request_type.get("issueTypeId")),
+                group_ids=group_ids,
+            )
+        )
+
+    return request_types
+
+
+def get_customer_request(
+    jira_client: JIRA,
+    issue_id_or_key: str,
+    expand: str = JSM_REQUEST_EXPAND,
+) -> dict[str, Any] | None:
+    return jsm_get_json_optional(
+        jira_client=jira_client,
+        path=f"request/{issue_id_or_key}",
+        params={"expand": expand},
+        allowed_status_codes=(403, 404),
+    )
+
+
+def list_request_participants(
+    jira_client: JIRA,
+    issue_id_or_key: str,
+) -> list[dict[str, Any]]:
+    return list(
+        iter_jsm_paginated_values(
+            jira_client=jira_client,
+            path=f"request/{issue_id_or_key}/participant",
+        )
+    )
+
+
+def list_request_slas(
+    jira_client: JIRA,
+    issue_id_or_key: str,
+) -> list[dict[str, Any]]:
+    payload = jsm_get_json_optional(
+        jira_client=jira_client,
+        path=f"request/{issue_id_or_key}/sla",
+        allowed_status_codes=(403, 404),
+    )
+    if payload is None:
+        return []
+
+    raw_values = payload.get("values", [])
+    if not isinstance(raw_values, list):
+        return []
+
+    return [value for value in raw_values if isinstance(value, dict)]
+
+
+def list_request_approvals(
+    jira_client: JIRA,
+    issue_id_or_key: str,
+) -> list[dict[str, Any]]:
+    payload = jsm_get_json_optional(
+        jira_client=jira_client,
+        path=f"request/{issue_id_or_key}/approval",
+        allowed_status_codes=(403, 404),
+    )
+    if payload is None:
+        return []
+
+    raw_values = payload.get("values", [])
+    if not isinstance(raw_values, list):
+        return []
+
+    return [value for value in raw_values if isinstance(value, dict)]
+
+
+def get_approval(
+    jira_client: JIRA,
+    issue_id_or_key: str,
+    approval_id: str,
+) -> dict[str, Any] | None:
+    return jsm_get_json_optional(
+        jira_client=jira_client,
+        path=f"request/{issue_id_or_key}/approval/{approval_id}",
+        allowed_status_codes=(403, 404),
+    )
+
+
+def list_queues(
+    jira_client: JIRA,
+    service_desk_id: str,
+) -> list[JSMQueue]:
+    queues: list[JSMQueue] = []
+    path = f"servicedesk/{service_desk_id}/queue"
+
+    for raw_queue in iter_jsm_paginated_values(
+        jira_client=jira_client,
+        path=path,
+        params={"includeCount": "true"},
+    ):
+        queue_id = _coerce_optional_str(raw_queue.get("id"))
+        if not queue_id:
+            continue
+
+        issue_count: int | None = None
+        raw_issue_count = raw_queue.get("issueCount")
+        if isinstance(raw_issue_count, int):
+            issue_count = raw_issue_count
+        elif isinstance(raw_issue_count, str) and raw_issue_count.isdigit():
+            issue_count = int(raw_issue_count)
+
+        queues.append(
+            JSMQueue(
+                queue_id=queue_id,
+                name=_coerce_optional_str(raw_queue.get("name")),
+                jql=_coerce_optional_str(raw_queue.get("jql")),
+                issue_count=issue_count,
+            )
+        )
+
+    return queues
+
+
+def build_queue_membership_map(
+    jira_client: JIRA,
+    service_desk_id: str,
+    queue_scan_limit: int = JSM_QUEUE_ISSUE_SCAN_LIMIT,
+) -> dict[str, list[JSMQueue]]:
+    queues = list_queues(jira_client=jira_client, service_desk_id=service_desk_id)
+    total_issue_refs = sum(queue.issue_count or 0 for queue in queues)
+    if total_issue_refs > queue_scan_limit:
+        logger.info(
+            "Skipping JSM queue membership scan for service desk %s because %s issue references exceed limit %s",
+            service_desk_id,
+            total_issue_refs,
+            queue_scan_limit,
+        )
+        return {}
+
+    membership: defaultdict[str, list[JSMQueue]] = defaultdict(list)
+    for queue in queues:
+        path = f"servicedesk/{service_desk_id}/queue/{queue.queue_id}/issue"
+        for raw_issue in iter_jsm_paginated_values(
+            jira_client=jira_client,
+            path=path,
+        ):
+            issue_key = extract_queue_issue_key(raw_issue)
+            if not issue_key:
+                continue
+            membership[issue_key].append(queue)
+
+    return dict(membership)
+
+
+def extract_queue_issue_key(raw_issue: dict[str, Any]) -> str | None:
+    possible_keys = (
+        raw_issue.get("issueKey"),
+        raw_issue.get("key"),
+        raw_issue.get("idOrKey"),
+    )
+    for possible_key in possible_keys:
+        normalized = _coerce_optional_str(possible_key)
+        if normalized:
+            return normalized
+
+    issue = raw_issue.get("issue")
+    if isinstance(issue, dict):
+        return extract_queue_issue_key(issue)
+
+    return None
+
+
+def jsm_user_to_basic_expert_info(user: dict[str, Any] | None) -> dict[str, str] | None:
+    if not user:
+        return None
+
+    display_name = _coerce_optional_str(
+        user.get("displayName")
+        or user.get("name")
+        or user.get("fullName")
+        or user.get("accountId")
+    )
+    email = _coerce_optional_str(user.get("emailAddress") or user.get("email"))
+    account_id = _coerce_optional_str(user.get("accountId"))
+
+    if not display_name and not email and not account_id:
+        return None
+
+    user_info: dict[str, str] = {}
+    if display_name:
+        user_info["display_name"] = display_name
+    if email:
+        user_info["email"] = email
+    if account_id:
+        user_info["account_id"] = account_id
+    return user_info
+
+
+def format_request_field_values(
+    request_field_values: list[dict[str, Any]],
+) -> list[str]:
+    formatted_fields: list[str] = []
+
+    for field_value in request_field_values:
+        label = _coerce_optional_str(
+            field_value.get("label")
+            or field_value.get("fieldName")
+            or field_value.get("fieldId")
+        )
+        if not label:
+            continue
+
+        rendered_value = field_value.get("renderedValue")
+        value = rendered_value if rendered_value is not None else field_value.get("value")
+        text_value = stringify_jsm_value(value)
+        if text_value:
+            formatted_fields.append(f"{label}: {text_value}")
+
+    return formatted_fields
+
+
+def format_sla_summaries(slas: list[dict[str, Any]]) -> list[str]:
+    summaries: list[str] = []
+
+    for sla in slas:
+        name = _coerce_optional_str(sla.get("name") or sla.get("metricName"))
+        if not name:
+            continue
+
+        details: list[str] = []
+        ongoing_cycle = sla.get("ongoingCycle")
+        if isinstance(ongoing_cycle, dict):
+            if _extract_friendly_time(ongoing_cycle.get("elapsedTime")):
+                details.append(
+                    f"elapsed {_extract_friendly_time(ongoing_cycle.get('elapsedTime'))}"
+                )
+            if _extract_friendly_time(ongoing_cycle.get("remainingTime")):
+                details.append(
+                    f"remaining {_extract_friendly_time(ongoing_cycle.get('remainingTime'))}"
+                )
+            if ongoing_cycle.get("breached") is True:
+                details.append("breached")
+        else:
+            completed_cycles = sla.get("completedCycles")
+            if isinstance(completed_cycles, list) and completed_cycles:
+                latest_cycle = completed_cycles[-1]
+                if isinstance(latest_cycle, dict):
+                    if _extract_friendly_time(latest_cycle.get("elapsedTime")):
+                        details.append(
+                            f"completed in {_extract_friendly_time(latest_cycle.get('elapsedTime'))}"
+                        )
+                    if latest_cycle.get("breached") is True:
+                        details.append("breached")
+
+        summaries.append(f"{name}: {', '.join(details) if details else 'tracked'}")
+
+    return summaries
+
+
+def format_approval_summaries(approvals: list[dict[str, Any]]) -> list[str]:
+    summaries: list[str] = []
+
+    for approval in approvals:
+        name = _coerce_optional_str(approval.get("name")) or "Approval"
+        approvers = approval.get("approvers")
+        approver_names: list[str] = []
+        if isinstance(approvers, list):
+            for approver in approvers:
+                if isinstance(approver, dict):
+                    user = approver.get("approver")
+                    if isinstance(user, dict):
+                        user_info = jsm_user_to_basic_expert_info(user)
+                        if user_info and user_info.get("display_name"):
+                            approver_names.append(user_info["display_name"])
+
+        decision = _coerce_optional_str(
+            approval.get("finalDecision")
+            or approval.get("canAnswerApproval")
+            or approval.get("status")
+        )
+        decision_text = decision or "pending"
+        if approver_names:
+            summaries.append(f"{name}: {decision_text} ({', '.join(approver_names)})")
+        else:
+            summaries.append(f"{name}: {decision_text}")
+
+    return summaries
+
+
+def format_queue_summaries(queues: list[JSMQueue]) -> list[str]:
+    summaries: list[str] = []
+    for queue in queues:
+        queue_name = queue.name or queue.queue_id
+        if queue.issue_count is not None:
+            summaries.append(f"{queue_name} ({queue.issue_count})")
+        else:
+            summaries.append(queue_name)
+    return summaries
+
+
+def stringify_jsm_value(value: Any) -> str:
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value.strip()
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    if isinstance(value, list):
+        parts = [stringify_jsm_value(item) for item in value]
+        return ", ".join([part for part in parts if part])
+
+    if isinstance(value, dict):
+        if "friendly" in value and isinstance(value["friendly"], str):
+            return value["friendly"].strip()
+
+        if "displayName" in value and isinstance(value["displayName"], str):
+            return value["displayName"].strip()
+
+        if "name" in value and isinstance(value["name"], str):
+            return value["name"].strip()
+
+        if "emailAddress" in value and isinstance(value["emailAddress"], str):
+            return value["emailAddress"].strip()
+
+        if "text" in value and isinstance(value["text"], str):
+            return value["text"].strip()
+
+        if "html" in value and isinstance(value["html"], str):
+            return _strip_html(value["html"])
+
+        if "value" in value:
+            return stringify_jsm_value(value["value"])
+
+        if "content" in value:
+            try:
+                adf_text = extract_text_from_adf(value)
+                if adf_text:
+                    return adf_text
+            except Exception:
+                pass
+
+        parts = []
+        for nested_key in ("label", "status", "statusCategory", "currentStatus"):
+            if nested_key in value:
+                nested_value = stringify_jsm_value(value[nested_key])
+                if nested_value:
+                    parts.append(nested_value)
+        return ", ".join(parts)
+
+    return str(value).strip()
+
+
+def append_with_byte_limit(
+    existing_text: str,
+    text_to_append: str,
+    max_bytes: int,
+) -> str:
+    existing_text_bytes = existing_text.encode("utf-8")
+    if len(existing_text_bytes) >= max_bytes:
+        return existing_text
+
+    if not text_to_append:
+        return existing_text
+
+    combined_text = existing_text.rstrip()
+    separator = "\n\n" if combined_text else ""
+    appended = f"{combined_text}{separator}{text_to_append.strip()}"
+    if len(appended.encode("utf-8")) <= max_bytes:
+        return appended
+
+    remaining_bytes = max_bytes - len((combined_text + separator).encode("utf-8"))
+    if remaining_bytes <= 0:
+        return combined_text
+
+    truncated = _truncate_to_byte_limit(text_to_append.strip(), remaining_bytes)
+    return f"{combined_text}{separator}{truncated}".strip()
+
+
+def absolute_jsm_link(base_url: str, maybe_relative_url: str | None) -> str | None:
+    if not maybe_relative_url:
+        return None
+
+    if maybe_relative_url.startswith("http://") or maybe_relative_url.startswith(
+        "https://"
+    ):
+        return maybe_relative_url
+
+    return urljoin(base_url.rstrip("/") + "/", maybe_relative_url.lstrip("/"))
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    coerced = str(value).strip()
+    return coerced or None
+
+
+def _extract_friendly_time(value: Any) -> str | None:
+    if isinstance(value, dict):
+        friendly = value.get("friendly")
+        if isinstance(friendly, str) and friendly.strip():
+            return friendly.strip()
+    return None
+
+
+def _strip_html(value: str) -> str:
+    without_tags = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", html.unescape(without_tags)).strip()
+
+
+def _truncate_to_byte_limit(value: str, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+
+    truncated = encoded[: max(0, max_bytes - 3)].decode("utf-8", errors="ignore")
+    return truncated.rstrip() + "..."

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -23,6 +23,8 @@ def source_to_github_img_link(source: DocumentSource) -> str | None:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Confluence.png"
     if source == DocumentSource.JIRA.value:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Jira.png"
+    if source == DocumentSource.JIRA_SERVICE_MANAGEMENT.value:
+        return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Jira.png"
     if source == DocumentSource.NOTION.value:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/web/public/Notion.png"
     if source == DocumentSource.ZENDESK.value:

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management_connector.py
@@ -1,0 +1,253 @@
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.utils import JIRA_SERVER_API_VERSION
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.jira_service_management.utils import JSMQueue
+from onyx.connectors.jira_service_management.utils import JSMRequestType
+from onyx.connectors.jira_service_management.utils import JSMServiceDesk
+from onyx.connectors.models import TextSection
+
+
+@pytest.fixture
+def mock_jira_client() -> MagicMock:
+    mock = MagicMock(spec=JIRA)
+    mock.search_issues = MagicMock()
+    mock.project = MagicMock()
+    mock.projects = MagicMock()
+    mock._options = {
+        "server": "https://jira.example.com",
+        "rest_api_version": JIRA_SERVER_API_VERSION,
+    }
+    mock._session = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def jsm_connector(mock_jira_client: MagicMock) -> Generator[JiraServiceManagementConnector, None, None]:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://jira.example.com",
+        comment_email_blacklist=["blacklist@example.com"],
+    )
+    connector._jira_client = mock_jira_client
+    connector._service_desk_by_project_key = {
+        "HELP": JSMServiceDesk(
+            service_desk_id="1",
+            project_key="HELP",
+            project_name="Help Desk",
+            project_id="10000",
+            portal_id="1",
+        ),
+        "IT": JSMServiceDesk(
+            service_desk_id="2",
+            project_key="IT",
+            project_name="IT Support",
+            project_id="10001",
+            portal_id="2",
+        ),
+    }
+    yield connector
+
+
+def _create_mock_issue(
+    key: str = "HELP-1",
+    project_key: str = "HELP",
+    summary: str = "Password reset request",
+) -> MagicMock:
+    issue = MagicMock(spec=Issue)
+    issue.key = key
+    issue.raw = {"fields": {"description": "Reset my password"}}
+    issue.fields = MagicMock()
+    issue.fields.summary = summary
+    issue.fields.updated = "2024-01-01T12:00:00.000+0000"
+    issue.fields.description = "Reset my password"
+    issue.fields.labels = []
+    issue.fields.comment = MagicMock()
+    issue.fields.comment.comments = [MagicMock(body="Initial customer comment")]
+    issue.fields.reporter = MagicMock()
+    issue.fields.reporter.displayName = "Alice Customer"
+    issue.fields.reporter.emailAddress = "alice@example.com"
+    issue.fields.assignee = MagicMock()
+    issue.fields.assignee.displayName = "Bob Agent"
+    issue.fields.assignee.emailAddress = "bob@example.com"
+    issue.fields.priority = MagicMock()
+    issue.fields.priority.name = "High"
+    issue.fields.status = MagicMock()
+    issue.fields.status.name = "Waiting for support"
+    issue.fields.resolution = None
+    issue.fields.duedate = None
+    issue.fields.issuetype = MagicMock()
+    issue.fields.issuetype.name = "Service Request"
+    issue.fields.parent = None
+    issue.fields.project = MagicMock()
+    issue.fields.project.key = project_key
+    issue.fields.project.name = "Help Desk"
+    return issue
+
+
+def test_get_jql_query_scopes_to_service_desk_projects(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+    end = datetime(2024, 1, 2, tzinfo=timezone.utc).timestamp()
+
+    query = jsm_connector._get_jql_query(start, end)
+
+    assert 'project in ("HELP", "IT")' in query
+    assert "updated >= '2024-01-01 00:00'" in query
+    assert "updated <= '2024-01-02 00:00'" in query
+
+
+def test_process_issue_enriches_document_with_jsm_metadata(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    issue = _create_mock_issue()
+
+    with (
+        patch(
+            "onyx.connectors.jira_service_management.connector.get_customer_request",
+            return_value={
+                "issueId": "10001",
+                "requestTypeId": "11",
+                "currentStatus": {"status": "Waiting for support"},
+                "reporter": {
+                    "displayName": "Alice Customer",
+                    "emailAddress": "alice@example.com",
+                    "accountId": "acct-1",
+                },
+                "requestFieldValues": [
+                    {"label": "Urgency", "value": "High"},
+                    {"label": "Affected system", "value": "SSO"},
+                ],
+                "_links": {"web": "/servicedesk/customer/portal/1/HELP-1"},
+            },
+        ),
+        patch(
+            "onyx.connectors.jira_service_management.connector.list_request_participants",
+            return_value=[
+                {
+                    "displayName": "Charlie Collaborator",
+                    "emailAddress": "charlie@example.com",
+                }
+            ],
+        ),
+        patch(
+            "onyx.connectors.jira_service_management.connector.list_request_slas",
+            return_value=[
+                {
+                    "name": "Time to resolution",
+                    "ongoingCycle": {
+                        "remainingTime": {"friendly": "2h"},
+                        "elapsedTime": {"friendly": "30m"},
+                        "breached": False,
+                    },
+                }
+            ],
+        ),
+        patch(
+            "onyx.connectors.jira_service_management.connector.list_request_approvals",
+            return_value=[
+                {"id": "77", "name": "Manager approval"}
+            ],
+        ),
+        patch(
+            "onyx.connectors.jira_service_management.connector.get_approval",
+            return_value={
+                "id": "77",
+                "name": "Manager approval",
+                "finalDecision": "approved",
+                "approvers": [
+                    {
+                        "approver": {
+                            "displayName": "Dana Manager",
+                            "emailAddress": "dana@example.com",
+                        }
+                    }
+                ],
+            },
+        ),
+        patch.object(
+            jsm_connector,
+            "_get_request_type_map",
+            return_value={
+                "11": JSMRequestType(
+                    request_type_id="11",
+                    name="Access Request",
+                    description="Request system access",
+                    help_text="Use this for access requests",
+                    issue_type_id="10010",
+                    group_ids=("100",),
+                )
+            },
+        ),
+        patch.object(
+            jsm_connector,
+            "_get_request_queues",
+            return_value=[
+                JSMQueue(
+                    queue_id="3",
+                    name="Waiting for support",
+                    jql="project = HELP",
+                    issue_count=12,
+                )
+            ],
+        ),
+    ):
+        document = jsm_connector._process_issue(
+            issue=issue,
+            parent_hierarchy_raw_node_id="HELP",
+        )
+
+    assert document is not None
+    assert document.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    assert document.metadata["jsm_service_desk"] == "Help Desk"
+    assert document.metadata["jsm_request_type"] == "Access Request"
+    assert document.metadata["jsm_customer"] == "Alice Customer"
+    assert document.metadata["jsm_customer_email"] == "alice@example.com"
+    assert document.metadata["jsm_queues"] == ["Waiting for support (12)"]
+    assert document.metadata["jsm_slas"] == [
+        "Time to resolution: elapsed 30m, remaining 2h"
+    ]
+    assert document.metadata["jsm_approvals"] == [
+        "Manager approval: approved (Dana Manager)"
+    ]
+    assert document.secondary_owners is not None
+    assert {owner.get_semantic_name() for owner in document.secondary_owners} == {
+        "Charlie Collaborator",
+        "Dana Manager",
+    }
+
+    section = document.sections[0]
+    assert isinstance(section, TextSection)
+    assert "Jira Service Management Details:" in section.text
+    assert "Request type: Access Request" in section.text
+    assert "Urgency: High" in section.text
+    assert "Approvals:" in section.text
+    assert "Portal URL: https://jira.example.com/servicedesk/customer/portal/1/HELP-1" in section.text
+
+
+def test_process_issue_skips_non_request_issues(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    issue = _create_mock_issue(key="HELP-2")
+
+    with patch(
+        "onyx.connectors.jira_service_management.connector.get_customer_request",
+        return_value=None,
+    ):
+        document = jsm_connector._process_issue(
+            issue=issue,
+            parent_hierarchy_raw_node_id="HELP",
+        )
+
+    assert document is None

--- a/web/src/components/admin/connectors/ConnectorTitle.tsx
+++ b/web/src/components/admin/connectors/ConnectorTitle.tsx
@@ -65,12 +65,29 @@ export const ConnectorTitle = ({
         typedConnector.connector_specific_config.page_id
       );
     }
-  } else if (connector.source === "jira") {
+  } else if (
+    connector.source === "jira" ||
+    connector.source === "jira_service_management"
+  ) {
     const typedConnector = connector as Connector<JiraConfig>;
-    additionalMetadata.set(
-      "Jira Project URL",
-      typedConnector.connector_specific_config.jira_project_url
-    );
+    const jiraBaseUrl =
+      typedConnector.connector_specific_config.jira_base_url ||
+      typedConnector.connector_specific_config.jira_project_url;
+    const projectKey = typedConnector.connector_specific_config.project_key;
+    if (jiraBaseUrl) {
+      additionalMetadata.set(
+        "Jira Base URL",
+        jiraBaseUrl
+      );
+    }
+    if (projectKey) {
+      additionalMetadata.set(
+        connector.source === "jira_service_management"
+          ? "Service Desk Project"
+          : "Project Key",
+        projectKey
+      );
+    }
   } else if (connector.source === "slack") {
     const typedConnector = connector as Connector<SlackConfig>;
     if (

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -745,6 +745,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management service requests to index. You can index all accessible service desks, a specific service desk project, or a scoped JQL query.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your Jira Service Management?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "Everything",
+            fields: [
+              {
+                type: "string_tab",
+                label: "Everything",
+                name: "everything",
+                description:
+                  "This connector will index all accessible Jira Service Management service requests for the provided credentials.",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Service Desk",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the service desk project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The project key of a specific Jira Service Management service desk to index (e.g., 'HELP').",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "JQL Query",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to further filter Jira Service Management service requests." +
+                  "\n\nIMPORTANT: Do not include any time-based filters in the JQL query as that will conflict with the connector's logic. Additionally, do not include ORDER BY clauses." +
+                  "\n\nThe connector automatically restricts results to accessible Jira Service Management projects.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -1928,11 +2013,15 @@ export interface ConfluenceConfig {
 }
 
 export interface JiraConfig {
-  jira_project_url: string;
+  jira_base_url: string;
+  jira_project_url?: string;
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+  scoped_token?: boolean;
 }
+
+export interface JiraServiceManagementConfig extends JiraConfig {}
 
 export interface SalesforceConfig {
   requested_objects?: string[];

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -309,6 +309,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -242,6 +242,13 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: JiraIcon,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+    isPopular: true,
+  },
   zendesk: {
     icon: ZendeskIcon,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -492,6 +492,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
## Summary

Adds a dedicated **Jira Service Management (JSM)** connector that extends the existing Jira connector with JSM-specific features.

### JSM Features Added
- **Service desk discovery** — auto-discovers JSM service desks and scopes indexing
- **Customer requests** — fetches full request details via `/rest/servicedeskapi/request`
- **Request types** — maps requests to their configured request types and groups
- **SLA tracking** — captures ongoing/completed SLA cycles with breach detection
- **Approval workflows** — retrieves approval details with approver information
- **Queue membership** — maps issues to their JSM queues
- **Participant tracking** — captures request participants beyond reporter/assignee
- **Portal URLs** — resolves customer portal links for each request
- **Rich metadata** — enriches documents with JSM-specific metadata fields

### Architecture
- Inherits from `JiraConnector` — reuses checkpoint, permission sync, slim document, and hierarchy interfaces
- Refactors parent to expose overridable methods (`_process_issue`, `_get_document_external_access`, `_build_time_jql`, `document_source` property) for clean extension
- Uses `/rest/servicedeskapi/*` endpoints for all JSM-specific data
- Graceful error handling with warn-once pattern (degraded but functional on permission errors)

### Changes
- `backend/onyx/connectors/jira_service_management/` — new connector + utils (1350 lines)
- `backend/onyx/connectors/jira/connector.py` — refactored for extensibility (no behavior change)
- `backend/onyx/configs/constants.py` — added `JIRA_SERVICE_MANAGEMENT` source
- `backend/onyx/connectors/registry.py` — registered new connector
- Frontend wiring (connector config, credentials, source mapping, icons)
- Unit tests

### Testing
- All new Python files pass syntax checks
- Unit tests included for connector and utils
- Designed for both Jira Cloud and Jira Server/Data Center

Fixes #2281

/claim #2281

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Jira Service Management connector to index customer requests with SLAs, approvals, queues, and JSM-specific metadata, built on top of the existing Jira connector. Refactors the Jira connector for clean extension without changing existing behavior. Fixes #2281.

- New Features
  - New `JiraServiceManagementConnector` registered under source `jira_service_management`.
  - Service desk discovery and scoped JQL; uses `/rest/servicedeskapi/*`.
  - Indexes customer requests, request types/groups, participants, approvals, SLAs, and queue membership.
  - Enriches docs with JSM metadata (service desk, request type/ID/status, participants, approvals, queues, SLAs, portal URL).
  - Appends JSM details to the ticket body within `JIRA_CONNECTOR_MAX_TICKET_SIZE`.
  - Permissions: no doc-level perms set (JSM visibility differs from Jira project).
  - Frontend support: new connector config (`jira_base_url`, optional `project_key`, `jql_query`, `comment_email_blacklist`, `scoped_token`), credentials template, source mapping, and icon.
  - Unit tests for connector and helpers.

- Refactors
  - `JiraConnector` now exposes `document_source`, `_process_issue`, `_get_document_external_access`, and `_build_time_jql` for subclassing.
  - No behavior change to existing Jira connector; only extension points added.

<sup>Written for commit 45236340d60e4f991fd86503c430570e53ef5886. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

