### PR TITLE
chore(voice): support non-default FE ports for `IS_DEV`

### DIFF
--- a/web/src/hooks/useVoiceRecorder.ts
+++ b/web/src/hooks/useVoiceRecorder.ts
@@ -1,5 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 
+import { IS_DEV } from "@/lib/constants";
+
 // Target format for OpenAI Realtime API
 const TARGET_SAMPLE_RATE = 24000;
 const CHUNK_INTERVAL_MS = 250;
@@ -245,9 +247,8 @@ class VoiceRecorderSession {
     const { token } = await tokenResponse.json();
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const isDev = window.location.port === "3000";
-    const host = isDev ? "localhost:8080" : window.location.host;
-    const path = isDev
+    const host = IS_DEV ? "localhost:8080" : window.location.host;
+    const path = IS_DEV
       ? "/voice/transcribe/stream"
       : "/api/voice/transcribe/stream";
     return `${protocol}//${host}${path}?token=${encodeURIComponent(token)}`;

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,3 +1,5 @@
+export const IS_DEV = process.env.NODE_ENV === "development";
+
 export enum AuthType {
   BASIC = "basic",
   GOOGLE_OAUTH = "google_oauth",

--- a/web/src/lib/streamingTTS.ts
+++ b/web/src/lib/streamingTTS.ts
@@ -3,6 +3,8 @@
  * Plays audio chunks as they arrive for smooth, low-latency playback.
  */
 
+import { IS_DEV } from "@/lib/constants";
+
 /**
  * HTTPStreamingTTSPlayer - Uses HTTP streaming with MediaSource Extensions
  * for smooth, gapless audio playback. This is the recommended approach for
@@ -382,9 +384,8 @@ export class WebSocketStreamingTTSPlayer {
     const { token } = await tokenResponse.json();
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const isDev = window.location.port === "3000";
-    const host = isDev ? "localhost:8080" : window.location.host;
-    const path = isDev
+    const host = IS_DEV ? "localhost:8080" : window.location.host;
+    const path = IS_DEV
       ? "/voice/synthesize/stream"
       : "/api/voice/synthesize/stream";
     return `${protocol}//${host}${path}?token=${encodeURIComponent(token)}`;


### PR DESCRIPTION
## Description

I run `nginx` on port `3000` and my dev server on `3001` which means the dev server incorrectly resolves `IS_DEV`. Instead, prefer checking `NODE_ENV` which is a well-known variable for defining dev mode.

## How Has This Been Tested?

Captured by existing. Confirmed my microphone can be accessed locally

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch dev detection to `process.env.NODE_ENV === "development"` via a shared `IS_DEV` constant, fixing voice WebSocket URLs when the frontend runs on non-default ports.

- **Bug Fixes**
  - Added `IS_DEV` in `web/src/lib/constants.ts` and used in `useVoiceRecorder` and `streamingTTS` to build WS URLs.
  - In dev, connect to `localhost:8080` with `/voice/.../stream`; otherwise use current host with `/api/voice/.../stream`.

<sup>Written for commit 7bdbe0cfe5fe3a21b24191438d6b82d46649205a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

