### PR TITLE
chore(tests): fix flaky `test_run_with_timeout_raises_on_timeout`

### DIFF
--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -45,6 +45,21 @@ npx playwright test <TEST_NAME>
 Shared fixtures live in `backend/tests/conftest.py`. Test subdirectories can define
 their own `conftest.py` for directory-scoped fixtures.
 
+## Running Tests Repeatedly (`pytest-repeat`)
+
+Use `pytest-repeat` to catch flaky tests by running them multiple times:
+
+```bash
+# Run a specific test 50 times
+pytest --count=50 backend/tests/unit/path/to/test.py::test_name
+
+# Stop on first failure with -x
+pytest --count=50 -x backend/tests/unit/path/to/test.py::test_name
+
+# Repeat an entire test file
+pytest --count=10 backend/tests/unit/path/to/test_file.py
+```
+
 ## Best Practices
 
 ### Use `enable_ee` fixture instead of inlining

--- a/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
@@ -32,15 +32,17 @@ def test_run_with_timeout_raises_on_timeout(slow: float, timeout: float) -> None
     """Test that a function that exceeds timeout raises TimeoutError"""
 
     def slow_function() -> None:
-        time.sleep(slow)  # Sleep for 2 seconds
+        time.sleep(slow)
 
+    start = time.monotonic()
     with pytest.raises(TimeoutError) as exc_info:
-        start = time.time()
-        run_with_timeout(timeout, slow_function)  # Set timeout to 0.1 seconds
-        end = time.time()
-        assert end - start >= timeout
-        assert end - start < (slow + timeout) / 2
+        run_with_timeout(timeout, slow_function)
+    elapsed = time.monotonic() - start
+
     assert f"timed out after {timeout} seconds" in str(exc_info.value)
+    assert elapsed >= timeout
+    # Should return around the timeout duration, not the full sleep duration
+    assert elapsed == pytest.approx(timeout, abs=0.8)
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")


### PR DESCRIPTION
## Description

Replaces `time.time` with more reliable `time.monotonic` and replaces the `(slow + timeout) / 2` tolerance with a static `0.8s` since this overhead is static and unaffected by the expected timeouts themselves.

Fixes https://github.com/onyx-dot-app/onyx/actions/runs/23156918148/job/67274026572#step:6:2297

## How Has This Been Tested?

`uv run pytest --count=500 backend/tests/unit/onyx/utils/test_threadpool_concurrency.py::test_run_with_timeout_raises_on_timeout`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flakiness in `test_run_with_timeout_raises_on_timeout` by timing with `time.monotonic` and using a fixed tolerance. Adds README guidance for repeating tests with `pytest-repeat` to catch flakes.

- **Bug Fixes**
  - Use `time.monotonic` to measure elapsed time.
  - Replace dynamic tolerance with `pytest.approx(timeout, abs=0.8)` for stable assertions.

<sup>Written for commit e6c9229d5cf3e3950d65f14d9093cc1acd5f4f91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

