### PR TITLE
fix(celery): Limiting connector_hierarchy_fetching jobs

### DIFF
--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -64,7 +64,6 @@ def _connector_supports_hierarchy_fetching(
     try:
         connector_class = identify_connector_class(
             cc_pair.connector.source,
-            cc_pair.connector.input_type,
         )
     except ConnectorMissingException as e:
         task_logger.warning(

--- a/backend/tests/unit/onyx/background/celery/tasks/test_hierarchyfetching_queue.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_hierarchyfetching_queue.py
@@ -57,6 +57,7 @@ def test_connector_supports_hierarchy_fetching_false_for_non_hierarchy_connector
     mock_identify_connector_class.return_value = _NonHierarchyConnector
 
     assert _connector_supports_hierarchy_fetching(_build_cc_pair_mock()) is False
+    mock_identify_connector_class.assert_called_once_with("mock-source")
 
 
 @patch(f"{TASKS_MODULE}.task_logger.warning")
@@ -78,6 +79,7 @@ def test_connector_supports_hierarchy_fetching_true_for_supported_connector(
     mock_identify_connector_class.return_value = _HierarchyCapableConnector
 
     assert _connector_supports_hierarchy_fetching(_build_cc_pair_mock()) is True
+    mock_identify_connector_class.assert_called_once_with("mock-source")
 
 
 @patch(f"{TASKS_MODULE}._try_creating_hierarchy_fetching_task")


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
We have historically been firing a `connector_hierarchy_fetching` job every hour but this is not currently supported so adding in a proper fix to ensure that we are not adding to the queue yet. 

This will be worked on later on and there will be a worker that will consume from this queue.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added new unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop scheduling `connector_hierarchy_fetching` tasks for connectors that don’t implement hierarchy fetching. This avoids queuing jobs until a worker exists.

- **Bug Fixes**
  - Added `_connector_supports_hierarchy_fetching` using `identify_connector_class` + `issubclass`; logs a warning and skips when the class is missing.
  - Updated `check_for_hierarchy_fetching` to skip unsupported connectors before due checks; only enqueues when supported and due; added tests for unsupported, missing class, supported+due, and supported+not-due cases.

<sup>Written for commit 0b60f8bd257a968578cc916b9e1035f0fde25c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

