### PR TITLE
chore(fe): make sidebar scrollbar flush with edge

### DIFF
--- a/web/src/sections/sidebar/SidebarBody.tsx
+++ b/web/src/sections/sidebar/SidebarBody.tsx
@@ -33,7 +33,7 @@ export default function SidebarBody({
       <OverflowDiv className="gap-3 px-2" scrollKey={scrollKey}>
         {children}
       </OverflowDiv>
-      {footer}
+      {footer && <div className="px-2">{footer}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Description

This doesn't seem intentional or desired.

## How Has This Been Tested?

**before**
<img width="1316" height="1820" alt="20260316_14h46m18s_grim" src="https://github.com/user-attachments/assets/2de07140-8721-4cbc-9c33-6bd7f30ad063" />

**after**
<img width="1316" height="1820" alt="20260316_14h46m06s_grim" src="https://github.com/user-attachments/assets/08c42a87-793b-45fc-93db-19ed4126feb4" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the sidebar scrollbar flush with the edge by removing wrapper padding and moving it to the header, scrollable content, and footer. Removes the extra right gutter so the scroll track aligns with the sidebar border.

<sup>Written for commit 1afa3e568e24eb695c91e36f0ad372887d8b15c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

