### PR TITLE
chore(playwright): make project name human-readable

### DIFF
--- a/web/tests/e2e/chat/project_files_visual_regression.spec.ts
+++ b/web/tests/e2e/chat/project_files_visual_regression.spec.ts
@@ -3,7 +3,7 @@ import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
 import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
-const TEST_PREFIX = "E2E-PROJECT-FILES-VISUAL";
+const PROJECT_NAME = "E2E-PROJECT-FILES-VISUAL";
 const ATTACHMENT_ITEM_TITLE_TEST_ID = "attachment-item-title";
 const ATTACHMENT_ITEM_ICON_WRAPPER_TEST_ID = "attachment-item-icon-wrapper";
 const LONG_FILE_NAME =
@@ -106,7 +106,7 @@ test.describe("Project Files visual regression", () => {
     await loginAsWorkerUser(page, workerInfo.workerIndex);
     const client = new OnyxApiClient(page.request);
 
-    projectId = await client.createProject(`${TEST_PREFIX}-${Date.now()}`);
+    projectId = await client.createProject(PROJECT_NAME);
     await uploadFileToProject(page, projectId, LONG_FILE_NAME, FILE_CONTENT);
 
     await context.close();


### PR DESCRIPTION
## Description

Makes the screenshots deterministic between runs,

<img width="1897" height="2085" alt="20260316_15h49m40s_grim" src="https://github.com/user-attachments/assets/043b8846-3e83-4306-b5f8-af32191b49eb" />

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a fixed, human-readable project name in Playwright visual regression tests to remove timestamp variance and make screenshots deterministic across runs.

<sup>Written for commit 5a818869a369d5b0f39a024c5d3cc46c59cb67f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

