### PR TITLE
chore(fe): admin navigation always goes to LLM config page

### DIFF
--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -603,7 +603,7 @@ const MemoizedAppSidebarInner = memo(
         <div>
           {(isAdmin || isCurator) && (
             <SidebarTab
-              href="/admin/configuration/llm"
+              href={isCurator ? "/admin/agents" : "/admin/configuration/llm"}
               icon={SvgSettings}
               folded={folded}
             >


### PR DESCRIPTION
## Description

Now that the LLM config page is at the top, we should navigate there by default.

## How Has This Been Tested?

Tested manually

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Settings tab routing: admins open the LLM configuration page (`/admin/configuration/llm`), curators open Agents (`/admin/agents`). Removes the previous `vector_db_enabled` default and drops the extra memo dependency.

<sup>Written for commit ce60d9136a7b18850ed8acc8dbccebfd28fb1bf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

