### PR TITLE
fix(search-ui): center pagination in `SearchUI`

### DIFF
--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -391,11 +391,13 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
 
       {/* ── Bottom row: Pagination ── */}
       {!showEmpty && (
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onChange={setCurrentPage}
-        />
+        <Section height="fit">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onChange={setCurrentPage}
+          />
+        </Section>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Center the pagination component in the SearchUI results page by wrapping it in a flex container.

## Screenshots + Videos

### Before

<img width="1811" height="1829" alt="image" src="https://github.com/user-attachments/assets/79d3eb2d-e3b9-4a57-9780-5d165e2610a8" />

### After

<img width="1814" height="1831" alt="image" src="https://github.com/user-attachments/assets/6f22b9a8-d9dc-48df-93e1-ed160dcee728" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check