### PR TITLE
fix(fe): redirect to status page after deleting connector

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -158,25 +158,24 @@ function Main({ ccPairId }: { ccPairId: number }) {
     mutate(buildCCPairInfoUrl(ccPairId));
   }, [ccPairId]);
 
-  const shouldConfirmConnectorDeletion = true;
+  const finishConnectorDeletion = useCallback(() => {
+    router.push("/admin/indexing/status?message=connector-deleted");
+  }, [router]);
 
-  const scheduleConnectorDeletion = useCallback(async () => {
+  const scheduleConnectorDeletion = useCallback(() => {
     if (!ccPair) return;
     if (isSchedulingConnectorDeletionRef.current) return;
     isSchedulingConnectorDeletionRef.current = true;
 
-    try {
-      await deleteCCPair(ccPair.connector.id, ccPair.credential.id, () =>
-        mutate(buildCCPairInfoUrl(ccPair.id))
+    deleteCCPair(ccPair.connector.id, ccPair.credential.id, () =>
+      mutate(buildCCPairInfoUrl(ccPair.id))
+    ).catch((error) => {
+      toast.error(
+        "Failed to schedule deletion of connector - " + error.message
       );
-      refresh();
-    } catch (error) {
-      console.error("Error deleting connector:", error);
-    } finally {
-      setShowDeleteConnectorConfirmModal(false);
-      isSchedulingConnectorDeletionRef.current = false;
-    }
-  }, [ccPair, refresh]);
+    });
+    finishConnectorDeletion();
+  }, [ccPair, finishConnectorDeletion]);
 
   const latestIndexAttempt = indexAttempts?.[0];
   const canManageInlineFileConnectorFiles =
@@ -193,10 +192,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
     !indexAttemptErrors?.items?.some(
       (error) => error.index_attempt_id === latestIndexAttempt?.id
     );
-
-  const finishConnectorDeletion = useCallback(() => {
-    router.push("/admin/indexing/status?message=connector-deleted");
-  }, [router]);
 
   const handleStatusUpdate = async (
     newStatus: ConnectorCredentialPairStatus
@@ -520,13 +515,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
                 )}
                 {!isDeleting && (
                   <DropdownMenuItemWithTooltip
-                    onClick={async () => {
-                      if (shouldConfirmConnectorDeletion) {
-                        setShowDeleteConnectorConfirmModal(true);
-                        return;
-                      }
-
-                      await scheduleConnectorDeletion();
+                    onClick={() => {
+                      setShowDeleteConnectorConfirmModal(true);
                     }}
                     disabled={!statusIsNotCurrentlyActive(ccPair.status)}
                     className="flex items-center gap-x-2 cursor-pointer px-3 py-2 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"

--- a/web/src/lib/documentDeletion.ts
+++ b/web/src/lib/documentDeletion.ts
@@ -34,12 +34,9 @@ export async function deleteCCPair(
     credentialId
   );
   if (deletionScheduleError) {
-    toast.error(
-      "Failed to schedule deletion of connector - " + deletionScheduleError
-    );
-  } else {
-    toast.success("Scheduled deletion of connector!");
+    throw new Error(deletionScheduleError);
   }
+  toast.success("Scheduled deletion of connector!");
   onCompletion();
 }
 


### PR DESCRIPTION
## Description

Fires-and-forgets the connector deleting request and immediately navigates to the connector status page. Any errors from scheduling the deleting are still reported back to the user via toast using the global app state.

## How Has This Been Tested?

Tested manually

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects to the indexing status page after scheduling a connector deletion so the modal is dismissed by navigation and users see clear feedback. Addresses Linear ENG-3816.

- **Bug Fixes**
  - Navigate to `/admin/indexing/status?message=connector-deleted` after successful `deleteCCPair`; on error, show a toast and reset the in-flight flag (modal stays open).
  - Streamlined deletion flow: extracted `finishConnectorDeletion`, switched to a promise chain, made `deleteCCPair` throw on schedule errors, and rely on `mutate(buildCCPairInfoUrl(...))` + redirect.

<sup>Written for commit e18eb29bc529be374e37d921d068111bc1b37b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

