### PR TITLE
fix(vespa): use weightedSet for ACL filters to prevent query failures

### DIFF
--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -501,20 +501,31 @@ def query_vespa(
             response = http_client.post(SEARCH_ENDPOINT, json=params)
             response.raise_for_status()
     except httpx.HTTPError as e:
-        error_base = "Failed to query Vespa"
-        logger.error(
-            f"{error_base}:\n"
-            f"Request URL: {e.request.url}\n"
-            f"Request Headers: {e.request.headers}\n"
-            f"Request Payload: {params}\n"
-            f"Exception: {str(e)}"
-            + (
-                f"\nResponse: {e.response.text}"
-                if isinstance(e, httpx.HTTPStatusError)
-                else ""
-            )
+        response_text = (
+            e.response.text if isinstance(e, httpx.HTTPStatusError) else None
         )
-        raise httpx.HTTPError(error_base) from e
+        status_code = (
+            e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None
+        )
+        yql_value = params.get("yql", "")
+        yql_length = len(str(yql_value))
+
+        # Log each detail on its own line so log collectors capture them
+        # as separate entries rather than truncating a single multiline msg
+        logger.error(
+            f"Failed to query Vespa | "
+            f"status={status_code} | "
+            f"yql_length={yql_length} | "
+            f"exception={str(e)}"
+        )
+        if response_text:
+            logger.error(f"Vespa error response: {response_text[:1000]}")
+        logger.error(f"Vespa request URL: {e.request.url}")
+
+        # Re-raise with diagnostics so callers see what actually went wrong
+        raise httpx.HTTPError(
+            f"Failed to query Vespa (status={status_code}, " f"yql_length={yql_length})"
+        ) from e
 
     response_json: dict[str, Any] = response.json()
 

--- a/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
+++ b/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
@@ -43,6 +43,22 @@ def build_vespa_filters(
             return ""
         return f"({' or '.join(eq_elems)})"
 
+    def _build_weighted_set_filter(key: str, vals: list[str] | None) -> str:
+        """Build a Vespa weightedSet filter for large value lists.
+
+        Uses Vespa's native weightedSet() operator instead of OR-chained
+        'contains' clauses.  This is critical for fields like
+        access_control_list where a single user may have tens of thousands
+        of ACL entries — OR clauses at that scale cause Vespa to reject
+        the query with HTTP 400."""
+        if not key or not vals:
+            return ""
+        filtered = [val for val in vals if val]
+        if not filtered:
+            return ""
+        items = ", ".join(f'"{val}":1' for val in filtered)
+        return f"weightedSet({key}, {{{items}}})"
+
     def _build_int_or_filters(key: str, vals: list[int] | None) -> str:
         """For an integer field filter.
         Returns a bare clause or ""."""
@@ -157,11 +173,16 @@ def build_vespa_filters(
     if filters.tenant_id and MULTI_TENANT:
         filter_parts.append(build_tenant_id_filter(filters.tenant_id))
 
-    # ACL filters
+    # ACL filters — use weightedSet for efficient matching against the
+    # access_control_list weightedset<string> field.  OR-chaining thousands
+    # of 'contains' clauses causes Vespa to reject the query (HTTP 400)
+    # for users with large numbers of external permission groups.
     if filters.access_control_list is not None:
         _append(
             filter_parts,
-            _build_or_filters(ACCESS_CONTROL_LIST, filters.access_control_list),
+            _build_weighted_set_filter(
+                ACCESS_CONTROL_LIST, filters.access_control_list
+            ),
         )
 
     # Source type filters

--- a/backend/tests/unit/onyx/utils/test_vespa_query.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_query.py
@@ -44,13 +44,13 @@ class TestBuildVespaFilters:
         assert result == f'({SOURCE_TYPE} contains "web") and '
 
     def test_acl(self) -> None:
-        """Test with acls."""
+        """Test with acls — uses weightedSet operator for efficient matching."""
         # Single ACL
         filters = IndexFilters(access_control_list=["user1"])
         result = build_vespa_filters(filters)
         assert (
             result
-            == f'!({HIDDEN}=true) and (access_control_list contains "user1") and '
+            == f'!({HIDDEN}=true) and weightedSet(access_control_list, {{"user1":1}}) and '
         )
 
         # Multiple ACL's
@@ -58,7 +58,7 @@ class TestBuildVespaFilters:
         result = build_vespa_filters(filters)
         assert (
             result
-            == f'!({HIDDEN}=true) and (access_control_list contains "user2" or access_control_list contains "group2") and '
+            == f'!({HIDDEN}=true) and weightedSet(access_control_list, {{"user2":1, "group2":1}}) and '
         )
 
     def test_tenant_filter(self) -> None:
@@ -250,7 +250,7 @@ class TestBuildVespaFilters:
         result = build_vespa_filters(filters)
 
         expected = f"!({HIDDEN}=true) and "
-        expected += '(access_control_list contains "user1" or access_control_list contains "group1") and '
+        expected += 'weightedSet(access_control_list, {"user1":1, "group1":1}) and '
         expected += f'({SOURCE_TYPE} contains "web") and '
         expected += f'({METADATA_LIST} contains "color{INDEX_SEPARATOR}red") and '
         # Knowledge scope filters are OR'd together
@@ -289,6 +289,38 @@ class TestBuildVespaFilters:
         result = build_vespa_filters(filters)
         expected = f'!({HIDDEN}=true) and (({DOCUMENT_SETS} contains "engineering") or ({DOCUMENT_ID} contains "{str(id1)}")) and '
         assert expected == result
+
+    def test_acl_large_list_uses_weighted_set(self) -> None:
+        """Verify that large ACL lists produce a weightedSet clause
+        instead of OR-chained contains — this is what prevents Vespa
+        HTTP 400 errors for users with thousands of permission groups."""
+        acl = [f"external_group:google_drive_{i}" for i in range(10_000)]
+        acl += ["user_email:user@example.com", "__PUBLIC__"]
+        filters = IndexFilters(access_control_list=acl)
+        result = build_vespa_filters(filters)
+
+        assert "weightedSet(access_control_list, {" in result
+        # Must NOT contain OR-chained contains clauses
+        assert "access_control_list contains" not in result
+        # All entries should be present
+        assert '"external_group:google_drive_0":1' in result
+        assert '"external_group:google_drive_9999":1' in result
+        assert '"user_email:user@example.com":1' in result
+        assert '"__PUBLIC__":1' in result
+
+    def test_acl_empty_strings_filtered(self) -> None:
+        """Empty strings in the ACL list should be filtered out."""
+        filters = IndexFilters(access_control_list=["user1", "", "group1"])
+        result = build_vespa_filters(filters)
+        assert (
+            result
+            == f'!({HIDDEN}=true) and weightedSet(access_control_list, {{"user1":1, "group1":1}}) and '
+        )
+
+        # All empty
+        filters = IndexFilters(access_control_list=["", ""])
+        result = build_vespa_filters(filters)
+        assert result == f"!({HIDDEN}=true) and "
 
     def test_empty_or_none_values(self) -> None:
         """Test with empty or None values in filter lists."""


### PR DESCRIPTION
## Description

Users with large numbers of external permission groups (e.g. 10k+ Google Drive folder ACLs) cause Vespa search queries to fail with HTTP 400. The root cause is that `build_vespa_filters()` constructs the `access_control_list` filter as OR-chained `contains` clauses — for users with 10k+ permission groups, this produces a YQL WHERE clause with 10k+ OR nodes that Vespa's YQL parser cannot handle. The parser has to build a recursive boolean expression tree where each `or` creates a new tree node, and at that scale it rejects the query.

**Fix:** Switch the ACL filter from OR-chained `contains` to Vespa's native `weightedSet()` operator. Unlike OR chains, `weightedSet` acts as a single query node regardless of how many values are in the set ([docs](https://docs.vespa.ai/en/reference/querying/yql.html)). The YQL parser treats the values as a flat map literal instead of a recursive boolean tree, so it scales to arbitrarily large ACL lists. The `access_control_list` field is already a `weightedset<string>` type in the Vespa schema, making this a natural fit.

Tested directly against production Vespa with 11k+ ACL entries:
- OR `contains` approach: **HTTP 400** (query rejected by parser)
- `weightedSet` approach: **HTTP 200** in 0.4s, 100% coverage

Correctness verified by comparing hit counts between both approaches with identical ACL inputs (PUBLIC-only, single-user, bogus-ACL) — results match exactly.

Also improves Vespa query error logging:
- Logs status code, YQL length, and response body as structured single-line fields instead of a multiline message that log collectors truncate
- Preserves error diagnostics in the re-raised exception instead of a generic "Failed to query Vespa" message

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check