### PR TITLE
fix: make ConnectorCredentialPair name required

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -511,7 +511,7 @@ def add_credential_to_connector(
     user: User,
     connector_id: int,
     credential_id: int,
-    cc_pair_name: str | None,
+    cc_pair_name: str,
     access_type: AccessType,
     groups: list[int] | None,
     auto_sync_options: dict | None = None,

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -408,7 +408,7 @@ class FailedConnectorIndexingStatus(BaseModel):
     """Simplified version of ConnectorIndexingStatus for failed indexing attempts"""
 
     cc_pair_id: int
-    name: str | None
+    name: str
     error_msg: str | None
     is_deletable: bool
     connector_id: int
@@ -422,7 +422,7 @@ class ConnectorStatus(BaseModel):
     """
 
     cc_pair_id: int
-    name: str | None
+    name: str
     connector: ConnectorSnapshot
     credential: CredentialSnapshot
     access_type: AccessType
@@ -453,7 +453,7 @@ class DocsCountOperator(str, Enum):
 
 class ConnectorIndexingStatusLite(BaseModel):
     cc_pair_id: int
-    name: str | None
+    name: str
     source: DocumentSource
     access_type: AccessType
     cc_pair_status: ConnectorCredentialPairStatus
@@ -501,7 +501,7 @@ class CCStatusUpdateRequest(BaseModel):
 
 class ConnectorCredentialPairDescriptor(BaseModel):
     id: int
-    name: str | None = None
+    name: str
     connector: ConnectorSnapshot
     credential: CredentialSnapshot
     access_type: AccessType
@@ -511,7 +511,7 @@ class CCPairSummary(BaseModel):
     """Simplified connector-credential pair information with just essential data"""
 
     id: int
-    name: str | None
+    name: str
     source: DocumentSource
     access_type: AccessType
 

--- a/web/src/components/admin/connectors/ConnectorTitle.tsx
+++ b/web/src/components/admin/connectors/ConnectorTitle.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 interface ConnectorTitleProps {
   connector: Connector<any>;
   ccPairId: number;
-  ccPairName: string | null | undefined;
+  ccPairName: string;
   isPublic?: boolean;
   owner?: string;
   isLink?: boolean;

--- a/web/src/lib/credential.ts
+++ b/web/src/lib/credential.ts
@@ -87,7 +87,7 @@ export async function forceDeleteCredential<T>(credentialId: number) {
 export function linkCredential(
   connectorId: number,
   credentialId: number,
-  name?: string,
+  name: string,
   accessType?: AccessType,
   groups?: number[],
   autoSyncOptions?: Record<string, any>,
@@ -101,7 +101,7 @@ export function linkCredential(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        name: name || null,
+        name,
         access_type: accessType !== undefined ? accessType : "public",
         groups: groups || null,
         auto_sync_options: autoSyncOptions || null,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -184,7 +184,7 @@ export interface DocumentBoostStatus {
 
 export interface FailedConnectorIndexingStatus {
   cc_pair_id: number;
-  name: string | null;
+  name: string;
   error_msg: string | null;
   is_deletable: boolean;
   connector_id: number;
@@ -207,7 +207,7 @@ export interface IndexAttemptSnapshot {
 
 export interface ConnectorStatus<ConnectorConfigType, ConnectorCredentialType> {
   cc_pair_id: number;
-  name: string | null;
+  name: string;
   connector: Connector<ConnectorConfigType>;
   credential: Credential<ConnectorCredentialType>;
   access_type: AccessType;
@@ -230,7 +230,7 @@ export interface ConnectorIndexingStatus<
 
 export interface ConnectorIndexingStatusLite {
   cc_pair_id: number;
-  name: string | null;
+  name: string;
   source: ValidSources;
   access_type: AccessType;
   in_progress: boolean;
@@ -343,7 +343,7 @@ export interface DeletionAttemptSnapshot {
 // DOCUMENT SETS
 export interface CCPairDescriptor<ConnectorType, CredentialType> {
   id: number;
-  name: string | null;
+  name: string;
   connector: Connector<ConnectorType>;
   credential: Credential<CredentialType>;
   access_type: AccessType;
@@ -364,7 +364,7 @@ export interface FederatedConnectorDescriptor {
 // Simplified interfaces with minimal data
 export interface CCPairSummary {
   id: number;
-  name: string | null;
+  name: string;
   source: ValidSources;
   access_type: AccessType;
 }


### PR DESCRIPTION
This PR is a clone of #8722. It extends @ciaransweet 's work to make all callers in this flow non-null. DB model was already set to not nullable, meaning callers would have received errors anyways. This PR makes the contract correct/clear

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `name` required in `ConnectorCredentialPairMetadata` to enforce explicit naming and prevent null metadata.

- **Migration**
  - Always provide `name` when creating `ConnectorCredentialPairMetadata`.
  - Add a default name in callers that previously omitted it.

<sup>Written for commit 5b57e20686c9d89506e09ccf127c2576d1679797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

