### PR TITLE
chore(fe): rm dead stackTraceModalContent

### DIFF
--- a/web/src/lib/documentDeletion.ts
+++ b/web/src/lib/documentDeletion.ts
@@ -5,7 +5,6 @@ export async function scheduleDeletionJobForConnector(
   connectorId: number,
   credentialId: number
 ) {
-  await new Promise((resolve) => setTimeout(resolve, 5000));
   // Will schedule a background job which will:
   // 1. Remove all documents indexed by the connector / credential pair
   // 2. Remove the connector (if this is the only pair using the connector)


### PR DESCRIPTION
## Description

This modal is unreachable, so delete. My guess is this became obsolete with the in-chat stack trace feature.

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead `ExceptionTraceModal` and its `stackTraceModalContent` state from `AppPage` to clean up unreachable UI.

<sup>Written for commit 0d03486c2395ef9768337caea8b9511905d8a2dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

