### PR TITLE
chore(opensearch): Make Password Default Empty

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -19,12 +19,13 @@
 
 ## Output template to file and inspect
 * cd charts/onyx
-* helm template test-output . > test-output.yaml
+* helm template test-output . --set auth.opensearch.values.opensearch_admin_password='StrongPassword123!' > test-output.yaml
 
 ## Test the entire cluster manually
 * cd charts/onyx
-* helm install onyx . -n onyx --set postgresql.primary.persistence.enabled=false
+* helm install onyx . -n onyx --set postgresql.primary.persistence.enabled=false --set auth.opensearch.values.opensearch_admin_password='StrongPassword123!'
   * the postgres flag is to keep the storage ephemeral for testing. You probably don't want to set that in prod.
+  * the OpenSearch admin password must be set on first install unless you are supplying `auth.opensearch.existingSecret`.
   * no flag for ephemeral vespa storage yet, might be good for testing
 * kubectl -n onyx port-forward service/onyx-nginx 8080:80
   * this will forward the local port 8080 to the installed chart for you to run tests, etc.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.35
+version: 0.4.36
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/ci/ct-values.yaml
+++ b/deployment/helm/charts/onyx/ci/ct-values.yaml
@@ -1,6 +1,9 @@
 # Values for chart-testing (ct lint/install)
 # This file is automatically used by ct when running lint and install commands
 auth:
+  opensearch:
+    values:
+      opensearch_admin_password: "placeholder-OpenSearch1!"
   userauth:
     values:
       user_auth_secret: "placeholder-for-ci-testing"

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1177,12 +1177,17 @@ auth:
     # Secrets values IF existingSecret is empty. Key here must match the value
     # in secretKeys to be used. Values will be base64 encoded in the k8s
     # cluster.
+    # For the bundled OpenSearch chart, the admin password is consumed during
+    # initial cluster setup. Changing this value later will update Onyx's
+    # client credentials, but will not rotate the OpenSearch admin password.
+    # Set this before first install or use existingSecret to preserve the
+    # current secret on upgrade.
     # Password must meet OpenSearch complexity requirements:
     # min 8 chars, uppercase, lowercase, digit, and special character.
-    # CHANGE THIS FOR PRODUCTION.
+    # Required when auth.opensearch.enabled=true and no existing secret exists.
     values:
       opensearch_admin_username: "admin"
-      opensearch_admin_password: "OnyxDev1!"
+      opensearch_admin_password: ""
   userauth:
     # -- Used for password reset / verification tokens and OAuth/OIDC state signing.
     # Disabled by default to preserve upgrade compatibility for existing Helm customers.


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Making the OpenSearch Password empty to ensure that first time upgraders are blocked and need to set a password for this deployment if they use the containerized OpenSearch setup

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Helm template and validated it blocks as expected

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default `auth.opensearch.values.opensearch_admin_password` to empty in the `onyx` Helm chart to require an explicit admin password on first install/upgrade with bundled OpenSearch. Updated README examples, added a CI placeholder password, and bumped the chart to 0.4.36.

- **Migration**
  - For first install (or when enabling bundled OpenSearch), set `auth.opensearch.values.opensearch_admin_password` or provide `auth.opensearch.existingSecret` to avoid a blocked install.
  - Changing `auth.opensearch.values.opensearch_admin_password` after initial setup only updates Onyx’s client credentials; it does not rotate the OpenSearch admin password.

<sup>Written for commit 26ea6c52d08fab5cb772d0bd2280578a9635fd98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

