### PR TITLE
chore(devtools): `ods backend` scans for available ports

### DIFF
--- a/tools/ods/cmd/backend.go
+++ b/tools/ods/cmd/backend.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -92,11 +94,56 @@ Examples:
 	return cmd
 }
 
+func isPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func getProcessOnPort(port int) string {
+	out, err := exec.Command("lsof", "-i", fmt.Sprintf(":%d", port), "-t").Output()
+	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
+		return "an unknown process"
+	}
+	pid := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
+	nameOut, err := exec.Command("ps", "-p", pid, "-o", "comm=").Output()
+	if err != nil || len(strings.TrimSpace(string(nameOut))) == 0 {
+		return fmt.Sprintf("process (PID %s)", pid)
+	}
+	return fmt.Sprintf("%s (PID %s)", strings.TrimSpace(string(nameOut)), pid)
+}
+
+func resolvePort(port string) string {
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		log.Fatalf("Invalid port %q: %v", port, err)
+	}
+	if isPortAvailable(portNum) {
+		return port
+	}
+	proc := getProcessOnPort(portNum)
+	candidate := portNum + 1
+	for candidate <= 65535 {
+		if isPortAvailable(candidate) {
+			log.Warnf("⚠ Port %d is in use by %s, using available port %d instead.", portNum, proc, candidate)
+			return strconv.Itoa(candidate)
+		}
+		candidate++
+	}
+	log.Fatalf("No available ports found starting from %d", portNum)
+	return port
+}
+
 func runBackendService(name, module, port string, opts *BackendOptions) {
 	root, err := paths.GitRoot()
 	if err != nil {
 		log.Fatalf("Failed to find git root: %v", err)
 	}
+
+	port = resolvePort(port)
 
 	envFile := ensureBackendEnvFile(root)
 	fileVars := loadBackendEnvFile(envFile)


### PR DESCRIPTION
## Description

I want to have the entire application running via docker and interchange the frontend and backend services running on my host as I need (at least as a workaround until we implement mounting source code into the containers to enable HMR w/ docker) while keeping all containers running.

Updates `ods backend` to scans for available ports before starting the server. This is similar to how the frontend `next dev` function.

## How Has This Been Tested?

```
cd tools/ods/
go install .
~/.go/bin/ods backend api
```

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ods backend` check the requested port before starting and automatically switch to the next available port if it’s taken. This reduces conflicts when swapping host and Docker services, similar to `next dev`.

- **New Features**
  - Detects port conflicts via a quick bind check; if in use, logs the blocking process (name and PID) and switches to the next available port (scans upward).
  - Validates and resolves the port at startup so the backend starts reliably; fails fast on invalid ports or if none are available.

<sup>Written for commit fe201f133485337a8dfca4a3c40d4c4ee68924fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



