### PR TITLE
chore: bump next to 16.1.7

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -61,7 +61,7 @@
         "mdast-util-find-and-replace": "^3.0.1",
         "mime": "^4.1.0",
         "motion": "^12.29.0",
-        "next": "16.1.6",
+        "next": "16.1.7",
         "next-themes": "^0.4.4",
         "postcss": "^8.5.6",
         "posthog-js": "^1.176.0",
@@ -2896,9 +2896,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
+      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2942,9 +2942,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
+      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
       "cpu": [
         "arm64"
       ],
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
+      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
       "cpu": [
         "x64"
       ],
@@ -2974,9 +2974,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
+      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
       "cpu": [
         "arm64"
       ],
@@ -2990,9 +2990,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
+      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
       "cpu": [
         "arm64"
       ],
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
+      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
       "cpu": [
         "x64"
       ],
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
+      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
       "cpu": [
         "x64"
       ],
@@ -3038,9 +3038,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
+      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
       "cpu": [
         "arm64"
       ],
@@ -3054,9 +3054,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
+      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
       "cpu": [
         "x64"
       ],
@@ -14068,14 +14068,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
+      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.1.7",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -14087,14 +14087,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
+        "@next/swc-darwin-arm64": "16.1.7",
+        "@next/swc-darwin-x64": "16.1.7",
+        "@next/swc-linux-arm64-gnu": "16.1.7",
+        "@next/swc-linux-arm64-musl": "16.1.7",
+        "@next/swc-linux-x64-gnu": "16.1.7",
+        "@next/swc-linux-x64-musl": "16.1.7",
+        "@next/swc-win32-arm64-msvc": "16.1.7",
+        "@next/swc-win32-x64-msvc": "16.1.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -79,7 +79,7 @@
     "mdast-util-find-and-replace": "^3.0.1",
     "mime": "^4.1.0",
     "motion": "^12.29.0",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "next-themes": "^0.4.4",
     "postcss": "^8.5.6",
     "posthog-js": "^1.176.0",


### PR DESCRIPTION
## Description

This patch fixes a few vulnerabilites. It also fixes a PostCSS worker explosion issue i was hitting locally and causing my machine to crash. That seems to be a new tailwind bug in the prior patch. Release notes don't call this out but this bump still seems to fix the issue.

https://github.com/vercel/next.js/releases/tag/v16.1.7

## How Has This Been Tested?

local testing monitoring memory growth and postcss worker explosion

before:
```
 ~/ ~/monitor-node-memory.sh
Auto-detecting Next.js dev server...
Monitoring main process: PID 70522 (node)
Also tracking all postcss.js + webpack-loaders.js workers
Logging to /Users/nikolas/node-memory-log.csv
Sampling every 3s — Ctrl+C to stop and see summary

TIMESTAMP            MAIN_MB   CPU% |  PC#    PC_MB |  WP#    WP_MB |  TOTAL_MB PROCS
------------------- -------- ------ | ---- -------- | ---- -------- | --------- -----
2026-03-17 14:15:45      73      0 |    0       0 |    0       0 |       73     1
2026-03-17 14:15:48      73      0 |    0       0 |   22    3701 |     3774    23
2026-03-17 14:15:51      70      0 |   29    3077 |   28    6144 |     9291    58 ⚠️
2026-03-17 14:15:55      69      0 |   66    7676 |   28    3840 |    11585    95 ⚠️
2026-03-17 14:15:58      37      0 |  109   13074 |   28    3850 |    16961   138 ⚠️
2026-03-17 14:16:02      36      0 |  157   15246 |   28    1221 |    16503   186 ⚠️
2026-03-17 14:16:06      36      0 |  201   14129 |   28    1565 |    15730   230 ⚠️
2026-03-17 14:16:10      36      0 |  245   15492 |   28    2131 |    17659   274 ⚠️
^C

╔══════════════════════════════════════════════╗
║       MEMORY MONITOR SUMMARY                ║
╠══════════════════════════════════════════════╣
║  Samples collected:  8                       ║
║  Peak total RSS:     17659 MB                ║
║  Peak worker count:  273                     ║
║  First total RSS:    73 MB                   ║
║  Growth:             17586 MB over 27s       ║
║  Growth rate:        ~39080.00 MB/min        ║
╠══════════════════════════════════════════════╣
║  ⚠️  WORKER EXPLOSION DETECTED               ║
║  PostCSS/webpack workers peaked at 273       ║
║  This is the cause of your memory issues.   ║
║  Normal is ~4-16 workers, not hundreds.     ║
╚══════════════════════════════════════════════╝
```

After:
```
 ~/ ~/monitor-node-memory.sh
Auto-detecting Next.js dev server...
Monitoring main process: PID 82000 (node)
Also tracking all postcss.js + webpack-loaders.js workers
Logging to /Users/nikolas/node-memory-log.csv
Sampling every 3s — Ctrl+C to stop and see summary

TIMESTAMP            MAIN_MB   CPU% |  PC#    PC_MB |  WP#    WP_MB |  TOTAL_MB PROCS
------------------- -------- ------ | ---- -------- | ---- -------- | --------- -----
2026-03-17 14:23:15      71    2.3 |    0       0 |    0       0 |       71     1
2026-03-17 14:23:19      74      0 |    0       0 |    1      51 |      125     2
2026-03-17 14:23:22      74      0 |    5     947 |   15    3188 |     4209    21
2026-03-17 14:23:25      74      0 |    5     969 |   15    3673 |     4716    21
2026-03-17 14:23:28      74      0 |    5     967 |   15    4404 |     5445    21
2026-03-17 14:23:32      70    3.2 |    5     864 |   15    4413 |     5347    21
2026-03-17 14:23:35      70      0 |    5     864 |   15    4413 |     5347    21
2026-03-17 14:23:38      70      0 |    5     602 |   15    4390 |     5062    21
2026-03-17 14:23:41      70      0 |    5     593 |   15    4233 |     4896    21
2026-03-17 14:23:45      70      0 |    5     593 |   15    4145 |     4808    21
2026-03-17 14:23:48      70      0 |    5     593 |   15    4097 |     4760    21
2026-03-17 14:23:51      70      0 |    5     593 |   15    4097 |     4760    21
2026-03-17 14:23:54      70      0 |    5     593 |   15    4097 |     4760    21
2026-03-17 14:23:57      70      0 |    5     593 |   15    4097 |     4760    21
2026-03-17 14:24:01      70      0 |    5     593 |   15    3993 |     4656    21
2026-03-17 14:24:04      70      0 |    5     593 |   15    3993 |     4656    21
^C

╔══════════════════════════════════════════════╗
║       MEMORY MONITOR SUMMARY                ║
╠══════════════════════════════════════════════╣
║  Samples collected:  16                      ║
║  Peak total RSS:     5445 MB                 ║
║  Peak worker count:  20                      ║
║  First total RSS:    71 MB                   ║
║  Growth:             5374 MB over 51s        ║
║  Growth rate:        ~6322.35 MB/min         ║
╠══════════════════════════════════════════════╣
║  Worker count looks normal.                 ║
╚══════════════════════════════════════════════╝
```

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
