### PR TITLE
chore(docker): configurable api_server resource limits

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
       resources:
         limits:
           cpus: "${API_SERVER_CPU_LIMIT:-0}"
-          memory: "${API_SERVER_MEMORY_LIMIT:-0}"
+          memory: "${API_SERVER_MEM_LIMIT:-0}"
 
   # Uncomment the block below to enable the MCP server for Onyx.
   # mcp_server:


### PR DESCRIPTION
## Description

I am currently, recursively indexing wikipedia and it is making my entire computer go boom, so allow some custom resource constraints on the api_server container via `.env`.

## How Has This Been Tested?

```
$ docker inspect onyx-api_server-1 --format '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}}'
20000000000 25769803776
```

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `api_server` CPU and memory limits configurable via `.env` to prevent local overload during heavy runs.

- **New Features**
  - Added `deploy.resources.limits` for `api_server` in `docker-compose.dev.yml`.
  - New `.env` vars: `API_SERVER_CPU_LIMIT`, `API_SERVER_MEM_LIMIT` (default `0` = no limit).

<sup>Written for commit bdc52edb2112c9764dc0b67068bbf889b0a553ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

