### PR TITLE
chore(opensearch): Disable `test_update_single_can_clear_user_projects_and_personas`

### DIFF
--- a/backend/tests/external_dependency_unit/document_index/test_document_index_old.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index_old.py
@@ -297,6 +297,10 @@ def index_batch_params(
 class TestDocumentIndexOld:
     """Tests the old DocumentIndex interface."""
 
+    # TODO(ENG-3864)(andrei): Re-enable this test.
+    @pytest.mark.xfail(
+        reason="Flaky test: Retrieved chunks vary non-deterministically before and after changing user projects and personas. Likely a timing issue with the index being updated."
+    )
     def test_update_single_can_clear_user_projects_and_personas(
         self,
         document_indices: list[DocumentIndex],


### PR DESCRIPTION
## Description
This test is flaky, likely because we are sleeping between index updates.

## How Has This Been Tested?
'twas not.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked flaky OpenSearch test `test_update_single_can_clear_user_projects_and_personas` as `@pytest.mark.xfail` to stabilize CI while we fix non-deterministic index update timing.
Tracked by ENG-3864; will re-enable once the flakiness is resolved.

<sup>Written for commit cab745f3b3b9c0c28187713270d276110e8156b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

