### PR TITLE
fix(fe): replace users table buttons with LineItems

### DIFF
--- a/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
@@ -214,7 +214,6 @@ export default function UserRowActions({
           <Section
             gap={0.5}
             height="auto"
-            width="full"
             alignItems="stretch"
             justifyContent="start"
           >


### PR DESCRIPTION
## Description

`Button`s aren't intended to fill the parent, so these buttons don't fill on hover.

## How Has This Been Tested?

**before**
<img width="1677" height="2085" alt="20260317_16h23m18s_grim" src="https://github.com/user-attachments/assets/42736171-378a-4b90-8be6-2b2ab7ab5a1b" />


**after**
<img width="1677" height="2085" alt="20260317_16h23m00s_grim" src="https://github.com/user-attachments/assets/ad7d8200-7ed6-4ab5-916b-931f39b127ff" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Users table action menu so each item fills the menu width and highlights on hover by replacing buttons with line items. Improves click targets and visual consistency with no behavior changes.

- **Bug Fixes**
  - Replaced action `Button`s with `LineItem`s so actions are full-width with proper hover/active states.
  - Set `Section` `width="full"` and retained separators for spacing.
  - Kept all modal triggers and action logic intact; destructive actions use `danger`.

<sup>Written for commit 268cdf41e5af174381c49384e2d52b9d01cc07b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

