### PR TITLE
fix(ui): Refresh Token Race Condition

### DIFF
--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -19,16 +19,58 @@ const DEFAULT_AUTH_ERROR_MSG =
 
 const DEFAULT_ERROR_MSG = "An error occurred while fetching the data.";
 
+// Coalescing refresh gate: when multiple fetchers hit 403 simultaneously,
+// only one refresh call is made and the others wait for it.
+let refreshPromise: Promise<boolean> | null = null;
+
+async function attemptTokenRefresh(): Promise<boolean> {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  refreshPromise = (async () => {
+    try {
+      const response = await fetch("/api/auth/refresh", {
+        method: "POST",
+        credentials: "include",
+      });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
 export const errorHandlingFetcher = async <T>(url: string): Promise<T> => {
   const res = await fetch(url);
 
   if (res.status === 403) {
-    const redirect = new RedirectError(
+    // Attempt a token refresh before giving up
+    const refreshed = await attemptTokenRefresh();
+    if (refreshed) {
+      // Retry the original request with the new token
+      const retryRes = await fetch(url);
+      if (retryRes.ok) {
+        return retryRes.json();
+      }
+      // Retry still failed — use retry response for error info
+      throw new RedirectError(
+        DEFAULT_AUTH_ERROR_MSG,
+        retryRes.status,
+        await retryRes.json().catch(() => ({}))
+      );
+    }
+
+    // Refresh failed — use original response for error info
+    throw new RedirectError(
       DEFAULT_AUTH_ERROR_MSG,
       res.status,
-      await res.json()
+      await res.json().catch(() => ({}))
     );
-    throw redirect;
   }
 
   if (!res.ok) {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently there is a race condition that occurs when a token has been refreshed but the old token is used to do validation and thus the user gets a refreshed token + an old token in their cache that causes a massive amount of 403s to take place and take down the cluster due to the failed cycled loop that occurs. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested this manually by having two tokens where one is valid and running out of time and ensuring the refresh logic worked properly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a refresh token race condition by gating refresh calls and retrying the original request after a successful refresh. This stops 403 storms and prevents the failure loop that could overload the cluster.

- **Bug Fixes**
  - Added a shared `refreshPromise` gate in `web/src/lib/fetcher.ts` to coalesce concurrent refreshes.
  - On 403, POST to `/api/auth/refresh` with credentials and, if successful, retry the original fetch once; otherwise throw a `RedirectError`.
  - Safer error handling with JSON parsing wrapped in `.catch(() => ({}))` to avoid secondary failures.

<sup>Written for commit 4e94e347d18850a87532aa8c5aac62005cc7d6fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

