### PR TITLE
chore(playwright): projects screenshot is main container only

### DIFF
--- a/web/tests/e2e/chat/project_files_visual_regression.spec.ts
+++ b/web/tests/e2e/chat/project_files_visual_regression.spec.ts
@@ -169,7 +169,9 @@ test.describe("Project Files visual regression", () => {
       .first();
     await expect(iconWrapper).toBeVisible();
 
-    await expectElementScreenshot(filesSection, {
+    const container = page.locator("[data-main-container]");
+    await expect(container).toBeVisible();
+    await expectElementScreenshot(container, {
       name: "project-files-long-underscore-filename",
     });
 


### PR DESCRIPTION
## Description

The sidebar is flaky and not relevant for this screenshot, so ignore

<img width="2880" height="1920" alt="20260317_21h23m35s_grim" src="https://github.com/user-attachments/assets/07b90097-1489-47f1-bc11-740e67059466" />

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture screenshots from the main container (`[data-main-container]`) only in the Project Files visual regression test. Excludes the sidebar to reduce flakiness and keep snapshots focused on relevant UI.

<sup>Written for commit 52cd5e9bc9e5ee3e9a84dfcb8f308903c70844ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

