### PR TITLE
fix: handle source_types passed as JSON string in MCP search tool

### DIFF
--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -104,7 +104,7 @@ async def search_indexed_documents(
     if isinstance(source_types, str):
         try:
             parsed = json.loads(source_types)
-            if isinstance(parsed, list):
+            if isinstance(parsed, list) and all(isinstance(s, str) for s in parsed):
                 source_types = parsed
             else:
                 source_types = [parsed] if isinstance(parsed, str) else [source_types]


### PR DESCRIPTION
## Summary
- Some MCP clients (e.g. Cursor, Windsurf) incorrectly serialize list parameters as JSON strings (`'["jira"]'` instead of `["jira"]`), which violates the MCP spec (JSON-RPC) but is a common real-world behavior
- Added defensive server-side parsing: accept `str` type for `source_types`, attempt `json.loads`, and fall back to wrapping in a list
- Prevents `DocumentSource` enum conversion failure when clients send malformed list arguments

## Test plan
- [ ] Pass `source_types` as a JSON string (e.g. `'["jira"]'`) via MCP Inspector and verify search works
- [ ] Pass `source_types` as a normal list `["jira"]` and verify no regression
- [ ] Pass a plain string `"jira"` and verify it gets wrapped into `["jira"]`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `source_types` passed as JSON strings or plain strings in the MCP search tool to prevent enum conversion errors and character-by-character iteration. Accept `list[str] | str | None`, parse strings with `json.loads`, only use the result if it’s a list of strings, and otherwise wrap the value in a list for compatibility with clients like Cursor and Windsurf.

<sup>Written for commit 8c801850d5e6854930dbd7f3c51364d06b9d7851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

