### PR TITLE
feat(admin): groups page - list page and group cards

### DIFF
--- a/web/src/app/admin/groups/page.tsx
+++ b/web/src/app/admin/groups/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/refresh-pages/admin/GroupsPage";

--- a/web/src/app/ee/admin/groups2/page.tsx
+++ b/web/src/app/ee/admin/groups2/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/refresh-pages/admin/GroupsPage";

--- a/web/src/refresh-components/Separator.tsx
+++ b/web/src/refresh-components/Separator.tsx
@@ -9,6 +9,8 @@ export interface SeparatorProps
   noPadding?: boolean;
   /** Custom horizontal padding in rem. Overrides the default padding. */
   paddingXRem?: number;
+  /** Custom vertical padding in rem. Overrides the default padding. */
+  paddingYRem?: number;
 }
 
 /**
@@ -37,7 +39,7 @@ const Separator = React.forwardRef(
     {
       noPadding,
       paddingXRem,
-
+      paddingYRem,
       className,
       orientation = "horizontal",
       decorative = true,
@@ -54,6 +56,12 @@ const Separator = React.forwardRef(
             ? {
                 paddingLeft: `${paddingXRem}rem`,
                 paddingRight: `${paddingXRem}rem`,
+              }
+            : {}),
+          ...(paddingYRem != null
+            ? {
+                paddingTop: `${paddingYRem}rem`,
+                paddingBottom: `${paddingYRem}rem`,
               }
             : {}),
         }}

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { UserGroup } from "@/lib/types";
+import { SvgChevronRight, SvgUserManage, SvgUsers } from "@opal/icons";
+import { ContentAction } from "@opal/layouts";
+import { Section } from "@/layouts/general-layouts";
+import Card from "@/refresh-components/cards/Card";
+import IconButton from "@/refresh-components/buttons/IconButton";
+import Text from "@/refresh-components/texts/Text";
+import { buildGroupDescription, formatMemberCount } from "./utils";
+
+interface GroupCardProps {
+  group: UserGroup;
+}
+
+function GroupCard({ group }: GroupCardProps) {
+  const isBasic = group.name === "Basic";
+  const isAdmin = group.name === "Admin";
+
+  return (
+    <Card padding={0.5}>
+      <ContentAction
+        icon={isAdmin ? SvgUserManage : SvgUsers}
+        title={group.name}
+        description={buildGroupDescription(group)}
+        sizePreset="main-content"
+        variant="section"
+        tag={isBasic ? { title: "Default" } : undefined}
+        rightChildren={
+          <Section flexDirection="row" alignItems="center">
+            <Text mainUiBody text03>
+              {formatMemberCount(group.users.length)}
+            </Text>
+            <IconButton icon={SvgChevronRight} tertiary tooltip="View group" />
+          </Section>
+        }
+      />
+    </Card>
+  );
+}
+
+export default GroupCard;

--- a/web/src/refresh-pages/admin/GroupsPage/GroupsList.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupsList.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMemo } from "react";
+import type { UserGroup } from "@/lib/types";
+import Separator from "@/refresh-components/Separator";
+import GroupCard from "./GroupCard";
+import { isBuiltInGroup } from "./utils";
+import { Section } from "@/layouts/general-layouts";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNoResult from "@opal/illustrations/no-result";
+
+interface GroupsListProps {
+  groups: UserGroup[];
+  searchQuery: string;
+}
+
+function GroupsList({ groups, searchQuery }: GroupsListProps) {
+  const filtered = useMemo(() => {
+    if (!searchQuery.trim()) return groups;
+    const q = searchQuery.toLowerCase();
+    return groups.filter((g) => g.name.toLowerCase().includes(q));
+  }, [groups, searchQuery]);
+
+  if (filtered.length === 0) {
+    return (
+      <IllustrationContent
+        illustration={SvgNoResult}
+        title="No groups found"
+        description={`No groups matching "${searchQuery}"`}
+      />
+    );
+  }
+
+  const builtInGroups = filtered.filter(isBuiltInGroup);
+  const customGroups = filtered.filter((g) => !isBuiltInGroup(g));
+
+  return (
+    <Section flexDirection="column" gap={0.5}>
+      {builtInGroups.map((group) => (
+        <GroupCard key={group.id} group={group} />
+      ))}
+
+      {builtInGroups.length > 0 && customGroups.length > 0 && (
+        <Separator paddingYRem={0.5} />
+      )}
+
+      {customGroups.map((group) => (
+        <GroupCard key={group.id} group={group} />
+      ))}
+    </Section>
+  );
+}
+
+export default GroupsList;

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { SvgPlusCircle, SvgUsers } from "@opal/icons";
+import { Button } from "@opal/components";
+import * as SettingsLayouts from "@/layouts/settings-layouts";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import type { UserGroup } from "@/lib/types";
+import { USER_GROUP_URL } from "./svc";
+import GroupsList from "./GroupsList";
+import { Section } from "@/layouts/general-layouts";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNoResult from "@opal/illustrations/no-result";
+
+function GroupsPage() {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const {
+    data: groups,
+    error,
+    isLoading,
+  } = useSWR<UserGroup[]>(USER_GROUP_URL, errorHandlingFetcher);
+
+  return (
+    <SettingsLayouts.Root>
+      {/* This is the sticky header for the groups page. It is used to display
+       * the groups page title and search input when scrolling down.
+       */}
+      <div className="sticky top-0 z-settings-header bg-background-tint-01">
+        <SettingsLayouts.Header icon={SvgUsers} title="Groups" separator />
+
+        <Section flexDirection="row" padding={1}>
+          <InputTypeIn
+            placeholder="Search groups..."
+            variant="internal"
+            value={searchQuery}
+            leftSearchIcon
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <Button icon={SvgPlusCircle}>New Group</Button>
+        </Section>
+      </div>
+
+      <SettingsLayouts.Body>
+        {isLoading && <SimpleLoader />}
+
+        {error && (
+          <IllustrationContent
+            illustration={SvgNoResult}
+            title="Failed to load groups."
+            description="Please check the console for more details."
+          />
+        )}
+
+        {!isLoading && !error && groups && (
+          <GroupsList groups={groups} searchQuery={searchQuery} />
+        )}
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}
+
+export default GroupsPage;

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -1,0 +1,5 @@
+/** API helpers for the Groups list page. */
+
+const USER_GROUP_URL = "/api/manage/admin/user-group";
+
+export { USER_GROUP_URL };

--- a/web/src/refresh-pages/admin/GroupsPage/utils.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/utils.ts
@@ -1,0 +1,57 @@
+import type { UserGroup } from "@/lib/types";
+
+/** Groups that are created by the system and cannot be deleted. */
+export const BUILT_IN_GROUP_NAMES = ["Basic", "Admin"] as const;
+
+export function isBuiltInGroup(group: UserGroup): boolean {
+  return (BUILT_IN_GROUP_NAMES as readonly string[]).includes(group.name);
+}
+
+/** Human-readable description for built-in groups. */
+const BUILT_IN_DESCRIPTIONS: Record<string, string> = {
+  Basic: "Default group for all users with basic permissions.",
+  Admin: "Built-in admin group with full access to manage all permissions.",
+};
+
+/**
+ * Build the description line(s) shown beneath the group name.
+ *
+ * Built-in groups use a fixed label.
+ * Custom groups list resource counts ("3 connectors · 2 document sets · 2 agents")
+ * or fall back to "No private connectors / document sets / agents".
+ */
+export function buildGroupDescription(group: UserGroup): string {
+  if (isBuiltInGroup(group)) {
+    return BUILT_IN_DESCRIPTIONS[group.name] ?? "";
+  }
+
+  const parts: string[] = [];
+  if (group.cc_pairs.length > 0) {
+    parts.push(
+      `${group.cc_pairs.length} connector${
+        group.cc_pairs.length !== 1 ? "s" : ""
+      }`
+    );
+  }
+  if (group.document_sets.length > 0) {
+    parts.push(
+      `${group.document_sets.length} document set${
+        group.document_sets.length !== 1 ? "s" : ""
+      }`
+    );
+  }
+  if (group.personas.length > 0) {
+    parts.push(
+      `${group.personas.length} agent${group.personas.length !== 1 ? "s" : ""}`
+    );
+  }
+
+  return parts.length > 0
+    ? parts.join(" · ")
+    : "No private connectors / document sets / agents";
+}
+
+/** Format the member count badge, e.g. "306 Members" or "1 Member". */
+export function formatMemberCount(count: number): string {
+  return `${count} ${count === 1 ? "Member" : "Members"}`;
+}

--- a/web/src/refresh-pages/admin/UsersPage/index.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/index.tsx
@@ -8,11 +8,11 @@ import { useScimToken } from "@/hooks/useScimToken";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import useUserCounts from "@/hooks/useUserCounts";
 import { UserStatus } from "@/lib/types";
-import type { StatusFilter } from "./UsersPage/interfaces";
+import type { StatusFilter } from "./interfaces";
 
-import UsersSummary from "./UsersPage/UsersSummary";
-import UsersTable from "./UsersPage/UsersTable";
-import InviteUsersModal from "./UsersPage/InviteUsersModal";
+import UsersSummary from "./UsersSummary";
+import UsersTable from "./UsersTable";
+import InviteUsersModal from "./InviteUsersModal";
 
 // ---------------------------------------------------------------------------
 // Users page content


### PR DESCRIPTION
## Description

Add the Groups list page using the refresh-pages pattern with SettingsLayouts shell, ContentAction group cards, search filtering, and built-in/custom group separation via Separator.

Will be wiring things up in the coming PRs.

Page is viewable at `/admin/groups2` but is not accessible in the sidebar yet.

closes https://linear.app/onyx-app/issue/ENG-3842/groups-list-page-shell-group-cards

## How Has This Been Tested?

manual testing

![2026-03-18 11 02 19](https://github.com/user-attachments/assets/e5ac5d8d-3d0f-4b83-bf95-30a3c5499d4b)


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
