### PR TITLE
fix(celery): add task expiry to upload API send_task call

### DIFF
--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from starlette.background import BackgroundTasks
 
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.constants import CELERY_USER_FILE_PROCESSING_TASK_EXPIRES
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -144,6 +145,7 @@ def upload_files_to_user_files_with_indexing(
                 kwargs={"user_file_id": user_file.id, "tenant_id": tenant_id},
                 queue=OnyxCeleryQueues.USER_FILE_PROCESSING,
                 priority=OnyxCeleryPriority.HIGH,
+                expires=CELERY_USER_FILE_PROCESSING_TASK_EXPIRES,
             )
             logger.info(
                 f"Triggered indexing for user_file_id={user_file.id} with task_id={task.id}"

--- a/backend/tests/unit/onyx/db/test_projects_upload_task_expiry.py
+++ b/backend/tests/unit/onyx/db/test_projects_upload_task_expiry.py
@@ -1,0 +1,63 @@
+"""
+Unit test verifying that the upload API path sends tasks with expires=.
+
+The upload_files_to_user_files_with_indexing function must include expires=
+on every send_task call to prevent phantom task accumulation if the worker
+is down or slow.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from onyx.configs.constants import CELERY_USER_FILE_PROCESSING_TASK_EXPIRES
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.models import UserFile
+from onyx.db.projects import upload_files_to_user_files_with_indexing
+
+
+def _make_mock_user_file() -> MagicMock:
+    uf = MagicMock(spec=UserFile)
+    uf.id = str(uuid4())
+    return uf
+
+
+@patch("onyx.db.projects.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.db.projects.create_user_files")
+@patch(
+    "onyx.background.celery.versioned_apps.client.app",
+    new_callable=MagicMock,
+)
+def test_send_task_includes_expires(
+    mock_client_app: MagicMock,
+    mock_create: MagicMock,
+    mock_tenant: MagicMock,  # noqa: ARG001
+) -> None:
+    """Every send_task call from the upload path must include expires=."""
+    user_files = [_make_mock_user_file(), _make_mock_user_file()]
+    mock_create.return_value = MagicMock(
+        user_files=user_files,
+        rejected_files=[],
+        id_to_temp_id={},
+    )
+
+    mock_user = MagicMock()
+    mock_db_session = MagicMock()
+
+    upload_files_to_user_files_with_indexing(
+        files=[],
+        project_id=None,
+        user=mock_user,
+        temp_id_map=None,
+        db_session=mock_db_session,
+    )
+
+    assert mock_client_app.send_task.call_count == len(user_files)
+
+    for call in mock_client_app.send_task.call_args_list:
+        assert call.args[0] == OnyxCeleryTask.PROCESS_SINGLE_USER_FILE
+        assert call.kwargs.get("queue") == OnyxCeleryQueues.USER_FILE_PROCESSING
+        assert (
+            call.kwargs.get("expires") == CELERY_USER_FILE_PROCESSING_TASK_EXPIRES
+        ), "send_task must include expires= to prevent phantom task accumulation"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The upload path in `upload_files_to_user_files_with_indexing` was calling `send_task` without `expires=`, which violates the project rule that all enqueued tasks must have an expiration. Without expiry, tasks can accumulate indefinitely if workers are down or slow.

Adds `expires=CELERY_USER_FILE_PROCESSING_TASK_EXPIRES` to the `send_task` call, consistent with the beat path in `check_user_file_processing`.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Adding a proper test to capture this edge case

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Celery task expiry to the upload API path to prevent orphan tasks when workers are down. This enforces the “all tasks must expire” rule and matches the beat path behavior.

- **Bug Fixes**
  - Set `expires=CELERY_USER_FILE_PROCESSING_TASK_EXPIRES` on `send_task` in `upload_files_to_user_files_with_indexing`.
  - Added a unit test that verifies each upload-triggered task sets `expires` and targets the correct queue/task.

<sup>Written for commit 7efb44bb7e4df123dab9405ef98d76b4f9de9c48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

