### PR TITLE
fix(logging): extract LiteLLM error details in image summarization failures

### DIFF
--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -138,7 +138,23 @@ def _summarize_image(
         return summary
 
     except Exception as e:
-        raise ValueError(f"Summarization failed: {type(e).__name__}: {e}") from e
+        # Extract structured details from LiteLLM exceptions when available,
+        # rather than dumping the full messages payload (which contains base64
+        # image data and produces enormous, unreadable error logs).
+        str_e = str(e)
+        if len(str_e) > 512:
+            str_e = str_e[:512] + "... (truncated)"
+        parts = [f"Summarization failed: {type(e).__name__}: {str_e}"]
+        status_code = getattr(e, "status_code", None)
+        llm_provider = getattr(e, "llm_provider", None)
+        model = getattr(e, "model", None)
+        if status_code is not None:
+            parts.append(f"status_code={status_code}")
+        if llm_provider is not None:
+            parts.append(f"llm_provider={llm_provider}")
+        if model is not None:
+            parts.append(f"model={model}")
+        raise ValueError(" | ".join(parts)) from e
 
 
 def _encode_image_for_llm_prompt(image_data: bytes) -> str:

--- a/backend/tests/unit/onyx/file_processing/test_image_summarization_litellm_errors.py
+++ b/backend/tests/unit/onyx/file_processing/test_image_summarization_litellm_errors.py
@@ -1,0 +1,141 @@
+"""
+Unit tests verifying that LiteLLM error details are extracted and surfaced
+in image summarization error messages.
+
+When the LLM call fails, the error handler should include the status_code,
+llm_provider, and model from LiteLLM exceptions so operators can diagnose
+the root cause (rate limit, content filter, unsupported vision, etc.)
+without needing to dig through LiteLLM internals.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.file_processing.image_summarization import _summarize_image
+
+
+def _make_litellm_style_error(
+    *,
+    message: str = "API error",
+    status_code: int | None = None,
+    llm_provider: str | None = None,
+    model: str | None = None,
+) -> RuntimeError:
+    """Create an exception with LiteLLM-style attributes."""
+    exc = RuntimeError(message)
+    if status_code is not None:
+        exc.status_code = status_code  # type: ignore[attr-defined]
+    if llm_provider is not None:
+        exc.llm_provider = llm_provider  # type: ignore[attr-defined]
+    if model is not None:
+        exc.model = model  # type: ignore[attr-defined]
+    return exc
+
+
+class TestLiteLLMErrorExtraction:
+    """Verify that LiteLLM error attributes are included in the ValueError."""
+
+    def test_status_code_included(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = _make_litellm_style_error(
+            message="Content filter triggered",
+            status_code=400,
+            llm_provider="azure",
+            model="gpt-4o",
+        )
+
+        with pytest.raises(ValueError, match="status_code=400"):
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+    def test_llm_provider_included(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = _make_litellm_style_error(
+            message="Bad request",
+            status_code=400,
+            llm_provider="azure",
+        )
+
+        with pytest.raises(ValueError, match="llm_provider=azure"):
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+    def test_model_included(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = _make_litellm_style_error(
+            message="Bad request",
+            model="gpt-4o",
+        )
+
+        with pytest.raises(ValueError, match="model=gpt-4o"):
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+    def test_all_fields_in_single_message(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = _make_litellm_style_error(
+            message="Rate limit exceeded",
+            status_code=429,
+            llm_provider="azure",
+            model="gpt-4o",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+        msg = str(exc_info.value)
+        assert "status_code=429" in msg
+        assert "llm_provider=azure" in msg
+        assert "model=gpt-4o" in msg
+        assert "Rate limit exceeded" in msg
+
+    def test_plain_exception_without_litellm_attrs(self) -> None:
+        """Non-LiteLLM exceptions should still produce a useful message."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = ConnectionError("Connection refused")
+
+        with pytest.raises(ValueError) as exc_info:
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+        msg = str(exc_info.value)
+        assert "ConnectionError" in msg
+        assert "Connection refused" in msg
+        # Should not contain status_code/llm_provider/model
+        assert "status_code" not in msg
+        assert "llm_provider" not in msg
+
+    def test_no_base64_in_error(self) -> None:
+        """Error messages must not contain the full base64 image payload.
+
+        Some LiteLLM exceptions echo the request body (including base64 images)
+        in their message.  The truncation guard ensures the bulk of such a
+        payload is stripped from the re-raised ValueError.
+        """
+        mock_llm = MagicMock()
+        # Build a long base64-like payload that exceeds the 512-char truncation
+        fake_b64_payload = "iVBORw0KGgo" * 100  # ~1100 chars
+        fake_b64 = f"data:image/png;base64,{fake_b64_payload}"
+
+        mock_llm.invoke.side_effect = RuntimeError(
+            f"Request failed for payload: {fake_b64}"
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _summarize_image(fake_b64, mock_llm)
+
+        msg = str(exc_info.value)
+        # The full payload must not appear (truncation should have kicked in)
+        assert fake_b64_payload not in msg
+        assert "truncated" in msg
+
+    def test_long_error_message_truncated(self) -> None:
+        """Exception messages longer than 512 chars are truncated."""
+        mock_llm = MagicMock()
+        long_msg = "x" * 1000
+        mock_llm.invoke.side_effect = RuntimeError(long_msg)
+
+        with pytest.raises(ValueError) as exc_info:
+            _summarize_image("data:image/png;base64,abc", mock_llm)
+
+        msg = str(exc_info.value)
+        assert "truncated" in msg
+        # The full 1000-char string should not appear
+        assert long_msg not in msg


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
When the LLM call fails during image summarization, the error handler now extracts status_code, llm_provider, and model from LiteLLM exceptions. This surfaces the actual API error (rate limit, content filter, unsupported vision, etc.) instead of dumping base64 image data into the error message.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added some tests to make sure we capture this change

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved image summarization error handling by extracting `litellm` error details (status_code, `llm_provider`, model) and truncating long messages so we surface the real failure reason without logging base64 image data.

- **Bug Fixes**
  - Include `status_code`, `llm_provider`, and `model` from `litellm` exceptions in the raised `ValueError`.
  - Truncate exception messages to 512 chars and avoid logging request payloads (no base64).
  - Added unit tests for attribute extraction, plain exceptions, truncation, and base64 sanitization.

<sup>Written for commit efd0f0040c6e0d8ce4b0bf16702c85329bb436e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

