### PR TITLE
fix(fe): truncate connector names in table

### DIFF
--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -166,9 +166,7 @@ function ConnectorRow({
       onClick={handleRowClick}
     >
       <TableCell className="">
-        <Truncated className="max-w-[200px] xl:max-w-[400px] inline-block ellipsis truncate">
-          {ccPairsIndexingStatus.name}
-        </Truncated>
+        <Truncated>{ccPairsIndexingStatus.name}</Truncated>
       </TableCell>
       <TableCell>
         {timeAgo(ccPairsIndexingStatus?.last_success) || "-"}
@@ -247,9 +245,7 @@ function FederatedConnectorRow({
       onClick={handleRowClick}
     >
       <TableCell className="">
-        <Truncated className="max-w-[200px] xl:max-w-[400px] inline-block ellipsis truncate">
-          {federatedConnector.name}
-        </Truncated>
+        <Truncated>{federatedConnector.name}</Truncated>
       </TableCell>
       <TableCell>N/A</TableCell>
       <TableCell>


### PR DESCRIPTION
## Description

These names are defined by users and therefore should be truncated.

## How Has This Been Tested?

**before**
<img width="1512" height="2085" alt="20260318_12h45m46s_grim" src="https://github.com/user-attachments/assets/5fa91a71-24e1-46c3-9e00-1d0cfd89d3df" />


**after**
<img width="1512" height="2085" alt="20260318_12h45m37s_grim" src="https://github.com/user-attachments/assets/e4fa0ac6-777c-4cab-b0f3-7413ad31e848" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate user-defined connector names in the Indexing Status table to prevent overflow and keep rows readable. Replaced inline truncation styles with the shared `Truncated` component for both connector and federated rows.

<sup>Written for commit 32d3f25d58d2bc8767e6605689eb70a11101c31d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

