### PR TITLE
fix(image): add diagnostic logging to vision model selection

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -395,6 +395,12 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         llm = get_default_llm_with_vision()
 
     if not llm:
+        if get_image_extraction_and_analysis_enabled():
+            logger.warning(
+                "Image analysis is enabled but no vision-capable LLM is "
+                "available — images will not be summarized. Configure a "
+                "vision model in the admin LLM settings."
+            )
         # Even without LLM, we still convert to IndexingDocument with base Sections
         return [
             IndexingDocument(

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -168,10 +168,23 @@ def get_default_llm_with_vision(
             if model_supports_image_input(
                 default_model.name, default_model.llm_provider.provider
             ):
+                logger.info(
+                    "Using default vision model: %s (provider=%s)",
+                    default_model.name,
+                    default_model.llm_provider.provider,
+                )
                 return create_vision_llm(
                     LLMProviderView.from_model(default_model.llm_provider),
                     default_model.name,
                 )
+            else:
+                logger.warning(
+                    "Default vision model %s (provider=%s) does not support "
+                    "image input — falling back to searching all providers",
+                    default_model.name,
+                    default_model.llm_provider.provider,
+                )
+
         # Fall back to searching all providers
         models = fetch_existing_models(
             db_session=db_session,
@@ -179,6 +192,10 @@ def get_default_llm_with_vision(
         )
 
         if not models:
+            logger.warning(
+                "No LLM models with VISION or CHAT flow type found — "
+                "image summarization will be disabled"
+            )
             return None
 
         for model in models:
@@ -200,11 +217,25 @@ def get_default_llm_with_vision(
 
     for model in sorted_models:
         if model_supports_image_input(model.name, model.llm_provider.provider):
+            logger.info(
+                "Using fallback vision model: %s (provider=%s)",
+                model.name,
+                model.llm_provider.provider,
+            )
             return create_vision_llm(
                 provider_map[model.llm_provider_id],
                 model.name,
             )
 
+    checked_models = [
+        f"{m.name} (provider={m.llm_provider.provider})" for m in sorted_models
+    ]
+    logger.warning(
+        "No vision-capable model found among %d candidates: %s — "
+        "image summarization will be disabled",
+        len(sorted_models),
+        ", ".join(checked_models),
+    )
     return None
 
 

--- a/backend/tests/unit/onyx/llm/test_vision_model_selection_logging.py
+++ b/backend/tests/unit/onyx/llm/test_vision_model_selection_logging.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for vision model selection logging in get_default_llm_with_vision.
+
+Verifies that operators get clear feedback about:
+1. Which vision model was selected and why
+2. When the default vision model doesn't support image input
+3. When no vision-capable model exists at all
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.llm.factory import get_default_llm_with_vision
+
+
+_FACTORY = "onyx.llm.factory"
+
+
+def _make_mock_model(
+    *,
+    name: str = "gpt-4o",
+    provider: str = "openai",
+    provider_id: int = 1,
+    flow_types: list[str] | None = None,
+) -> MagicMock:
+    model = MagicMock()
+    model.name = name
+    model.llm_provider_id = provider_id
+    model.llm_provider.provider = provider
+    model.llm_model_flow_types = flow_types or []
+    return model
+
+
+@patch(f"{_FACTORY}.get_session_with_current_tenant")
+@patch(f"{_FACTORY}.fetch_default_vision_model")
+@patch(f"{_FACTORY}.model_supports_image_input", return_value=True)
+@patch(f"{_FACTORY}.llm_from_provider")
+@patch(f"{_FACTORY}.LLMProviderView")
+@patch(f"{_FACTORY}.logger")
+def test_logs_when_using_default_vision_model(
+    mock_logger: MagicMock,
+    mock_provider_view: MagicMock,  # noqa: ARG001
+    mock_llm_from: MagicMock,  # noqa: ARG001
+    mock_supports: MagicMock,  # noqa: ARG001
+    mock_fetch_default: MagicMock,
+    mock_session: MagicMock,  # noqa: ARG001
+) -> None:
+    mock_fetch_default.return_value = _make_mock_model(name="gpt-4o", provider="azure")
+
+    get_default_llm_with_vision()
+
+    mock_logger.info.assert_called_once()
+    log_msg = mock_logger.info.call_args[0][0]
+    assert "default vision model" in log_msg.lower()
+
+
+@patch(f"{_FACTORY}.get_session_with_current_tenant")
+@patch(f"{_FACTORY}.fetch_default_vision_model")
+@patch(f"{_FACTORY}.model_supports_image_input", return_value=False)
+@patch(f"{_FACTORY}.fetch_existing_models", return_value=[])
+@patch(f"{_FACTORY}.logger")
+def test_warns_when_default_model_lacks_vision(
+    mock_logger: MagicMock,
+    mock_fetch_models: MagicMock,  # noqa: ARG001
+    mock_supports: MagicMock,  # noqa: ARG001
+    mock_fetch_default: MagicMock,
+    mock_session: MagicMock,  # noqa: ARG001
+) -> None:
+    mock_fetch_default.return_value = _make_mock_model(
+        name="text-only-model", provider="azure"
+    )
+
+    result = get_default_llm_with_vision()
+
+    assert result is None
+    # Should have warned about the default model not supporting vision
+    warning_calls = [
+        call
+        for call in mock_logger.warning.call_args_list
+        if "does not support" in str(call)
+    ]
+    assert len(warning_calls) >= 1
+
+
+@patch(f"{_FACTORY}.get_session_with_current_tenant")
+@patch(f"{_FACTORY}.fetch_default_vision_model", return_value=None)
+@patch(f"{_FACTORY}.fetch_existing_models", return_value=[])
+@patch(f"{_FACTORY}.logger")
+def test_warns_when_no_models_exist(
+    mock_logger: MagicMock,
+    mock_fetch_models: MagicMock,  # noqa: ARG001
+    mock_fetch_default: MagicMock,  # noqa: ARG001
+    mock_session: MagicMock,  # noqa: ARG001
+) -> None:
+    result = get_default_llm_with_vision()
+
+    assert result is None
+    mock_logger.warning.assert_called_once()
+    log_msg = mock_logger.warning.call_args[0][0]
+    assert "no llm models" in log_msg.lower()
+
+
+@patch(f"{_FACTORY}.get_session_with_current_tenant")
+@patch(f"{_FACTORY}.fetch_default_vision_model", return_value=None)
+@patch(f"{_FACTORY}.fetch_existing_models")
+@patch(f"{_FACTORY}.model_supports_image_input", return_value=False)
+@patch(f"{_FACTORY}.LLMProviderView")
+@patch(f"{_FACTORY}.logger")
+def test_warns_when_no_model_supports_vision(
+    mock_logger: MagicMock,
+    mock_provider_view: MagicMock,  # noqa: ARG001
+    mock_supports: MagicMock,  # noqa: ARG001
+    mock_fetch_models: MagicMock,
+    mock_fetch_default: MagicMock,  # noqa: ARG001
+    mock_session: MagicMock,  # noqa: ARG001
+) -> None:
+    mock_fetch_models.return_value = [
+        _make_mock_model(name="text-model-1", provider="openai"),
+        _make_mock_model(name="text-model-2", provider="azure", provider_id=2),
+    ]
+
+    result = get_default_llm_with_vision()
+
+    assert result is None
+    warning_calls = [
+        call
+        for call in mock_logger.warning.call_args_list
+        if "no vision-capable model" in str(call).lower()
+    ]
+    assert len(warning_calls) == 1


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
get_default_llm_with_vision() previously had zero logging, making it impossible to diagnose why image summarization was silently disabled. Operators had no way to know if the configured model lacked vision support or if no vision-capable model existed at all.

Now logs:
- Which vision model was selected (info level)
- When the default vision model fails the image input check (warning)
- When no models with VISION/CHAT flow type exist (warning)
- When candidates exist but none support image input (warning, lists the models that were checked)

Also adds a warning in process_image_sections when image analysis is enabled but no vision LLM is available.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
New tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds diagnostic logging to vision model selection so operators can see which model is used and why image summarization might be disabled. Also warns when image analysis is enabled but no vision-capable LLM is available.

- **Bug Fixes**
  - Log selected vision model at info level in `get_default_llm_with_vision()`.
  - Warn when the default model lacks image input, when no VISION/CHAT models exist, or when none of the candidates support images (includes checked models).
  - Warn in `process_image_sections` if image analysis is enabled but no vision LLM is configured.
  - Add unit tests for all logging paths.

<sup>Written for commit eda94cb0092dde4bd941a88c854bbd462e91d976. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

