### PR TITLE
fix(fe): truncate project name in sidebar button

### DIFF
--- a/web/src/sections/sidebar/ProjectFolderButton.tsx
+++ b/web/src/sections/sidebar/ProjectFolderButton.tsx
@@ -12,6 +12,7 @@ import { cn, noProp } from "@/lib/utils";
 import { DRAG_TYPES } from "./constants";
 import SidebarTab from "@/refresh-components/buttons/SidebarTab";
 import IconButton from "@/refresh-components/buttons/IconButton";
+import Truncated from "@/refresh-components/texts/Truncated";
 import { Button } from "@opal/components";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
 import type { IconProps } from "@opal/types";
@@ -181,7 +182,7 @@ const ProjectFolderButton = memo(({ project }: ProjectFolderButtonProps) => {
                 onClose={() => setIsEditing(false)}
               />
             ) : (
-              project.name
+              <Truncated>{project.name}</Truncated>
             )}
           </SidebarTab>
         </Popover.Anchor>


### PR DESCRIPTION
## Description



## How Has This Been Tested?

<img width="1512" height="2085" alt="20260318_12h44m32s_grim" src="https://github.com/user-attachments/assets/7cb65caf-99b5-40f0-8b41-126e2c701279" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate long project names in the sidebar project button to prevent overflow and keep the layout stable. Uses the `Truncated` component to ellipsize `project.name` inside `ProjectFolderButton`.

<sup>Written for commit b49ef52364d9823c08dbad1c4a2405db58f802b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

