### PR TITLE
fix(fe): make indexing attempt error rows click to show trace

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -169,6 +169,7 @@ export function IndexAttemptsTable({
                 <td className="w-0 p-0">
                   {indexAttempt.full_exception_trace && (
                     <button
+                      type="button"
                       aria-label="View full trace"
                       onClick={() =>
                         setIndexAttemptTracePopupId(indexAttempt.id)


### PR DESCRIPTION
## Description

Removes the `View Full Trace` button for errored indexing attempts and instead makes the entire table row a clickable to view the trace. This is similar behavior to the `Query History` table.

## How Has This Been Tested?

**before**
<img width="3840" height="2160" alt="20260318_13h04m53s_grim" src="https://github.com/user-attachments/assets/b0af0ecd-0d42-48fa-87f0-7ac8eddf8bbf" />


**after**
<img width="3840" height="2160" alt="20260318_13h04m05s_grim" src="https://github.com/user-attachments/assets/16b3fc0e-427a-4aaf-932a-c60b00e82379" />


## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make indexing attempt rows with a full exception trace clickable to open the trace, replacing the “View Full Trace” link. Add an invisible full-row button (with aria-label) and hover/cursor styles on those rows, and center pagination to match Query History.

<sup>Written for commit 62cc5d742be0de497ba2a56c3a8421529e9f8566. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

