### PR TITLE
fix(fe): migrate `UsersTable` to use the new API

### DIFF
--- a/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
@@ -219,6 +219,7 @@ export default function UsersTable({
         data={filteredUsers}
         columns={columns}
         getRowId={(row) => row.id ?? row.email}
+        qualifier="avatar"
         pageSize={PAGE_SIZE}
         searchTerm={searchTerm}
         emptyState={


### PR DESCRIPTION
## Description

Add `qualifier="avatar"` to the UsersTable component so user avatars are rendered in the qualifier column. Without this prop, the table defaults to `qualifier="simple"` which shows no avatar.

## How Has This Been Tested?

- `bun run types:check` passes
- `bun run build` passes
- Visual verification on the admin users page

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show user avatars in the admin Users table by setting qualifier="avatar" on UsersTable. This renders avatars in the qualifier column instead of the default simple view that showed none.

<sup>Written for commit 6b88583cfc98f8da4a5d60f57d1dcfb1fd86329b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

