### PR TITLE
chore(fe): reduce padding on elements at the bottom of modal headers

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -458,40 +458,38 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
         height="fit"
         {...props}
       >
-        <Section padding={0.5} alignItems="start">
-          <Section
-            flexDirection="row"
-            justifyContent="between"
-            alignItems="start"
-            gap={0}
-            padding={0}
-          >
-            <div className="relative w-full">
-              {/* Close button is absolutely positioned because:
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="start"
+          gap={0}
+          padding={0.5}
+        >
+          <div className="relative w-full">
+            {/* Close button is absolutely positioned because:
                1. Figma mocks place it overlapping the top-right of the content area
                2. Using ContentAction with rightChildren causes the description
                   to wrap to the second line early due to the button reserving space */}
-              <div className="absolute top-0 right-0">{closeButton}</div>
-              <DialogPrimitive.Title asChild>
-                <div>
-                  <Content
-                    icon={icon}
-                    moreIcon1={moreIcon1}
-                    moreIcon2={moreIcon2}
-                    title={title}
-                    description={description}
-                    sizePreset="section"
-                    variant="heading"
-                  />
-                  {description && (
-                    <DialogPrimitive.Description className="hidden">
-                      {description}
-                    </DialogPrimitive.Description>
-                  )}
-                </div>
-              </DialogPrimitive.Title>
-            </div>
-          </Section>
+            <div className="absolute top-0 right-0">{closeButton}</div>
+            <DialogPrimitive.Title asChild>
+              <div>
+                <Content
+                  icon={icon}
+                  moreIcon1={moreIcon1}
+                  moreIcon2={moreIcon2}
+                  title={title}
+                  description={description}
+                  sizePreset="section"
+                  variant="heading"
+                />
+                {description && (
+                  <DialogPrimitive.Description className="hidden">
+                    {description}
+                  </DialogPrimitive.Description>
+                )}
+              </div>
+            </DialogPrimitive.Title>
+          </div>
         </Section>
         {children}
       </Section>


### PR DESCRIPTION
## Description

We want the search icon to be aligned with the main header icon rather than the input target box/border, so allow content at the bottom of the header with less padding to achieve this.

Part of https://linear.app/onyx-app/issue/ENG-3635/memory-popup

## How Has This Been Tested?

<img width="1572" height="2085" alt="20260319_11h00m59s_grim" src="https://github.com/user-attachments/assets/6685a8aa-fbf5-4009-bec3-1591f659b42b" />
<img width="1572" height="2085" alt="20260319_11h01m24s_grim" src="https://github.com/user-attachments/assets/025d39f8-ef25-462d-8c93-411e090d76dd" />
<img width="1572" height="2085" alt="20260319_11h01m33s_grim" src="https://github.com/user-attachments/assets/b1d3e88b-94af-421c-9d8a-f1b3e6b08ea0" />


## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced padding in `Modal.Header` so bottom content aligns with the header icon and spacing is tighter. The title row keeps its visual padding; bottom content uses the reduced outer padding.

- **Refactors**
  - Set outer padding to 0.5 and inner header row padding to 0.5; bottom content (`children`) sits outside the padded row and inherits only the reduced padding.

<sup>Written for commit 89755ab9d4e7bdff899fbee3ae89db5c4ca4b1a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

