### PR TITLE
fix(mcp): Normalize MCP Tool Schema

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1164,7 +1164,7 @@ def _upsert_db_tools(
         description = tool.description or ""
         annotations_title = tool.annotations.title if tool.annotations else None
         display_name = tool.title or annotations_title or tool_name
-        input_schema = normalize_mcp_input_schema(tool.inputSchema)
+        input_schema = normalize_mcp_input_schema(tool.inputSchema, tool_name=tool_name)
 
         if existing_tool := existing_by_name.get(tool_name):
             if existing_tool.description != description:

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -61,9 +61,11 @@ class MCPTool(Tool[None]):
         self._additional_headers = additional_headers or {}
 
         self._name = tool_name
-        self._tool_definition = normalize_mcp_input_schema(tool_definition)
+        self._tool_definition = normalize_mcp_input_schema(
+            tool_definition, tool_name=tool_name
+        )
         self._description = tool_description
-        self._display_name = tool_definition.get("displayName", tool_name)
+        self._display_name = self._tool_definition.get("displayName", tool_name)
         self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
 
     @property

--- a/backend/onyx/tools/tool_implementations/mcp/schema_utils.py
+++ b/backend/onyx/tools/tool_implementations/mcp/schema_utils.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
 
 def normalize_mcp_input_schema(
     schema: dict[str, Any] | None,
+    *,
+    tool_name: str | None = None,
 ) -> dict[str, Any]:
     """Normalize MCP tool schemas for providers that require object parameters."""
     if not schema:
@@ -13,16 +19,29 @@ def normalize_mcp_input_schema(
 
     normalized = deepcopy(schema)
     schema_type = normalized.get("type")
-    looks_like_object = schema_type == "object" or any(
+    looks_like_object = any(
         key in normalized for key in ("properties", "required", "additionalProperties")
     )
 
     if looks_like_object:
-        normalized.setdefault("type", "object")
+        if schema_type != "object":
+            logger.warning(
+                "MCP tool schema for %s had root type %r but object-like fields; normalizing to object schema",
+                tool_name or "<unknown>",
+                schema_type,
+            )
+            normalized["type"] = "object"
+        else:
+            normalized.setdefault("type", "object")
         normalized.setdefault("properties", {})
         return normalized
 
     # MCP tool arguments are sent as a JSON object on the wire. If an upstream
     # server publishes a non-object root schema, fall back to an empty object so
     # strict providers like Vertex/Gemini don't reject the entire toolset.
+    logger.warning(
+        "MCP tool schema for %s had non-object root type %r; falling back to empty object schema",
+        tool_name or "<unknown>",
+        schema_type,
+    )
     return {"type": "object", "properties": {}}

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
 
+import pytest
+
 from onyx.db.models import MCPServer
 from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
 from onyx.tools.tool_implementations.mcp.schema_utils import normalize_mcp_input_schema
@@ -30,6 +32,21 @@ class TestNormalizeMcpInputSchema:
             "required": ["query"],
         }
 
+    def test_object_like_schema_with_invalid_type_gets_overridden(self) -> None:
+        assert normalize_mcp_input_schema(
+            {
+                "type": "array",
+                "properties": {
+                    "query": {"type": "string"},
+                },
+            }
+        ) == {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+            },
+        }
+
     def test_non_object_root_schema_degrades_to_empty_object(self) -> None:
         assert normalize_mcp_input_schema(
             {"type": "array", "items": {"type": "string"}}
@@ -37,6 +54,19 @@ class TestNormalizeMcpInputSchema:
             "type": "object",
             "properties": {},
         }
+
+    def test_non_object_root_schema_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+
+        normalize_mcp_input_schema(
+            {"type": "array", "items": {"type": "string"}},
+            tool_name="falcon_list_enabled_modules",
+        )
+
+        assert "falcon_list_enabled_modules" in caplog.text
+        assert "falling back to empty object schema" in caplog.text
 
 
 class TestMCPToolDefinition:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This PR aims to normalize the mcp tool schemas given a customer had hit an issue where they saw the following error: 

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/litellm/litellm_core_utils/streaming_handler.py", line 1646, in __next__
    self.fetch_sync_stream()
  File "/usr/local/lib/python3.11/site-packages/litellm/litellm_core_utils/streaming_handler.py", line 1788, in fetch_sync_stream
    self.completion_stream = self.make_call(client=litellm.module_level_client)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py", line 2164, in make_sync_call
    response = client.post(
               ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py", line 979, in post
    raise e
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py", line 961, in post
    response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 829, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://aiplatform.googleapis.com/v1/projects/infras-management-401607/locations/global/publishers/google/models/gemini-3-pro-preview:streamGenerateContent?alt=sse'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/onyx/chat/process_message.py", line 638, in handle_stream_message_objects
    yield from run_chat_loop_with_state_containers(
  File "/app/onyx/chat/chat_state.py", line 179, in run_chat_loop_with_state_containers
    raise pkt.obj.exception
  File "/app/onyx/chat/chat_state.py", line 136, in run_with_exception_capture
    func(emitter, *args, **kwargs_with_state)
  File "/app/onyx/chat/llm_loop.py", line 549, in run_llm_loop
    llm_step_result, has_reasoned = run_llm_step(
                                    ^^^^^^^^^^^^^
  File "/app/onyx/chat/llm_step.py", line 1057, in run_llm_step
    packet = next(step_generator)
             ^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/chat/llm_step.py", line 705, in run_llm_step_pkt_generator
    for packet in llm.stream(
  File "/app/onyx/llm/multi_llm.py", line 500, in stream
    for chunk in response:
  File "/usr/local/lib/python3.11/site-packages/litellm/litellm_core_utils/streaming_handler.py", line 1779, in __next__
    raise exception_type(
          ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2340, in exception_type
    raise e
  File "/usr/local/lib/python3.11/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 1359, in exception_type
    raise BadRequestError(
litellm.exceptions.BadRequestError: litellm.BadRequestError: Vertex_ai_betaException BadRequestError - b'{\n  "error": {\n    "code": 400,\n    "message": "Unable to submit request because `falcon_list_enabled_modules` functionDeclaration parameters schema should be of type OBJECT. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling",\n    "status": "INVALID_ARGUMENT"\n  }\n}\n'
```

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Validated the fix at three levels:

- Added focused unit tests for MCP schema normalization in [backend/tests/unit/onyx/tools/test_mcp_tool_schema.py](/Users/justintahara/onyx/onyx/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py), covering:
  - empty MCP schemas (`{}`) being normalized to an object schema
  - object-like schemas missing `type: "object"` being repaired
  - non-object root schemas degrading safely to an empty object schema
  - `MCPTool.tool_definition()` emitting Vertex-compatible parameters

- Ran targeted regression tests:
  - `uv run pytest backend/tests/unit/onyx/tools/test_mcp_tool_schema.py backend/tests/unit/onyx/tools/test_file_reader_tool.py backend/tests/external_dependency_unit/tools/test_mcp_passthrough_oauth.py`

- Ran type checking on the touched files:
  - `uv run mypy backend/onyx/server/features/mcp/api.py backend/onyx/tools/tool_implementations/mcp/mcp_tool.py backend/onyx/tools/tool_implementations/mcp/schema_utils.py backend/tests/unit/onyx/tools/test_mcp_tool_schema.py`

Also verified locally with a minimal zero-arg MCP server exposing `falcon_list_enabled_modules`; Onyx successfully called the tool through a Vertex-backed chat flow without triggering the previous `parameters schema should be of type OBJECT` error.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize MCP tool input schemas to always use object parameters, preventing 400s from providers that require `function.parameters` to be an object (e.g., Vertex/Gemini). Handles empty schemas, object-like schemas with missing/wrong `type`, and non-object roots.

- **Bug Fixes**
  - Added `normalize_mcp_input_schema` to coerce empty/non-object schemas to `{"type": "object", "properties": {}}` and add/fix missing or wrong `type`.
  - Applied normalization in `mcp_tool.py` (tool definition and `displayName`) and in the tool upsert flow in `api.py` so LLMs always receive object parameters.
  - Log warnings when auto-correcting incompatible schemas; added unit tests for empty, object-like, and non-object schemas, plus `MCPTool` definition coverage.

<sup>Written for commit 7a61a2fa1516ca2756b5b8437dc3e12b2a65f30f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



