### PR TITLE
fix(fe): fix memories immediately losing focus on click

### DIFF
--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -112,9 +112,11 @@ function MemoryItem({
             />
           </Disabled>
         </Section>
-        {isFocused && (
+        <div
+          className={isFocused ? "visible" : "invisible h-0 overflow-hidden"}
+        >
           <CharacterCount value={memory.content} limit={MAX_MEMORY_LENGTH} />
-        )}
+        </div>
       </Section>
     </div>
   );


### PR DESCRIPTION
## Description

When a memory is focused, the `CharacterCount` element is added/removed from the DOM which immediately triggers the `onBlur` event cause the memory to immediately lose focus. Instead, always render the character count element and conditionally make it visible on focus.

## How Has This Been Tested?

Tested manually

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory inputs losing focus on click by keeping the character count mounted and only toggling its visibility. This removes the DOM change that triggered onBlur, so focus stays stable while editing.

<sup>Written for commit e30fb39f17df3983573a14e32429b0967e094bc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

