### PR TITLE
fix(code interpreter): Caching files (#9484)

### DIFF
--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -1,3 +1,4 @@
+import hashlib
 import mimetypes
 from io import BytesIO
 from typing import Any
@@ -85,6 +86,14 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
     def __init__(self, tool_id: int, emitter: Emitter) -> None:
         super().__init__(emitter=emitter)
         self._id = tool_id
+        # Cache of (filename, content_hash) -> ci_file_id to avoid re-uploading
+        # the same file on every tool call iteration within the same agent session.
+        # Filename is included in the key so two files with identical bytes but
+        # different names each get their own upload slot.
+        # TTL assumption: code-interpreter file TTLs (typically hours) greatly
+        # exceed the lifetime of a single agent session (at most MAX_LLM_CYCLES
+        # iterations, typically a few minutes), so stale-ID eviction is not needed.
+        self._uploaded_file_cache: dict[tuple[str, str], str] = {}
 
     @property
     def id(self) -> int:
@@ -184,8 +193,13 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             for ind, chat_file in enumerate(chat_files):
                 file_name = chat_file.filename or f"file_{ind}"
                 try:
-                    # Upload to Code Interpreter
-                    ci_file_id = client.upload_file(chat_file.content, file_name)
+                    content_hash = hashlib.sha256(chat_file.content).hexdigest()
+                    cache_key = (file_name, content_hash)
+                    ci_file_id = self._uploaded_file_cache.get(cache_key)
+                    if ci_file_id is None:
+                        # Upload to Code Interpreter
+                        ci_file_id = client.upload_file(chat_file.content, file_name)
+                        self._uploaded_file_cache[cache_key] = ci_file_id
 
                     # Stage for execution
                     files_to_stage.append({"path": file_name, "file_id": ci_file_id})
@@ -303,15 +317,10 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
                             f"file {ci_file_id}: {e}"
                         )
 
-                # Cleanup staged input files
-                for file_mapping in files_to_stage:
-                    try:
-                        client.delete_file(file_mapping["file_id"])
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to delete Code Interpreter staged "
-                            f"file {file_mapping['file_id']}: {e}"
-                        )
+                # Note: staged input files are intentionally not deleted here because
+                # _uploaded_file_cache reuses their file_ids across iterations. They are
+                # orphaned when the session ends, but the code interpreter cleans up
+                # stale files on its own TTL.
 
                 # Emit file_ids once files are processed
                 if generated_file_ids:

--- a/backend/tests/external_dependency_unit/tools/test_python_tool.py
+++ b/backend/tests/external_dependency_unit/tools/test_python_tool.py
@@ -1218,15 +1218,16 @@ def test_code_interpreter_receives_chat_files(
         finally:
             ci_mod.CodeInterpreterClient.__init__.__defaults__ = original_defaults
 
-    # Verify: file uploaded, code executed via streaming, staged file cleaned up
+    # Verify: file uploaded and code executed via streaming.
     assert len(mock_ci_server.get_requests(method="POST", path="/v1/files")) == 1
     assert (
         len(mock_ci_server.get_requests(method="POST", path="/v1/execute/stream")) == 1
     )
 
-    delete_requests = mock_ci_server.get_requests(method="DELETE")
-    assert len(delete_requests) == 1
-    assert delete_requests[0].path.startswith("/v1/files/")
+    # Staged input files are intentionally NOT deleted — PythonTool caches their
+    # file IDs across agent-loop iterations to avoid re-uploading on every call.
+    # The code interpreter cleans them up via its own TTL.
+    assert len(mock_ci_server.get_requests(method="DELETE")) == 0
 
     execute_body = mock_ci_server.get_requests(
         method="POST", path="/v1/execute/stream"

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -1,0 +1,208 @@
+"""Unit tests for PythonTool file-upload caching.
+
+Verifies that PythonTool reuses code-interpreter file IDs across multiple
+run() calls within the same session instead of re-uploading identical content
+on every agent loop iteration.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.tools.models import ChatFile
+from onyx.tools.models import PythonToolOverrideKwargs
+from onyx.tools.tool_implementations.python.code_interpreter_client import (
+    StreamResultEvent,
+)
+from onyx.tools.tool_implementations.python.python_tool import PythonTool
+
+TOOL_MODULE = "onyx.tools.tool_implementations.python.python_tool"
+
+
+def _make_stream_result() -> StreamResultEvent:
+    return StreamResultEvent(
+        exit_code=0,
+        timed_out=False,
+        duration_ms=10,
+        files=[],
+    )
+
+
+def _make_tool() -> PythonTool:
+    emitter = MagicMock()
+    return PythonTool(tool_id=1, emitter=emitter)
+
+
+def _make_override(files: list[ChatFile]) -> PythonToolOverrideKwargs:
+    return PythonToolOverrideKwargs(chat_files=files)
+
+
+def _run_tool(tool: PythonTool, mock_client: MagicMock, files: list[ChatFile]) -> None:
+    """Call tool.run() with a mocked CodeInterpreterClient context manager."""
+    from onyx.server.query_and_chat.placement import Placement
+
+    mock_client.execute_streaming.return_value = iter([_make_stream_result()])
+
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=mock_client)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    placement = Placement(turn_index=0, tab_index=0)
+    override = _make_override(files)
+
+    with patch(f"{TOOL_MODULE}.CodeInterpreterClient", return_value=ctx):
+        tool.run(placement=placement, override_kwargs=override, code="print('hi')")
+
+
+# ---------------------------------------------------------------------------
+# Cache hit: same content uploaded in a second call reuses the file_id
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_same_file_uploaded_only_once_across_two_runs() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.return_value = "file-id-abc"
+
+    pptx_content = b"fake pptx bytes"
+    files = [ChatFile(filename="report.pptx", content=pptx_content)]
+
+    _run_tool(tool, client, files)
+    _run_tool(tool, client, files)
+
+    # upload_file should only have been called once across both runs
+    client.upload_file.assert_called_once_with(pptx_content, "report.pptx")
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_cached_file_id_is_staged_on_second_run() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.return_value = "file-id-abc"
+
+    files = [ChatFile(filename="data.pptx", content=b"content")]
+
+    _run_tool(tool, client, files)
+
+    # On the second run, execute_streaming should still receive the file
+    client.execute_streaming.return_value = iter([_make_stream_result()])
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=client)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    from onyx.server.query_and_chat.placement import Placement
+
+    placement = Placement(turn_index=1, tab_index=0)
+    with patch(f"{TOOL_MODULE}.CodeInterpreterClient", return_value=ctx):
+        tool.run(
+            placement=placement,
+            override_kwargs=_make_override(files),
+            code="print('hi')",
+        )
+
+    # The second execute_streaming call should include the file
+    _, kwargs = client.execute_streaming.call_args
+    staged_files = kwargs.get("files") or []
+    assert any(f["file_id"] == "file-id-abc" for f in staged_files)
+
+
+# ---------------------------------------------------------------------------
+# Cache miss: different content triggers a new upload
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_different_file_content_uploaded_separately() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["file-id-v1", "file-id-v2"]
+
+    file_v1 = ChatFile(filename="report.pptx", content=b"version 1")
+    file_v2 = ChatFile(filename="report.pptx", content=b"version 2")
+
+    _run_tool(tool, client, [file_v1])
+    _run_tool(tool, client, [file_v2])
+
+    assert client.upload_file.call_count == 2
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_multiple_distinct_files_each_uploaded_once() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-a", "id-b"]
+
+    files = [
+        ChatFile(filename="a.pptx", content=b"aaa"),
+        ChatFile(filename="b.xlsx", content=b"bbb"),
+    ]
+
+    _run_tool(tool, client, files)
+    _run_tool(tool, client, files)
+
+    # Two distinct files — each uploaded exactly once
+    assert client.upload_file.call_count == 2
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_same_content_different_filename_uploaded_separately() -> None:
+    # Identical bytes but different names must each get their own upload slot
+    # so both files appear under their respective paths in the workspace.
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-v1", "id-v2"]
+
+    same_bytes = b"shared content"
+    files = [
+        ChatFile(filename="report_v1.csv", content=same_bytes),
+        ChatFile(filename="report_v2.csv", content=same_bytes),
+    ]
+
+    _run_tool(tool, client, files)
+
+    assert client.upload_file.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# No cross-instance sharing: a fresh PythonTool re-uploads everything
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_new_tool_instance_re_uploads_file() -> None:
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-session-1", "id-session-2"]
+
+    files = [ChatFile(filename="deck.pptx", content=b"slide data")]
+
+    tool_session_1 = _make_tool()
+    _run_tool(tool_session_1, client, files)
+
+    tool_session_2 = _make_tool()
+    _run_tool(tool_session_2, client, files)
+
+    # Different instances — each uploads independently
+    assert client.upload_file.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Upload failure: failed upload is not cached, retried next run
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_upload_failure_not_cached() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    # First call raises, second succeeds
+    client.upload_file.side_effect = [Exception("network error"), "file-id-ok"]
+
+    files = [ChatFile(filename="slides.pptx", content=b"data")]
+
+    # First run — upload fails, file is skipped but not cached
+    _run_tool(tool, client, files)
+
+    # Second run — should attempt upload again
+    _run_tool(tool, client, files)
+
+    assert client.upload_file.call_count == 2


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Code Interpreter uploads in the Python tool so identical files aren’t re-uploaded between iterations in the same session. This reduces latency and CI API calls.

- **Bug Fixes**
  - Cache per-session using (filename + SHA-256 content hash) -> file_id to reuse uploads.
  - Stop deleting staged input files after execution; rely on CI TTL cleanup so cached IDs stay valid.
  - Add unit tests for cache hits/misses, new-instance behavior, and retry on upload failure; update existing test to assert no DELETE requests.

<sup>Written for commit a7b456566d6a5ee243fb5951b1dcffdcd758abef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

