### PR TITLE
fix: drive rate limit retry

### DIFF
--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -157,9 +157,7 @@ def _execute_single_retrieval(
             logger.error(f"Error executing request: {e}")
             raise e
         elif _is_rate_limit_error(e):
-            results = _execute_with_retry(
-                lambda: retrieval_function(**request_kwargs).execute()
-            )
+            results = _execute_with_retry(retrieval_function(**request_kwargs))
         elif e.resp.status == 404 or e.resp.status == 403:
             if continue_on_404_or_403:
                 logger.debug(f"Error executing request: {e}")


### PR DESCRIPTION
## Description

fix retry logic in rare user rate limit cases

## How Has This Been Tested?

this fixes an error from a connector test run so I'm pretty confident

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rate‑limit retry for Google Drive requests by passing the Google API request object to `_execute_with_retry` instead of a lambda. This ensures the backoff logic properly re‑executes the request when user rate limits are hit.

<sup>Written for commit 302be491fe6369b15cc501a5a6ad16dfae0743f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

