### PR TITLE
fix(a11y): hidden buttons appear on tabbing

### DIFF
--- a/web/lib/opal/src/core/animations/components.tsx
+++ b/web/lib/opal/src/core/animations/components.tsx
@@ -88,9 +88,12 @@ function HoverableRoot({
   ref,
   onMouseEnter: consumerMouseEnter,
   onMouseLeave: consumerMouseLeave,
+  onFocusCapture: consumerFocusCapture,
+  onBlurCapture: consumerBlurCapture,
   ...props
 }: HoverableRootProps) {
   const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
 
   const onMouseEnter = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -108,16 +111,40 @@ function HoverableRoot({
     [consumerMouseLeave]
   );
 
+  const onFocusCapture = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      setFocused(true);
+      consumerFocusCapture?.(e);
+    },
+    [consumerFocusCapture]
+  );
+
+  const onBlurCapture = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (
+        !(e.relatedTarget instanceof Node) ||
+        !e.currentTarget.contains(e.relatedTarget)
+      ) {
+        setFocused(false);
+      }
+      consumerBlurCapture?.(e);
+    },
+    [consumerBlurCapture]
+  );
+
+  const active = hovered || focused;
   const GroupContext = getOrCreateContext(group);
 
   return (
-    <GroupContext.Provider value={hovered}>
+    <GroupContext.Provider value={active}>
       <div
         {...props}
         ref={ref}
         className={cn(widthVariants[widthVariant])}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
+        onFocusCapture={onFocusCapture}
+        onBlurCapture={onBlurCapture}
       >
         {children}
       </div>

--- a/web/lib/opal/src/core/animations/styles.css
+++ b/web/lib/opal/src/core/animations/styles.css
@@ -16,3 +16,15 @@
 .hoverable-item[data-hoverable-variant="opacity-on-hover"][data-hoverable-local="true"]:hover {
   opacity: 1;
 }
+
+/* Focus — item (or a focusable descendant) receives keyboard focus */
+.hoverable-item[data-hoverable-variant="opacity-on-hover"]:has(:focus-visible) {
+  opacity: 1;
+}
+
+/* Focus ring on keyboard focus */
+.hoverable-item:focus-visible {
+  outline: 2px solid var(--border-04);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}

--- a/web/lib/opal/src/core/interactive/shared.css
+++ b/web/lib/opal/src/core/interactive/shared.css
@@ -15,13 +15,21 @@
   initial-value: transparent;
 }
 
+/* Shared timing tokens — used by .interactive and other surfaces (e.g. table rows) */
+:root {
+  --interactive-duration: 150ms;
+  --interactive-easing: ease-in-out;
+}
+
 /* Base interactive surface */
 .interactive {
   @apply cursor-pointer select-none;
   transition:
-    background-color 150ms ease-in-out,
-    --interactive-foreground 150ms ease-in-out,
-    --interactive-foreground-icon 150ms ease-in-out;
+    background-color var(--interactive-duration) var(--interactive-easing),
+    --interactive-foreground var(--interactive-duration)
+      var(--interactive-easing),
+    --interactive-foreground-icon var(--interactive-duration)
+      var(--interactive-easing);
 }
 .interactive[data-disabled] {
   @apply cursor-not-allowed;

--- a/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
@@ -7,9 +7,9 @@ import {
   useCallback,
   useEffect,
 } from "react";
+import { Hoverable } from "@opal/core";
 import { SvgEdit } from "@opal/icons";
-import { Tag } from "@opal/components";
-import IconButton from "@/refresh-components/buttons/IconButton";
+import { Button, Tag } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import EditUserModal from "./EditUserModal";
@@ -136,53 +136,55 @@ export default function GroupsCell({
 
   return (
     <>
-      <div
-        className={`group/groups relative flex items-center w-full min-w-0 ${
-          user.id ? "cursor-pointer" : ""
-        }`}
-        onClick={user.id ? () => setShowModal(true) : undefined}
-      >
-        {groups.length === 0 ? (
-          <div
-            ref={containerRef}
-            className="flex items-center gap-1 overflow-hidden flex-nowrap min-w-0 pr-7"
-          >
-            <Text as="span" secondaryBody text03>
-              —
-            </Text>
-          </div>
-        ) : (
-          <SimpleTooltip
-            side="bottom"
-            align="start"
-            tooltip={allGroupsTooltip}
-            disabled={!hasOverflow}
-            className="bg-background-neutral-01 shadow-sm"
-            delayDuration={200}
-          >
+      <Hoverable.Root group="tags">
+        <div
+          className={`relative flex justify-between items-center w-full min-w-0 ${
+            user.id ? "cursor-pointer" : ""
+          }`}
+          onClick={user.id ? () => setShowModal(true) : undefined}
+        >
+          {groups.length === 0 ? (
             <div
               ref={containerRef}
-              className="flex items-center gap-1 overflow-hidden flex-nowrap min-w-0 pr-7"
+              className="flex items-center gap-1 overflow-hidden flex-nowrap min-w-0 -mr-7"
             >
-              {tagsContent}
+              <Text as="span" secondaryBody text03>
+                —
+              </Text>
             </div>
-          </SimpleTooltip>
-        )}
-        {user.id && (
-          <IconButton
-            tertiary
-            icon={SvgEdit}
-            tooltip="Edit"
-            toolTipPosition="left"
-            tooltipSize="sm"
-            className="absolute right-0 opacity-0 group-hover/groups:opacity-100 transition-opacity"
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowModal(true);
-            }}
-          />
-        )}
-      </div>
+          ) : (
+            <SimpleTooltip
+              side="bottom"
+              align="start"
+              tooltip={allGroupsTooltip}
+              disabled={!hasOverflow}
+              className="bg-background-neutral-01 shadow-sm"
+              delayDuration={200}
+            >
+              <div
+                ref={containerRef}
+                className="flex items-center gap-1 overflow-hidden flex-nowrap min-w-0 -mr-7"
+              >
+                {tagsContent}
+              </div>
+            </SimpleTooltip>
+          )}
+          {user.id && (
+            <Hoverable.Item group="tags" variant="opacity-on-hover">
+              <Button
+                icon={SvgEdit}
+                prominence="tertiary"
+                tooltip="Edit"
+                tooltipSide="left"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowModal(true);
+                }}
+              />
+            </Hoverable.Item>
+          )}
+        </div>
+      </Hoverable.Root>
       {showModal && user.id != null && (
         <EditUserModal
           user={{ ...user, id: user.id }}


### PR DESCRIPTION
## Description

Second attempt at having buttons transition to `100` opacity on tabbing. Implements the styling in `Hoverable` per https://github.com/onyx-dot-app/onyx/pull/9481#issuecomment-4092902058.

**before**
<img width="2880" height="1920" alt="20260318_21h19m20s_grim" src="https://github.com/user-attachments/assets/7ab8956b-8a51-4ef5-82d7-eece85cd5de8" />

**after**
<img width="2880" height="1920" alt="20260318_21h18m45s_grim" src="https://github.com/user-attachments/assets/b056674e-382c-4728-99a3-96799aefea7c" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make hover-only action buttons reveal on keyboard focus (Tab) and add a clear focus ring for better accessibility. The Users table Edit button now appears on Tab, not just on hover.

- **Bug Fixes**
  - `@opal/core` `Hoverable.Root`: add `onFocusCapture`/`onBlurCapture` to track focus within; include focus in group state so items reveal on Tab.
  - `opacity-on-hover`: reveal when the item or a descendant has `:focus-visible` (via `:has()`); add a visible focus ring.
  - Shared timing tokens `--interactive-duration` and `--interactive-easing` for smoother `.interactive` transitions.
  - Admin Users page: wrap row with `Hoverable.Root`; move Edit into `Hoverable.Item` (group "tags"); replace `IconButton` with `@opal/components` `Button` so Edit reveals on hover or Tab.

<sup>Written for commit 63a0ce953a8246baf8d2337117b65e06650ea37e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

