### PR TITLE
fix(fe): dim project name in sidebar color

### DIFF
--- a/web/src/sections/sidebar/ProjectFolderButton.tsx
+++ b/web/src/sections/sidebar/ProjectFolderButton.tsx
@@ -182,7 +182,7 @@ const ProjectFolderButton = memo(({ project }: ProjectFolderButtonProps) => {
                 onClose={() => setIsEditing(false)}
               />
             ) : (
-              <Truncated>{project.name}</Truncated>
+              <Truncated text03>{project.name}</Truncated>
             )}
           </SidebarTab>
         </Popover.Anchor>


### PR DESCRIPTION
## Description

This regressed in fix(fe): truncate project name in sidebar button (#9462). It appears `Truncated` is not a drop-in replacement as I assumed :/

## How Has This Been Tested?

**before**
<img width="1587" height="2085" alt="20260320_10h27m59s_grim" src="https://github.com/user-attachments/assets/03818e35-f8bc-4012-928e-da97e270ecca" />


**after**
<img width="1587" height="2085" alt="20260320_10h27m50s_grim" src="https://github.com/user-attachments/assets/372b1e0a-d819-44d9-81d7-e880252b738d" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dim the project name in the sidebar by applying the `text03` color to the truncation component, restoring the intended subdued styling when not editing and fixing the recent regression.

<sup>Written for commit c78c47e26d68304311dc63dc4c1d2923a5818067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

