### PR TITLE
feat(tf): Port over WAF updates

### DIFF
--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -127,6 +127,7 @@ Inputs (common):
 - `name` (default `onyx`), `region` (default `us-west-2`), `tags`
 - `postgres_username`, `postgres_password`
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
+- WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention
 
 ### `vpc`
 - Builds a VPC sized for EKS with multiple private and public subnets

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -88,6 +88,8 @@ module "waf" {
   tags = local.merged_tags
 
   # WAF configuration with sensible defaults
+  allowed_ip_cidrs                      = var.waf_allowed_ip_cidrs
+  common_rule_set_count_rules           = var.waf_common_rule_set_count_rules
   rate_limit_requests_per_5_minutes     = var.waf_rate_limit_requests_per_5_minutes
   api_rate_limit_requests_per_5_minutes = var.waf_api_rate_limit_requests_per_5_minutes
   geo_restriction_countries             = var.waf_geo_restriction_countries

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -117,6 +117,18 @@ variable "waf_rate_limit_requests_per_5_minutes" {
   default     = 2000
 }
 
+variable "waf_allowed_ip_cidrs" {
+  type        = list(string)
+  description = "Optional IPv4 CIDR ranges allowed through the WAF. Leave empty to disable IP allowlisting."
+  default     = []
+}
+
+variable "waf_common_rule_set_count_rules" {
+  type        = list(string)
+  description = "Subrules within AWSManagedRulesCommonRuleSet to override to COUNT instead of BLOCK."
+  default     = []
+}
+
 variable "waf_api_rate_limit_requests_per_5_minutes" {
   type        = number
   description = "Rate limit for API requests per 5 minutes per IP address"

--- a/deployment/terraform/modules/aws/waf/main.tf
+++ b/deployment/terraform/modules/aws/waf/main.tf
@@ -1,6 +1,20 @@
 locals {
-  name = var.name
-  tags = var.tags
+  name                  = var.name
+  tags                  = var.tags
+  ip_allowlist_enabled  = length(var.allowed_ip_cidrs) > 0
+  managed_rule_priority = local.ip_allowlist_enabled ? 1 : 0
+}
+
+resource "aws_wafv2_ip_set" "allowed_ips" {
+  count = local.ip_allowlist_enabled ? 1 : 0
+
+  name               = "${local.name}-allowed-ips"
+  description        = "IP allowlist for ${local.name}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = var.allowed_ip_cidrs
+
+  tags = local.tags
 }
 
 # AWS WAFv2 Web ACL
@@ -13,10 +27,38 @@ resource "aws_wafv2_web_acl" "main" {
     allow {}
   }
 
+  dynamic "rule" {
+    for_each = local.ip_allowlist_enabled ? [1] : []
+    content {
+      name     = "BlockRequestsOutsideAllowedIPs"
+      priority = 1
+
+      action {
+        block {}
+      }
+
+      statement {
+        not_statement {
+          statement {
+            ip_set_reference_statement {
+              arn = aws_wafv2_ip_set.allowed_ips[0].arn
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "BlockRequestsOutsideAllowedIPsMetric"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
   # AWS Managed Rules - Core Rule Set
   rule {
     name     = "AWSManagedRulesCommonRuleSet"
-    priority = 1
+    priority = 1 + local.managed_rule_priority
 
     override_action {
       none {}
@@ -26,6 +68,16 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        dynamic "rule_action_override" {
+          for_each = var.common_rule_set_count_rules
+          content {
+            name = rule_action_override.value
+            action_to_use {
+              count {}
+            }
+          }
+        }
       }
     }
 
@@ -39,7 +91,7 @@ resource "aws_wafv2_web_acl" "main" {
   # AWS Managed Rules - Known Bad Inputs
   rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 2
+    priority = 2 + local.managed_rule_priority
 
     override_action {
       none {}
@@ -62,7 +114,7 @@ resource "aws_wafv2_web_acl" "main" {
   # Rate Limiting Rule
   rule {
     name     = "RateLimitRule"
-    priority = 3
+    priority = 3 + local.managed_rule_priority
 
     action {
       block {}
@@ -87,7 +139,7 @@ resource "aws_wafv2_web_acl" "main" {
     for_each = length(var.geo_restriction_countries) > 0 ? [1] : []
     content {
       name     = "GeoRestrictionRule"
-      priority = 4
+      priority = 4 + local.managed_rule_priority
 
       action {
         block {}
@@ -110,7 +162,7 @@ resource "aws_wafv2_web_acl" "main" {
   # IP Rate Limiting
   rule {
     name     = "APIRateLimitRule"
-    priority = 5
+    priority = 5 + local.managed_rule_priority
 
     action {
       block {}
@@ -133,7 +185,7 @@ resource "aws_wafv2_web_acl" "main" {
   # SQL Injection Protection
   rule {
     name     = "AWSManagedRulesSQLiRuleSet"
-    priority = 6
+    priority = 6 + local.managed_rule_priority
 
     override_action {
       none {}
@@ -156,7 +208,7 @@ resource "aws_wafv2_web_acl" "main" {
   # Anonymous IP Protection
   rule {
     name     = "AWSManagedRulesAnonymousIpList"
-    priority = 7
+    priority = 7 + local.managed_rule_priority
 
     override_action {
       none {}

--- a/deployment/terraform/modules/aws/waf/variables.tf
+++ b/deployment/terraform/modules/aws/waf/variables.tf
@@ -9,6 +9,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "allowed_ip_cidrs" {
+  type        = list(string)
+  description = "Optional IPv4 CIDR ranges allowed to reach the application. Leave empty to disable IP allowlisting."
+  default     = []
+}
+
+variable "common_rule_set_count_rules" {
+  type        = list(string)
+  description = "Subrules within AWSManagedRulesCommonRuleSet to override to COUNT instead of BLOCK."
+  default     = []
+}
+
 variable "rate_limit_requests_per_5_minutes" {
   type        = number
   description = "Rate limit for requests per 5 minutes per IP address"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Porting over the WAF updates from our internal testing 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Already tested internally on our own dog fooding cluster

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the latest WAF improvements to our Terraform modules. Adds optional IP allowlisting and fine‑grained rule overrides, wired through `onyx`, with no breaking defaults.

- New Features
  - Optional IPv4 allowlist via `allowed_ip_cidrs` (creates an IP set and blocks non-allowed IPs when set).
  - Adjusted rule priorities so the allowlist runs before managed rules when enabled.
  - Per-subrule COUNT overrides for `AWSManagedRulesCommonRuleSet` via `common_rule_set_count_rules`.
  - Exposed `waf_allowed_ip_cidrs` and `waf_common_rule_set_count_rules` in the `onyx` module.
  - Updated README to document new WAF controls.

- Migration
  - No action needed; defaults preserve current behavior. Set `waf_allowed_ip_cidrs` and/or `waf_common_rule_set_count_rules` to enable the new controls.

<sup>Written for commit 4fef28d95a08c0a6adda2b49f78b41ab6c5c9be3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

