### PR TITLE
feat(tf): Introduce Opensearch Terraform for AWS

### DIFF
--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -8,6 +8,7 @@ This directory contains Terraform modules to provision the core AWS infrastructu
 - `postgres`: Creates an Amazon RDS for PostgreSQL instance and returns a connection URL
 - `redis`: Creates an ElastiCache for Redis replication group
 - `s3`: Creates an S3 bucket and locks access to a provided S3 VPC endpoint
+- `opensearch`: Creates an Amazon OpenSearch domain for managed search workloads
 - `onyx`: A higher-level composition that wires the above modules together for a complete, opinionated stack
 
 Use the `onyx` module if you want a working EKS + Postgres + Redis + S3 stack with sane defaults. Use the individual modules if you need more granular control.
@@ -128,6 +129,7 @@ Inputs (common):
 - `postgres_username`, `postgres_password`
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
 - WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention
+- Optional OpenSearch controls such as `enable_opensearch`, sizing, credentials, and log retention
 
 ### `vpc`
 - Builds a VPC sized for EKS with multiple private and public subnets
@@ -158,6 +160,11 @@ Key inputs include:
 
 ### `s3`
 - Creates an S3 bucket for file storage and scopes access to the provided S3 gateway VPC endpoint
+
+### `opensearch`
+- Creates an Amazon OpenSearch domain inside the VPC
+- Supports custom subnets, security groups, fine-grained access control, encryption, and CloudWatch log publishing
+- Outputs domain endpoints, ARN, and the managed security group ID when it creates one
 
 ## Installing the Onyx Helm chart (after Terraform)
 Once the cluster is active, deploy application workloads via Helm. You can use the chart in `deployment/helm/charts/onyx`.

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -1,12 +1,13 @@
 locals {
-  workspace     = terraform.workspace
-  name          = var.name
-  merged_tags   = merge(var.tags, { tenant = local.name, environment = local.workspace })
-  vpc_name      = "${var.name}-vpc-${local.workspace}"
-  cluster_name  = "${var.name}-${local.workspace}"
-  bucket_name   = "${var.name}-file-store-${local.workspace}"
-  redis_name    = "${var.name}-redis-${local.workspace}"
-  postgres_name = "${var.name}-postgres-${local.workspace}"
+  workspace       = terraform.workspace
+  name            = var.name
+  merged_tags     = merge(var.tags, { tenant = local.name, environment = local.workspace })
+  vpc_name        = "${var.name}-vpc-${local.workspace}"
+  cluster_name    = "${var.name}-${local.workspace}"
+  bucket_name     = "${var.name}-file-store-${local.workspace}"
+  redis_name      = "${var.name}-redis-${local.workspace}"
+  postgres_name   = "${var.name}-postgres-${local.workspace}"
+  opensearch_name = var.opensearch_domain_name != null ? var.opensearch_domain_name : "${var.name}-opensearch-${local.workspace}"
 
   vpc_id          = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
   private_subnets = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
@@ -95,4 +96,39 @@ module "waf" {
   geo_restriction_countries             = var.waf_geo_restriction_countries
   enable_logging                        = var.waf_enable_logging
   log_retention_days                    = var.waf_log_retention_days
+}
+
+module "opensearch" {
+  source = "../opensearch"
+  count  = var.enable_opensearch ? 1 : 0
+
+  name   = local.opensearch_name
+  vpc_id = local.vpc_id
+  # Prefer setting subnet_ids explicitly if the state of private_subnets is
+  # unclear.
+  subnet_ids    = length(var.opensearch_subnet_ids) > 0 ? var.opensearch_subnet_ids : slice(local.private_subnets, 0, 3)
+  ingress_cidrs = [local.vpc_cidr_block]
+  tags          = local.merged_tags
+
+  # Reuse EKS security groups
+  security_group_ids = [module.eks.node_security_group_id, module.eks.cluster_security_group_id]
+
+  # Configuration
+  engine_version                = var.opensearch_engine_version
+  instance_type                 = var.opensearch_instance_type
+  instance_count                = var.opensearch_instance_count
+  dedicated_master_enabled      = var.opensearch_dedicated_master_enabled
+  dedicated_master_type         = var.opensearch_dedicated_master_type
+  multi_az_with_standby_enabled = var.opensearch_multi_az_with_standby_enabled
+  ebs_volume_size               = var.opensearch_ebs_volume_size
+  ebs_throughput                = var.opensearch_ebs_throughput
+
+  # Authentication
+  internal_user_database_enabled = var.opensearch_internal_user_database_enabled
+  master_user_name               = var.opensearch_master_user_name
+  master_user_password           = var.opensearch_master_user_password
+
+  # Logging
+  enable_logging     = var.opensearch_enable_logging
+  log_retention_days = var.opensearch_log_retention_days
 }

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -32,3 +32,18 @@ output "postgres_dbi_resource_id" {
   description = "RDS DB instance resource id"
   value       = module.postgres.dbi_resource_id
 }
+
+output "opensearch_endpoint" {
+  description = "OpenSearch domain endpoint"
+  value       = var.enable_opensearch ? module.opensearch[0].domain_endpoint : null
+}
+
+output "opensearch_dashboard_endpoint" {
+  description = "OpenSearch Dashboards endpoint"
+  value       = var.enable_opensearch ? module.opensearch[0].kibana_endpoint : null
+}
+
+output "opensearch_domain_arn" {
+  description = "OpenSearch domain ARN"
+  value       = var.enable_opensearch ? module.opensearch[0].domain_arn : null
+}

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -152,3 +152,101 @@ variable "waf_log_retention_days" {
   description = "Number of days to retain WAF logs"
   default     = 90
 }
+
+# OpenSearch Configuration Variables
+variable "enable_opensearch" {
+  type        = bool
+  description = "Whether to create an OpenSearch domain"
+  default     = false
+}
+
+variable "opensearch_engine_version" {
+  type        = string
+  description = "OpenSearch engine version"
+  default     = "3.3"
+}
+
+variable "opensearch_instance_type" {
+  type        = string
+  description = "Instance type for OpenSearch data nodes"
+  default     = "r8g.large.search"
+}
+
+variable "opensearch_instance_count" {
+  type        = number
+  description = "Number of OpenSearch data nodes"
+  default     = 3
+}
+
+variable "opensearch_dedicated_master_enabled" {
+  type        = bool
+  description = "Whether to enable dedicated master nodes for OpenSearch"
+  default     = true
+}
+
+variable "opensearch_dedicated_master_type" {
+  type        = string
+  description = "Instance type for dedicated master nodes"
+  default     = "m7g.large.search"
+}
+
+variable "opensearch_multi_az_with_standby_enabled" {
+  type        = bool
+  description = "Whether to enable Multi-AZ with Standby deployment"
+  default     = true
+}
+
+variable "opensearch_ebs_volume_size" {
+  type        = number
+  description = "EBS volume size in GiB per OpenSearch node"
+  default     = 512
+}
+
+variable "opensearch_ebs_throughput" {
+  type        = number
+  description = "Throughput in MiB/s for gp3 volumes"
+  default     = 256
+}
+
+variable "opensearch_internal_user_database_enabled" {
+  type        = bool
+  description = "Whether to enable the internal user database for fine-grained access control"
+  default     = true
+}
+
+variable "opensearch_master_user_name" {
+  type        = string
+  description = "Master user name for OpenSearch internal user database"
+  default     = null
+  sensitive   = true
+}
+
+variable "opensearch_master_user_password" {
+  type        = string
+  description = "Master user password for OpenSearch internal user database"
+  default     = null
+  sensitive   = true
+}
+
+variable "opensearch_domain_name" {
+  type        = string
+  description = "Override the OpenSearch domain name. If null, defaults to {name}-opensearch-{workspace}."
+  default     = null
+}
+
+variable "opensearch_enable_logging" {
+  type    = bool
+  default = false
+}
+
+variable "opensearch_log_retention_days" {
+  type        = number
+  description = "Number of days to retain OpenSearch CloudWatch logs (0 = never expire)"
+  default     = 0
+}
+
+variable "opensearch_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for OpenSearch. If empty, uses first 3 private subnets."
+  default     = []
+}

--- a/deployment/terraform/modules/aws/opensearch/main.tf
+++ b/deployment/terraform/modules/aws/opensearch/main.tf
@@ -1,0 +1,229 @@
+# OpenSearch domain security group
+resource "aws_security_group" "opensearch_sg" {
+  count       = length(var.security_group_ids) > 0 ? 0 : 1
+  name        = "${var.name}-sg"
+  description = "Allow inbound traffic to OpenSearch from VPC"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Service-linked role for OpenSearch (required for VPC deployment)
+# This may already exist in your account - if so, import it or set create_service_linked_role = false
+resource "aws_iam_service_linked_role" "opensearch" {
+  count            = var.create_service_linked_role ? 1 : 0
+  aws_service_name = "opensearchservice.amazonaws.com"
+}
+
+# IAM policy for OpenSearch access
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# KMS key lookup for encryption at rest
+data "aws_kms_key" "opensearch" {
+  key_id = "alias/aws/es"
+}
+
+# Access policy - allows all principals within the VPC (secured by VPC + security groups)
+data "aws_iam_policy_document" "opensearch_access" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["es:*"]
+
+    resources = [
+      "arn:aws:es:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:domain/${var.name}/*"
+    ]
+  }
+}
+
+# OpenSearch domain
+resource "aws_opensearch_domain" "main" {
+  domain_name    = var.name
+  engine_version = "OpenSearch_${var.engine_version}"
+
+  cluster_config {
+    instance_type                 = var.instance_type
+    instance_count                = var.instance_count
+    zone_awareness_enabled        = var.zone_awareness_enabled
+    dedicated_master_enabled      = var.dedicated_master_enabled
+    dedicated_master_type         = var.dedicated_master_enabled ? var.dedicated_master_type : null
+    dedicated_master_count        = var.dedicated_master_enabled ? var.dedicated_master_count : null
+    multi_az_with_standby_enabled = var.multi_az_with_standby_enabled
+    warm_enabled                  = var.warm_enabled
+    warm_type                     = var.warm_enabled ? var.warm_type : null
+    warm_count                    = var.warm_enabled ? var.warm_count : null
+
+    dynamic "zone_awareness_config" {
+      for_each = var.zone_awareness_enabled ? [1] : []
+      content {
+        availability_zone_count = var.availability_zone_count
+      }
+    }
+
+    dynamic "cold_storage_options" {
+      for_each = var.cold_storage_enabled ? [1] : []
+      content {
+        enabled = true
+      }
+    }
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = var.ebs_volume_type
+    volume_size = var.ebs_volume_size
+    iops        = var.ebs_volume_type == "gp3" || var.ebs_volume_type == "io1" ? var.ebs_iops : null
+    throughput  = var.ebs_volume_type == "gp3" ? var.ebs_throughput : null
+  }
+
+  vpc_options {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.opensearch_sg[0].id]
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = var.kms_key_id != null ? var.kms_key_id : data.aws_kms_key.opensearch.arn
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = var.tls_security_policy
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = var.internal_user_database_enabled
+
+    dynamic "master_user_options" {
+      for_each = var.internal_user_database_enabled ? [1] : []
+      content {
+        master_user_name     = var.master_user_name
+        master_user_password = var.master_user_password
+      }
+    }
+
+    dynamic "master_user_options" {
+      for_each = var.internal_user_database_enabled ? [] : [1]
+      content {
+        master_user_arn = var.master_user_arn
+      }
+    }
+  }
+
+  advanced_options = var.advanced_options
+
+  access_policies = data.aws_iam_policy_document.opensearch_access.json
+
+  auto_tune_options {
+    desired_state       = var.auto_tune_enabled ? "ENABLED" : "DISABLED"
+    rollback_on_disable = var.auto_tune_rollback_on_disable
+  }
+
+  off_peak_window_options {
+    enabled = var.off_peak_window_enabled
+
+    dynamic "off_peak_window" {
+      for_each = var.off_peak_window_enabled ? [1] : []
+      content {
+        window_start_time {
+          hours   = var.off_peak_window_start_hours
+          minutes = var.off_peak_window_start_minutes
+        }
+      }
+    }
+  }
+
+  software_update_options {
+    auto_software_update_enabled = var.auto_software_update_enabled
+  }
+
+  dynamic "log_publishing_options" {
+    for_each = var.enable_logging ? ["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS", "ES_APPLICATION_LOGS"] : []
+    content {
+      cloudwatch_log_group_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.log_group_name}"
+      log_type                 = log_publishing_options.value
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    aws_iam_service_linked_role.opensearch,
+    aws_cloudwatch_log_resource_policy.opensearch
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = !var.internal_user_database_enabled || var.master_user_name != null
+      error_message = "master_user_name is required when internal_user_database_enabled is true."
+    }
+    precondition {
+      condition     = !var.internal_user_database_enabled || var.master_user_password != null
+      error_message = "master_user_password is required when internal_user_database_enabled is true."
+    }
+  }
+}
+
+# CloudWatch log group for OpenSearch
+locals {
+  log_group_name = var.log_group_name != null ? var.log_group_name : "/aws/OpenSearchService/domains/${var.name}/search-logs"
+}
+
+resource "aws_cloudwatch_log_group" "opensearch" {
+  count             = var.enable_logging ? 1 : 0
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}
+
+# CloudWatch log resource policy for OpenSearch
+data "aws_iam_policy_document" "opensearch_log_policy" {
+  count = var.enable_logging ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+    ]
+
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.log_group_name}:*"]
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch" {
+  count           = var.enable_logging ? 1 : 0
+  policy_name     = "OpenSearchService-${var.name}-Search-logs"
+  policy_document = data.aws_iam_policy_document.opensearch_log_policy[0].json
+}

--- a/deployment/terraform/modules/aws/opensearch/outputs.tf
+++ b/deployment/terraform/modules/aws/opensearch/outputs.tf
@@ -1,0 +1,29 @@
+output "domain_endpoint" {
+  description = "The endpoint of the OpenSearch domain"
+  value       = aws_opensearch_domain.main.endpoint
+}
+
+output "domain_arn" {
+  description = "The ARN of the OpenSearch domain"
+  value       = aws_opensearch_domain.main.arn
+}
+
+output "domain_id" {
+  description = "The unique identifier for the OpenSearch domain"
+  value       = aws_opensearch_domain.main.domain_id
+}
+
+output "domain_name" {
+  description = "The name of the OpenSearch domain"
+  value       = aws_opensearch_domain.main.domain_name
+}
+
+output "kibana_endpoint" {
+  description = "The OpenSearch Dashboards endpoint"
+  value       = aws_opensearch_domain.main.dashboard_endpoint
+}
+
+output "security_group_id" {
+  description = "The ID of the OpenSearch security group"
+  value       = length(aws_security_group.opensearch_sg) > 0 ? aws_security_group.opensearch_sg[0].id : null
+}

--- a/deployment/terraform/modules/aws/opensearch/variables.tf
+++ b/deployment/terraform/modules/aws/opensearch/variables.tf
@@ -1,0 +1,242 @@
+variable "name" {
+  description = "Name of the OpenSearch domain"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC to deploy the OpenSearch domain into"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the OpenSearch domain"
+  type        = list(string)
+}
+
+variable "ingress_cidrs" {
+  description = "CIDR blocks allowed to access OpenSearch"
+  type        = list(string)
+}
+
+variable "engine_version" {
+  description = "OpenSearch engine version (e.g., 2.17, 3.3)"
+  type        = string
+  default     = "3.3"
+}
+
+variable "instance_type" {
+  description = "Instance type for data nodes"
+  type        = string
+  default     = "r8g.large.search"
+}
+
+variable "instance_count" {
+  description = "Number of data nodes"
+  type        = number
+  default     = 3
+}
+
+variable "zone_awareness_enabled" {
+  description = "Whether to enable zone awareness for the cluster"
+  type        = bool
+  default     = true
+}
+
+variable "availability_zone_count" {
+  description = "Number of availability zones (2 or 3)"
+  type        = number
+  default     = 3
+}
+
+variable "dedicated_master_enabled" {
+  description = "Whether to enable dedicated master nodes"
+  type        = bool
+  default     = true
+}
+
+variable "dedicated_master_type" {
+  description = "Instance type for dedicated master nodes"
+  type        = string
+  default     = "m7g.large.search"
+}
+
+variable "dedicated_master_count" {
+  description = "Number of dedicated master nodes (must be 3 or 5)"
+  type        = number
+  default     = 3
+}
+
+variable "multi_az_with_standby_enabled" {
+  description = "Whether to enable Multi-AZ with Standby deployment"
+  type        = bool
+  default     = true
+}
+
+variable "warm_enabled" {
+  description = "Whether to enable warm storage"
+  type        = bool
+  default     = false
+}
+
+variable "warm_type" {
+  description = "Instance type for warm nodes"
+  type        = string
+  default     = "ultrawarm1.medium.search"
+}
+
+variable "warm_count" {
+  description = "Number of warm nodes"
+  type        = number
+  default     = 2
+}
+
+variable "cold_storage_enabled" {
+  description = "Whether to enable cold storage"
+  type        = bool
+  default     = false
+}
+
+variable "ebs_volume_type" {
+  description = "EBS volume type (gp3, gp2, io1)"
+  type        = string
+  default     = "gp3"
+}
+
+variable "ebs_volume_size" {
+  description = "EBS volume size in GB per node"
+  type        = number
+  default     = 512
+}
+
+variable "ebs_iops" {
+  description = "IOPS for gp3/io1 volumes"
+  type        = number
+  default     = 3000
+}
+
+variable "ebs_throughput" {
+  description = "Throughput in MiB/s for gp3 volumes"
+  type        = number
+  default     = 256
+}
+
+variable "kms_key_id" {
+  description = "KMS key ID for encryption at rest (uses AWS managed key if not specified)"
+  type        = string
+  default     = null
+}
+
+variable "tls_security_policy" {
+  description = "TLS security policy for HTTPS endpoints"
+  type        = string
+  default     = "Policy-Min-TLS-1-2-2019-07"
+}
+
+variable "internal_user_database_enabled" {
+  description = "Whether to enable the internal user database for fine-grained access control"
+  type        = bool
+  default     = true
+}
+
+variable "master_user_name" {
+  description = "Master user name for internal user database"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "master_user_password" {
+  description = "Master user password for internal user database"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "master_user_arn" {
+  description = "IAM ARN for the master user (used when internal_user_database_enabled is false)"
+  type        = string
+  default     = null
+}
+
+variable "advanced_options" {
+  description = "Advanced options for OpenSearch"
+  type        = map(string)
+  default = {
+    "indices.fielddata.cache.size"           = "20"
+    "indices.query.bool.max_clause_count"    = "1024"
+    "override_main_response_version"         = "false"
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+}
+
+variable "auto_tune_enabled" {
+  description = "Whether to enable Auto-Tune"
+  type        = bool
+  default     = true
+}
+
+variable "auto_tune_rollback_on_disable" {
+  description = "Whether to roll back Auto-Tune changes when disabled"
+  type        = string
+  default     = "NO_ROLLBACK"
+}
+
+variable "off_peak_window_enabled" {
+  description = "Whether to enable off-peak window for maintenance"
+  type        = bool
+  default     = true
+}
+
+variable "off_peak_window_start_hours" {
+  description = "Hour (UTC) when off-peak window starts (0-23)"
+  type        = number
+  default     = 6
+}
+
+variable "off_peak_window_start_minutes" {
+  description = "Minutes when off-peak window starts (0-59)"
+  type        = number
+  default     = 0
+}
+
+variable "auto_software_update_enabled" {
+  description = "Whether to enable automatic software updates"
+  type        = bool
+  default     = false
+}
+
+variable "enable_logging" {
+  description = "Whether to enable CloudWatch logging"
+  type        = bool
+  default     = false
+}
+
+variable "create_service_linked_role" {
+  description = "Whether to create the OpenSearch service-linked role (set to false if it already exists)"
+  type        = bool
+  default     = false
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch logs"
+  type        = number
+  default     = 30
+}
+
+variable "security_group_ids" {
+  description = "Existing security group IDs to attach. If empty, a new SG is created."
+  type        = list(string)
+  default     = []
+}
+
+variable "log_group_name" {
+  description = "CloudWatch log group name. Defaults to AWS console convention."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to OpenSearch resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Introducing the OpenSearch Terraform for AWS into our main repo

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
This has already been tested for our internal clusters

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AWS OpenSearch Terraform module and integrates it into the `onyx` stack for optional, VPC‑isolated search. Provides secure defaults, multi‑AZ support, and outputs for the domain and Dashboards endpoints.

- **New Features**
  - New `deployment/terraform/modules/aws/opensearch` module: VPC deployment, encryption at rest, node‑to‑node TLS, fine‑grained access control, gp3 EBS, Auto‑Tune, and optional CloudWatch logs.
  - `onyx` integration behind `enable_opensearch`; reuses EKS security groups, selects private subnets, and tags resources.
  - Configurable engine/version and sizing (data nodes, dedicated masters, Multi‑AZ with Standby, EBS size/throughput).
  - New outputs: domain endpoint, Dashboards endpoint, and domain ARN. README updated to document the `opensearch` module.

- **Migration**
  - To enable, set `enable_opensearch = true` in `onyx` and provide `opensearch_master_user_name` and `opensearch_master_user_password` (internal user DB is on by default).
  - Optionally set `opensearch_subnet_ids` and `opensearch_domain_name`; otherwise uses the first 3 private subnets and a derived name.
  - Ensure the OpenSearch service‑linked role exists in the account; create it beforehand if needed.
  - For logs, set `opensearch_enable_logging` and `opensearch_log_retention_days`.

<sup>Written for commit 2d1d73948af02b3827753c1bed4227422b42d398. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

