### PR TITLE
feat(ux): handle when chat session id cannot be found

### DIFF
--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -7,8 +7,11 @@ import { processRawChatHistory } from "@/app/app/services/lib";
 import { getLatestMessageChain } from "@/app/app/services/messageTree";
 import HumanMessage from "@/app/app/message/HumanMessage";
 import AgentMessage from "@/app/app/message/messageComponents/AgentMessage";
-import { Callout } from "@/components/ui/callout";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
+import { Section } from "@/layouts/general-layouts";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNotFound from "@opal/illustrations/not-found";
+import { Button } from "@opal/components";
 import { Persona } from "@/app/admin/agents/interfaces";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import PreviewModal from "@/sections/modals/PreviewModal";
@@ -33,12 +36,17 @@ export default function SharedChatDisplay({
 
   if (!chatSession) {
     return (
-      <div className="min-h-full w-full">
-        <div className="mx-auto w-fit pt-8">
-          <Callout type="danger" title="Shared Chat Not Found">
-            Did not find a shared chat with the specified ID.
-          </Callout>
-        </div>
+      <div className="h-full w-full flex flex-col items-center justify-center">
+        <Section flexDirection="column" alignItems="center" gap={1}>
+          <IllustrationContent
+            illustration={SvgNotFound}
+            title="Shared chat not found"
+            description="Did not find a shared chat with the specified ID."
+          />
+          <Button href="/app" prominence="secondary">
+            Start a new chat
+          </Button>
+        </Section>
       </div>
     );
   }
@@ -51,12 +59,17 @@ export default function SharedChatDisplay({
 
   if (firstMessage === undefined) {
     return (
-      <div className="min-h-full w-full">
-        <div className="mx-auto w-fit pt-8">
-          <Callout type="danger" title="Shared Chat Not Found">
-            No messages found in shared chat.
-          </Callout>
-        </div>
+      <div className="h-full w-full flex flex-col items-center justify-center">
+        <Section flexDirection="column" alignItems="center" gap={1}>
+          <IllustrationContent
+            illustration={SvgNotFound}
+            title="Shared chat not found"
+            description="No messages found in shared chat."
+          />
+          <Button href="/app" prominence="secondary">
+            Start a new chat
+          </Button>
+        </Section>
       </div>
     );
   }

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -61,6 +61,11 @@ interface UseChatSessionControllerProps {
   }) => Promise<void>;
 }
 
+export type SessionFetchError = {
+  type: "not_found" | "access_denied" | "unknown";
+  detail: string;
+} | null;
+
 export default function useChatSessionController({
   existingChatSessionId,
   searchParams,
@@ -80,6 +85,8 @@ export default function useChatSessionController({
   const [currentSessionFileTokenCount, setCurrentSessionFileTokenCount] =
     useState<number>(0);
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
+  const [sessionFetchError, setSessionFetchError] =
+    useState<SessionFetchError>(null);
   // Store actions
   const updateSessionAndMessageTree = useChatSessionStore(
     (state) => state.updateSessionAndMessageTree
@@ -151,6 +158,8 @@ export default function useChatSessionController({
     }
 
     async function initialSessionFetch() {
+      setSessionFetchError(null);
+
       if (existingChatSessionId === null) {
         // Clear the current session in the store to show intro messages
         setCurrentSession(null);
@@ -178,9 +187,42 @@ export default function useChatSessionController({
       setCurrentSession(existingChatSessionId);
       setIsFetchingChatMessages(existingChatSessionId, true);
 
-      const response = await fetch(
-        `/api/chat/get-chat-session/${existingChatSessionId}`
-      );
+      let response: Response;
+      try {
+        response = await fetch(
+          `/api/chat/get-chat-session/${existingChatSessionId}`
+        );
+      } catch (error) {
+        setIsFetchingChatMessages(existingChatSessionId, false);
+        console.error("Failed to fetch chat session", {
+          chatSessionId: existingChatSessionId,
+          error,
+        });
+        setSessionFetchError({
+          type: "unknown",
+          detail: "Failed to load chat session. Please check your connection.",
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        setIsFetchingChatMessages(existingChatSessionId, false);
+        let detail = "An unexpected error occurred.";
+        try {
+          const errorBody = await response.json();
+          detail = errorBody.detail || detail;
+        } catch {
+          // ignore parse errors
+        }
+        const type =
+          response.status === 404
+            ? "not_found"
+            : response.status === 403
+              ? "access_denied"
+              : "unknown";
+        setSessionFetchError({ type, detail });
+        return;
+      }
 
       const session = await response.json();
       const chatSession = session as BackendChatSession;
@@ -356,5 +398,6 @@ export default function useChatSessionController({
     currentSessionFileTokenCount,
     onMessageSelection,
     projectFiles,
+    sessionFetchError,
   };
 }

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -5,6 +5,7 @@ import { personaIncludesRetrieval } from "@/app/app/services/lib";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast, useToastFromQuery } from "@/hooks/useToast";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
+import { Section } from "@/layouts/general-layouts";
 import { useFederatedConnectors, useFilters, useLlmManager } from "@/lib/hooks";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
@@ -62,6 +63,9 @@ import { useShowOnboarding } from "@/hooks/useShowOnboarding";
 import * as AppLayouts from "@/layouts/app-layouts";
 import { SvgChevronDown, SvgFileText } from "@opal/icons";
 import { Button } from "@opal/components";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNotFound from "@opal/illustrations/not-found";
+import SvgNoAccess from "@opal/illustrations/no-access";
 import Spacer from "@/refresh-components/Spacer";
 import useAppFocus from "@/hooks/useAppFocus";
 import { useQueryController } from "@/providers/QueryControllerProvider";
@@ -381,23 +385,26 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     setSelectedAgentFromId,
   });
 
-  const { onMessageSelection, currentSessionFileTokenCount } =
-    useChatSessionController({
-      existingChatSessionId: currentChatSessionId,
-      searchParams,
-      filterManager,
-      firstMessage,
-      setSelectedAgentFromId,
-      setSelectedDocuments,
-      setCurrentMessageFiles,
-      chatSessionIdRef,
-      loadedIdSessionRef,
-      chatInputBarRef,
-      isInitialLoad,
-      submitOnLoadPerformed,
-      refreshChatSessions,
-      onSubmit,
-    });
+  const {
+    onMessageSelection,
+    currentSessionFileTokenCount,
+    sessionFetchError,
+  } = useChatSessionController({
+    existingChatSessionId: currentChatSessionId,
+    searchParams,
+    filterManager,
+    firstMessage,
+    setSelectedAgentFromId,
+    setSelectedDocuments,
+    setCurrentMessageFiles,
+    chatSessionIdRef,
+    loadedIdSessionRef,
+    chatInputBarRef,
+    isInitialLoad,
+    submitOnLoadPerformed,
+    refreshChatSessions,
+    onSubmit,
+  });
 
   useSendMessageToParent();
 
@@ -679,7 +686,10 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                   {/* ChatUI */}
                   <Fade
                     show={
-                      appFocus.isChat() && !!currentChatSessionId && !!liveAgent
+                      appFocus.isChat() &&
+                      !!currentChatSessionId &&
+                      !!liveAgent &&
+                      !sessionFetchError
                     }
                     className="h-full w-full flex flex-col items-center"
                   >
@@ -706,6 +716,45 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         anchorNodeId={anchorNodeId}
                       />
                     </ChatScrollContainer>
+                  </Fade>
+
+                  {/* Session fetch error (404 / 403) */}
+                  <Fade
+                    show={appFocus.isChat() && sessionFetchError !== null}
+                    className="h-full w-full flex flex-col items-center justify-center"
+                  >
+                    {sessionFetchError && (
+                      <Section
+                        flexDirection="column"
+                        alignItems="center"
+                        gap={1}
+                      >
+                        <IllustrationContent
+                          illustration={
+                            sessionFetchError.type === "access_denied"
+                              ? SvgNoAccess
+                              : SvgNotFound
+                          }
+                          title={
+                            sessionFetchError.type === "not_found"
+                              ? "Chat not found"
+                              : sessionFetchError.type === "access_denied"
+                                ? "Access denied"
+                                : "Something went wrong"
+                          }
+                          description={
+                            sessionFetchError.type === "not_found"
+                              ? "This chat session doesn't exist or has been deleted."
+                              : sessionFetchError.type === "access_denied"
+                                ? "You don't have permission to view this chat session."
+                                : sessionFetchError.detail
+                          }
+                        />
+                        <Button href="/app" prominence="secondary">
+                          Start a new chat
+                        </Button>
+                      </Section>
+                    )}
                   </Fade>
 
                   {/* ProjectUI */}
@@ -736,7 +785,12 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
 
                 {/* ── Middle-center: AppInputBar ── */}
-                <div className="row-start-2 flex flex-col items-center px-4">
+                <div
+                  className={cn(
+                    "row-start-2 flex flex-col items-center px-4",
+                    sessionFetchError && "hidden"
+                  )}
+                >
                   <div className="relative w-full max-w-[var(--app-page-main-content-width)] flex flex-col">
                     {/* Scroll to bottom button - positioned absolutely above AppInputBar */}
                     {appFocus.isChat() && showScrollButton && (

--- a/web/tests/e2e/chat/chat_session_not_found.spec.ts
+++ b/web/tests/e2e/chat/chat_session_not_found.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
+
+const NON_EXISTENT_CHAT_ID = "00000000-0000-0000-0000-000000000000";
+
+for (const theme of THEMES) {
+  test.describe(`Chat session not found (${theme} mode)`, () => {
+    test.beforeEach(async ({ page }) => {
+      await setThemeBeforeNavigation(page, theme);
+    });
+
+    test("should show 404 page for a non-existent chat session", async ({
+      page,
+    }) => {
+      await page.goto(`/app?chatId=${NON_EXISTENT_CHAT_ID}`);
+
+      await expect(page.getByText("Chat not found")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.getByText("This chat session doesn't exist or has been deleted.")
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Start a new chat" })
+      ).toBeVisible();
+
+      // Sidebar should still be visible
+      await expect(page.getByTestId("AppSidebar/new-session")).toBeVisible();
+
+      const container = page.locator("[data-main-container]");
+      await expect(container).toBeVisible();
+      await expectElementScreenshot(container, {
+        name: `chat-session-not-found-${theme}`,
+      });
+    });
+
+    test("should navigate to /app when clicking Start a new chat", async ({
+      page,
+    }) => {
+      await page.goto(`/app?chatId=${NON_EXISTENT_CHAT_ID}`);
+
+      await expect(page.getByText("Chat not found")).toBeVisible({
+        timeout: 10000,
+      });
+
+      await page.getByRole("link", { name: "Start a new chat" }).click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL("/app");
+      await expect(page.getByText("Chat not found")).toBeHidden();
+    });
+  });
+}


### PR DESCRIPTION
## Description

I delete chat sessions frequently (and also typo copying URLs) and the chat page looks awkward without messages + it throws a console error because `rawMessages` is undefined, so handle 404s fetching chat sessions.

<img width="1572" height="1351" alt="20260320_12h50m42s_grim" src="https://github.com/user-attachments/assets/16ab1cca-b21f-488c-9eb5-44acb2f3f068" />

## How Has This Been Tested?

Adding playwright test

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear error state when a chat session can’t be found, accessed, or fails to load, including shared chats. Hide the chat UI and input on errors and provide a quick way to start a new chat.

- **New Features**
  - Added `sessionFetchError` to `useChatSessionController` with types `not_found`, `access_denied`, `unknown`; handles 404/403 and network failures, parsing server `detail` when available.
  - In `AppPage`, show “Chat not found”, “Access denied”, or “Something went wrong” with an illustration and a “Start a new chat” button; hide chat UI and input when an error exists.
  - In `SharedChatDisplay`, show a “Shared chat not found” illustration and a “Start a new chat” button when the shared chat or its messages are missing.
  - Added Playwright tests for a non-existent chat session, including theme snapshots and navigation back to `/app`.

<sup>Written for commit bfdeb65bbb57a1b8ba18e931bbc585967f6e67e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

