### PR TITLE
fix: deadlock in multitenant test

### DIFF
--- a/backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py
+++ b/backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 import uuid
 from collections.abc import Generator
 
@@ -27,6 +28,9 @@ from onyx.db.engine.sql_engine import SqlEngine
 _BACKEND_DIR = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
 )
+
+_DROP_SCHEMA_MAX_RETRIES = 3
+_DROP_SCHEMA_RETRY_DELAY_SEC = 2
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +52,39 @@ def _run_script(
         text=True,
         env=env,
     )
+
+
+def _force_drop_schema(engine: Engine, schema: str) -> None:
+    """Terminate backends using *schema* then drop it, retrying on deadlock.
+
+    Background Celery workers may discover test schemas (they match the
+    ``tenant_`` prefix) and hold locks on tables inside them.  A bare
+    ``DROP SCHEMA … CASCADE`` can deadlock with those workers, so we
+    first kill their connections and retry if we still hit a deadlock.
+    """
+    for attempt in range(_DROP_SCHEMA_MAX_RETRIES):
+        try:
+            with engine.connect() as conn:
+                conn.execute(
+                    text(
+                        """
+                        SELECT pg_terminate_backend(l.pid)
+                        FROM pg_locks l
+                        JOIN pg_class c ON c.oid = l.relation
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        WHERE n.nspname = :schema
+                          AND l.pid != pg_backend_pid()
+                        """
+                    ),
+                    {"schema": schema},
+                )
+                conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+                conn.commit()
+            return
+        except Exception:
+            if attempt == _DROP_SCHEMA_MAX_RETRIES - 1:
+                raise
+            time.sleep(_DROP_SCHEMA_RETRY_DELAY_SEC)
 
 
 # ---------------------------------------------------------------------------
@@ -104,9 +141,7 @@ def tenant_schema_at_head(
 
     yield schema
 
-    with engine.connect() as conn:
-        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
-        conn.commit()
+    _force_drop_schema(engine, schema)
 
 
 @pytest.fixture
@@ -123,9 +158,7 @@ def tenant_schema_empty(engine: Engine) -> Generator[str, None, None]:
 
     yield schema
 
-    with engine.connect() as conn:
-        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
-        conn.commit()
+    _force_drop_schema(engine, schema)
 
 
 @pytest.fixture
@@ -150,9 +183,7 @@ def tenant_schema_bad_rev(engine: Engine) -> Generator[str, None, None]:
 
     yield schema
 
-    with engine.connect() as conn:
-        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
-        conn.commit()
+    _force_drop_schema(engine, schema)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

We were occasionally seeing deadlock in multitenant tests when we try to clean up schemas; this lets us more forcibly delete them.

## How Has This Been Tested?

CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent deadlocks when cleaning up multitenant test schemas by terminating open connections and retrying schema drops. This stabilizes CI runs that race with `Celery` workers.

- **Bug Fixes**
  - Added `_force_drop_schema` to kill backends on a schema, drop it with CASCADE, and retry on deadlock (3 attempts, 2s delay).
  - Updated multitenant migration test fixtures to use the new helper for teardown.

<sup>Written for commit 4d2343c81eb56518f7d2385d454521b2d90e83ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

