### PR TITLE
feat: installer invocable from other bash script

### DIFF
--- a/deployment/docker_compose/install.ps1
+++ b/deployment/docker_compose/install.ps1
@@ -364,7 +364,7 @@ function Invoke-OnyxDeleteData {
     Write-Host "`n=== WARNING: This will permanently delete all Onyx data ===`n" -ForegroundColor Red
     Print-Warning "This action will remove all Onyx containers, volumes, files, and user data."
     if (Test-Interactive) {
-        $confirm = Read-Host "Type 'DELETE' to confirm"
+        $confirm = Prompt-OrDefault "Type 'DELETE' to confirm" ""
         if ($confirm -ne "DELETE") { Print-Info "Operation cancelled."; return }
     } else {
         Print-OnyxError "Cannot confirm destructive operation in non-interactive mode."
@@ -806,7 +806,7 @@ function Main {
 
     if (Test-Interactive) {
         Write-Host "`nPlease acknowledge and press Enter to continue..." -ForegroundColor Yellow
-        Read-Host | Out-Null
+        $null = Prompt-OrDefault "" ""
     } else {
         Write-Host "`nRunning in non-interactive mode - proceeding automatically..." -ForegroundColor Yellow
     }

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -174,34 +174,42 @@ ensure_file() {
 
 # --- Interactive prompt helpers ---
 is_interactive() {
-    [[ "$NO_PROMPT" = false ]]
+    [[ "$NO_PROMPT" = false ]] && [[ -r /dev/tty ]] && [[ -w /dev/tty ]]
+}
+
+read_prompt_line() {
+    local prompt_text="$1"
+    if ! is_interactive; then
+        REPLY=""
+        return
+    fi
+    [[ -n "$prompt_text" ]] && printf "%s" "$prompt_text" > /dev/tty
+    IFS= read -r REPLY < /dev/tty || REPLY=""
+}
+
+read_prompt_char() {
+    local prompt_text="$1"
+    if ! is_interactive; then
+        REPLY=""
+        return
+    fi
+    [[ -n "$prompt_text" ]] && printf "%s" "$prompt_text" > /dev/tty
+    IFS= read -r -n 1 REPLY < /dev/tty || REPLY=""
+    printf "\n" > /dev/tty
 }
 
 prompt_or_default() {
     local prompt_text="$1"
     local default_value="$2"
-    if is_interactive; then
-        read -p "$prompt_text" -r REPLY
-        if [[ -z "$REPLY" ]]; then
-            REPLY="$default_value"
-        fi
-    else
-        REPLY="$default_value"
-    fi
+    read_prompt_line "$prompt_text"
+    [[ -z "$REPLY" ]] && REPLY="$default_value"
 }
 
 prompt_yn_or_default() {
     local prompt_text="$1"
     local default_value="$2"
-    if is_interactive; then
-        read -p "$prompt_text" -n 1 -r
-        echo ""
-        if [[ -z "$REPLY" ]]; then
-            REPLY="$default_value"
-        fi
-    else
-        REPLY="$default_value"
-    fi
+    read_prompt_char "$prompt_text"
+    [[ -z "$REPLY" ]] && REPLY="$default_value"
 }
 
 confirm_action() {
@@ -302,8 +310,8 @@ if [ "$DELETE_DATA_MODE" = true ]; then
     echo "  • All user data and documents"
     echo ""
     if is_interactive; then
-        read -p "Are you sure you want to continue? Type 'DELETE' to confirm: " -r
-        echo ""
+        prompt_or_default "Are you sure you want to continue? Type 'DELETE' to confirm: " ""
+        echo "" > /dev/tty
         if [ "$REPLY" != "DELETE" ]; then
             print_info "Operation cancelled."
             exit 0
@@ -497,7 +505,7 @@ echo ""
 
 if is_interactive; then
     echo -e "${YELLOW}${BOLD}Please acknowledge and press Enter to continue...${NC}"
-    read -r
+    read_prompt_line ""
     echo ""
 else
     echo -e "${YELLOW}${BOLD}Running in non-interactive mode - proceeding automatically...${NC}"


### PR DESCRIPTION
## Description

This allows invoking install.sh from another script being run via curl <script hosted url> | bash

## How Has This Been Tested?

tested manually

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable running the Docker Compose installer from other bash scripts and via curl | bash. Prompts now use /dev/tty so interactive steps work even when stdin is piped, with safe defaults in non-interactive mode.

- **New Features**
  - Read prompts from /dev/tty using new read_prompt_line/read_prompt_char helpers.
  - Updated prompt_or_default/prompt_yn_or_default and all confirmations (e.g., DELETE) to use tty.
  - Adjusted `install.ps1` to use `Prompt-OrDefault` for confirmations and the pause step.

<sup>Written for commit 0aea44e960398b37f0a11754412525ab1977a758. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

