### PR TITLE
fix: csv test with newlines

### DIFF
--- a/backend/tests/integration/tests/query_history/test_query_history.py
+++ b/backend/tests/integration/tests/query_history/test_query_history.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import os
 from datetime import datetime
 from datetime import timedelta
@@ -139,12 +141,12 @@ def test_chat_history_csv_export(
     assert headers["Content-Type"] == "text/csv; charset=utf-8"
     assert "Content-Disposition" in headers
 
-    # Verify CSV content
-    csv_lines = csv_content.strip().split("\n")
-    assert len(csv_lines) == 3  # Header + 2 QA pairs
-    assert "chat_session_id" in csv_content
-    assert "user_message" in csv_content
-    assert "ai_response" in csv_content
+    # Use csv.reader to properly handle newlines inside quoted fields
+    csv_rows = list(csv.reader(io.StringIO(csv_content)))
+    assert len(csv_rows) == 3  # Header + 2 QA pairs
+    assert csv_rows[0][0] == "chat_session_id"
+    assert "user_message" in csv_rows[0]
+    assert "ai_response" in csv_rows[0]
     assert "What was the Q1 revenue?" in csv_content
     assert "What about Q2 revenue?" in csv_content
 
@@ -156,5 +158,5 @@ def test_chat_history_csv_export(
         end_time=past_end,
         user_performing_action=admin_user,
     )
-    csv_lines = csv_content.strip().split("\n")
-    assert len(csv_lines) == 1  # Only header, no data rows
+    csv_rows = list(csv.reader(io.StringIO(csv_content)))
+    assert len(csv_rows) == 1  # Only header, no data rows


### PR DESCRIPTION
## Description

We were seeing sporadic failures in CI for test_chat_history_csv_export due to some naive logic around newlines; we're trying to avoid those with this change

## How Has This Been Tested?

CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky CSV export test by using Python’s `csv.reader` to parse content instead of splitting on newlines. This properly handles newlines in quoted fields and stabilizes CI.

<sup>Written for commit 5d2d123bc65fa47458671dd53cb014ea6535bb9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

