### PR TITLE
fix(mt): Tenant Provisioning Fixes

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -25,9 +25,6 @@ from onyx.redis.redis_pool import get_redis_client
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import TENANT_ID_PREFIX
 
-# Default number of pre-provisioned tenants to maintain
-DEFAULT_TARGET_AVAILABLE_TENANTS = 5
-
 # Soft time limit for tenant pre-provisioning tasks (in seconds)
 _TENANT_PROVISIONING_SOFT_TIME_LIMIT = 60 * 5  # 5 minutes
 # Hard time limit for tenant pre-provisioning tasks (in seconds)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
There was a bug with how we were looking at the Env Var so it was only ever making 5 tenants available. Even if you set the env var it was not being read in properly since we were looking for the Values variable. 

This fixes that issue as well as the cache expiration issue

These bugs meant we were only ever making 5 tenants ahead of time and we were always running into issue provisioning and thus we were getting DB connections that were stuck for minutes waiting for things to properly provision for new tenants

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
