### PR TITLE
fix(fe): fallback font offline is sans-serif

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -83,11 +83,7 @@ export default async function RootLayout({
     combinedSettings?.settings.application_status ?? ApplicationStatus.ACTIVE;
 
   const getPageContent = async (content: React.ReactNode) => (
-    <html
-      lang="en"
-      className={`${inter.variable} ${hankenGrotesk.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" className={`${inter.variable}`} suppressHydrationWarning>
       <head>
         <meta
           name="viewport"


### PR DESCRIPTION
## Description

The secondary font is a serif font which is too fancy

## How Has This Been Tested?

**before**
<img width="1156" height="1820" alt="20260320_18h59m46s_grim" src="https://github.com/user-attachments/assets/494bdd87-14ee-4da6-a7aa-934d931b8b57" />

**after**
<img width="1156" height="1820" alt="20260320_18h58m58s_grim" src="https://github.com/user-attachments/assets/e51bdabf-7fe5-425c-8a8f-95b83fe90692" />


## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the offline fallback font to sans-serif by removing the serif `hankenGrotesk` from the root HTML element’s class. The app now defaults to `inter` when web fonts aren’t available.

<sup>Written for commit 27f24ddcb107075217fe368ecce9474b228d5715. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

