### PR TITLE
fix(opal): remove table-layout fixed, right-align actions column

### DIFF
--- a/web/lib/opal/src/components/table/ActionsContainer.tsx
+++ b/web/lib/opal/src/components/table/ActionsContainer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@opal/utils";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 
 interface ActionsContainerProps {
@@ -25,14 +24,7 @@ export default function ActionsContainer({
       data-size={size}
       onClick={onClick}
     >
-      <div
-        className={cn(
-          "flex h-full items-center",
-          type === "cell" ? "justify-end" : "justify-center"
-        )}
-      >
-        {children}
-      </div>
+      <div className="flex h-full items-center justify-end">{children}</div>
     </Tag>
   );
 }

--- a/web/lib/opal/src/components/table/TableElement.tsx
+++ b/web/lib/opal/src/components/table/TableElement.tsx
@@ -47,7 +47,7 @@ function Table({
     <table
       ref={ref}
       className={cn("border-separate border-spacing-0", !width && "min-w-full")}
-      style={{ tableLayout: "fixed", width }}
+      style={{ width }}
       data-size={size}
       data-variant={variant}
       data-selection={selectionBehavior}

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -92,9 +92,7 @@ export default function TableHead({
       data-size={resolvedSize}
       data-bottom-border={bottomBorder || undefined}
     >
-      <div
-        className={cn("flex items-center gap-1", alignmentFlexClass[alignment])}
-      >
+      <div className="flex items-center gap-1">
         <div className="table-head-label">
           <Text
             mainUiAction={!isSmall}


### PR DESCRIPTION
## Description

- Remove `table-layout: fixed` from `TableElement` so columns can auto-size to fit cell content (e.g. action buttons that vary per row)
- Right-align actions column content for both header and cells
- Simplify `TableHead` inner flex (remove unused alignment class)

## Screenshots + Videos

Notice how the buttons inside of the actions column's header are aligned to the right. Before, they were centrally aligned.

<img width="862" height="63" alt="image" src="https://github.com/user-attachments/assets/9687398a-595c-455e-8e60-a3dc9660423c" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let table columns auto-size by removing `table-layout: fixed` in `TableElement`, so action buttons and varying content fit without clipping. Right-align the actions column in header and cells, and simplify `TableHead` and `ActionsContainer` markup (remove alignment classes and `cn` from `@opal/utils`) for a cleaner layout.

<sup>Written for commit 0a4ab7f42a96161b72fbaf0246f76503229c34f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->