### PR TITLE
fix(opal): reduce table qualifier icon sizes

### DIFF
--- a/web/lib/opal/src/components/table/DragOverlayRow.tsx
+++ b/web/lib/opal/src/components/table/DragOverlayRow.tsx
@@ -61,6 +61,7 @@ function DragOverlayRowInner<TData>({
                     imageSrc={qualifierColumn.getImageSrc?.(row.original)}
                     imageAlt={qualifierColumn.getImageAlt?.(row.original)}
                     background={qualifierColumn.background}
+                    iconSize={qualifierColumn.iconSize}
                     selectable={isSelectable}
                     selected={isSelectable && row.getIsSelected()}
                   />

--- a/web/lib/opal/src/components/table/TableQualifier.tsx
+++ b/web/lib/opal/src/components/table/TableQualifier.tsx
@@ -26,11 +26,13 @@ interface TableQualifierProps {
   imageAlt?: string;
   /** Show a tinted background container behind the content. */
   background?: boolean;
+  /** Icon size preset. `"lg"` = 28/24, `"md"` = 20/16. @default "md" */
+  iconSize?: "lg" | "md";
 }
 
-const iconSizes = {
-  lg: 28,
-  md: 24,
+const iconSizesMap = {
+  lg: { lg: 28, md: 24 },
+  md: { lg: 20, md: 16 },
 } as const;
 
 function getOverlayStyles(selected: boolean, disabled: boolean) {
@@ -53,9 +55,10 @@ function TableQualifier({
   imageSrc,
   imageAlt = "",
   background = false,
+  iconSize: iconSizePreset = "md",
 }: TableQualifierProps) {
   const resolvedSize = useTableSize();
-  const iconSize = iconSizes[resolvedSize];
+  const iconSize = iconSizesMap[iconSizePreset][resolvedSize];
   const overlayStyles = getOverlayStyles(selected, disabled);
 
   function renderContent() {

--- a/web/lib/opal/src/components/table/columns.ts
+++ b/web/lib/opal/src/components/table/columns.ts
@@ -33,6 +33,8 @@ interface QualifierConfig<TData> {
   getImageAlt?: (row: TData) => string;
   /** Show a tinted background container behind the content. @default false */
   background?: boolean;
+  /** Icon size preset. `"lg"` = 28/24, `"md"` = 20/16. @default "md" */
+  iconSize?: "lg" | "md";
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +162,7 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
         getImageSrc: config?.getImageSrc,
         getImageAlt: config?.getImageAlt,
         background: config?.background,
+        iconSize: config?.iconSize,
       };
     },
 

--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -544,6 +544,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
                               imageSrc={qDef.getImageSrc?.(row.original)}
                               imageAlt={qDef.getImageAlt?.(row.original)}
                               background={qDef.background}
+                              iconSize={qDef.iconSize}
                               selectable={showQualifierCheckbox}
                               selected={
                                 showQualifierCheckbox && row.getIsSelected()

--- a/web/lib/opal/src/components/table/types.ts
+++ b/web/lib/opal/src/components/table/types.ts
@@ -59,6 +59,8 @@ export interface OnyxQualifierColumn<TData> extends OnyxColumnBase<TData> {
   getImageAlt?: (row: TData) => string;
   /** Show a tinted background container behind the content. @default false */
   background?: boolean;
+  /** Icon size preset. Use `"lg"` for avatars, `"md"` for regular icons. @default "md" */
+  iconSize?: "lg" | "md";
 }
 
 /** Data column — accessor-based column with sorting/resizing. */

--- a/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
@@ -77,6 +77,7 @@ function buildColumns(onMutate: () => void) {
   return [
     tc.qualifier({
       content: "icon",
+      iconSize: "lg",
       getContent: (row) => {
         const user = {
           email: row.email,


### PR DESCRIPTION
## Description

Reduce icon sizes passed to qualifier content from 28/24 to 20/16 (lg/md) so icons fit properly within the qualifier container.

## Screenshots + Videos

<img width="896" height="150" alt="image" src="https://github.com/user-attachments/assets/cf182b8b-9469-46e5-abd9-71b77ec47eeb" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `iconSize` to table qualifiers to control icon dimensions.
Default is `md` (20/16) to fix overflow; `lg` (28/24) is for avatars, wired through column config and drag overlay, and applied to the Admin Users table.

<sup>Written for commit 2bc021a912ae815e04181cdfc4e284095c9cad5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

