### PR TITLE
chore(fe): memories save after pressing enter

### DIFF
--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -102,7 +102,11 @@ function MemoryItem({
               void onBlur(originalIndex);
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+              if (
+                e.key === "Enter" &&
+                !e.shiftKey &&
+                !e.nativeEvent.isComposing
+              ) {
                 e.preventDefault();
                 textareaRef.current?.blur();
               }


### PR DESCRIPTION
## Description

Enter saves the memory and blurs in the input. Newlines are still supported with `Shift+Enter`.

Related to https://linear.app/onyx-app/issue/ENG-3635/memory-popup

## How Has This Been Tested?

Tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pressing Enter in the Memories input now saves by blurring the textarea, and is ignored during IME composition; Shift+Enter inserts a newline. This aligns with Linear ENG-3635 for the memory popup.

<sup>Written for commit 4a406ccfd89925d706592e2d3328bdb45365dd76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

