### PR TITLE
chore(fe): position memories modal at the top

### DIFF
--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -120,6 +120,10 @@ export interface ModalContentProps
   > {
   width?: keyof typeof widthClasses;
   height?: keyof typeof heightClasses;
+  /** Vertical placement of the modal. `"center"` (default) centers in the
+   *  viewport/container. `"top"` pins the modal near the top of the viewport,
+   *  matching the position used by CommandMenu. */
+  position?: "center" | "top";
   preventAccidentalClose?: boolean;
   skipOverlay?: boolean;
   background?: "default" | "gray";
@@ -136,6 +140,7 @@ const ModalContent = React.forwardRef<
       children,
       width = "md",
       height = "fit",
+      position = "center",
       preventAccidentalClose = true,
       skipOverlay = false,
       background = "default",
@@ -267,27 +272,39 @@ const ModalContent = React.forwardRef<
 
     const { centerX, centerY, hasContainerCenter } = useContainerCenter();
 
+    const isTop = position === "top";
+
     const animationClasses = cn(
       "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
       "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
-      "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
+      !isTop &&
+        "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
       "duration-200"
     );
 
-    const containerStyle: React.CSSProperties | undefined = hasContainerCenter
-      ? ({
-          left: centerX,
-          top: centerY,
-          "--tw-enter-translate-x": "-50%",
-          "--tw-exit-translate-x": "-50%",
-          "--tw-enter-translate-y": "-50%",
-          "--tw-exit-translate-y": "-50%",
-        } as React.CSSProperties)
-      : undefined;
+    const containerStyle: React.CSSProperties | undefined =
+      hasContainerCenter && !isTop
+        ? ({
+            left: centerX,
+            top: centerY,
+            "--tw-enter-translate-x": "-50%",
+            "--tw-exit-translate-x": "-50%",
+            "--tw-enter-translate-y": "-50%",
+            "--tw-exit-translate-y": "-50%",
+          } as React.CSSProperties)
+        : hasContainerCenter && isTop
+          ? ({
+              left: centerX,
+              "--tw-enter-translate-x": "-50%",
+              "--tw-exit-translate-x": "-50%",
+            } as React.CSSProperties)
+          : undefined;
 
     const positionClasses = cn(
-      "fixed -translate-x-1/2 -translate-y-1/2",
-      !hasContainerCenter && "left-1/2 top-1/2"
+      "fixed -translate-x-1/2",
+      isTop
+        ? cn("top-[72px]", !hasContainerCenter && "left-1/2")
+        : cn("-translate-y-1/2", !hasContainerCenter && "left-1/2 top-1/2")
     );
 
     const dialogEventHandlers = {

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -228,7 +228,7 @@ export default function MemoriesModal({
 
   return (
     <Modal open onOpenChange={(open) => !open && close?.()}>
-      <Modal.Content width="sm" height="lg">
+      <Modal.Content width="sm" height="lg" position="top">
         <Modal.Header
           icon={SvgAddLines}
           title="Memory"


### PR DESCRIPTION
## Description

Allows the modal to be positioned relative to the top of the viewport. This modal expands in size with usage and we want it to expand in only 1 direction.

Related to https://linear.app/onyx-app/issue/ENG-3635/memory-popup

## How Has This Been Tested?

**before**
<img width="2880" height="1920" alt="20260323_09h29m39s_grim" src="https://github.com/user-attachments/assets/f140d798-9c7b-447e-98ea-d4f094997c5a" />

**after**
<img width="2880" height="1920" alt="20260323_09h29m30s_grim" src="https://github.com/user-attachments/assets/12e77083-aba2-4384-84e0-6c2ff827beea" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Positions the Memories modal near the top of the viewport so it grows downward. Adds a `position` prop to `Modal.Content` for top or center placement to meet ENG-3635 (memory popup).

- **New Features**
  - Introduced `position?: "center" | "top"` on `Modal.Content` (default: `center`); `top` anchors at 72px and keeps horizontal centering.
  - Updated `MemoriesModal` to use `position="top"` for single-direction growth.

<sup>Written for commit f0710af7a2d481d3d900d8ca534a0e6be6f5ad74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

