### PR TITLE
feat(opal): add `SvgStarOff` icon

### DIFF
--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -159,6 +159,7 @@ export { default as SvgSort } from "@opal/icons/sort";
 export { default as SvgSortOrder } from "@opal/icons/sort-order";
 export { default as SvgSparkle } from "@opal/icons/sparkle";
 export { default as SvgStar } from "@opal/icons/star";
+export { default as SvgStarOff } from "@opal/icons/star-off";
 export { default as SvgStep1 } from "@opal/icons/step1";
 export { default as SvgStep2 } from "@opal/icons/step2";
 export { default as SvgStep3 } from "@opal/icons/step3";

--- a/web/lib/opal/src/icons/star-off.tsx
+++ b/web/lib/opal/src/icons/star-off.tsx
@@ -1,0 +1,22 @@
+import type { IconProps } from "@opal/types";
+
+const SvgStarOff = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      d="M1 1L5.56196 5.56196M15 15L5.56196 5.56196M5.56196 5.56196L1.33333 6.18004L4.66666 9.42671L3.88 14.0134L8 11.8467L12.12 14.0134L11.7267 11.72M12.1405 8.64051L14.6667 6.18004L10.06 5.50671L8 1.33337L6.95349 3.45349"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SvgStarOff;


### PR DESCRIPTION
## Description

Add `SvgStarOff` icon to `@opal/icons` — a star with a strikethrough line, used for "unfeature" actions.

## Screenshots + Videos

<img width="91" height="50" alt="image" src="https://github.com/user-attachments/assets/6fc4e714-30af-4ce6-acf9-aff123356699" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SvgStarOff` icon to `@opal/icons` for “unfeature” or “remove favorite” actions. Exported from the icons index as `SvgStarOff`.

<sup>Written for commit 46ed0b76a6d67b30b2dad07bf1455d6456d12511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

