### PR TITLE
chore: web connector wait for page networkidle before continuing

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -554,7 +554,7 @@ class WebConnector(LoadConnector):
             # asynchronously after the initial JS bundle have time to render.
             try:
                 # A bit of extra time to account for long-polling, websockets, etc.
-                page.wait_for_load_state("networkidle", PAGE_RENDER_TIMEOUT_MS)
+                page.wait_for_load_state("networkidle", timeout=PAGE_RENDER_TIMEOUT_MS)
             except TimeoutError:
                 pass
 


### PR DESCRIPTION
## Description

- renames bot detection timeout to a more generic page load timeout
- add a small wait for `networkidle` before continuing in case SPA rendering has not finished

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
