### PR TITLE
fix(voice): add WebSocket upgrade headers to nginx configs

### DIFF
--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -23,6 +23,12 @@ upstream web_server {
 # Conditionally include MCP upstream configuration
 include /etc/nginx/conf.d/mcp_upstream.conf.inc;
 
+# WebSocket support: only set Connection "upgrade" for actual upgrade requests
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80 default_server;
 
@@ -49,7 +55,7 @@ server {
         # need to use 1.1 to support chunked transfers and WebSocket
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
 
         # timeout settings

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -23,6 +23,12 @@ upstream web_server {
 # Conditionally include MCP upstream configuration
 include /etc/nginx/conf.d/mcp_upstream.conf.inc;
 
+# WebSocket support: only set Connection "upgrade" for actual upgrade requests
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80 default_server;
 
@@ -50,7 +56,7 @@ server {
         # need to use 1.1 to support chunked transfers and WebSocket
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
 
         # we don't want nginx trying to do something clever with
@@ -95,7 +101,7 @@ server {
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -23,6 +23,12 @@ upstream web_server {
 # Conditionally include MCP upstream configuration
 include /etc/nginx/conf.d/mcp_upstream.conf.inc;
 
+# WebSocket support: only set Connection "upgrade" for actual upgrade requests
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80 default_server;
 
@@ -50,7 +56,7 @@ server {
         # need to use 1.1 to support chunked transfers and WebSocket
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
 
         # timeout settings
@@ -109,7 +115,7 @@ server {
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
 
         # timeout settings

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -28,6 +28,12 @@ data:
     }
     {{- end }}
 
+    # WebSocket support: only set Connection "upgrade" for actual upgrade requests
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
   server.conf: |
     server {
         listen 1024;
@@ -66,7 +72,7 @@ data:
             proxy_set_header Host $host;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
             proxy_buffering off;
             proxy_redirect off;
             # timeout settings

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -282,7 +282,7 @@ nginx:
     # The ingress-nginx subchart doesn't auto-detect our custom ConfigMap changes.
     # Workaround: Helm upgrade will restart if the following annotation value changes.
     podAnnotations:
-      onyx.app/nginx-config-version: "1"
+      onyx.app/nginx-config-version: "2"
 
     # Propagate DOMAIN into nginx so server_name continues to use the same env var
     extraEnvs:


### PR DESCRIPTION
## Description

The voice feature (PR #8715) added the first WebSocket endpoints in Onyx (`/voice/transcribe/stream` and `/voice/synthesize/stream`). All shipped nginx configs (docker compose, prod/TLS, no-letsencrypt, and Helm) were missing the `Upgrade` and `Connection` headers required to proxy WebSocket handshakes. Self-hosted customers hitting these endpoints get a **404 from nginx** because the WebSocket upgrade is silently dropped.

Adds `proxy_set_header Upgrade` and `proxy_set_header Connection` (using the standard nginx `map` pattern) to the `/api` location blocks in all 4 nginx config files. For the two-hop TLS configs (prod and no-letsencrypt), the headers are also added to the port-443 passthrough block so they survive both proxy hops.

## How Has This Been Tested?

Ran the backend and frontend locally, then started a standalone nginx:1.25.5-alpine Docker container with the updated config proxying to the local services. Verified:

1. **Regular API requests** — `GET /api/health` through nginx returns 200, confirming no regression for normal HTTP traffic.
2. **WebSocket upgrade with wrong origin** — Returns 403 "Invalid origin" from the backend's WebSocket auth. Before the fix, this was a 404 from nginx (request never reached the backend).
3. **WebSocket upgrade with correct origin + fake token** — Returns 403 "Invalid or expired authentication token", confirming the request passes through nginx and hits the full WebSocket auth pipeline.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check