### PR TITLE
chore(fe): memory input defaults to 1 row with max of 3

### DIFF
--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -111,7 +111,9 @@ function MemoryItem({
                 textareaRef.current?.blur();
               }
             }}
-            rows={3}
+            rows={1}
+            autoResize
+            maxRows={3}
             maxLength={MAX_MEMORY_LENGTH}
             resizable={false}
             className="bg-background-tint-01 hover:bg-background-tint-00 focus-within:bg-background-tint-00"


### PR DESCRIPTION
## Description

Updates the default number of rows of memories to `1` with a max of `3`.

Closes https://linear.app/onyx-app/issue/ENG-3635/memory-popup

## How Has This Been Tested?

**before**
<img width="1482" height="2085" alt="20260323_11h12m41s_grim" src="https://github.com/user-attachments/assets/33b7e8e4-535e-4eaa-a78b-5dae1fb4f069" />

**after**
<img width="1482" height="2085" alt="20260323_11h14m04s_grim" src="https://github.com/user-attachments/assets/48974b81-b01f-4784-8de5-30ae66f852e5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the memory input to default to 1 row and auto-resize up to 3 rows, reducing the modal’s initial height and keeping entries concise. Implements Linear ENG-3635 (memory popup).

<sup>Written for commit cfa268d1eac259310f179fc978830aca60025664. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

