### PR TITLE
fix(ux): give a tooltip with reason agent edit cannot save

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -1201,18 +1201,33 @@ export default function AgentEditorPage({
                           >
                             Cancel
                           </OpalButton>
-                          <Disabled
-                            disabled={
-                              isSubmitting ||
-                              !isValid ||
-                              !dirty ||
-                              hasUploadingFiles
+                          <SimpleTooltip
+                            tooltip={
+                              isSubmitting
+                                ? "Saving changes..."
+                                : !isValid
+                                  ? "Please fix the errors in the form before saving."
+                                  : !dirty
+                                    ? "No changes have been made."
+                                    : hasUploadingFiles
+                                      ? "Please wait for files to finish uploading."
+                                      : undefined
                             }
+                            side="bottom"
                           >
-                            <OpalButton type="submit">
-                              {existingAgent ? "Save" : "Create"}
-                            </OpalButton>
-                          </Disabled>
+                            <Disabled
+                              disabled={
+                                isSubmitting ||
+                                !isValid ||
+                                !dirty ||
+                                hasUploadingFiles
+                              }
+                            >
+                              <OpalButton type="submit">
+                                {existingAgent ? "Save" : "Create"}
+                              </OpalButton>
+                            </Disabled>
+                          </SimpleTooltip>
                         </div>
                       }
                       backButton


### PR DESCRIPTION
## Description

There are a few reasons this button may be disabled and some aren't necessarily apparent, so give hints.

## How Has This Been Tested?

<img width="1482" height="2085" alt="20260323_13h24m28s_grim" src="https://github.com/user-attachments/assets/196f8c25-6f4b-4f16-a60a-a5ae8b4e9e2e" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tooltip to the Agent Editor Save/Create button to explain why the action is disabled, improving clarity and reducing confusion.

- **New Features**
  - Shows contextual messages for: submitting, invalid form, no changes, and pending file uploads.

<sup>Written for commit 6564e397721d9c302d77894e813d288977fc24f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

