### PR TITLE
fix: clarify service account API key upgrade message for trial accounts

### DIFF
--- a/web/src/app/admin/api-key/page.tsx
+++ b/web/src/app/admin/api-key/page.tsx
@@ -30,7 +30,7 @@ import CreateButton from "@/refresh-components/buttons/CreateButton";
 import { Button } from "@opal/components";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import Text from "@/refresh-components/texts/Text";
-import { SvgEdit, SvgKey, SvgRefreshCw } from "@opal/icons";
+import { SvgEdit, SvgInfo, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
@@ -87,10 +87,19 @@ function Main() {
         </CreateButton>
       ) : (
         <div className="flex flex-col gap-2 rounded-lg bg-background-tint-02 p-4">
-          <Text as="p" text04>
-            This feature requires an active paid subscription.
-          </Text>
-          <Button href="/admin/billing">Upgrade Plan</Button>
+          <div className="flex items-center gap-1.5">
+            <Text as="p" text04>
+              Upgrade to a paid plan to create API keys.
+            </Text>
+            <Button
+              variant="none"
+              prominence="tertiary"
+              size="2xs"
+              icon={SvgInfo}
+              tooltip="API keys enable programmatic access to Onyx for service accounts and integrations. Trial accounts do not include API key access — purchase a paid subscription to unlock this feature."
+            />
+          </div>
+          <Button href="/admin/billing">Upgrade to Paid Plan</Button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Updates the API key page upgrade prompt to be clearer for trial account users. Changes the message from a generic "requires an active paid subscription" to "Upgrade to a paid plan to create API keys" with an info icon tooltip that explicitly explains trial accounts do not include API key access and a paid subscription must be purchased.

## How Has This Been Tested?

<img width="933" height="367" alt="Screenshot 2026-03-25 at 4 22 27 PM" src="https://github.com/user-attachments/assets/7f80c157-a1e0-4647-a60c-438bf06934fd" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check