### PR TITLE
fix(ux): display invalid agent fields on load

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -967,6 +967,14 @@ export default function AgentEditorPage({
           validateOnChange
           validateOnBlur
           validateOnMount
+          initialTouched={{
+            description:
+              initialValues.description.length >
+              MAX_CHARACTERS_AGENT_DESCRIPTION,
+            starter_messages: initialValues.starter_messages.map(
+              (msg) => msg.length > MAX_CHARACTERS_STARTER_MESSAGE
+            ) as unknown as boolean,
+          }}
           initialStatus={{ warnings: {} }}
         >
           {({ isSubmitting, isValid, dirty, values, setFieldValue }) => {


### PR DESCRIPTION
## Description

In 9d11d1f218, we introduced a requirement that conversation starters were <200 characters and agent descriptions <500. When either limits are exceeded, an error is presented to the user except when the agent is already configured to exceed these limit as the validation is only triggered on user edit. This updates these fields to trigger an initial validation on page load to catch cases agents which were created before these requirements existed, so the errors are apparent to the user.

## How Has This Been Tested?

Manually set the limit to `300`, saved the agent, reset it to `200` and confirmed the error was presented on refresh.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show validation errors on load for agent descriptions (>500 chars) and conversation starters (>200 chars) in the Agent Editor. Triggers initial validation so legacy agents that exceed limits display errors without requiring edits.

<sup>Written for commit 5cb5caa88367ab4c7540cba87fbb24812b106270. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

