### PR TITLE
chore(playwright): mask date switcher in screenshots

### DIFF
--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
@@ -47,11 +47,12 @@ export const AdminDateRangeSelector = memo(function AdminDateRangeSelector({
   ];
 
   return (
-    <div data-testid="admin-date-range-selector" className="grid gap-2">
+    <div className="grid gap-2">
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <Popover.Trigger asChild>
           {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
           <Button
+            data-testid="admin-date-range-selector-button"
             secondary
             className={cn("justify-start", !value && "text-muted-foreground")}
             leftIcon={SvgCalendar}

--- a/web/tests/e2e/admin/admin_pages.spec.ts
+++ b/web/tests/e2e/admin/admin_pages.spec.ts
@@ -189,7 +189,7 @@ for (const theme of THEMES) {
         )}`;
         await expectScreenshot(page, {
           name: screenshotName,
-          mask: ['[data-testid="admin-date-range-selector"]'],
+          mask: ['[data-testid="admin-date-range-selector-button"]'],
         });
       });
     }


### PR DESCRIPTION
## Description

Fixes:

<img width="2880" height="1920" alt="20260323_17h29m50s_grim" src="https://github.com/user-attachments/assets/3ae1f928-1572-48be-abe6-63cdbee3fba4" />

## How Has This Been Tested?

`npx playwright test web/tests/e2e/admin/admin_pages.spec.ts`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mask the admin date range button in visual screenshots to prevent flaky diffs from changing dates. Stabilizes Playwright visual tests on admin pages.

- **Bug Fixes**
  - Added `data-testid="admin-date-range-selector-button"` to the date range trigger button.
  - Updated `admin_pages.spec.ts` to mask `[data-testid="admin-date-range-selector-button"]` in `expectScreenshot`.

<sup>Written for commit 235a6494ffe0a81998b64289b879a84e29238620. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

