### PR TITLE
fix(fe): map snake_case auth type API response to camelCase

### DIFF
--- a/web/src/hooks/useAuthTypeMetadata.ts
+++ b/web/src/hooks/useAuthTypeMetadata.ts
@@ -1,6 +1,15 @@
 import useSWR from "swr";
 import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 
+interface AuthTypeAPIResponse {
+  auth_type: string;
+  requires_verification: boolean;
+  anonymous_user_enabled: boolean | null;
+  password_min_length: number;
+  has_users: boolean;
+  oauth_enabled: boolean;
+}
+
 export interface AuthTypeMetadata {
   authType: AuthType;
   autoRedirect: boolean;
@@ -24,7 +33,7 @@ const DEFAULT_AUTH_TYPE_METADATA: AuthTypeMetadata = {
 async function fetchAuthTypeMetadata(url: string): Promise<AuthTypeMetadata> {
   const res = await fetch(url);
   if (!res.ok) throw new Error("Failed to fetch auth type metadata");
-  const data = await res.json();
+  const data: AuthTypeAPIResponse = await res.json();
   const authType = NEXT_PUBLIC_CLOUD_ENABLED
     ? AuthType.CLOUD
     : (data.auth_type as AuthType);


### PR DESCRIPTION
## Summary
- The SSR→CSR migration (#9529) introduced `useAuthTypeMetadata`, which passes raw `/api/auth/type` JSON (snake_case keys like `password_min_length`) directly into a camelCase TypeScript interface (`passwordMinLength`). Every field silently resolved to `undefined` at runtime.
- This caused `passwordMinLength` to always fall back to `8` regardless of the `PASSWORD_MIN_LENGTH` env var, and likely broke `autoRedirect`, `requiresVerification`, `hasUsers`, etc. in the same way.
- Fix: use a custom SWR fetcher that maps snake_case → camelCase, matching the existing server-side logic in `userSS.ts`.

**Follow-up:** The rest of the codebase uses snake_case interfaces that match the API directly. This hook's camelCase interface is an outlier introduced by the migration — a follow-up PR should convert `AuthTypeMetadata` and all its ~20 consumers to snake_case for consistency.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `useAuthTypeMetadata` by mapping `/api/auth/type` snake_case to camelCase, restoring correct auth settings. Prevents defaults overriding values like `passwordMinLength` and fixes flags like `autoRedirect` and `requiresVerification`.

- **Bug Fixes**
  - Added a custom SWR fetcher that maps snake_case → camelCase, accepts the SWR URL param, and types the API payload via `AuthTypeAPIResponse`; replaced `errorHandlingFetcher` without changing SWR behavior.
  - Computes `authType` with `NEXT_PUBLIC_CLOUD_ENABLED` and derives `autoRedirect` for OIDC/SAML.

<sup>Written for commit b054e994d3aca3d9be5456a45e9b3b839b5f3ee4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



