### PR TITLE
feat(metrics): add reusable Prometheus metrics server for celery workers

### DIFF
--- a/backend/onyx/server/metrics/metrics_server.py
+++ b/backend/onyx/server/metrics/metrics_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import os
+import threading
 
 from prometheus_client import start_http_server
 
@@ -26,6 +27,7 @@ _DEFAULT_PORTS: dict[str, int] = {
 }
 
 _server_started = False
+_server_lock = threading.Lock()
 
 
 def start_metrics_server(worker_type: str) -> int | None:
@@ -42,34 +44,44 @@ def start_metrics_server(worker_type: str) -> int | None:
     """
     global _server_started
 
-    if _server_started:
-        logger.debug(f"Metrics server already started for {worker_type}")
-        return None
+    with _server_lock:
+        if _server_started:
+            logger.debug(f"Metrics server already started for {worker_type}")
+            return None
 
-    enabled = os.environ.get("PROMETHEUS_METRICS_ENABLED", "true").lower()
-    if enabled in ("false", "0", "no"):
-        logger.info(f"Prometheus metrics server disabled for {worker_type}")
-        return None
+        enabled = os.environ.get("PROMETHEUS_METRICS_ENABLED", "true").lower()
+        if enabled in ("false", "0", "no"):
+            logger.info(f"Prometheus metrics server disabled for {worker_type}")
+            return None
 
-    port_str = os.environ.get("PROMETHEUS_METRICS_PORT")
-    if port_str:
-        port = int(port_str)
-    elif worker_type in _DEFAULT_PORTS:
-        port = _DEFAULT_PORTS[worker_type]
-    else:
-        logger.info(
-            f"No default metrics port for worker type '{worker_type}' "
-            "and PROMETHEUS_METRICS_PORT not set. Skipping metrics server."
-        )
-        return None
+        port_str = os.environ.get("PROMETHEUS_METRICS_PORT")
+        if port_str:
+            try:
+                port = int(port_str)
+            except ValueError:
+                logger.warning(
+                    f"Invalid PROMETHEUS_METRICS_PORT '{port_str}' for {worker_type}, "
+                    "must be a numeric port. Skipping metrics server."
+                )
+                return None
+        elif worker_type in _DEFAULT_PORTS:
+            port = _DEFAULT_PORTS[worker_type]
+        else:
+            logger.info(
+                f"No default metrics port for worker type '{worker_type}' "
+                "and PROMETHEUS_METRICS_PORT not set. Skipping metrics server."
+            )
+            return None
 
-    try:
-        start_http_server(port)
-        _server_started = True
-        logger.info(f"Prometheus metrics server started on :{port} for {worker_type}")
-        return port
-    except OSError as e:
-        logger.warning(
-            f"Failed to start metrics server on :{port} for {worker_type}: {e}"
-        )
-        return None
+        try:
+            start_http_server(port)
+            _server_started = True
+            logger.info(
+                f"Prometheus metrics server started on :{port} for {worker_type}"
+            )
+            return port
+        except OSError as e:
+            logger.warning(
+                f"Failed to start metrics server on :{port} for {worker_type}: {e}"
+            )
+            return None

--- a/backend/tests/unit/server/metrics/test_metrics_server.py
+++ b/backend/tests/unit/server/metrics/test_metrics_server.py
@@ -60,3 +60,10 @@ class TestStartMetricsServer:
         mock_start.side_effect = OSError("Address already in use")
         port = start_metrics_server("monitoring")
         assert port is None
+
+    @patch("onyx.server.metrics.metrics_server.start_http_server")
+    @patch.dict("os.environ", {"PROMETHEUS_METRICS_PORT": "not_a_number"})
+    def test_invalid_port_env_var_returns_none(self, mock_start: MagicMock) -> None:
+        port = start_metrics_server("monitoring")
+        assert port is None
+        mock_start.assert_not_called()


### PR DESCRIPTION
## Description

Adds a reusable module that any Onyx process (API server or celery worker) can use to start a standalone Prometheus metrics HTTP server. Each celery worker now exposes its own `/metrics` endpoint on a per-worker-type port.

**Architecture:**
- API server already has `/metrics` via FastAPI instrumentator (unchanged)
- Each celery worker starts a `prometheus_client.start_http_server()` in a background thread on `worker_ready`
- Port resolution: `PROMETHEUS_METRICS_PORT` env var > per-worker-type default (9091-9099) > skip
- Can be disabled with `PROMETHEUS_METRICS_ENABLED=false`

**Files:**
- `backend/onyx/server/metrics/metrics_server.py` — reusable module wrapping `start_http_server()`
- `backend/onyx/background/celery/apps/app_base.py` — hooks `start_metrics_server()` into `on_worker_ready()`
- `backend/tests/unit/server/metrics/test_metrics_server.py` — 9 unit tests

PR 1 of 3 for the Prometheus metrics initiative. PR 2 (#9590) adds queue depth and connector health collectors. PR 3 (#9602) adds task lifecycle metrics, Redis/worker health, and retry tracking.

## How Has This Been Tested?

9 unit tests covering: default port resolution, env var override, disable flag, unknown worker type, idempotency, OSError handling, worker type extraction from hostname.

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check