### PR TITLE
fix(fe): settings page layout shift on load

### DIFF
--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -28,7 +28,12 @@ export default function Layout({ children }: LayoutProps) {
         <SettingsLayouts.Header icon={SvgSliders} title="Settings" separator />
 
         <SettingsLayouts.Body>
-          <Section flexDirection="row" alignItems="start" gap={1.5}>
+          <Section
+            flexDirection="row"
+            justifyContent="start"
+            alignItems="start"
+            gap={1.5}
+          >
             {/* Left: Tab Navigation */}
             <div
               data-testid="settings-left-tab-navigation"


### PR DESCRIPTION
## Description

Aligns the settings left sidebar regardless of right content. The right content sometimes loads after and causes the layout to shift a bit.

## How Has This Been Tested?

**before**
<img width="1512" height="2085" alt="20260324_10h13m41s_grim" src="https://github.com/user-attachments/assets/d08311dd-0ff5-4ef4-b3e0-f8139cfe6d6f" />

**after**
<img width="1512" height="2085" alt="20260324_10h13m25s_grim" src="https://github.com/user-attachments/assets/f13f2bff-d627-47cd-84b2-ac6166e91cb8" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings page layout shift by pinning the left sidebar while the right pane loads. Adds `justifyContent="start"` to the row Section so the nav stays fixed and the initial jitter is gone.

<sup>Written for commit 628acab18f666dfe65cab2507649a4e04c39f075. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

