### PR TITLE
fix: update values.yaml comment for opensearch admin password secretKeyRef

### DIFF
--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -103,7 +103,7 @@ opensearch:
     - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: onyx-opensearch  # Must match auth.opensearch.secretName.
+          name: onyx-opensearch  # Must match auth.opensearch.secretName or auth.opensearch.existingSecret if defined.
           key: opensearch_admin_password  # Must match auth.opensearch.secretKeys value.
 
   resources:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Upon trying to use `externalSecret`'s for `auth.*` entries, I discovered that `onyx-opensearch` is hardcoded on line `106` and the comment mentions `Must match auth.opensearch.secretName` - This behaviour is slightly different to the other `auth.*` entries in that if you set `externalSecret` for opensearch, it's really easy to miss the hardcoded value. I had deployment issues as `opensearch` was still trying to refer to `onyx-opensearch`.

This PR simply updates the comment to also mention it should match `auth.opensearch.existingSecret` if defined, it should at least clear up some confusion.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

I modified `opensearch.extraEnvs.OPENSEARCH_INITIAL_ADMIN_PASSWORD.valueFrom.secretKeyRef.name` to the name of my `externalSecret` and the deployment was successful.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `values.yaml` comment for the OpenSearch admin password. `secretKeyRef.name` must match `auth.opensearch.secretName`, or `auth.opensearch.existingSecret` when set, to prevent failed deployments when using an external secret instead of `onyx-opensearch`.

<sup>Written for commit b7d7fadc081cd8a36003e5735005995bde6ac991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

