### PR TITLE
feat(helm): Adding pginto specific host

### DIFF
--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -10,7 +10,7 @@ data:
     #!/usr/bin/env sh
     set -eu
 
-    HOST="${POSTGRES_HOST:-localhost}"
+    HOST="${PGINTO_HOST:-${POSTGRES_HOST:-localhost}}"
     PORT="${POSTGRES_PORT:-5432}"
     USER="${POSTGRES_USER:-postgres}"
     DB="${POSTGRES_DB:-postgres}"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding an additional host to read from if we want to configure something like PGBouncer for the cluster but still want this workflow to connect directly to the DB. 

This is specifically for debugging purposes and should not be a production workflow

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Applied to our internal cluster and validated that everything is operational

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow pginto tooling to use a dedicated `PGINTO_HOST` env var, falling back to `POSTGRES_HOST` then `localhost`. This enables direct DB connections (bypassing PgBouncer) for debugging without changing production defaults.

<sup>Written for commit 22d3a6b51b646dbaa53858a79047d15d21d297bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

