### PR TITLE
fix(ui): Text focused paste from PowerPoint

### DIFF
--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -13,6 +13,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useRouter } from "next/navigation";
+import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { cn, isImageFile } from "@/lib/utils";
 import { Disabled } from "@opal/core";
 import {
@@ -230,21 +231,11 @@ const InputBar = memo(
 
       const handlePaste = useCallback(
         (event: ClipboardEvent) => {
-          const items = event.clipboardData?.items;
-          if (items) {
-            const pastedFiles: File[] = [];
-            for (let i = 0; i < items.length; i++) {
-              const item = items[i];
-              if (item && item.kind === "file") {
-                const file = item.getAsFile();
-                if (file) pastedFiles.push(file);
-              }
-            }
-            if (pastedFiles.length > 0) {
-              event.preventDefault();
-              // Context handles session binding internally
-              uploadFiles(pastedFiles);
-            }
+          const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
+          if (pastedFiles.length > 0) {
+            event.preventDefault();
+            // Context handles session binding internally
+            uploadFiles(pastedFiles);
           }
         },
         [uploadFiles]

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -1,0 +1,89 @@
+import { getPastedFilesIfNoText } from "./clipboard";
+
+type MockClipboardData = Parameters<typeof getPastedFilesIfNoText>[0];
+
+function makeClipboardData({
+  textPlain = "",
+  text = "",
+  files = [],
+}: {
+  textPlain?: string;
+  text?: string;
+  files?: File[];
+}): MockClipboardData {
+  return {
+    items: files.map((file) => ({
+      kind: "file",
+      getAsFile: () => file,
+    })),
+    getData: (format: string) => {
+      if (format === "text/plain") {
+        return textPlain;
+      }
+
+      if (format === "text") {
+        return text;
+      }
+
+      return "";
+    },
+  };
+}
+
+describe("getPastedFilesIfNoText", () => {
+  it("prefers plain text over pasted files when both are present", () => {
+    const imageFile = new File(["slide preview"], "slide.png", {
+      type: "image/png",
+    });
+
+    expect(
+      getPastedFilesIfNoText(
+        makeClipboardData({
+          textPlain: "Welcome to PowerPoint for Mac",
+          files: [imageFile],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("falls back to text data when text/plain is empty", () => {
+    const imageFile = new File(["slide preview"], "slide.png", {
+      type: "image/png",
+    });
+
+    expect(
+      getPastedFilesIfNoText(
+        makeClipboardData({
+          text: "Welcome to PowerPoint for Mac",
+          files: [imageFile],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("still returns files for image-only pastes", () => {
+    const imageFile = new File(["slide preview"], "slide.png", {
+      type: "image/png",
+    });
+
+    expect(
+      getPastedFilesIfNoText(makeClipboardData({ files: [imageFile] }))
+    ).toEqual([imageFile]);
+  });
+
+  it("ignores whitespace-only text and keeps file pastes working", () => {
+    const imageFile = new File(["slide preview"], "slide.png", {
+      type: "image/png",
+    });
+
+    expect(
+      getPastedFilesIfNoText(
+        makeClipboardData({
+          textPlain: "   ",
+          text: "\n",
+          files: [imageFile],
+        })
+      )
+    ).toEqual([imageFile]);
+  });
+});

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,52 @@
+type ClipboardFileItem = {
+  kind: string;
+  getAsFile: () => File | null;
+};
+
+type ClipboardDataLike = {
+  items?: ArrayLike<ClipboardFileItem> | null;
+  getData: (format: string) => string;
+};
+
+function getClipboardText(
+  clipboardData: ClipboardDataLike,
+  format: "text/plain" | "text"
+): string {
+  try {
+    return clipboardData.getData(format);
+  } catch {
+    return "";
+  }
+}
+
+export function getPastedFilesIfNoText(
+  clipboardData?: ClipboardDataLike | null
+): File[] {
+  if (!clipboardData) {
+    return [];
+  }
+
+  const plainText = getClipboardText(clipboardData, "text/plain").trim();
+  const fallbackText = getClipboardText(clipboardData, "text").trim();
+
+  // Apps like PowerPoint on macOS can place both rendered image data and the
+  // original text on the clipboard. Prefer letting the textarea consume text.
+  if (plainText || fallbackText || !clipboardData.items) {
+    return [];
+  }
+
+  const pastedFiles: File[] = [];
+  for (let i = 0; i < clipboardData.items.length; i++) {
+    const item = clipboardData.items[i];
+    if (item?.kind !== "file") {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (file) {
+      pastedFiles.push(file);
+    }
+  }
+
+  return pastedFiles;
+}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -20,6 +20,7 @@ import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { ChatState } from "@/app/app/interfaces";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
+import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { cn, isImageFile } from "@/lib/utils";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
@@ -300,20 +301,10 @@ const AppInputBar = React.memo(
     }, [showFiles, currentMessageFiles]);
 
     function handlePaste(event: React.ClipboardEvent) {
-      const items = event.clipboardData?.items;
-      if (items) {
-        const pastedFiles = [];
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
-          if (item && item.kind === "file") {
-            const file = item.getAsFile();
-            if (file) pastedFiles.push(file);
-          }
-        }
-        if (pastedFiles.length > 0) {
-          event.preventDefault();
-          handleFileUpload(pastedFiles);
-        }
+      const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
+      if (pastedFiles.length > 0) {
+        event.preventDefault();
+        handleFileUpload(pastedFiles);
       }
     }
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently when you copy and paste text from a powerpoint slide into Onyx, since the clipboard has metadata that there is an image within the clipboard, we allow for the image to be forced through instead of the fact that the item copied is text. 

This seems to be how powerpoint is setup but we have decided to prioritize the text from the clipboard. 

This is now centralized and fixed and tests have been added. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added a targeted test + tested locally to validate that the behavior now matches what we expect of just copying in the text.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes paste behavior to prefer text over images when pasting from PowerPoint, so users get text instead of slide thumbnails. Centralizes clipboard parsing and adds tests.

- **Bug Fixes**
  - Prefer `text/plain` or `text` clipboard data; only upload files when there’s no non-whitespace text.

- **Refactors**
  - Extracted `getPastedFilesIfNoText` to `web/src/lib/clipboard.ts` and used in `InputBar` and `AppInputBar`.
  - Added unit tests in `web/src/lib/clipboard.test.ts`.

<sup>Written for commit a27ac627c2e43c2d3f1cfb6f49555ada353b08e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

