### PR TITLE
fix(ux): disable MCP Tools toggle if needs authenticated

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -114,6 +114,10 @@ function MCPServerCard({
   const allToolIds = tools.map((t) => t.id);
   const serverEnabled =
     tools.length > 0 && tools.some((t) => isToolEnabled(t.id));
+  const needsAuth = !server.is_authenticated;
+  const authTooltip = needsAuth
+    ? "Authenticate this MCP server before enabling its tools."
+    : undefined;
 
   return (
     <ExpandableCard.Root isFolded={isFolded} onFoldedChange={setIsFolded}>
@@ -122,10 +126,13 @@ function MCPServerCard({
         description={server.description}
         icon={getActionIcon(server.server_url, server.name)}
         rightChildren={
-          <Switch
-            checked={serverEnabled}
-            onCheckedChange={(checked) => onToggleTools(allToolIds, checked)}
-          />
+          <SimpleTooltip tooltip={authTooltip} side="top">
+            <Switch
+              checked={serverEnabled}
+              onCheckedChange={(checked) => onToggleTools(allToolIds, checked)}
+              disabled={needsAuth}
+            />
+          </SimpleTooltip>
         }
       >
         {tools.length > 0 && (
@@ -158,12 +165,15 @@ function MCPServerCard({
                 description={tool.description}
                 icon={tool.icon}
                 rightChildren={
-                  <Switch
-                    checked={isToolEnabled(tool.id)}
-                    onCheckedChange={(checked) =>
-                      onToggleTool(tool.id, checked)
-                    }
-                  />
+                  <SimpleTooltip tooltip={authTooltip} side="top">
+                    <Switch
+                      checked={isToolEnabled(tool.id)}
+                      onCheckedChange={(checked) =>
+                        onToggleTool(tool.id, checked)
+                      }
+                      disabled={needsAuth}
+                    />
+                  </SimpleTooltip>
                 }
               />
             ))}


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3757/action-controls

## How Has This Been Tested?

**before**
<img width="1587" height="2085" alt="20260324_15h05m12s_grim" src="https://github.com/user-attachments/assets/0338e78c-0339-44b6-bcf9-d35dcc214574" />

**after**
<img width="1587" height="2085" alt="20260324_15h05m24s_grim" src="https://github.com/user-attachments/assets/d8bf60fa-8d8a-4376-9a00-6a6cf0171335" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable MCP server and tool toggles when the server is not authenticated, and show a tooltip explaining the required step. Prevents enabling unauthenticated tools and meets Linear ENG-3757 (Action controls).

<sup>Written for commit b91ae31f5b8ad7f87c973eb45483fd84eae6c77d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

