### PR TITLE
fix(fe): Popover content doesnt overflow on small screens

### DIFF
--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -142,6 +142,7 @@ function PopoverContent({
         collisionPadding={8}
         className={cn(
           "bg-background-neutral-00 p-1 z-popover rounded-12 border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "flex flex-col",
           "max-h-[var(--radix-popover-content-available-height)]",
           "overflow-hidden",
           widthClasses[width]
@@ -226,7 +227,7 @@ export function PopoverMenu({
   });
 
   return (
-    <Section alignItems="stretch">
+    <Section alignItems="stretch" height="auto" className="flex-1 min-h-0">
       <ShadowDiv
         scrollContainerRef={scrollContainerRef}
         className="flex flex-col gap-1 max-h-[20rem] w-full"

--- a/web/src/refresh-components/ShadowDiv.tsx
+++ b/web/src/refresh-components/ShadowDiv.tsx
@@ -105,7 +105,7 @@ export default function ShadowDiv({
   }, [containerRef, checkScroll]);
 
   return (
-    <div className="relative min-h-0">
+    <div className="relative min-h-0 flex flex-col">
       <div
         ref={containerRef}
         className={cn("overflow-y-auto", className)}


### PR DESCRIPTION
## Description

Per Claude,

>  The problem: On small screens, --radix-popover-content-available-height is ~373px but the ShadowDiv scroll area had a hardcoded max-h-[20rem] (320px). This left no room for the search input and temperature slider within the popover's overflow-hidden boundary.
>
>  The fix — 3 changes across 2 files:
>
>  1. Popover.tsx (PopoverContent) — Added `flex flex-col` so it becomes a flex container. Children can now participate in flex sizing within the `max-h` constraint.
>  2. ShadowDiv.tsx — Changed wrapper from `relative min-h-0` to `relative min-h-0 flex flex-col`. This makes the scroll container a flex item that can shrink when its parent is constrained (overflow:auto elements have an effective min-height of 0 in flex contexts).
>  3. Popover.tsx (PopoverMenu) — Changed the Section from `height="full"` (default) to `height="auto"` `className="flex-1 min-h-0"`. This makes PopoverMenu fill available space via flex instead of demanding 100% height.
>
>  Result: On small screens, the flex chain propagates the height constraint from PopoverContent → Section → PopoverMenu → ShadowDiv, and the model list scroll area shrinks to fit, keeping the search input and temperature slider visible.

Closes https://linear.app/onyx-app/issue/ENG-3499/contextual-menu-anti-collision-model-selector-going-off-screen-on

## How Has This Been Tested?

**before**
<img width="1362" height="2085" alt="20260324_15h58m42s_grim" src="https://github.com/user-attachments/assets/5e9eaa50-3bb1-465d-97d6-8f2c66e63b69" />

**after**
<img width="1362" height="2085" alt="20260324_15h58m28s_grim" src="https://github.com/user-attachments/assets/c9548eca-cbfc-465d-8a2e-ec74e2c21ad4" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes popover menu overflow on small screens. The model list now scrolls, and the search input and temperature slider stay visible.

- **Bug Fixes**
  - Made `PopoverContent` a flex column to allow children to size within the max height.
  - Updated `PopoverMenu` Section to `height="auto"` with `flex-1 min-h-0` for proper flex sizing.
  - Switched `ShadowDiv` wrapper to `flex flex-col` so the scroll area can shrink under constraints.

<sup>Written for commit e816e06a049c920676cf465cb5c601a3939000d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

