### PR TITLE
fix(width): UI update model width definition.

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -98,7 +98,7 @@ export default function IndexAttemptErrorsModal({
 
   return (
     <Modal open onOpenChange={onClose}>
-      <Modal.Content width="lg" height="full">
+      <Modal.Content width="full" height="full">
         <Modal.Header
           icon={SvgAlertTriangle}
           title="Indexing Errors"

--- a/web/src/app/craft/v1/configure/components/ConfigureConnectorModal.tsx
+++ b/web/src/app/craft/v1/configure/components/ConfigureConnectorModal.tsx
@@ -151,7 +151,7 @@ export default function ConfigureConnectorModal({
   return (
     <>
       <Modal open={open} onOpenChange={onClose}>
-        <Modal.Content width="md" height="fit">
+        <Modal.Content width="xl" height="fit">
           <Modal.Header
             icon={SvgPlug}
             title={getStepTitle()}

--- a/web/src/app/craft/v1/configure/components/CredentialStep.tsx
+++ b/web/src/app/craft/v1/configure/components/CredentialStep.tsx
@@ -263,7 +263,7 @@ export default function CredentialStep({
                 open
                 onOpenChange={() => setCreateCredentialFormToggle(false)}
               >
-                <Modal.Content width="md" height="fit">
+                <Modal.Content width="xl" height="fit">
                   <Modal.Header
                     icon={SvgKey}
                     title={`Create a ${getSourceDisplayName(

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -215,7 +215,7 @@ export default function UserLibraryModal({
   return (
     <>
       <Modal open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-        <Modal.Content width="md" height="fit">
+        <Modal.Content width="xl" height="fit">
           <Modal.Header
             icon={SvgFileText}
             title="Your Files"

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -178,7 +178,7 @@ function PreviousQueryHistoryExportsModal({
 
   return (
     <Modal open onOpenChange={() => setShowModal(false)}>
-      <Modal.Content width="lg" height="full">
+      <Modal.Content width="full" height="full">
         <Modal.Header
           icon={SvgFileText}
           title="Previous Query History Exports"

--- a/web/src/refresh-components/Modal.stories.tsx
+++ b/web/src/refresh-components/Modal.stories.tsx
@@ -67,7 +67,7 @@ function LargeModalDemo() {
     <div style={{ padding: 32 }}>
       <Button onClick={() => setOpen(true)}>Open Large Modal</Button>
       <Modal open={open} onOpenChange={setOpen}>
-        <Modal.Content width="lg" height="full">
+        <Modal.Content width="full" height="full">
           <Modal.Header
             icon={SvgInfoSmall}
             title="Large Modal"

--- a/web/src/refresh-components/Modal.tsx
+++ b/web/src/refresh-components/Modal.tsx
@@ -76,10 +76,11 @@ const useModalContext = () => {
 };
 
 const widthClasses = {
-  lg: "w-[80dvw]",
-  md: "w-[60rem]",
-  "md-sm": "w-[50rem]",
-  sm: "w-[32rem]",
+  full: "w-[80dvw]",
+  xl: "w-[60rem]",
+  lg: "w-[50rem]",
+  md: "w-[40rem]",
+  sm: "w-[30rem]",
 };
 
 const heightClasses = {
@@ -97,20 +98,20 @@ const heightClasses = {
  * @example
  * ```tsx
  * // Using width and height props
- * <Modal.Content width="lg" height="full">
- *   {/* Large modal: w-[80dvw] h-[80dvh] *\/}
+ * <Modal.Content width="full" height="full">
+ *   {/* Full modal: w-[80dvw] h-[80dvh] *\/}
  * </Modal.Content>
  *
- * <Modal.Content width="md" height="fit">
- *   {/* Medium modal: w-[60rem] h-fit *\/}
+ * <Modal.Content width="xl" height="fit">
+ *   {/* XL modal: w-[60rem] h-fit *\/}
  * </Modal.Content>
  *
  * <Modal.Content width="sm" height="sm">
- *   {/* Small modal: w-[32rem] max-h-[30rem] *\/}
+ *   {/* Small modal: w-[30rem] max-h-[30rem] *\/}
  * </Modal.Content>
  *
  * <Modal.Content width="sm" height="lg">
- *   {/* Tall modal: w-[32rem] max-h-[calc(100dvh-4rem)] *\/}
+ *   {/* Tall modal: w-[30rem] max-h-[calc(100dvh-4rem)] *\/}
  * </Modal.Content>
  * ```
  */
@@ -138,7 +139,7 @@ const ModalContent = React.forwardRef<
   (
     {
       children,
-      width = "md",
+      width = "xl",
       height = "fit",
       position = "center",
       preventAccidentalClose = true,

--- a/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
+++ b/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
@@ -321,7 +321,7 @@ export default function ExpandableTextDisplay({
 
       {/* Expanded Modal */}
       <Modal open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <Modal.Content height="lg" width="md-sm" preventAccidentalClose={false}>
+        <Modal.Content height="lg" width="lg" preventAccidentalClose={false}>
           {/* Header */}
           <div className="flex items-start justify-between px-4 py-3">
             <div className="flex flex-col">

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -767,7 +767,7 @@ function ChatPreferencesForm() {
         open={systemPromptModalOpen}
         onOpenChange={setSystemPromptModalOpen}
       >
-        <Modal.Content width="md" height="fit">
+        <Modal.Content width="xl" height="fit">
           <Modal.Header
             icon={SvgAddLines}
             title="System Prompt"

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -237,7 +237,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
       onOpenChange={agentViewerModal.toggle}
     >
       <Modal.Content
-        width="md-sm"
+        width="lg"
         height="lg"
         bottomSlot={<AgentChatInput agent={agent} onSubmit={handleStartChat} />}
       >

--- a/web/src/sections/modals/PreviewModal/ExceptionTraceModal.tsx
+++ b/web/src/sections/modals/PreviewModal/ExceptionTraceModal.tsx
@@ -17,7 +17,7 @@ export default function ExceptionTraceModal({
 }: ExceptionTraceModalProps) {
   return (
     <Modal open onOpenChange={onOutsideClick}>
-      <Modal.Content width="lg" height="full">
+      <Modal.Content width="full" height="full">
         <Modal.Header
           icon={SvgAlertTriangle}
           title="Full Exception Trace"

--- a/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
@@ -10,7 +10,7 @@ import {
 
 export const codeVariant: PreviewVariant = {
   matches: (name) => !!getCodeLanguage(name || ""),
-  width: "md",
+  width: "xl",
   height: "lg",
   needsTextContent: true,
   codeBackground: true,

--- a/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
@@ -31,7 +31,7 @@ function parseCsv(content: string): CsvData {
 export const csvVariant: PreviewVariant = {
   matches: (name, mime) =>
     mime.startsWith("text/csv") || (name || "").toLowerCase().endsWith(".csv"),
-  width: "lg",
+  width: "full",
   height: "full",
   needsTextContent: true,
   codeBackground: false,

--- a/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
@@ -22,7 +22,7 @@ function formatContent(language: string, content: string): string {
 export const dataVariant: PreviewVariant = {
   matches: (name, mime) =>
     !!getDataLanguage(name || "") || !!getLanguageByMime(mime),
-  width: "md",
+  width: "xl",
   height: "lg",
   needsTextContent: true,
   codeBackground: true,

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -127,7 +127,7 @@ export const docxVariant: PreviewVariant = {
     const lower = (name || "").toLowerCase();
     return lower.endsWith(".docx") || lower.endsWith(".doc");
   },
-  width: "lg",
+  width: "full",
   height: "full",
   needsTextContent: false,
   codeBackground: false,

--- a/web/src/sections/modals/PreviewModal/variants/imageVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/imageVariant.tsx
@@ -8,7 +8,7 @@ import {
 
 export const imageVariant: PreviewVariant = {
   matches: (_name, mime) => mime.startsWith("image/"),
-  width: "lg",
+  width: "full",
   height: "full",
   needsTextContent: false,
   codeBackground: false,

--- a/web/src/sections/modals/PreviewModal/variants/markdownVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/markdownVariant.tsx
@@ -19,7 +19,7 @@ export const markdownVariant: PreviewVariant = {
     if (MARKDOWN_MIMES.some((m) => mime.startsWith(m))) return true;
     return isMarkdownFile(name || "");
   },
-  width: "lg",
+  width: "full",
   height: "full",
   needsTextContent: true,
   codeBackground: false,

--- a/web/src/sections/modals/PreviewModal/variants/pdfVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/pdfVariant.tsx
@@ -4,7 +4,7 @@ import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 
 export const pdfVariant: PreviewVariant = {
   matches: (_name, mime) => mime === "application/pdf",
-  width: "lg",
+  width: "full",
   height: "full",
   needsTextContent: false,
   codeBackground: false,

--- a/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
@@ -25,7 +25,7 @@ export const textVariant: PreviewVariant = {
     const lowerName = (name || "").toLowerCase();
     return TEXT_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
   },
-  width: "md",
+  width: "xl",
   height: "lg",
   needsTextContent: true,
   codeBackground: true,

--- a/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
@@ -5,7 +5,7 @@ import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 
 export const unsupportedVariant: PreviewVariant = {
   matches: () => true,
-  width: "md",
+  width: "xl",
   height: "full",
   needsTextContent: false,
   codeBackground: false,

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -633,7 +633,7 @@ export function LLMConfigurationModalWrapper({
 
   return (
     <Modal open onOpenChange={onClose}>
-      <Modal.Content width="md-sm" height="lg">
+      <Modal.Content width="lg" height="lg">
         <Form className="flex flex-col h-full min-h-0">
           <Modal.Header
             icon={providerIcon}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

  refactor(modal): rename and extend Modal width scale

  Summary

  - Renames the Modal.Content width tokens to better reflect their visual weight: lg → full, md → xl, md-sm → lg
  - Updates sm width from w-[32rem] to w-[30rem]
  - Adds a new intermediate md size at w-[40rem]
  - Updates the default width from the old md to xl (preserving the same rendered size)
  - Propagates all renames across 21 files, including direct JSX usages and dynamic PreviewModal variant objects

  New width scale
```
  ┌───────┬─────────────────┐
  │ Token │      Width      │
  ├───────┼─────────────────┤
  │ full  │ w-[80dvw]       │
  ├───────┼─────────────────┤
  │ xl    │ w-[60rem]       │
  ├───────┼─────────────────┤
  │ lg    │ w-[50rem]       │
  ├───────┼─────────────────┤
  │ md    │ w-[40rem] (new) │
  ├───────┼─────────────────┤
  │ sm    │ w-[30rem]       │
  └───────┴─────────────────┘

```


 Popover.Content and SettingsLayouts.Root width tokens are unaffected — they have their own independent scales.

Linear: https://linear.app/onyx-app/project/hooks-14fc5597dc91/overview
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

spot check on UI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
