### PR TITLE
fix(web): restore api_base field in Custom Models modal

### DIFF
--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -212,9 +212,10 @@ export default function CustomModal({
   const initialValues = {
     ...buildDefaultInitialValues(
       existingLlmProvider,
-      undefined,
+      existingLlmProvider?.model_configurations,
       defaultModelName
     ),
+    api_base: existingLlmProvider?.api_base ?? "",
     ...(isOnboarding ? buildOnboardingInitialValues() : {}),
     provider: existingLlmProvider?.provider ?? "",
     model_configurations: existingLlmProvider?.model_configurations.map(
@@ -352,6 +353,19 @@ export default function CustomModal({
                     name="provider"
                     placeholder="Provider Name"
                     variant={existingLlmProvider ? "disabled" : undefined}
+                  />
+                </InputLayouts.Vertical>
+              </FieldWrapper>
+
+              <FieldWrapper>
+                <InputLayouts.Vertical
+                  name="api_base"
+                  title="API Base URL"
+                  subDescription="Custom endpoint for OpenAI-compatible providers (e.g. LiteLLM, vLLM, Ollama remote)."
+                >
+                  <InputTypeInField
+                    name="api_base"
+                    placeholder="https://your-custom-api.com/v1"
                   />
                 </InputLayouts.Vertical>
               </FieldWrapper>


### PR DESCRIPTION
## Summary
Restores the missing **API Base URL** (pi_base) field in the Custom Models modal after it was silently dropped during PR #9270 refactor.

## Changes
- **CustomModal.tsx**: Added pi_base field to form initial values and UI (uses same pattern as LiteLLMProxyModal)
- **CustomModal.tsx**: Fixed uildDefaultInitialValues() to pass model_configurations instead of undefined, ensuring default_model_name is properly populated

## Root Cause
After #9270 replaced inline form fields with shared components, pi_base had no equivalent shared component and was dropped. The default_model_name issue was caused by passing undefined instead of model_configurations to uildDefaultInitialValues().

## Testing
1. Go to Admin → Language Models → Add Provider → Custom
2. Verify API Base URL field is visible
3. Enter a custom endpoint (e.g. LiteLLM proxy URL)
4. Add a model and verify test request uses the custom endpoint

## Fixes onyx#9592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing API Base URL field in the Custom Models modal and fixes default model name initialization. This enables setting custom OpenAI-compatible endpoints again and shows the correct default model. Fixes onyx#9592.

- **Bug Fixes**
  - Added `api_base` to initial form values and UI in `CustomModal.tsx` (shows “API Base URL” input).
  - Passed `model_configurations` to `buildDefaultInitialValues()` to correctly populate `default_model_name`.

<sup>Written for commit 86f05b59a3e1ec7a85223673d84086d4305d6f96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

