### PR TITLE
fix: Fix tag widths

### DIFF
--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -256,6 +256,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 title="Featured"
                 sizePreset="main-ui"
                 variant="body"
+                widthVariant="fit"
               />
             )}
             <Content
@@ -264,6 +265,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
               sizePreset="main-ui"
               variant="body"
               prominence="muted"
+              widthVariant="fit"
             />
             {agent.is_public && (
               <Content
@@ -272,6 +274,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 sizePreset="main-ui"
                 variant="body"
                 prominence="muted"
+                widthVariant="fit"
               />
             )}
           </Section>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -7,6 +7,7 @@ import {
   SvgOrganization,
   SvgShare,
   SvgTag,
+  SvgUser,
   SvgUsers,
   SvgX,
 } from "@opal/icons";
@@ -18,7 +19,6 @@ import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboB
 import * as InputLayouts from "@/layouts/input-layouts";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import { SvgUser } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import useShareableUsers from "@/hooks/useShareableUsers";


### PR DESCRIPTION
## Description

- Add `widthVariant="fit"` to three `Content` components in `AgentViewerModal` to prevent them from stretching beyond their content width

## Screenshots + Videos

### Before

<img width="817" height="664" alt="image" src="https://github.com/user-attachments/assets/36f522e9-f35a-4e25-b715-7aafc97ed5c6" />

### After

<img width="817" height="661" alt="image" src="https://github.com/user-attachments/assets/4b1662b6-a9dd-4f2c-ac94-7997b26be2c2" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed AgentViewerModal layout by adding widthVariant="fit" to three Content items so content doesn’t stretch. Also deduplicated the SvgUser import in ShareAgentModal by using the existing `@opal/icons` import block.

<sup>Written for commit 8cda87c105b1a49a5d7f607985a492133c112dc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->