### PR TITLE
fix(api memory): replace glibc with jemalloc for memory allocating (#9196) to release v2.9

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update && \
         pkg-config \
         gcc \
         nano \
-        vim && \
+        vim \
+        libjemalloc2 \
+        && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -129,6 +131,13 @@ ENV PYTHONPATH=/app
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
+
+# Use jemalloc instead of glibc malloc to reduce memory fragmentation
+# in long-running Python processes (API server, Celery workers).
+# The soname is architecture-independent; the dynamic linker resolves
+# the correct path from standard library directories.
+# Placed after all RUN steps so build-time processes are unaffected.
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD


### PR DESCRIPTION
Cherry-pick of commit 2ec752677227b0e004809d2c11c0d3a68331539d to release/v2.9 branch.

Original PR: #9196

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch backend to use `libjemalloc2` via LD_PRELOAD to reduce memory fragmentation and stabilize memory usage for long-running API and Celery processes.

- **Bug Fixes**
  - Install `libjemalloc2` and set `LD_PRELOAD=libjemalloc.so.2` in `backend/Dockerfile`.
  - Mitigates steady memory growth by replacing glibc malloc with jemalloc.

<sup>Written for commit 950f1ea9e3df56908c2a53ec08a0a755247023d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

