### PR TITLE
fix(api memory): replace glibc with jemalloc for memory allocating (#9196) to release v2.10

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update && \
         pkg-config \
         gcc \
         nano \
-        vim && \
+        vim \
+        libjemalloc2 \
+        && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -129,6 +131,13 @@ ENV PYTHONPATH=/app
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
+
+# Use jemalloc instead of glibc malloc to reduce memory fragmentation
+# in long-running Python processes (API server, Celery workers).
+# The soname is architecture-independent; the dynamic linker resolves
+# the correct path from standard library directories.
+# Placed after all RUN steps so build-time processes are unaffected.
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD


### PR DESCRIPTION
Cherry-pick of commit 2ec752677227b0e004809d2c11c0d3a68331539d to release/v2.10 branch.

Original PR: #9196

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch backend runtime to `jemalloc` to reduce memory fragmentation and stabilize memory usage in long‑running Python processes (API server, Celery). Installs `libjemalloc2` and sets LD_PRELOAD=libjemalloc.so.2 at runtime; build steps and app code are unchanged.

<sup>Written for commit 5c56f11e53c386059f41049d63f1350901d30512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

