### PR TITLE
chore(playwright): rework admin navigation tests

### DIFF
--- a/web/tests/e2e/admin/admin_pages.spec.ts
+++ b/web/tests/e2e/admin/admin_pages.spec.ts
@@ -39,7 +39,7 @@ for (const theme of THEMES) {
     ).toBeGreaterThan(0);
 
     for (const href of adminHrefs) {
-      const slug = href.replace("/admin/", "").replace(/\//g, "-");
+      const slug = href.replace(/^\/admin\//, "").replace(/\//g, "--");
 
       await test.step(
         slug,


### PR DESCRIPTION
## Description

Reworks to admin navigation playwright tests to instead programmatically collect pages to navigate to. We've added some pages recently and they aren't being covered.

## How Has This Been Tested?

Captured by CI

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked admin navigation tests to auto-discover `/admin/*` pages from the sidebar instead of a hard-coded list. Keeps coverage current and captures snapshots for both themes.

- **Refactors**
  - Scrape sidebar `<a href="/admin/...">` on `/admin/configuration/llm` and de-dupe links.
  - Single test per theme iterates discovered pages with `test.step` (using `{ box: true }`), waits for `networkidle`, and asserts the admin title is visible.
  - Snapshots named `admin-${theme}-${slug}`; path segments use `--`; mask the date-range selector for stability.
  - Added a defensive check to require at least one page is discovered.

<sup>Written for commit 3240e5c5b79a74c614407a964c9b9d9c289299a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

