### PR TITLE
refactor(indexing): Refactor indexing vector db abstraction

### DIFF
--- a/backend/onyx/indexing/adapters/document_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/document_indexing_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 from collections.abc import Generator
 

--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -69,7 +69,14 @@ def write_chunks_to_vector_db_with_backoff(
     def key(chunk: DocMetadataAwareIndexChunk) -> str:
         return chunk.source_document.id
 
+    seen_doc_ids: set[str] = set()
     for doc_id, chunks_for_doc in groupby(make_chunks(), key=key):
+        if doc_id in seen_doc_ids:
+            raise RuntimeError(
+                f"Doc chunks are not arriving in order. Current doc_id={doc_id}, seen_doc_ids={list(seen_doc_ids)}"
+            )
+        seen_doc_ids.add(doc_id)
+
         first_chunk = next(chunks_for_doc)
         chunks_for_doc = chain([first_chunk], chunks_for_doc)
 


### PR DESCRIPTION
## Description
Refactor vector_db_insertion.py to handle the new iterable approach.

## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored vector DB insertion and the indexing pipeline to stream chunk batches via a `make_chunks` creator. Adds a runtime check that throws if chunks are not contiguous per document.

- **Refactors**
  - `DocumentIndex`/`DocumentIndexNew` now accept `Iterable[DocMetadataAwareIndexChunk]` instead of `list`.
  - `write_chunks_to_vector_db_with_backoff` takes `make_chunks: Callable[[], Iterable[DocMetadataAwareIndexChunk]]`, streams per-doc fallback via `itertools.groupby`, and raises `RuntimeError` if doc IDs are out of order.
  - `indexing_pipeline` passes a `make_chunks` creator to vector DB insertion.
  - OpenSearch and Vespa indexers stream chunks, delete per doc once, and bulk-flush in batches capped by `MAX_CHUNKS_PER_DOC_BATCH`.

- **Migration**
  - Update custom `DocumentIndex` implementations to stream/process per doc and batch-flush if needed.
  - Update callers to pass `make_chunks` (it may be called more than once; return a fresh iterable each time).
  - Ensure chunks are contiguous by document ID; out-of-order chunks will throw at runtime.
  - Adapters must implement `prepare_enrichment(...)` and enrich chunks during batching.

<sup>Written for commit 219a21b402b8677cc061b575c4946bcd823342a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

