### PR TITLE
fix(admin): wrap system prompt modal in Formik with markdown subDescription

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -786,7 +786,6 @@ function ChatPreferencesForm() {
                 toast.error("Failed to update system prompt");
               }
             }}
-            enableReinitialize
           >
             {({ dirty, isSubmitting, submitForm }) => (
               <Form>
@@ -816,7 +815,7 @@ function ChatPreferencesForm() {
                       sizePreset="main-ui"
                       icon={SvgAlertCircle}
                       title="Modify with caution."
-                      description="System prompt affect all chats, agent, and projects. Significant changes may degrade response quality."
+                      description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
                     />
                   </OpalCard>
                 </Modal.Body>


### PR DESCRIPTION
## Description

Adds a sub-description + warning to the "Modify System Prompt" modal.

## Screenshots + Videos

<img width="977" height="815" alt="image" src="https://github.com/user-attachments/assets/4f14c63e-408f-48fe-976c-27e6171c9f2e" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check