### PR TITLE
fix(billing): retry claimLicense up to 3x after Stripe checkout return

### DIFF
--- a/web/src/app/admin/billing/page.test.tsx
+++ b/web/src/app/admin/billing/page.test.tsx
@@ -209,9 +209,9 @@ describe("BillingPage — handleBillingReturn retry logic", () => {
     await waitFor(() => {
       expect(mockClaimLicense).toHaveBeenCalledTimes(3);
     });
-    // User just paid — they must not be stranded on plans view
+    // User stays on plans view with the activating banner
     await waitFor(() => {
-      expect(screen.getByTestId("billing-details-view")).toBeInTheDocument();
+      expect(screen.getByTestId("plans-view")).toBeInTheDocument();
     });
     // refreshBilling still fires so billing state is up to date
     expect(mockRefreshBilling).toHaveBeenCalled();

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -109,14 +109,7 @@ export default function BillingPage() {
   const [transitionType, setTransitionType] = useState<
     "expand" | "collapse" | "fade"
   >("fade");
-  const [isActivating, setIsActivating] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    const raw = sessionStorage.getItem(BILLING_ACTIVATING_KEY);
-    if (!raw) return false;
-    if (Number(raw) > Date.now()) return true;
-    sessionStorage.removeItem(BILLING_ACTIVATING_KEY);
-    return false;
-  });
+  const [isActivating, setIsActivating] = useState<boolean>(false);
 
   const {
     data: billingData,
@@ -166,6 +159,17 @@ export default function BillingPage() {
     licenseData?.has_license,
     view,
   ]);
+
+  // Read activating state from sessionStorage after mount (avoids SSR hydration mismatch)
+  useEffect(() => {
+    const raw = sessionStorage.getItem(BILLING_ACTIVATING_KEY);
+    if (!raw) return;
+    if (Number(raw) > Date.now()) {
+      setIsActivating(true);
+    } else {
+      sessionStorage.removeItem(BILLING_ACTIVATING_KEY);
+    }
+  }, []);
 
   // Show license activation card when there's a Stripe error
   useEffect(() => {
@@ -218,14 +222,13 @@ export default function BillingPage() {
             "Failed to sync license after billing return:",
             lastError
           );
-          // Show an activating banner and keep retrying in the background.
-          // The user just paid — they must not be stranded on the plans view.
+          // Show an activating banner on the plans view and keep retrying in the background.
           sessionStorage.setItem(
             BILLING_ACTIVATING_KEY,
             String(Date.now() + 120_000)
           );
           setIsActivating(true);
-          changeView("details");
+          changeView("plans");
         }
       }
       if (!cancelled) refreshBilling();
@@ -235,10 +238,9 @@ export default function BillingPage() {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     // changeView intentionally omitted: it only calls stable state setters and the
     // effect runs at most once (when session_id/portal_return params are present).
-  }, [searchParams, router, refreshBilling, refreshLicense]);
+  }, [searchParams, router, refreshBilling, refreshLicense]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll every 15s while activating, up to 2 minutes, to detect when the license arrives.
   useEffect(() => {
@@ -250,7 +252,8 @@ export default function BillingPage() {
       if (requestInFlight) return;
       const raw = sessionStorage.getItem(BILLING_ACTIVATING_KEY);
       if (!raw || Number(raw) <= Date.now()) {
-        // Expired — stop waiting
+        // Expired — stop immediately without waiting for React cleanup
+        clearInterval(intervalId);
         sessionStorage.removeItem(BILLING_ACTIVATING_KEY);
         setIsActivating(false);
         return;
@@ -477,7 +480,7 @@ export default function BillingPage() {
               warning
               large
               text="Your license is still activating"
-              description="Your license is being processed. This page will update automatically once confirmed."
+              description="Your license is being processed. You'll be taken to billing details automatically once confirmed."
               icon
               close
               onClose={() => {


### PR DESCRIPTION
## Description

Fixes two related issues with Stripe checkout return handling on the self-hosted billing page.

**Problem:** The browser redirect from Stripe checkout and the Stripe webhook fire nearly simultaneously. If the license webhook hasn't finished processing when the user lands back on the billing page, `claimLicense` returns a 404. Before this fix, the user was left on the plans view with no feedback even though they just paid — potentially locked out of their instance.

Retries `claimLicense` up to 3 times with 2s backoff on checkout return. A `cancelled` flag in the effect cleanup stops the loop if the component unmounts.

When all 3 retries fail, shows a `Message static warning` banner at the top of the billing page and starts a 15s background poll (up to 2 minutes). The polling state is written to `sessionStorage` with a unix-ms expiry so the banner survives page refreshes. The banner auto-dismisses when the poll confirms the license is active. Users can also dismiss it manually.

## How Has This Been Tested?

<img width="930" height="795" alt="Screenshot 2026-03-26 at 12 11 24 PM" src="https://github.com/user-attachments/assets/aeb7ad4b-eaf9-4e95-8ced-a560e24e6458" />


11 unit tests co-located with the source (`page.test.tsx`):

Retry logic (5 tests):
- First-attempt success: `claimLicense` called once, router/billing refreshed
- Retry on failure: retries on first failure, succeeds on second attempt
- Total failure (3×): all 3 attempts exhausted, error logged, details view rendered
- Portal return: `claimLicense` called without `session_id`
- No-op: `claimLicense` not called when no billing-return params present

Activating banner (6 tests):
- 3× failure sets sessionStorage key and shows banner
- Banner not rendered with no activating state
- Banner shown on mount when sessionStorage key is present and not expired
- Banner not shown on mount when sessionStorage key is expired (key also removed)
- Poll calls `claimLicense(undefined)` after 15s and clears banner on success
- Close button removes banner and clears sessionStorage

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check