### PR TITLE
fix(api-key): clarify upgrade message for trial accounts

### DIFF
--- a/web/src/app/admin/api-key/page.tsx
+++ b/web/src/app/admin/api-key/page.tsx
@@ -46,15 +46,12 @@ function Main() {
     error,
   } = useSWR<APIKey[]>("/api/admin/api-key", errorHandlingFetcher);
 
-  const canCreateKeys = false; // MOCK: hardcoded for screenshot
+  const canCreateKeys = useCloudSubscription();
   const { data: billingData } = useBillingInformation();
-  const billingIsTrialing =
+  const isTrialing =
     billingData !== undefined &&
     hasActiveSubscription(billingData) &&
     billingData.status === BillingStatus.TRIALING;
-  const isTrialing =
-    true || // MOCK: hardcoded for screenshot
-    billingIsTrialing;
 
   const [fullApiKey, setFullApiKey] = useState<string | null>(null);
   const [keyIsGenerating, setKeyIsGenerating] = useState(false);


### PR DESCRIPTION
## Description

Updates the admin API key page to display a clear warning message to trial users that API key creation requires a paid subscription, with an upgrade CTA linking to billing. Also fixes TypeScript errors in the `isTrialing` check — `billingData`'s narrowing from `!= null` wasn't propagating inside the `true || (...)` dead-code branch, causing TS18048/TS2339 errors. Fixed by extracting the billing check to its own const and using the existing `hasActiveSubscription` type predicate.

## How Has This Been Tested?
<img width="1866" height="734" alt="image" src="https://github.com/user-attachments/assets/7d7dacfa-7236-41c4-aa47-4b6faa7e0fcb" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check