### PR TITLE
chore(greptile): add nginx routing rule for non-api backend routes

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -24,6 +24,16 @@ When hardcoding a boolean variable to a constant value, remove the variable enti
 
 Code changes must consider both multi-tenant and single-tenant deployments. In multi-tenant mode, preserve tenant isolation, ensure tenant context is propagated correctly, and avoid assumptions that only hold for a single shared schema or globally shared state. In single-tenant mode, avoid introducing unnecessary tenant-specific requirements or cloud-only control-plane dependencies.
 
+## Nginx Routing — New Backend Routes
+
+Whenever a new backend route is added that does NOT start with `/api`, it must also be explicitly added to ALL nginx configs:
+- `deployment/helm/charts/onyx/templates/nginx-conf.yaml` (Helm/k8s)
+- `deployment/data/nginx/app.conf.template` (docker-compose dev)
+- `deployment/data/nginx/app.conf.template.prod` (docker-compose prod)
+- `deployment/data/nginx/app.conf.template.no-letsencrypt` (docker-compose no-letsencrypt)
+
+Routes not starting with `/api` are not caught by the existing `^/(api|openapi\.json)` location block and will fall through to `location /`, which proxies to the Next.js web server and returns an HTML 404. The new location block must be placed before the `/api` block. Examples of routes that need this treatment: `/scim`, `/mcp`.
+
 ## Full vs Lite Deployments
 
 Code changes must consider both regular Onyx deployments and Onyx lite deployments. Lite deployments disable the vector DB, Redis, model servers, and background workers by default, use PostgreSQL-backed cache/auth/file storage, and rely on the API server to handle background work. Do not assume those services are available unless the code path is explicitly limited to full deployments.


### PR DESCRIPTION
## Description

Adds a Greptile review rule to catch missing nginx location blocks for backend routes that don't start with `/api`.

The SCIM routing bug (onyx-dot-app/onyx#9686) was caused by a new backend route (`/scim/v2`) being added without corresponding nginx location blocks — it silently fell through to `location /` (Next.js) and returned HTML instead of JSON. This rule ensures Greptile flags any future PR that adds a non-`/api` backend route without updating all four nginx configs (Helm + three docker-compose templates).

## How Has This Been Tested?

N/A — rule-only change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check