### PR TITLE
feat(hook): admin page create or edit hook

### DIFF
--- a/backend/onyx/server/features/hooks/api.py
+++ b/backend/onyx/server/features/hooks/api.py
@@ -123,9 +123,8 @@ def _validate_endpoint(
     (not reachable — indicates the api_key is invalid).
 
     Timeout handling:
-    - ConnectTimeout: TCP handshake never completed → cannot_connect.
-    - ReadTimeout / WriteTimeout: TCP was established, server responded slowly → timeout
-      (operator should consider increasing timeout_seconds).
+    - Any httpx.TimeoutException (ConnectTimeout, ReadTimeout, WriteTimeout, PoolTimeout) →
+      timeout (operator should consider increasing timeout_seconds).
     - All other exceptions → cannot_connect.
     """
     _check_ssrf_safety(endpoint_url)

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -73,6 +73,15 @@ interface ContentMdProps {
   /** When `true`, the title color hooks into `Interactive`'s `--interactive-foreground` variable. */
   withInteractive?: boolean;
 
+  /** Optional class name applied to the title element. */
+  titleClassName?: string;
+
+  /** Optional class name applied to the icon element. */
+  iconClassName?: string;
+
+  /** Content rendered below the description, indented to align with it. */
+  bottomChildren?: React.ReactNode;
+
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -146,6 +155,9 @@ function ContentMd({
   tag,
   sizePreset = "main-ui",
   withInteractive,
+  titleClassName,
+  iconClassName,
+  bottomChildren,
   ref,
 }: ContentMdProps) {
   const [editing, setEditing] = useState(false);
@@ -184,7 +196,11 @@ function ContentMd({
             style={{ minHeight: config.lineHeight }}
           >
             <Icon
-              className={cn("opal-content-md-icon", config.iconColorClass)}
+              className={cn(
+                "opal-content-md-icon",
+                config.iconColorClass,
+                iconClassName
+              )}
               style={{ width: config.iconSize, height: config.iconSize }}
             />
           </div>
@@ -227,7 +243,8 @@ function ContentMd({
                 "opal-content-md-title",
                 config.titleFont,
                 "text-text-04",
-                editable && "cursor-pointer"
+                editable && "cursor-pointer",
+                titleClassName
               )}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
@@ -293,6 +310,13 @@ function ContentMd({
           style={Icon ? { paddingLeft: config.descriptionIndent } : undefined}
         >
           {resolveStr(description)}
+        </div>
+      )}
+      {bottomChildren && (
+        <div
+          style={Icon ? { paddingLeft: config.descriptionIndent } : undefined}
+        >
+          {bottomChildren}
         </div>
       )}
     </div>

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -138,6 +138,12 @@ type MdContentProps = ContentBaseProps & {
   auxIcon?: "info-gray" | "info-blue" | "warning" | "error";
   /** Tag rendered beside the title. */
   tag?: TagProps;
+  /** Optional class name applied to the title element. */
+  titleClassName?: string;
+  /** Optional class name applied to the icon element. */
+  iconClassName?: string;
+  /** Content rendered below the description, indented to align with it. */
+  bottomChildren?: React.ReactNode;
 };
 
 /** ContentSm does not support descriptions or inline editing. */

--- a/web/src/refresh-pages/admin/HooksPage/ConnectedHookCard.tsx
+++ b/web/src/refresh-pages/admin/HooksPage/ConnectedHookCard.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@/hooks/useToast";
+import { Button } from "@opal/components";
+import { Disabled } from "@opal/core";
+import { cn } from "@/lib/utils";
+import { ContentAction } from "@opal/layouts";
+import Card from "@/refresh-components/cards/Card";
+import Text from "@/refresh-components/texts/Text";
+import { Section } from "@/layouts/general-layouts";
+import {
+  SvgCheckCircle,
+  SvgExternalLink,
+  SvgPlug,
+  SvgRefreshCw,
+  SvgSettings,
+  SvgTrash,
+  SvgUnplug,
+} from "@opal/icons";
+import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
+import type {
+  HookPointMeta,
+  HookResponse,
+} from "@/refresh-pages/admin/HooksPage/interfaces";
+import {
+  activateHook,
+  deactivateHook,
+  deleteHook,
+  validateHook,
+} from "@/refresh-pages/admin/HooksPage/svc";
+import { getHookPointIcon } from "@/refresh-pages/admin/HooksPage/hookPointIcons";
+
+// ---------------------------------------------------------------------------
+// Sub-component: disconnect confirmation modal
+// ---------------------------------------------------------------------------
+
+interface DisconnectConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hook: HookResponse;
+  onDisconnect: () => void;
+  onDisconnectAndDelete: () => void;
+}
+
+function DisconnectConfirmModal({
+  open,
+  onOpenChange,
+  hook,
+  onDisconnect,
+  onDisconnectAndDelete,
+}: DisconnectConfirmModalProps) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <Modal.Content width="md" height="fit">
+        <Modal.Header
+          icon={(props) => (
+            <SvgUnplug {...props} className="text-action-danger-05" />
+          )}
+          title={`Disconnect ${hook.name}`}
+          onClose={() => onOpenChange(false)}
+        />
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <Text mainUiBody text03>
+              Onyx will stop calling this endpoint for hook{" "}
+              <strong>
+                <em>{hook.name}</em>
+              </strong>
+              . In-flight requests will continue to run. The external endpoint
+              may still retain data previously sent to it. You can reconnect
+              this hook later if needed.
+            </Text>
+            <Text mainUiBody text03>
+              You can also delete this hook. Deletion cannot be undone.
+            </Text>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <BasicModalFooter
+            cancel={
+              <Button
+                prominence="secondary"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+            }
+            submit={
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="danger"
+                  prominence="secondary"
+                  onClick={onDisconnectAndDelete}
+                >
+                  Disconnect &amp; Delete
+                </Button>
+                <Button
+                  variant="danger"
+                  prominence="primary"
+                  onClick={onDisconnect}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            }
+          />
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: delete confirmation modal
+// ---------------------------------------------------------------------------
+
+interface DeleteConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hook: HookResponse;
+  onDelete: () => void;
+}
+
+function DeleteConfirmModal({
+  open,
+  onOpenChange,
+  hook,
+  onDelete,
+}: DeleteConfirmModalProps) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <Modal.Content width="md" height="fit">
+        <Modal.Header
+          icon={(props) => (
+            <SvgTrash {...props} className="text-action-danger-05" />
+          )}
+          title={`Delete ${hook.name}`}
+          onClose={() => onOpenChange(false)}
+        />
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <Text mainUiBody text03>
+              Hook{" "}
+              <strong>
+                <em>{hook.name}</em>
+              </strong>{" "}
+              will be permanently removed from this hook point. The external
+              endpoint may still retain data previously sent to it.
+            </Text>
+            <Text mainUiBody text03>
+              Deletion cannot be undone.
+            </Text>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <BasicModalFooter
+            cancel={
+              <Button
+                prominence="secondary"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+            }
+            submit={
+              <Button variant="danger" prominence="primary" onClick={onDelete}>
+                Delete
+              </Button>
+            }
+          />
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ConnectedHookCard
+// ---------------------------------------------------------------------------
+
+export interface ConnectedHookCardProps {
+  hook: HookResponse;
+  spec: HookPointMeta | undefined;
+  onEdit: () => void;
+  onDeleted: () => void;
+  onToggled: (updated: HookResponse) => void;
+}
+
+export default function ConnectedHookCard({
+  hook,
+  spec,
+  onEdit,
+  onDeleted,
+  onToggled,
+}: ConnectedHookCardProps) {
+  const [isBusy, setIsBusy] = useState(false);
+  const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+  async function handleDelete() {
+    setDeleteConfirmOpen(false);
+    setIsBusy(true);
+    try {
+      await deleteHook(hook.id);
+      onDeleted();
+    } catch (err) {
+      console.error("Failed to delete hook:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to delete hook."
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleActivate() {
+    setIsBusy(true);
+    try {
+      const updated = await activateHook(hook.id);
+      onToggled(updated);
+    } catch (err) {
+      console.error("Failed to reconnect hook:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to reconnect hook."
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleDeactivate() {
+    setDisconnectConfirmOpen(false);
+    setIsBusy(true);
+    try {
+      const updated = await deactivateHook(hook.id);
+      onToggled(updated);
+    } catch (err) {
+      console.error("Failed to deactivate hook:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to deactivate hook."
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleDisconnectAndDelete() {
+    setDisconnectConfirmOpen(false);
+    setIsBusy(true);
+    try {
+      const deactivated = await deactivateHook(hook.id);
+      onToggled(deactivated);
+      await deleteHook(hook.id);
+      onDeleted();
+    } catch (err) {
+      console.error("Failed to disconnect hook:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to disconnect hook."
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleValidate() {
+    setIsBusy(true);
+    try {
+      const result = await validateHook(hook.id);
+      if (result.status === "passed") {
+        toast.success("Hook validated successfully.");
+      } else {
+        toast.error(
+          result.error_message ?? `Validation failed: ${result.status}`
+        );
+      }
+    } catch (err) {
+      console.error("Failed to validate hook:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to validate hook."
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  const HookIcon = getHookPointIcon(hook.hook_point);
+
+  return (
+    <>
+      <DisconnectConfirmModal
+        open={disconnectConfirmOpen}
+        onOpenChange={setDisconnectConfirmOpen}
+        hook={hook}
+        onDisconnect={handleDeactivate}
+        onDisconnectAndDelete={handleDisconnectAndDelete}
+      />
+      <DeleteConfirmModal
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        hook={hook}
+        onDelete={handleDelete}
+      />
+      <Card
+        variant="primary"
+        padding={0.5}
+        gap={0}
+        className={cn(
+          "hover:border-border-02",
+          !hook.is_active && "!bg-background-neutral-02"
+        )}
+      >
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          paddingVariant="sm"
+          icon={HookIcon}
+          title={hook.name}
+          titleClassName={!hook.is_active ? "line-through" : undefined}
+          iconClassName="text-text-04"
+          description={`Hook Point: ${spec?.display_name ?? hook.hook_point}`}
+          bottomChildren={
+            spec?.docs_url ? (
+              <a
+                href={spec.docs_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 w-fit font-secondary-body text-text-03"
+              >
+                <span className="underline">Documentation</span>
+                <SvgExternalLink size={12} className="shrink-0" />
+              </a>
+            ) : undefined
+          }
+          rightChildren={
+            <Section
+              flexDirection="column"
+              alignItems="end"
+              width="fit"
+              height="fit"
+              gap={0}
+            >
+              <div className="flex items-center gap-1 p-2">
+                {hook.is_active ? (
+                  <>
+                    <Text mainUiAction text03>
+                      Connected
+                    </Text>
+                    <SvgCheckCircle
+                      size={16}
+                      className="text-status-success-05"
+                    />
+                  </>
+                ) : (
+                  <div
+                    className={cn(
+                      "flex items-center gap-1",
+                      isBusy
+                        ? "opacity-50 pointer-events-none"
+                        : "cursor-pointer"
+                    )}
+                    onClick={handleActivate}
+                  >
+                    <Text mainUiAction text03>
+                      Reconnect
+                    </Text>
+                    <SvgPlug size={16} className="text-text-03 shrink-0" />
+                  </div>
+                )}
+              </div>
+              <Disabled disabled={isBusy}>
+                {/* Plain div instead of Section: Section applies style={{ padding }} inline which
+                    overrides Tailwind padding classes, making per-side padding (pl/pr/pb) ineffective. */}
+                <div className="flex items-center gap-0.5 pl-1 pr-1 pb-1">
+                  {hook.is_active ? (
+                    <>
+                      <Button
+                        prominence="tertiary"
+                        size="sm"
+                        icon={SvgUnplug}
+                        onClick={() => setDisconnectConfirmOpen(true)}
+                        tooltip="Disconnect Hook"
+                        aria-label="Deactivate hook"
+                      />
+                      <Button
+                        prominence="tertiary"
+                        size="sm"
+                        icon={SvgRefreshCw}
+                        onClick={handleValidate}
+                        tooltip="Test Connection"
+                        aria-label="Re-validate hook"
+                      />
+                    </>
+                  ) : (
+                    <Button
+                      prominence="tertiary"
+                      size="sm"
+                      icon={SvgTrash}
+                      onClick={() => setDeleteConfirmOpen(true)}
+                      tooltip="Delete"
+                      aria-label="Delete hook"
+                    />
+                  )}
+                  <Button
+                    prominence="tertiary"
+                    size="sm"
+                    icon={SvgSettings}
+                    onClick={onEdit}
+                    tooltip="Manage"
+                    aria-label="Configure hook"
+                  />
+                </div>
+              </Disabled>
+            </Section>
+          }
+        />
+      </Card>
+    </>
+  );
+}

--- a/web/src/refresh-pages/admin/HooksPage/HooksContent.tsx
+++ b/web/src/refresh-pages/admin/HooksPage/HooksContent.tsx
@@ -1,117 +1,211 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { toast } from "@/hooks/useToast";
+import { useState } from "react";
 import { useHookSpecs } from "@/hooks/useHookSpecs";
+import { useHooks } from "@/hooks/useHooks";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-import { ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
+import { ContentAction } from "@opal/layouts";
 import InputSearch from "@/refresh-components/inputs/InputSearch";
 import Card from "@/refresh-components/cards/Card";
 import Text from "@/refresh-components/texts/Text";
-import {
-  SvgArrowExchange,
-  SvgBubbleText,
-  SvgExternalLink,
-  SvgFileBroadcast,
-  SvgHookNodes,
-} from "@opal/icons";
-import { IconFunctionComponent } from "@opal/types";
+import { SvgArrowExchange, SvgExternalLink } from "@opal/icons";
+import HookFormModal from "@/refresh-pages/admin/HooksPage/HookFormModal";
+import ConnectedHookCard from "@/refresh-pages/admin/HooksPage/ConnectedHookCard";
+import { getHookPointIcon } from "@/refresh-pages/admin/HooksPage/hookPointIcons";
+import type {
+  HookPointMeta,
+  HookResponse,
+} from "@/refresh-pages/admin/HooksPage/interfaces";
 
-const HOOK_POINT_ICONS: Record<string, IconFunctionComponent> = {
-  document_ingestion: SvgFileBroadcast,
-  query_processing: SvgBubbleText,
-};
-
-function getHookPointIcon(hookPoint: string): IconFunctionComponent {
-  return HOOK_POINT_ICONS[hookPoint] ?? SvgHookNodes;
-}
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export default function HooksContent() {
   const [search, setSearch] = useState("");
+  const [connectSpec, setConnectSpec] = useState<HookPointMeta | null>(null);
+  const [editHook, setEditHook] = useState<HookResponse | null>(null);
 
-  const { specs, isLoading, error } = useHookSpecs();
+  const { specs, isLoading: specsLoading, error: specsError } = useHookSpecs();
+  const {
+    hooks,
+    isLoading: hooksLoading,
+    error: hooksError,
+    mutate,
+  } = useHooks();
 
-  useEffect(() => {
-    if (error) {
-      toast.error("Failed to load hook specifications.");
-    }
-  }, [error]);
-
-  if (isLoading) {
+  if (specsLoading || hooksLoading) {
     return <SimpleLoader />;
   }
 
-  if (error) {
+  if (specsError || hooksError) {
     return (
       <Text text03 secondaryBody>
-        Failed to load hook specifications. Please refresh the page.
+        Failed to load{specsError ? " hook specifications" : " hooks"}. Please
+        refresh the page.
       </Text>
     );
   }
 
-  const filtered = (specs ?? []).filter(
-    (spec) =>
-      spec.display_name.toLowerCase().includes(search.toLowerCase()) ||
-      spec.description.toLowerCase().includes(search.toLowerCase())
-  );
+  const hooksByPoint: Record<string, HookResponse[]> = {};
+  for (const hook of hooks ?? []) {
+    (hooksByPoint[hook.hook_point] ??= []).push(hook);
+  }
+
+  const searchLower = search.toLowerCase();
+
+  // Connected hooks sorted alphabetically by hook name
+  const connectedHooks = (hooks ?? [])
+    .filter(
+      (hook) =>
+        !searchLower ||
+        hook.name.toLowerCase().includes(searchLower) ||
+        specs
+          ?.find((s) => s.hook_point === hook.hook_point)
+          ?.display_name.toLowerCase()
+          .includes(searchLower)
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Unconnected hook point specs sorted alphabetically
+  const unconnectedSpecs = (specs ?? [])
+    .filter(
+      (spec) =>
+        (hooksByPoint[spec.hook_point]?.length ?? 0) === 0 &&
+        (!searchLower ||
+          spec.display_name.toLowerCase().includes(searchLower) ||
+          spec.description.toLowerCase().includes(searchLower))
+    )
+    .sort((a, b) => a.display_name.localeCompare(b.display_name));
+
+  function handleHookSuccess(updated: HookResponse) {
+    mutate((prev) => {
+      if (!prev) return [updated];
+      const idx = prev.findIndex((h) => h.id === updated.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = updated;
+        return next;
+      }
+      return [...prev, updated];
+    });
+  }
+
+  function handleHookDeleted(id: number) {
+    mutate((prev) => prev?.filter((h) => h.id !== id));
+  }
+
+  const connectSpec_ =
+    connectSpec ??
+    (editHook
+      ? specs?.find((s) => s.hook_point === editHook.hook_point)
+      : undefined);
 
   return (
-    <div className="flex flex-col gap-6">
-      <InputSearch
-        placeholder="Search hooks..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
+    <>
+      <div className="flex flex-col gap-6">
+        <InputSearch
+          placeholder="Search hooks..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        <div className="flex flex-col gap-2">
+          {connectedHooks.length === 0 && unconnectedSpecs.length === 0 ? (
+            <Text text03 secondaryBody>
+              {search
+                ? "No hooks match your search."
+                : "No hook points are available."}
+            </Text>
+          ) : (
+            <>
+              {connectedHooks.map((hook) => {
+                const spec = specs?.find(
+                  (s) => s.hook_point === hook.hook_point
+                );
+                return (
+                  <ConnectedHookCard
+                    key={hook.id}
+                    hook={hook}
+                    spec={spec}
+                    onEdit={() => setEditHook(hook)}
+                    onDeleted={() => handleHookDeleted(hook.id)}
+                    onToggled={handleHookSuccess}
+                  />
+                );
+              })}
+              {unconnectedSpecs.map((spec) => {
+                const UnconnectedIcon = getHookPointIcon(spec.hook_point);
+                return (
+                  <Card
+                    key={spec.hook_point}
+                    variant="secondary"
+                    padding={0.5}
+                    gap={0}
+                    className="hover:border-border-02"
+                  >
+                    <ContentAction
+                      sizePreset="main-ui"
+                      variant="section"
+                      paddingVariant="sm"
+                      icon={UnconnectedIcon}
+                      title={spec.display_name}
+                      iconClassName="text-text-04"
+                      description={spec.description}
+                      bottomChildren={
+                        spec.docs_url ? (
+                          <a
+                            href={spec.docs_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1 w-fit font-secondary-body text-text-03"
+                          >
+                            <span className="underline">Documentation</span>
+                            <SvgExternalLink size={12} className="shrink-0" />
+                          </a>
+                        ) : undefined
+                      }
+                      rightChildren={
+                        <Button
+                          prominence="tertiary"
+                          rightIcon={SvgArrowExchange}
+                          onClick={() => setConnectSpec(spec)}
+                        >
+                          Connect
+                        </Button>
+                      }
+                    />
+                  </Card>
+                );
+              })}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Create modal */}
+      <HookFormModal
+        key={connectSpec?.hook_point ?? "create"}
+        open={!!connectSpec}
+        onOpenChange={(open) => {
+          if (!open) setConnectSpec(null);
+        }}
+        spec={connectSpec ?? undefined}
+        onSuccess={handleHookSuccess}
       />
 
-      <div className="flex flex-col gap-2">
-        {filtered.length === 0 ? (
-          <Text text03 secondaryBody>
-            {search
-              ? "No hooks match your search."
-              : "No hook points are available."}
-          </Text>
-        ) : (
-          filtered.map((spec) => (
-            <Card
-              key={spec.hook_point}
-              variant="secondary"
-              padding={0.5}
-              gap={0}
-            >
-              <ContentAction
-                icon={getHookPointIcon(spec.hook_point)}
-                title={spec.display_name}
-                description={spec.description}
-                sizePreset="main-content"
-                variant="section"
-                paddingVariant="fit"
-                rightChildren={
-                  // TODO(Bo-Onyx): wire up Connect — open modal to create/edit hook
-                  <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
-                    Connect
-                  </Button>
-                }
-              />
-              {spec.docs_url && (
-                <div className="pl-7 pt-1">
-                  <a
-                    href={spec.docs_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1 w-fit text-text-03"
-                  >
-                    <Text as="span" secondaryBody text03 className="underline">
-                      Documentation
-                    </Text>
-                    <SvgExternalLink size={16} className="text-text-02" />
-                  </a>
-                </div>
-              )}
-            </Card>
-          ))
-        )}
-      </div>
-    </div>
+      {/* Edit modal */}
+      <HookFormModal
+        key={editHook?.id ?? "edit"}
+        open={!!editHook}
+        onOpenChange={(open) => {
+          if (!open) setEditHook(null);
+        }}
+        hook={editHook ?? undefined}
+        spec={connectSpec_ ?? undefined}
+        onSuccess={handleHookSuccess}
+      />
+    </>
   );
 }

--- a/web/src/refresh-pages/admin/HooksPage/hookPointIcons.ts
+++ b/web/src/refresh-pages/admin/HooksPage/hookPointIcons.ts
@@ -1,0 +1,13 @@
+import { SvgBubbleText, SvgFileBroadcast, SvgHookNodes } from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+
+const HOOK_POINT_ICONS: Record<string, IconFunctionComponent> = {
+  document_ingestion: SvgFileBroadcast,
+  query_processing: SvgBubbleText,
+};
+
+function getHookPointIcon(hookPoint: string): IconFunctionComponent {
+  return HOOK_POINT_ICONS[hookPoint] ?? SvgHookNodes;
+}
+
+export { HOOK_POINT_ICONS, getHookPointIcon };


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Summary

Implements the full hooks management UI: connected hook cards with status, actions (disconnect, reconnect, test connection, manage), confirmation modals for disconnect and delete, and optimistic SWR cache updates. Unconnected hook points show as secondary cards with a Connect action that opens the create modal.


Motivation: We want to support customer to inject function into certain point in our pipeline.
Eng Doc: https://docs.google.com/document/d/1wCQ4jcuscDLBIuVwzG8yT6UnHVWgIi5gdteOhe1SqhU/edit?tab=t.0
Linear: https://linear.app/onyx-app/project/hooks-14fc5597dc91/overview
UI mocks:
https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=4756-763808&p=f&m=dev

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

<img width="1125" height="564" alt="Screenshot 2026-03-26 at 3 36 10 PM" src="https://github.com/user-attachments/assets/c3f87c06-e56d-4313-ad10-8319b48bcad0" />
<img width="1051" height="552" alt="Screenshot 2026-03-26 at 3 35 53 PM" src="https://github.com/user-attachments/assets/7d035aca-182b-4ab2-b0e0-62ed0c4399a3" />
<img width="1216" height="599" alt="Screenshot 2026-03-26 at 3 38 04 PM" src="https://github.com/user-attachments/assets/9df644b6-3019-4e64-99a7-9b5593d28b99" />
<img width="1197" height="840" alt="Screenshot 2026-03-26 at 3 37 50 PM" src="https://github.com/user-attachments/assets/6ca1e3b5-cc15-4e81-bed2-b38d00ffe380" />
<img width="1138" height="730" alt="Screenshot 2026-03-26 at 3 37 41 PM" src="https://github.com/user-attachments/assets/73817a53-2ed3-42cc-9be6-bed72279a99c" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the Hooks admin page with create/edit and full management (connect, disconnect, reconnect, test) using optimistic updates. Aligns with the Hooks Linear project requirements.

- **New Features**
  - Connected hook cards with status and actions: Disconnect, Reconnect, Test, Manage (with confirm modals for Disconnect and Delete).
  - Unconnected hook points render as secondary cards; Connect opens the create modal.
  - Create/Edit via `HookFormModal`, with optimistic updates using `useHooks().mutate`.
  - Search across hook names and hook point display names/descriptions; lists are sorted alphabetically.

- **Refactors**
  - `@opal/layouts` (`ContentMd`/`components`): add `titleClassName`, `iconClassName`, and `bottomChildren` for richer cards (used for icons and a docs link).
  - Server docs: treat any `httpx.TimeoutException` as a timeout in the validation helper comments.

<sup>Written for commit 2a8b50f082239751d5ea79f74075e5bdcd8b6a92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

