### PR TITLE
perf(swr): add sessionStorage cache provider to persist SWR cache across reloads

### DIFF
--- a/web/src/providers/SWRConfigProvider.tsx
+++ b/web/src/providers/SWRConfigProvider.tsx
@@ -1,7 +1,51 @@
 "use client";
 
-import { SWRConfig } from "swr";
+import { SWRConfig, type State } from "swr";
 import { skipRetryOnAuthError } from "@/lib/fetcher";
+
+const CACHE_KEY = "onyx-swr-v1";
+
+/**
+ * Backs the SWR in-memory cache with sessionStorage so cached responses
+ * survive page reloads. SWR still revalidates on mount (stale-while-revalidate),
+ * so the UI renders immediately with cached data and updates when fresh data arrives.
+ *
+ * sessionStorage is used (not localStorage) so the cache is scoped to the tab
+ * session and is automatically cleared when the tab is closed.
+ */
+function sessionStorageProvider(): Map<string, State<unknown>> {
+  if (typeof window === "undefined") {
+    return new Map();
+  }
+
+  // State<unknown> matches what SWR stores; the actual generic parameter is
+  // resolved by each hook at read time, so unknown is the correct lower bound.
+  let map: Map<string, State<unknown>>;
+  try {
+    map = new Map<string, State<unknown>>(
+      JSON.parse(sessionStorage.getItem(CACHE_KEY) || "[]") as [
+        string,
+        State<unknown>,
+      ][]
+    );
+  } catch {
+    // Corrupted or unparseable cache — start fresh
+    map = new Map<string, State<unknown>>();
+  }
+
+  window.addEventListener("beforeunload", () => {
+    try {
+      sessionStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify(Array.from(map.entries()))
+      );
+    } catch {
+      // Storage quota exceeded or serialization error — ignore
+    }
+  });
+
+  return map;
+}
 
 export default function SWRConfigProvider({
   children,
@@ -9,7 +53,12 @@ export default function SWRConfigProvider({
   children: React.ReactNode;
 }) {
   return (
-    <SWRConfig value={{ onErrorRetry: skipRetryOnAuthError }}>
+    <SWRConfig
+      value={{
+        onErrorRetry: skipRetryOnAuthError,
+        provider: sessionStorageProvider,
+      }}
+    >
       {children}
     </SWRConfig>
   );


### PR DESCRIPTION
## Description

Every hard page reload was firing ~30 API requests from scratch because SWR's cache is in-memory only — wiped on every browser refresh. This adds a `sessionStorage`-backed cache provider to `SWRConfigProvider` so SWR can hydrate from cached responses immediately on reload, then revalidate in the background.

**What changed:**
- Added `sessionStorageProvider` function in `SWRConfigProvider.tsx` that reads the SWR cache from `sessionStorage` on init and writes it back on `beforeunload`
- Wired it into the global `SWRConfig` via the `provider` prop

**Behavior after this change:**
- First page load: all ~30 requests fire as usual (cache is empty)
- Subsequent reloads (F5): cached responses hydrate immediately → UI renders with stale data → SWR revalidates in background per each hook's existing settings (`revalidateOnMount: true` default)
- Tab close / new tab: `sessionStorage` clears → fresh fetch on next visit

`sessionStorage` (not `localStorage`) is used intentionally so the cache is scoped to the browser session and auto-clears when the tab closes.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check