### PR TITLE
perf(swr): convert raw-fetch hooks to SWR to eliminate duplicate requests

### DIFF
--- a/web/src/lib/hooks/useToolOAuthStatus.ts
+++ b/web/src/lib/hooks/useToolOAuthStatus.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import useSWR from "swr";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import { initiateOAuthFlow } from "@/lib/oauth/api";
 import { OAuthTokenStatus, ToolSnapshot } from "@/lib/tools/interfaces";
 
@@ -23,6 +23,9 @@ export function useToolOAuthStatus(agentId?: number) {
     {
       revalidateOnFocus: false,
       dedupingInterval: 60_000,
+      onErrorRetry: skipRetryOnAuthError,
+      onError: (err) =>
+        console.error("[useToolOAuthStatus] fetch failed:", err),
     }
   );
 

--- a/web/src/providers/ProjectsContext.tsx
+++ b/web/src/providers/ProjectsContext.tsx
@@ -13,7 +13,7 @@ import {
   SetStateAction,
 } from "react";
 import useSWR from "swr";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import type {
   CategorizedFiles,
   Project,
@@ -169,6 +169,9 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
   >("/api/user/files/recent", errorHandlingFetcher, {
     revalidateOnFocus: false,
     dedupingInterval: 60_000,
+    onErrorRetry: skipRetryOnAuthError,
+    onError: (err) =>
+      console.error("[ProjectsContext] recent files fetch failed:", err),
   });
   // Track whether allRecentFiles has been seeded from the initial server fetch.
   // Subsequent updates come through the merge effect below, not a full reset.


### PR DESCRIPTION
## Description

Two hooks were using `useState/useEffect` with raw `fetch()` calls instead of SWR, causing duplicate network requests on every page load:

**`useToolOAuthStatus`** (`web/src/lib/hooks/useToolOAuthStatus.ts`)
- Mounted simultaneously in `CustomToolAuthCard` and `ActionsPopover` with no deduplication → 2 requests to `/api/user-oauth-token/status` per mount
- React StrictMode double-invokes `useEffect` in dev → another duplicate
- Converted to `useSWR` with `dedupingInterval: 60_000`. SWR auto-deduplicates across all component instances sharing the same key

**`ProjectsContext.getRecentFiles`** (`web/src/providers/ProjectsContext.tsx`)
- The init `useEffect` called `getRecentFiles()` via raw `fetch()`. React StrictMode double-invokes effects on mount → 2 requests to `/api/user/files/recent`
- Replaced with a `useSWR` hook driving the same local state. The existing `allRecentFiles` merge effect and `refreshRecentFiles` are preserved; only the fetch mechanism changes

**Behavior preserved:**
- `refreshRecentFiles` still triggers a server revalidation (now via `mutate()`)
- `getRecentFiles` still works as an imperative call from context consumers
- `agentId` changes in `useToolOAuthStatus` still trigger a revalidation via `mutate()` in a `useEffect`

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check