### PR TITLE
fix(fe): Popover content doesnt overflow on small screens (#9612) to release v3.1

### DIFF
--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -142,6 +142,7 @@ function PopoverContent({
         collisionPadding={8}
         className={cn(
           "bg-background-neutral-00 p-1 z-popover rounded-12 border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "flex flex-col",
           "max-h-[var(--radix-popover-content-available-height)]",
           "overflow-hidden",
           widthClasses[width]
@@ -226,7 +227,7 @@ export function PopoverMenu({
   });
 
   return (
-    <Section alignItems="stretch">
+    <Section alignItems="stretch" height="auto" className="flex-1 min-h-0">
       <ShadowDiv
         scrollContainerRef={scrollContainerRef}
         className="flex flex-col gap-1 max-h-[20rem] w-full"

--- a/web/src/refresh-components/ShadowDiv.tsx
+++ b/web/src/refresh-components/ShadowDiv.tsx
@@ -105,7 +105,7 @@ export default function ShadowDiv({
   }, [containerRef, checkScroll]);
 
   return (
-    <div className="relative min-h-0">
+    <div className="relative min-h-0 flex flex-col">
       <div
         ref={containerRef}
         className={cn("overflow-y-auto", className)}


### PR DESCRIPTION
Cherry-pick of commit 2f672b3a4f215ffe8b045e933e8cb5f4d3f6cf48 to release/v3.1 branch.

Original PR: #9612

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents popover menus from overflowing on small screens by making the content layout flexible and scrollable. Keeps menu items visible within the viewport.

- **Bug Fixes**
  - Made `PopoverContent` and `ShadowDiv` flex column containers with `min-h-0` to allow proper height constraints and internal scrolling.
  - Updated `PopoverMenu` `Section` to `height="auto"` with `flex-1 min-h-0` so content scrolls inside the popover instead of overflowing.

<sup>Written for commit c31a8b26f83ba86c2dabb16fe979c361f64f4c7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

