### PR TITLE
chore(gha): pin helm release docker image

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -47,7 +47,8 @@ jobs:
           done
 
       - name: Publish Helm charts to gh-pages
-        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # ratchet:stefanprodan/helm-gh-pages@v1.7.0
+        # NOTE: HEAD of https://github.com/stefanprodan/helm-gh-pages/pull/42
+        uses: stefanprodan/helm-gh-pages@a30bb1574295fdff85fbb0efa6147f1e76bdf883
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts


### PR DESCRIPTION
## Description

This image is like 6 years old and we're getting rate-limited by Dockerhub, https://github.com/onyx-dot-app/onyx/actions/runs/23655494671/job/68911529671

## How Has This Been Tested?

:shrug: 

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the `stefanprodan/helm-gh-pages` action to a newer commit to use an up-to-date Docker image and avoid Docker Hub rate limiting when publishing Helm charts. Improves reliability of the Helm chart release workflow.

<sup>Written for commit ca3167ab11c1f63f92fa1b6eaf651f9292f7f567. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

