### PR TITLE
chore(gha): fix helm release after image update

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish Helm charts to gh-pages
         # NOTE: HEAD of https://github.com/stefanprodan/helm-gh-pages/pull/42
-        uses: stefanprodan/helm-gh-pages@a30bb1574295fdff85fbb0efa6147f1e76bdf883
+        uses: stefanprodan/helm-gh-pages@afc48f6110da0753ea6cb69e9e975020961a99be
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts


### PR DESCRIPTION
## Description

The onyx repo, not this `helm-gh-pages` repo, was being mounted inside the container and therefore failing to find the entrypoint, https://github.com/onyx-dot-app/onyx/actions/runs/23658635479/job/68922652739#step:7:10 . Updates the commit fix this.

## How Has This Been Tested?

:shrug: 

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Helm chart release by updating the `stefanprodan/helm-gh-pages` action so the workflow mounts the correct repo in the container and finds its entrypoint. This restores the publish step after the image update.

<sup>Written for commit 4e724ecdd1604f6d936a46c6ee57c736eaecd7b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

