### PR TITLE
chore(gha): helm release upstream nits

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish Helm charts to gh-pages
         # NOTE: HEAD of https://github.com/stefanprodan/helm-gh-pages/pull/43
-        uses: stefanprodan/helm-gh-pages@1061d7fae2594aecf5ffcb949c53bfe8b061aefd
+        uses: stefanprodan/helm-gh-pages@1061d7fae2594aecf5ffcb949c53bfe8b061aefd # zizmor: ignore[impostor-commit]
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts


### PR DESCRIPTION
## Description

That `bitnami/git` image was 1.3GB :woozy_face: so replace it with the base `alpine` image but pinned to latest of the official image.

## How Has This Been Tested?

:shrug: 

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Helm release workflow to `stefanprodan/helm-gh-pages` PR #43 (replaces PR #42) and add `zizmor: ignore[impostor-commit]`, so `gh-pages` includes the latest fixes.

<sup>Written for commit 8e5504c173f837855d93f9fe79eebdf3c0e2004d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

