### PR TITLE
chore(gha): fix git error after helm release migration to alpine base image

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish Helm charts to gh-pages
         # NOTE: HEAD of https://github.com/stefanprodan/helm-gh-pages/pull/43
-        uses: stefanprodan/helm-gh-pages@1061d7fae2594aecf5ffcb949c53bfe8b061aefd # zizmor: ignore[impostor-commit]
+        uses: stefanprodan/helm-gh-pages@ad32ad3b8720abfeaac83532fd1e9bdfca5bbe27 # zizmor: ignore[impostor-commit]
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts


### PR DESCRIPTION
## Description

Fixes https://github.com/onyx-dot-app/onyx/actions/runs/23660812081/job/68930239957#step:7:10: 

```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace

```

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Helm release workflow to a `stefanprodan/helm-gh-pages` version that fixes the Git "dubious ownership" error on Alpine, restoring chart publishing.

- **Bug Fixes**
  - Pins `stefanprodan/helm-gh-pages` to a ref that configures Git `safe.directory` for `/github/workspace`, preventing the fatal error during the publish step.

<sup>Written for commit 086614e01e7eef0c8928f0404031731373752963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

