### PR TITLE
fix(cli): `onyx-cli --version` interpolation

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,3 +1,4 @@
 onyx-cli
 cli
 onyx.cli
+__pycache__

--- a/cli/hatch_build.py
+++ b/cli/hatch_build.py
@@ -34,8 +34,7 @@ class CustomBuildHook(BuildHookInterface):
         # Build the Go binary (always rebuild to ensure correct version injection)
         if not os.path.exists(binary_name):
             print(f"Building Go binary '{binary_name}'...")
-            pkg = "github.com/onyx-dot-app/onyx/cli/cmd"
-            ldflags = f"-X {pkg}.version={tag}" f" -X {pkg}.commit={commit}" " -s -w"
+            ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
             subprocess.check_call(  # noqa: S603
                 ["go", "build", f"-ldflags={ldflags}", "-o", binary_name],
             )


### PR DESCRIPTION
## Description

I think the `version` and `commit` variables we're injecting was moved from `cmd/root.go` to `main.go` and this `pkg` should have been updated to match.


Currently the CLI gives the `dev` version and no sha,

```
$ uvx onyx-cli --version    
Installed 1 package in 58ms
onyx-cli version dev
```

## How Has This Been Tested?

```
$ GITHUB_REF_NAME="v0.1.2" GITHUB_SHA=$(git rev-parse HEAD) uv tool install .
$ ~/.local/bin/onyx-cli --version
onyx-cli version v0.1.2 (40420fc)
```

## Additional Options

- [x] [Optional] Override Linear Check
