### PR TITLE
fix(openpyxl): Colors must be aRGB hex values

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -44,6 +44,7 @@ KNOWN_OPENPYXL_BUGS = [
     "Value must be either numerical or a string containing a wildcard",
     "File contains no valid workbook part",
     "Unable to read workbook: could not read stylesheet from None",
+    "Colors must be aRGB hex values",
 ]
 
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
A customer is hitting an issue where the openpyxl is returning `"Colors must be aRGB hex values"` so we need to handle this error now

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options
https://linear.app/onyx-app/issue/CS-51

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle the `openpyxl` error "Colors must be aRGB hex values" during Excel text extraction to prevent crashes. Adds this message to the known workbook error list, addressing Linear CS-51.

<sup>Written for commit 138bf6313aebf419b51025d81cbaeacc047a5446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

