### PR TITLE
feat(opal): add SelectCard component and select-card Interactive variant

### DIFF
--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -1,0 +1,96 @@
+import "@opal/components/cards/select-card/styles.css";
+import type { ContainerSizeVariants } from "@opal/types";
+import { containerSizeVariants } from "@opal/shared";
+import { cn } from "@opal/utils";
+import { Interactive, type InteractiveStatefulProps } from "@opal/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SelectCardProps = InteractiveStatefulProps & {
+  /**
+   * Size preset — controls padding and border-radius.
+   *
+   * Padding comes from the shared size scale. Rounding follows the same
+   * mapping as `Card` / `Button` / `Interactive.Container`:
+   *
+   * | Size       | Rounding     |
+   * |------------|--------------|
+   * | `lg`       | `rounded-16` |
+   * | `md`–`sm`  | `rounded-12` |
+   * | `xs`–`2xs` | `rounded-08` |
+   * | `fit`      | `rounded-16` |
+   *
+   * @default "lg"
+   */
+  sizeVariant?: ContainerSizeVariants;
+
+  /** Ref forwarded to the root `<div>`. */
+  ref?: React.Ref<HTMLDivElement>;
+
+  children?: React.ReactNode;
+};
+
+// ---------------------------------------------------------------------------
+// Rounding
+// ---------------------------------------------------------------------------
+
+const roundingForSize: Record<ContainerSizeVariants, string> = {
+  lg: "rounded-16",
+  md: "rounded-12",
+  sm: "rounded-12",
+  xs: "rounded-08",
+  "2xs": "rounded-08",
+  fit: "rounded-16",
+};
+
+// ---------------------------------------------------------------------------
+// SelectCard
+// ---------------------------------------------------------------------------
+
+/**
+ * A stateful interactive card — the card counterpart to `SelectButton`.
+ *
+ * Built on `Interactive.Stateful` (Slot) → a structural `<div>`. The
+ * Stateful system owns background and foreground colors; the card owns
+ * padding, rounding, border, and overflow.
+ *
+ * Children are fully composable — use `ContentAction`, `Content`, buttons,
+ * `Interactive.Foldable`, etc. inside.
+ *
+ * @example
+ * ```tsx
+ * <SelectCard variant="select-heavy" state="selected" onClick={handleClick}>
+ *   <ContentAction
+ *     icon={SvgGlobe}
+ *     title="Google"
+ *     description="Search engine"
+ *     rightChildren={<Button>Set as Default</Button>}
+ *   />
+ * </SelectCard>
+ * ```
+ */
+function SelectCard({
+  sizeVariant = "lg",
+  ref,
+  children,
+  ...statefulProps
+}: SelectCardProps) {
+  const { padding } = containerSizeVariants[sizeVariant];
+  const rounding = roundingForSize[sizeVariant];
+
+  return (
+    <Interactive.Stateful {...statefulProps}>
+      <div ref={ref} className={cn("opal-select-card", padding, rounding)}>
+        {children}
+      </div>
+    </Interactive.Stateful>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { SelectCard, type SelectCardProps };

--- a/web/lib/opal/src/components/cards/select-card/styles.css
+++ b/web/lib/opal/src/components/cards/select-card/styles.css
@@ -1,0 +1,9 @@
+/* SelectCard — structural styles; colors handled by Interactive.Stateful */
+
+.opal-select-card {
+  @apply w-full overflow-clip border;
+}
+
+.opal-select-card[data-interactive-state="selected"] {
+  @apply border-action-link-05;
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -56,6 +56,12 @@ export {
   type BorderVariant,
 } from "@opal/components/cards/card/components";
 
+/* SelectCard */
+export {
+  SelectCard,
+  type SelectCardProps,
+} from "@opal/components/cards/select-card/components";
+
 /* EmptyMessageCard */
 export {
   EmptyMessageCard,

--- a/web/lib/opal/src/core/interactive/stateful/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateful/components.tsx
@@ -13,6 +13,7 @@ import type { ButtonType, WithoutStyles } from "@opal/types";
 type InteractiveStatefulVariant =
   | "select-light"
   | "select-heavy"
+  | "select-card"
   | "select-tinted"
   | "select-filter"
   | "sidebar-heavy"
@@ -32,6 +33,7 @@ interface InteractiveStatefulProps
    *
    * - `"select-light"` — transparent selected background (for inline toggles)
    * - `"select-heavy"` — tinted selected background (for list rows, model pickers)
+   * - `"select-card"` — like select-heavy but filled state has a visible background (for cards/larger surfaces)
    * - `"select-tinted"` — like select-heavy but with a tinted rest background
    * - `"select-filter"` — like select-tinted for empty/filled; selected state uses inverted tint backgrounds and inverted text (for filter buttons)
    * - `"sidebar-heavy"` — sidebar navigation items: muted when unselected (text-03/text-02), bold when selected (text-04/text-03)

--- a/web/lib/opal/src/core/interactive/stateful/styles.css
+++ b/web/lib/opal/src/core/interactive/stateful/styles.css
@@ -11,7 +11,7 @@
    Children read the variables with no independent transitions.
 
    State dimension: `data-interactive-state` = "empty" | "filled" | "selected"
-   Variant dimension: `data-interactive-variant` = "select-light" | "select-heavy" | "select-tinted" | "sidebar"
+   Variant dimension: `data-interactive-variant` = "select-light" | "select-heavy" | "select-card" | "select-tinted" | "select-filter" | "sidebar-heavy" | "sidebar-light"
 
    Interaction override: `data-interaction="hover"` and `data-interaction="active"`
    allow JS-controlled visual state overrides.
@@ -109,6 +109,108 @@
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"][data-disabled] {
+  @apply bg-transparent;
+  --interactive-foreground: var(--action-link-03);
+  --interactive-foreground-icon: var(--action-link-03);
+}
+
+/* ===========================================================================
+   Select-Card — like Select-Heavy but filled has a visible background.
+   Designed for larger surfaces (cards) where background carries more of
+   the visual distinction than foreground color alone.
+   =========================================================================== */
+
+/* ---------------------------------------------------------------------------
+   Select-Card — Empty
+   --------------------------------------------------------------------------- */
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"] {
+  @apply bg-transparent;
+  --interactive-foreground: var(--text-04);
+  --interactive-foreground-icon: var(--text-03);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"]:hover:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"][data-interaction="hover"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-tint-02;
+  --interactive-foreground-icon: var(--text-04);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"]:active:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"][data-interaction="active"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-neutral-00;
+  --interactive-foreground: var(--text-05);
+  --interactive-foreground-icon: var(--text-05);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="empty"][data-disabled] {
+  @apply bg-transparent;
+  --interactive-foreground: var(--text-01);
+  --interactive-foreground-icon: var(--text-01);
+}
+
+/* ---------------------------------------------------------------------------
+   Select-Card — Filled (visible background, neutral foreground)
+   --------------------------------------------------------------------------- */
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"] {
+  @apply bg-background-tint-00;
+  --interactive-foreground: var(--text-04);
+  --interactive-foreground-icon: var(--text-03);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"]:hover:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"][data-interaction="hover"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-tint-02;
+  --interactive-foreground-icon: var(--text-04);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"]:active:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"][data-interaction="active"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-tint-00;
+  --interactive-foreground: var(--text-05);
+  --interactive-foreground-icon: var(--text-05);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="filled"][data-disabled] {
+  @apply bg-transparent;
+  --interactive-foreground: var(--text-01);
+  --interactive-foreground-icon: var(--text-01);
+}
+
+/* ---------------------------------------------------------------------------
+   Select-Card — Selected
+   --------------------------------------------------------------------------- */
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"] {
+  @apply bg-[var(--action-link-01)];
+  --interactive-foreground: var(--action-link-05);
+  --interactive-foreground-icon: var(--action-link-05);
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"]:hover:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-interaction="hover"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-tint-02;
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"]:active:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-interaction="active"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-tint-00;
+}
+.interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-disabled] {
   @apply bg-transparent;
   --interactive-foreground: var(--action-link-03);
   --interactive-foreground-icon: var(--action-link-03);

--- a/web/lib/opal/src/layouts/cards/header-layout/components.tsx
+++ b/web/lib/opal/src/layouts/cards/header-layout/components.tsx
@@ -1,0 +1,73 @@
+import { Content, type ContentProps } from "@opal/layouts/content/components";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CardHeaderLayoutProps = ContentProps & {
+  /** Content rendered to the right of the Content block. */
+  rightChildren?: React.ReactNode;
+
+  /** Content rendered below `rightChildren` in the same column. */
+  bottomRightChildren?: React.ReactNode;
+};
+
+// ---------------------------------------------------------------------------
+// CardHeaderLayout
+// ---------------------------------------------------------------------------
+
+/**
+ * A card header layout that pairs a {@link Content} block (with `p-2`)
+ * with a right-side column.
+ *
+ * The right column contains two vertically stacked slots —
+ * `rightChildren` on top, `bottomRightChildren` below — with no
+ * padding or gap between them.
+ *
+ * @example
+ * ```tsx
+ * <CardHeaderLayout
+ *   icon={SvgGlobe}
+ *   title="Google"
+ *   description="Search engine"
+ *   sizePreset="main-ui"
+ *   variant="section"
+ *   rightChildren={<Button>Connect</Button>}
+ *   bottomRightChildren={
+ *     <>
+ *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
+ *       <Button icon={SvgSettings} size="sm" prominence="tertiary" />
+ *     </>
+ *   }
+ * />
+ * ```
+ */
+function CardHeaderLayout({
+  rightChildren,
+  bottomRightChildren,
+  ...contentProps
+}: CardHeaderLayoutProps) {
+  const hasRight = rightChildren || bottomRightChildren;
+
+  return (
+    <div className="flex flex-row items-stretch w-full">
+      <div className="flex-1 min-w-0 self-start p-2">
+        <Content {...contentProps} />
+      </div>
+      {hasRight && (
+        <div className="flex flex-col items-end justify-between shrink-0">
+          {rightChildren && <div>{rightChildren}</div>}
+          {bottomRightChildren && (
+            <div className="flex flex-row">{bottomRightChildren}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { CardHeaderLayout, type CardHeaderLayoutProps };

--- a/web/lib/opal/src/layouts/index.ts
+++ b/web/lib/opal/src/layouts/index.ts
@@ -12,6 +12,12 @@ export {
   type ContentActionProps,
 } from "@opal/layouts/content-action/components";
 
+/* CardHeaderLayout */
+export {
+  CardHeaderLayout,
+  type CardHeaderLayoutProps,
+} from "@opal/layouts/cards/header-layout/components";
+
 /* IllustrationContent */
 export {
   IllustrationContent,

--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -4,18 +4,27 @@ import Image from "next/image";
 import { useEffect, useMemo, useState, useReducer } from "react";
 import { InfoIcon } from "@/components/icons/icons";
 import Text from "@/refresh-components/texts/Text";
-import { Select } from "@/refresh-components/cards";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-import { Content } from "@opal/layouts";
+import { Content, CardHeaderLayout } from "@opal/layouts";
 import useSWR from "swr";
 import { errorHandlingFetcher, FetchError } from "@/lib/fetcher";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { Callout } from "@/components/ui/callout";
 import { cn } from "@/lib/utils";
 import { toast } from "@/hooks/useToast";
-import { SvgGlobe, SvgOnyxLogo, SvgSlash, SvgUnplug } from "@opal/icons";
-import { Button } from "@opal/components";
+import {
+  SvgArrowExchange,
+  SvgArrowRightCircle,
+  SvgCheckSquare,
+  SvgGlobe,
+  SvgOnyxLogo,
+  SvgSettings,
+  SvgSlash,
+  SvgUnplug,
+} from "@opal/icons";
+import { Button, SelectCard } from "@opal/components";
+import { Hoverable, Interactive } from "@opal/core";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { WebProviderSetupModal } from "@/app/admin/configuration/web-search/WebProviderSetupModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
@@ -218,6 +227,135 @@ function WebSearchDisconnectModal({
         </>
       )}
     </ConfirmationModalLayout>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ProviderCard — uses SelectCard for stateful interactive provider cards
+// ---------------------------------------------------------------------------
+
+type ProviderStatus = "disconnected" | "connected" | "selected";
+
+interface ProviderCardProps {
+  icon: React.FunctionComponent<{ size?: number; className?: string }>;
+  title: string;
+  description: string;
+  status: ProviderStatus;
+  onConnect?: () => void;
+  onSelect?: () => void;
+  onDeselect?: () => void;
+  onEdit?: () => void;
+  onDisconnect?: () => void;
+  selectedLabel?: string;
+}
+
+const STATUS_TO_STATE = {
+  disconnected: "empty",
+  connected: "filled",
+  selected: "selected",
+} as const;
+
+function ProviderCard({
+  icon,
+  title,
+  description,
+  status,
+  onConnect,
+  onSelect,
+  onDeselect,
+  onEdit,
+  onDisconnect,
+  selectedLabel = "Current Default",
+}: ProviderCardProps) {
+  const isDisconnected = status === "disconnected";
+  const isConnected = status === "connected";
+  const isSelected = status === "selected";
+
+  return (
+    <Hoverable.Root group="web-search/ProviderCard">
+      <SelectCard
+        variant="select-card"
+        state={STATUS_TO_STATE[status]}
+        sizeVariant="lg"
+        onClick={isDisconnected && onConnect ? onConnect : undefined}
+      >
+        <CardHeaderLayout
+          sizePreset="main-ui"
+          variant="section"
+          icon={icon}
+          title={title}
+          description={description}
+          rightChildren={
+            isDisconnected && onConnect ? (
+              <Button
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConnect();
+                }}
+              >
+                Connect
+              </Button>
+            ) : isConnected && onSelect ? (
+              <Hoverable.Item group="web-search/ProviderCard">
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgArrowRightCircle}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect();
+                  }}
+                >
+                  Set as Default
+                </Button>
+              </Hoverable.Item>
+            ) : isSelected ? (
+              <div className="p-2">
+                <Content
+                  title={selectedLabel}
+                  sizePreset="main-ui"
+                  variant="section"
+                  icon={SvgCheckSquare}
+                />
+              </div>
+            ) : undefined
+          }
+          bottomRightChildren={
+            !isDisconnected ? (
+              <div className="flex flex-row px-1 pb-1">
+                {onDisconnect && (
+                  <Hoverable.Item group="web-search/ProviderCard">
+                    <Button
+                      icon={SvgUnplug}
+                      tooltip="Disconnect"
+                      prominence="tertiary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDisconnect();
+                      }}
+                      size="md"
+                    />
+                  </Hoverable.Item>
+                )}
+                {onEdit && (
+                  <Button
+                    icon={SvgSettings}
+                    tooltip="Edit"
+                    prominence="tertiary"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEdit();
+                    }}
+                    size="md"
+                  />
+                )}
+              </div>
+            ) : undefined
+          }
+        />
+      </SelectCard>
+    </Hoverable.Root>
   );
 }
 
@@ -1091,7 +1229,7 @@ export default function Page() {
                         : "connected";
 
                   return (
-                    <Select
+                    <ProviderCard
                       key={`${key}-${providerType}`}
                       icon={() =>
                         logoSrc ? (
@@ -1207,7 +1345,7 @@ export default function Page() {
                   CONTENT_PROVIDER_DETAILS[provider.provider_type]?.logoSrc;
 
                 return (
-                  <Select
+                  <ProviderCard
                     key={`${provider.provider_type}-${provider.id}`}
                     icon={() =>
                       contentLogoSrc ? (


### PR DESCRIPTION
## Description

Add a stateful interactive card primitive (`SelectCard`) to the Opal design system, paralleling the `SelectButton` pattern:

- **`SelectCard`** (`@opal/components`) — Built on `Interactive.Stateful` (Slot) → structural div. Exposes the same `variant`/`state`/`interaction` props as `SelectButton`. Owns padding, rounding (bumped up one notch vs buttons — `rounded-16` at `lg`), border, and overflow. Children are fully composable.
- **`select-card` variant** (`Interactive.Stateful`) — Like `select-heavy` but tuned for larger surfaces: filled state gets `bg-background-tint-00` with neutral foreground (instead of transparent bg with blue text). Background carries the visual distinction on cards, not just foreground color.
- **`CardHeaderLayout`** (`@opal/layouts`) — A card header layout pairing `Content` (icon + title + description) with `rightChildren` and `bottomRightChildren` slots for vertically stacked actions.
- **Web-search refactor** — `/admin/configuration/web-search` now uses `SelectCard` + `CardHeaderLayout` instead of the legacy `Select` component from `refresh-components/cards`.

## How Has This Been Tested?

- `bun run types:check` passes cleanly
- Manual visual verification of the web-search admin page

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stateful `SelectCard` component and a new `select-card` `Interactive.Stateful` variant, plus a `CardHeaderLayout`, to improve card-based selection and actions. Refactors the web-search admin page to use these primitives for clearer, consistent UI.

- **New Features**
  - `SelectCard` (`@opal/components`): stateful card built on `Interactive.Stateful`; owns padding, rounding, border, and overflow; fully composable children.
  - `select-card` variant (`@opal/core`): tuned for larger surfaces; filled state uses `bg-background-tint-00` with neutral foreground.
  - `CardHeaderLayout` (`@opal/layouts`): header layout pairing `Content` with right and bottom-right action slots.

- **Refactors**
  - `/admin/configuration/web-search` now uses `SelectCard` + `CardHeaderLayout` and a `ProviderCard` wrapper, replacing the legacy `Select` from `refresh-components/cards`.

<sup>Written for commit ab967f99d2eed7b245ddfcfdebb00288bbacf39f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

