### PR TITLE
chore(fe): polish Query History table

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -330,46 +330,48 @@ export function QueryHistoryTable() {
           </div>
         </div>
         <Separator />
-        <Table className="py-4">
-          <TableHeader>
-            <TableRow>
-              <TableHead>First User Message</TableHead>
-              <TableHead>First AI Response</TableHead>
-              <TableHead>Feedback</TableHead>
-              <TableHead>User</TableHead>
-              <TableHead>Persona</TableHead>
-              <TableHead>Date</TableHead>
-            </TableRow>
-          </TableHeader>
-          {isLoading ? (
-            <TableBody>
+        <Section>
+          <Table className="mt-5">
+            <TableHeader>
               <TableRow>
-                <TableCell colSpan={6} className="text-center">
-                  <ThreeDotsLoader />
-                </TableCell>
+                <TableHead>First User Message</TableHead>
+                <TableHead>First AI Response</TableHead>
+                <TableHead>Feedback</TableHead>
+                <TableHead>User</TableHead>
+                <TableHead>Persona</TableHead>
+                <TableHead>Date</TableHead>
               </TableRow>
-            </TableBody>
-          ) : (
-            <TableBody>
-              {chatSessionData?.map((chatSessionMinimal) => (
-                <QueryHistoryTableRow
-                  key={chatSessionMinimal.id}
-                  chatSessionMinimal={chatSessionMinimal}
-                />
-              ))}
-            </TableBody>
-          )}
-        </Table>
+            </TableHeader>
+            {isLoading ? (
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center">
+                    <ThreeDotsLoader />
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            ) : (
+              <TableBody>
+                {chatSessionData?.map((chatSessionMinimal) => (
+                  <QueryHistoryTableRow
+                    key={chatSessionMinimal.id}
+                    chatSessionMinimal={chatSessionMinimal}
+                  />
+                ))}
+              </TableBody>
+            )}
+          </Table>
 
-        {chatSessionData && (
-          <Section>
-            <PageSelector
-              totalPages={totalPages}
-              currentPage={currentPage}
-              onPageChange={goToPage}
-            />
-          </Section>
-        )}
+          {chatSessionData && (
+            <Section>
+              <PageSelector
+                totalPages={totalPages}
+                currentPage={currentPage}
+                onPageChange={goToPage}
+              />
+            </Section>
+          )}
+        </Section>
       </CardSection>
 
       {showModal && (


### PR DESCRIPTION
## Description

Removes some custom HTML from this page

## How Has This Been Tested?

**before**
<img width="1602" height="2085" alt="20260330_12h20m50s_grim" src="https://github.com/user-attachments/assets/11037884-8df0-420e-9319-38f3508a79ad" />

**after**
<img width="1602" height="2085" alt="20260330_12h20m55s_grim" src="https://github.com/user-attachments/assets/f22ec8b1-fa0f-48a3-9668-ea5a22c24289" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Query History table by standardizing layout with `Section`, improving export UX with a proper `Button` for downloads, and tightening table spacing and pagination.

- **Refactors**
  - Used `Section` for filter controls, the main table block, and both paginations.
  - Simplified the Previous Exports modal by removing extra wrappers around the table.
  - Replaced the download link with a small, tertiary `Button` with icon; disabled until SUCCESS, with a tooltip and `href` only when ready.
  - Tweaked table spacing for more consistent layout.

<sup>Written for commit 631211c8ebefbd0cf5682d5fe1400eece15d7f73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

