### PR TITLE
chore(types): fix IconButton size props

### DIFF
--- a/web/src/refresh-components/buttons/IconButton.tsx
+++ b/web/src/refresh-components/buttons/IconButton.tsx
@@ -292,10 +292,9 @@ export interface IconButtonProps
   secondary?: boolean;
   tertiary?: boolean;
   internal?: boolean;
-  small?: boolean;
 
   // Button size
-  large?: boolean;
+  small?: boolean;
 
   // Button states
   transient?: boolean;


### PR DESCRIPTION
## Description

`large` does nothing when passed, so remove from the interface.

## How Has This Been Tested?

no-op

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `large` prop from `IconButtonProps` and kept `small` as the only size flag to match the component’s actual behavior and avoid confusion.

<sup>Written for commit af88b6b32f9b9ccf59e5f2c1a9f753aec1ee0bab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

