### PR TITLE
feat(sentry): add release tracking to backend and frontend

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -100,6 +100,7 @@ def get_model_app() -> FastAPI:
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
+            release=__version__,
         )
         logger.info("Sentry initialized")
     else:

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -20,6 +20,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from onyx import __version__
 from onyx.background.celery.apps.task_formatters import CeleryTaskColoredFormatter
 from onyx.background.celery.apps.task_formatters import CeleryTaskPlainFormatter
 from onyx.background.celery.celery_utils import celery_is_worker_primary
@@ -65,6 +66,7 @@ if SENTRY_DSN:
         dsn=SENTRY_DSN,
         integrations=[CeleryIntegration()],
         traces_sample_rate=0.1,
+        release=__version__,
     )
     logger.info("Sentry initialized")
 else:
@@ -515,7 +517,8 @@ def reset_tenant_id(
 
 
 def wait_for_vespa_or_shutdown(
-    sender: Any, **kwargs: Any  # noqa: ARG001
+    sender: Any,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
 ) -> None:  # noqa: ARG001
     """Waits for Vespa to become ready subject to a timeout.
     Raises WorkerShutdown if the timeout is reached."""

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -9,6 +9,7 @@ from celery import Celery
 from celery import shared_task
 from celery import Task
 
+from onyx import __version__
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.memory_monitoring import emit_process_memory
 from onyx.background.celery.tasks.docprocessing.heartbeat import start_heartbeat
@@ -137,6 +138,7 @@ def _docfetching_task(
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             traces_sample_rate=0.1,
+            release=__version__,
         )
         logger.info("Sentry initialized")
     else:

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -439,6 +439,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
+            release=__version__,
         )
         logger.info("Sentry initialized")
     else:

--- a/web/sentry.edge.config.ts
+++ b/web/sentry.edge.config.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/nextjs";
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
     // Only capture unhandled exceptions
     tracesSampleRate: 0,
     debug: false,

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/web/src/instrumentation-client.ts
+++ b/web/src/instrumentation-client.ts
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,


### PR DESCRIPTION
## Description

Adds `release` to all Sentry SDK initializations so errors can be correlated to specific deploys.

**Backend** — adds `release=__version__` to all four `sentry_sdk.init()` calls:
- `backend/onyx/main.py`
- `backend/onyx/background/celery/apps/app_base.py`
- `backend/onyx/background/celery/tasks/docfetching/tasks.py`
- `backend/model_server/main.py`

`__version__` is already set from the `ONYX_VERSION` env var at runtime, so no new env vars are needed on the backend.

**Frontend** — adds `release: process.env.SENTRY_RELEASE` to all three Sentry config files:
- `web/sentry.server.config.ts`
- `web/sentry.edge.config.ts`
- `web/src/instrumentation-client.ts`

**Infra requirement:** The deploy pipeline must set `SENTRY_RELEASE` (frontend) to the git ref at build time. This is a prerequisite for the follow-up source map upload PR.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check