### PR TITLE
chore(fe): prefer `Button` w/ `href` to wrapped `Link`

### DIFF
--- a/web/src/refresh-pages/admin/AgentsPage.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage.tsx
@@ -19,9 +19,9 @@ export default function AgentsPage() {
         description="Customize AI behavior and knowledge with agents. Manage agents in your organization."
         icon={SvgOnyxOctagon}
         rightChildren={
-          <Link href="/app/agents/create?admin=true">
-            <Button icon={SvgPlus}>New Agent</Button>
-          </Link>
+          <Button href="/app/agents/create?admin=true" icon={SvgPlus}>
+            New Agent
+          </Button>
         }
       />
       <SettingsLayouts.Body>


### PR DESCRIPTION
## Description

`Button` handles `href` internally, so no need to wrap with `Link`. This otherwise creates two distinct interactive elements which is confusing for a11y.

## How Has This Been Tested?

<img width="1512" height="2085" alt="20260330_14h35m36s_grim" src="https://github.com/user-attachments/assets/dc5c3212-70d4-4fbd-a507-3be0f39f1cbb" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the wrapped `Link` + `Button` with a single `Button` using `href` for the New Agent action on the Admin Agents page to remove nested interactive elements, improve accessibility, and keep navigation behavior unchanged.

<sup>Written for commit eb7427ccf87c95e47e0910f6b957e37820de52ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

