### PR TITLE
fix(llm): when multiple providers are same type ensure name is prioritized when default

### DIFF
--- a/web/src/lib/hooks.llmResolver.test.ts
+++ b/web/src/lib/hooks.llmResolver.test.ts
@@ -96,6 +96,54 @@ describe("LLM resolver helpers", () => {
     });
   });
 
+  test("prefers provider by name when multiple share the same type", () => {
+    const providers: LLMProviderDescriptor[] = [
+      makeProvider({
+        id: 1,
+        name: "Anthropic",
+        provider: "anthropic",
+        model_configurations: [
+          {
+            name: "claude-sonnet-4-5",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+      makeProvider({
+        id: 2,
+        name: "PersonalAnthropicToken",
+        provider: "anthropic",
+        model_configurations: [
+          {
+            name: "claude-sonnet-4-5",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+    ];
+
+    const descriptor = getValidLlmDescriptorForProviders(
+      structureValue(
+        "PersonalAnthropicToken",
+        "anthropic",
+        "claude-sonnet-4-5"
+      ),
+      providers
+    );
+
+    expect(descriptor).toEqual({
+      name: "PersonalAnthropicToken",
+      provider: "anthropic",
+      modelName: "claude-sonnet-4-5",
+    });
+  });
+
   test("uses first provider with models when no explicit default exists", () => {
     const providers: LLMProviderDescriptor[] = [
       makeProvider({

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -603,13 +603,16 @@ export function getValidLlmDescriptorForProviders(
     // This ensures we don't incorrectly match a model to the wrong provider
     // when the same model name exists across multiple providers (e.g., gpt-5 in Azure and OpenAI)
     if (model.provider && model.provider.length > 0) {
-      const matchingProvider = llmProviders.find(
-        (p) =>
-          p.provider === model.provider &&
-          p.model_configurations
-            .map((modelConfiguration) => modelConfiguration.name)
-            .includes(model.modelName)
+      const hasModel = (p: LLMProviderDescriptor) =>
+        p.model_configurations.some((mc) => mc.name === model.modelName);
+      const typeMatches = llmProviders.filter(
+        (p) => p.provider === model.provider && hasModel(p)
       );
+      // When multiple providers share the same type (e.g., two "anthropic"
+      // providers with different API keys), prefer the one whose name matches
+      // the user's explicit selection to avoid silently switching providers.
+      const matchingProvider =
+        typeMatches.find((p) => p.name === model.name) ?? typeMatches[0];
       if (matchingProvider) {
         return {
           ...model,


### PR DESCRIPTION
## Description
Respect correct default provider when multiple providers of same type are present
[Discord thread](https://discord.com/channels/1119886360506023946/1475489245169844246/1475489245169844246)
[ENG-3760](https://linear.app/onyx-app/issue/ENG-3760/2nd-llm-turn-swaps-provider)
## How Has This Been Tested?

Minimal change- Added new unit test
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
