### PR TITLE
fix(a11y): migrate some buttons to `Hoverable`

### DIFF
--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -1,5 +1,5 @@
 import { SvgDownload, SvgKey, SvgRefreshCw } from "@opal/icons";
-import { Interactive } from "@opal/core";
+import { Interactive, Hoverable } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
@@ -83,27 +83,30 @@ export default function ScimModal({
               onClose={onClose}
             />
             <Modal.Body>
-              <Interactive.Stateless
-                group="group/token"
-                onClick={() => copyToClipboard(view.rawToken)}
-              >
-                <InputTextArea
-                  value={view.rawToken}
-                  readOnly
-                  autoResize
-                  resizable={false}
-                  rows={2}
-                  className="font-main-ui-mono break-all cursor-pointer [&_textarea]:cursor-pointer"
-                  rightSection={
-                    <div
-                      className="opacity-0 group-hover/token:opacity-100 transition-opacity"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <CopyIconButton getCopyText={() => view.rawToken} />
-                    </div>
-                  }
-                />
-              </Interactive.Stateless>
+              <Hoverable.Root group="token">
+                <Interactive.Stateless
+                  onClick={() => copyToClipboard(view.rawToken)}
+                >
+                  <InputTextArea
+                    value={view.rawToken}
+                    readOnly
+                    autoResize
+                    resizable={false}
+                    rows={2}
+                    className="font-main-ui-mono break-all cursor-pointer [&_textarea]:cursor-pointer"
+                    rightSection={
+                      <div onClick={(e) => e.stopPropagation()}>
+                        <Hoverable.Item
+                          group="token"
+                          variant="opacity-on-hover"
+                        >
+                          <CopyIconButton getCopyText={() => view.rawToken} />
+                        </Hoverable.Item>
+                      </div>
+                    }
+                  />
+                </Interactive.Stateless>
+              </Hoverable.Root>
             </Modal.Body>
             <Modal.Footer>
               <BasicModalFooter

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -4,6 +4,7 @@ import { ImageShape } from "@/app/app/services/streamingModels";
 import { FullImageModal } from "@/app/app/components/files/images/FullImageModal";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Button } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import { cn } from "@/lib/utils";
 
 const DEFAULT_SHAPE: ImageShape = "square";
@@ -76,42 +77,42 @@ export const InMessageImage = memo(function InMessageImage({
         onOpenChange={(open) => setFullImageShowing(open)}
       />
 
-      <div className={cn("relative group", shapeContainerClasses)}>
-        {!imageLoaded && (
-          <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />
-        )}
-
-        <img
-          width={1200}
-          height={1200}
-          alt="Chat Message Image"
-          onLoad={() => {
-            loadedImages.add(fileId);
-            setImageLoaded(true);
-          }}
-          className={cn(
-            "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
-            shapeImageClasses,
-            imageLoaded ? "opacity-100" : "opacity-0"
+      <Hoverable.Root group="messageImage" widthVariant="fit">
+        <div className={cn("relative", shapeContainerClasses)}>
+          {!imageLoaded && (
+            <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />
           )}
-          onClick={() => setFullImageShowing(true)}
-          src={buildImgUrl(fileId)}
-          loading="lazy"
-        />
 
-        {/* Download button - appears on hover */}
-        <div
-          className={cn(
-            "absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 z-10"
-          )}
-        >
-          <Button
-            icon={SvgDownload}
-            tooltip="Download"
-            onClick={handleDownload}
+          <img
+            width={1200}
+            height={1200}
+            alt="Chat Message Image"
+            onLoad={() => {
+              loadedImages.add(fileId);
+              setImageLoaded(true);
+            }}
+            className={cn(
+              "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
+              shapeImageClasses,
+              imageLoaded ? "opacity-100" : "opacity-0"
+            )}
+            onClick={() => setFullImageShowing(true)}
+            src={buildImgUrl(fileId)}
+            loading="lazy"
           />
+
+          {/* Download button - appears on hover */}
+          <div className="absolute bottom-2 right-2 z-10">
+            <Hoverable.Item group="messageImage" variant="opacity-on-hover">
+              <Button
+                icon={SvgDownload}
+                tooltip="Download"
+                onClick={handleDownload}
+              />
+            </Hoverable.Item>
+          </div>
         </div>
-      </div>
+      </Hoverable.Root>
     </>
   );
 });

--- a/web/src/app/app/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/app/components/projects/ProjectContextPanel.tsx
@@ -20,6 +20,7 @@ import IconButton from "@/refresh-components/buttons/IconButton";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
 import { UserFileStatus } from "../../projects/projectsService";
 import { SvgAddLines, SvgEdit, SvgFiles, SvgFolderOpen } from "@opal/icons";
+import { Hoverable } from "@opal/core";
 
 export interface ProjectContextPanelProps {
   projectTokenCount?: number;
@@ -133,34 +134,40 @@ export default function ProjectContextPanel({
       <div className="flex flex-col gap-6 w-full max-w-[var(--app-page-main-content-width)] mx-auto p-4 pt-14 pb-6">
         <div className="flex flex-col gap-1 text-text-04">
           <SvgFolderOpen className="h-8 w-8 text-text-04" />
-          <div className="group flex items-center gap-2">
-            {isEditingName ? (
-              <ButtonRenaming
-                initialName={projectName}
-                onRename={async (newName) => {
-                  if (currentProjectId) {
-                    await renameProject(currentProjectId, newName);
-                  }
-                }}
-                onClose={cancelEditing}
-                className="font-heading-h2 text-text-04"
-              />
-            ) : (
-              <>
-                <Text as="p" headingH2 className="font-heading-h2">
-                  {projectName}
-                </Text>
-                {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-                <IconButton
-                  icon={SvgEdit}
-                  internal
-                  onClick={startEditing}
-                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-                  tooltip="Edit project name"
+          <Hoverable.Root group="projectName" widthVariant="fit">
+            <div className="flex items-center gap-2">
+              {isEditingName ? (
+                <ButtonRenaming
+                  initialName={projectName}
+                  onRename={async (newName) => {
+                    if (currentProjectId) {
+                      await renameProject(currentProjectId, newName);
+                    }
+                  }}
+                  onClose={cancelEditing}
+                  className="font-heading-h2 text-text-04"
                 />
-              </>
-            )}
-          </div>
+              ) : (
+                <>
+                  <Text as="p" headingH2 className="font-heading-h2">
+                    {projectName}
+                  </Text>
+                  {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+                  <Hoverable.Item
+                    group="projectName"
+                    variant="opacity-on-hover"
+                  >
+                    <IconButton
+                      icon={SvgEdit}
+                      internal
+                      onClick={startEditing}
+                      tooltip="Edit project name"
+                    />
+                  </Hoverable.Item>
+                </>
+              )}
+            </div>
+          </Hoverable.Root>
         </div>
 
         <Separator className="py-0" />

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -10,6 +10,7 @@ import useScreenSize from "@/hooks/useScreenSize";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Button } from "@opal/components";
 import { SvgEdit } from "@opal/icons";
+import { Hoverable } from "@opal/core";
 import FileDisplay from "./FileDisplay";
 
 interface MessageEditingProps {
@@ -170,9 +171,9 @@ const HumanMessage = React.memo(function HumanMessage({
     return undefined;
   };
 
-  const copyEditButton = useMemo(
+  const copyEditButtonContent = useMemo(
     () => (
-      <div className="flex flex-row flex-shrink px-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="flex flex-row flex-shrink px-1">
         <CopyIconButton
           getCopyText={() => content}
           prominence="tertiary"
@@ -190,86 +191,94 @@ const HumanMessage = React.memo(function HumanMessage({
     [content]
   );
 
+  const copyEditButton = (
+    <Hoverable.Item group="humanMessage" variant="opacity-on-hover">
+      {copyEditButtonContent}
+    </Hoverable.Item>
+  );
+
   return (
-    <div
-      id="onyx-human-message"
-      className="group flex flex-col justify-end w-full relative"
-    >
-      <FileDisplay files={files || []} />
-      {isEditing ? (
-        <MessageEditing
-          content={content}
-          onSubmitEdit={(editedContent) => {
-            // Don't update UI for edits that can't be persisted
-            if (messageId === undefined || messageId === null) {
-              setIsEditing(false);
-              return;
-            }
-            onEdit?.(editedContent, messageId);
-            setContent(editedContent);
-            setIsEditing(false);
-          }}
-          onCancelEdit={() => setIsEditing(false)}
-        />
-      ) : (
-        <div className="flex justify-end">
-          {onEdit && !isMobile && copyEditButton}
-          <div className="md:max-w-[37.5rem]">
-            <div
-              className={
-                "max-w-[30rem] md:max-w-[37.5rem] whitespace-break-spaces break-anywhere rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
+    <Hoverable.Root group="humanMessage" widthVariant="full">
+      <div
+        id="onyx-human-message"
+        className="flex flex-col justify-end w-full relative"
+      >
+        <FileDisplay files={files || []} />
+        {isEditing ? (
+          <MessageEditing
+            content={content}
+            onSubmitEdit={(editedContent) => {
+              // Don't update UI for edits that can't be persisted
+              if (messageId === undefined || messageId === null) {
+                setIsEditing(false);
+                return;
               }
-              onCopy={(e) => {
-                const selection = window.getSelection();
-                if (selection) {
-                  e.preventDefault();
-                  const text = selection
-                    .toString()
-                    .replace(/\n{2,}/g, "\n")
-                    .trim();
-                  e.clipboardData.setData("text/plain", text);
+              onEdit?.(editedContent, messageId);
+              setContent(editedContent);
+              setIsEditing(false);
+            }}
+            onCancelEdit={() => setIsEditing(false)}
+          />
+        ) : (
+          <div className="flex justify-end">
+            {onEdit && !isMobile && copyEditButton}
+            <div className="md:max-w-[37.5rem]">
+              <div
+                className={
+                  "max-w-[30rem] md:max-w-[37.5rem] whitespace-break-spaces break-anywhere rounded-t-16 rounded-bl-16 bg-background-tint-02 py-2 px-3"
                 }
-              }}
-            >
-              <Text
-                as="p"
-                className="inline-block align-middle"
-                mainContentBody
+                onCopy={(e) => {
+                  const selection = window.getSelection();
+                  if (selection) {
+                    e.preventDefault();
+                    const text = selection
+                      .toString()
+                      .replace(/\n{2,}/g, "\n")
+                      .trim();
+                    e.clipboardData.setData("text/plain", text);
+                  }
+                }}
               >
-                {content}
-              </Text>
+                <Text
+                  as="p"
+                  className="inline-block align-middle"
+                  mainContentBody
+                >
+                  {content}
+                </Text>
+              </div>
             </div>
           </div>
+        )}
+        <div className="flex justify-end pt-1">
+          {!isEditing && onEdit && isMobile && copyEditButton}
+          {currentMessageInd !== undefined &&
+            onMessageSelection &&
+            otherMessagesCanSwitchTo &&
+            otherMessagesCanSwitchTo.length > 1 && (
+              <MessageSwitcher
+                disableForStreaming={disableSwitchingForStreaming}
+                currentPage={currentMessageInd + 1}
+                totalPages={otherMessagesCanSwitchTo.length}
+                handlePrevious={() => {
+                  stopGenerating();
+                  const prevMessage = getPreviousMessage();
+                  if (prevMessage !== undefined) {
+                    onMessageSelection(prevMessage);
+                  }
+                }}
+                handleNext={() => {
+                  stopGenerating();
+                  const nextMessage = getNextMessage();
+                  if (nextMessage !== undefined) {
+                    onMessageSelection(nextMessage);
+                  }
+                }}
+              />
+            )}
         </div>
-      )}
-      <div className="flex justify-end pt-1">
-        {!isEditing && onEdit && isMobile && copyEditButton}
-        {currentMessageInd !== undefined &&
-          onMessageSelection &&
-          otherMessagesCanSwitchTo &&
-          otherMessagesCanSwitchTo.length > 1 && (
-            <MessageSwitcher
-              disableForStreaming={disableSwitchingForStreaming}
-              currentPage={currentMessageInd + 1}
-              totalPages={otherMessagesCanSwitchTo.length}
-              handlePrevious={() => {
-                stopGenerating();
-                const prevMessage = getPreviousMessage();
-                if (prevMessage !== undefined) {
-                  onMessageSelection(prevMessage);
-                }
-              }}
-              handleNext={() => {
-                stopGenerating();
-                const nextMessage = getNextMessage();
-                if (nextMessage !== undefined) {
-                  onMessageSelection(nextMessage);
-                }
-              }}
-            />
-          )}
       </div>
-    </div>
+    </Hoverable.Root>
   );
 }, arePropsEqual);
 

--- a/web/src/refresh-components/inputs/InputImage.tsx
+++ b/web/src/refresh-components/inputs/InputImage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React from "react";
 import { cn, noProp } from "@/lib/utils";
 import { SvgPlus, SvgX } from "@opal/icons";
+import { Hoverable } from "@opal/core";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import Text from "@/refresh-components/texts/Text";
@@ -173,103 +173,106 @@ export default function InputImage({
   const dropzoneProps = onDrop ? getRootProps() : {};
 
   return (
-    <div
-      className={cn("relative group", className)}
-      style={{ width: size, height: size }}
-      {...dropzoneProps}
-    >
-      {/* Hidden input for file selection */}
-      {onDrop && <input {...getInputProps()} />}
-
-      {/* Main container */}
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={disabled}
-        className={cn(
-          "relative w-full h-full rounded-full overflow-hidden",
-          "border flex items-center justify-center",
-          "transition-all duration-150",
-          containerClass
-        )}
-        aria-label={
-          isInteractive ? (hasImage ? "Edit image" : "Upload image") : undefined
-        }
+    <Hoverable.Root group="inputImage" widthVariant="fit">
+      <div
+        className={cn("relative", className)}
+        style={{ width: size, height: size }}
+        {...dropzoneProps}
       >
-        {/* Content */}
-        {hasImage ? (
-          <img
-            src={src}
-            alt={alt}
-            className="absolute inset-0 w-full h-full object-cover pointer-events-none"
-          />
-        ) : (
-          <SvgPlus
-            className={cn("w-6 h-6", placeholderClass, "pointer-events-none")}
-          />
-        )}
+        {/* Hidden input for file selection */}
+        {onDrop && <input {...getInputProps()} />}
 
-        {/* Drag overlay indicator */}
-        {isDragActive && (
-          <div className="absolute inset-0 bg-action-link-05/10 flex items-center justify-center rounded-full pointer-events-none">
-            <SvgPlus className="w-8 h-8 stroke-action-link-05" />
-          </div>
-        )}
+        {/* Main container */}
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={disabled}
+          className={cn(
+            "group relative w-full h-full rounded-full overflow-hidden",
+            "border flex items-center justify-center",
+            "transition-all duration-150",
+            containerClass
+          )}
+          aria-label={
+            isInteractive
+              ? hasImage
+                ? "Edit image"
+                : "Upload image"
+              : undefined
+          }
+        >
+          {/* Content */}
+          {hasImage ? (
+            <img
+              src={src}
+              alt={alt}
+              className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+            />
+          ) : (
+            <SvgPlus
+              className={cn("w-6 h-6", placeholderClass, "pointer-events-none")}
+            />
+          )}
 
-        {/* Edit overlay - shows on hover/focus when image is uploaded */}
-        {showEditOverlay && isInteractive && hasImage && !isDragActive && (
-          <div
-            className={cn(
-              "absolute bottom-0 left-0 right-0",
-              "flex items-center justify-center",
-              "pb-2.5 pt-1.5",
-              "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
-              "transition-opacity duration-150",
-              "backdrop-blur-sm bg-mask-01",
-              "pointer-events-none"
-            )}
-          >
-            <div className="pointer-events-auto">
-              <SimpleTooltip tooltip="Edit" side="top">
+          {/* Drag overlay indicator */}
+          {isDragActive && (
+            <div className="absolute inset-0 bg-action-link-05/10 flex items-center justify-center rounded-full pointer-events-none">
+              <SvgPlus className="w-8 h-8 stroke-action-link-05" />
+            </div>
+          )}
+
+          {/* Edit overlay - shows on hover/focus when image is uploaded */}
+          {showEditOverlay && isInteractive && hasImage && !isDragActive && (
+            <div className="absolute bottom-0 left-0 right-0 pointer-events-none">
+              <Hoverable.Item group="inputImage" variant="opacity-on-hover">
                 <div
                   className={cn(
                     "flex items-center justify-center",
-                    "px-1 py-0.5 rounded-08"
+                    "pb-2.5 pt-1.5",
+                    "backdrop-blur-sm bg-mask-01",
+                    "pointer-events-none"
                   )}
                 >
-                  <Text
-                    className="text-text-03 font-secondary-action"
-                    style={{ fontSize: "12px", lineHeight: "16px" }}
-                  >
-                    Edit
-                  </Text>
+                  <div className="pointer-events-auto">
+                    <SimpleTooltip tooltip="Edit" side="top">
+                      <div
+                        className={cn(
+                          "flex items-center justify-center",
+                          "px-1 py-0.5 rounded-08"
+                        )}
+                      >
+                        <Text
+                          className="text-text-03 font-secondary-action"
+                          style={{ fontSize: "12px", lineHeight: "16px" }}
+                        >
+                          Edit
+                        </Text>
+                      </div>
+                    </SimpleTooltip>
+                  </div>
                 </div>
-              </SimpleTooltip>
+              </Hoverable.Item>
             </div>
+          )}
+        </button>
+
+        {/* Remove button - top left corner (only when image is uploaded) */}
+        {isInteractive && hasImage && onRemove && (
+          <div className="absolute top-1 left-1">
+            <Hoverable.Item group="inputImage" variant="opacity-on-hover">
+              {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+              <IconButton
+                icon={SvgX}
+                onClick={noProp(onRemove)}
+                type="button"
+                primary
+                className="!w-5 !h-5 !p-0.5 !rounded-04"
+                aria-label="Remove image"
+              />
+            </Hoverable.Item>
           </div>
         )}
-      </button>
-
-      {/* Remove button - top left corner (only when image is uploaded) */}
-      {isInteractive && hasImage && onRemove && (
-        <div
-          className={cn(
-            "absolute top-1 left-1",
-            "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
-            "transition-opacity duration-150"
-          )}
-        >
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <IconButton
-            icon={SvgX}
-            onClick={noProp(onRemove)}
-            type="button"
-            primary
-            className="!w-5 !h-5 !p-0.5 !rounded-04"
-            aria-label="Remove image"
-          />
-        </div>
-      )}
-    </div>
+      </div>
+    </Hoverable.Root>
   );
 }

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from "react";
 import { cn, noProp } from "@/lib/utils";
 import { SvgMaximize2, SvgTextLines, SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";
+import { Hoverable } from "@opal/core";
 import IconButton from "../buttons/IconButton";
 import Text from "../texts/Text";
 import Truncated from "../texts/Truncated";
@@ -32,25 +33,32 @@ interface RemoveButtonProps {
 
 function RemoveButton({ onRemove }: RemoveButtonProps) {
   return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onRemove();
-      }}
-      title="Remove"
-      aria-label="Remove"
+    <div
       className={cn(
-        "absolute -left-1 -top-1 z-10 h-4 w-4",
-        "flex items-center justify-center",
-        "rounded-full bg-theme-primary-05 text-text-inverted-05",
-        "opacity-0 group-hover/Tile:opacity-100 focus:opacity-100",
-        "pointer-events-none group-hover/Tile:pointer-events-auto focus:pointer-events-auto",
-        "transition-opacity duration-150"
+        "absolute -left-1 -top-1 z-10",
+        "pointer-events-none focus-within:pointer-events-auto"
       )}
     >
-      <SvgX size={10} />
-    </button>
+      <Hoverable.Item group="fileTile" variant="opacity-on-hover">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          title="Remove"
+          aria-label="Remove"
+          className={cn(
+            "h-4 w-4",
+            "flex items-center justify-center",
+            "rounded-full bg-theme-primary-05 text-text-inverted-05",
+            "pointer-events-auto"
+          )}
+        >
+          <SvgX size={10} />
+        </button>
+      </Hoverable.Item>
+    </div>
   );
 }
 
@@ -70,7 +78,7 @@ export default function FileTile({
   const isMuted = state === "processing" || state === "disabled";
 
   return (
-    <div className="group/Tile">
+    <Hoverable.Root group="fileTile" widthVariant="fit">
       <div
         onClick={onOpen && state !== "disabled" ? () => onOpen() : undefined}
         className={cn(
@@ -83,8 +91,8 @@ export default function FileTile({
             ? "bg-background-neutral-02 border-border-01"
             : "bg-background-tint-00 border-border-01",
           // Hover overrides (disabled gets none)
-          state !== "disabled" && "group-hover/Tile:border-border-02",
-          state === "default" && "group-hover/Tile:bg-background-tint-02",
+          state !== "disabled" && "hover:border-border-02",
+          state === "default" && "hover:bg-background-tint-02",
           // Clickable cursor when onOpen is provided and not disabled
           onOpen && state !== "disabled" && "cursor-pointer"
         )}
@@ -114,7 +122,7 @@ export default function FileTile({
                     text02
                     className={cn(
                       "truncate",
-                      state === "processing" && "group-hover/Tile:text-text-03"
+                      state === "processing" && "hover:text-text-03"
                     )}
                   >
                     {title}
@@ -126,7 +134,7 @@ export default function FileTile({
                     text02
                     className={cn(
                       "line-clamp-2",
-                      state === "processing" && "group-hover/Tile:text-text-03"
+                      state === "processing" && "hover:text-text-03"
                     )}
                   >
                     {description}
@@ -159,6 +167,6 @@ export default function FileTile({
           </div>
         )}
       </div>
-    </div>
+    </Hoverable.Root>
   );
 }

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -6,7 +6,7 @@ import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
 import { Button as OpalButton } from "@opal/components";
-import { Disabled } from "@opal/core";
+import { Disabled, Hoverable } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Formik, Form, FieldArray } from "formik";
@@ -212,22 +212,25 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
 
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <Popover.Trigger asChild>
-          <InputAvatar className="group/InputAvatar relative flex flex-col items-center justify-center h-[7.5rem] w-[7.5rem]">
-            {/* We take the `InputAvatar`'s height/width (in REM) and multiply it by 16 (the REM -> px conversion factor). */}
-            <CustomAgentAvatar
-              size={imageSrc ? 7.5 * 16 : 40}
-              src={imageSrc}
-              iconName={values.icon_name ?? undefined}
-              name={values.name}
-            />
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <Button
-              className="absolute bottom-0 left-1/2 -translate-x-1/2 h-[1.75rem] mb-2 invisible group-hover/InputAvatar:visible"
-              secondary
-            >
-              Edit
-            </Button>
-          </InputAvatar>
+          <Hoverable.Root group="inputAvatar" widthVariant="fit">
+            <InputAvatar className="relative flex flex-col items-center justify-center h-[7.5rem] w-[7.5rem]">
+              {/* We take the `InputAvatar`'s height/width (in REM) and multiply it by 16 (the REM -> px conversion factor). */}
+              <CustomAgentAvatar
+                size={imageSrc ? 7.5 * 16 : 40}
+                src={imageSrc}
+                iconName={values.icon_name ?? undefined}
+                name={values.name}
+              />
+              {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+              <div className="absolute bottom-0 left-1/2 -translate-x-1/2 mb-2">
+                <Hoverable.Item group="inputAvatar" variant="opacity-on-hover">
+                  <Button className="h-[1.75rem]" secondary>
+                    Edit
+                  </Button>
+                </Hoverable.Item>
+              </div>
+            </InputAvatar>
+          </Hoverable.Root>
         </Popover.Trigger>
         <Popover.Content>
           <PopoverMenu>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -54,7 +54,7 @@ import useOpenApiTools from "@/hooks/useOpenApiTools";
 import * as ExpandableCard from "@/layouts/expandable-card-layouts";
 import * as ActionsLayouts from "@/layouts/actions-layouts";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
-import { Disabled } from "@opal/core";
+import { Disabled, Hoverable } from "@opal/core";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import useFilter from "@/hooks/useFilter";
@@ -281,7 +281,7 @@ function NumericLimitField({
   };
 
   return (
-    <div className="group w-full">
+    <Hoverable.Root group="numericLimit" widthVariant="full">
       <InputTypeInField
         name={name}
         inputMode="numeric"
@@ -291,7 +291,7 @@ function NumericLimitField({
         variant={isOverMax ? "error" : undefined}
         rightSection={
           (value || "") !== defaultValue ? (
-            <div className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+            <Hoverable.Item group="numericLimit" variant="opacity-on-hover">
               <IconButton
                 icon={SvgRefreshCw}
                 tooltip="Restore default"
@@ -299,12 +299,12 @@ function NumericLimitField({
                 type="button"
                 onClick={handleRestore}
               />
-            </div>
+            </Hoverable.Item>
           ) : undefined
         }
         onBlur={handleBlur}
       />
-    </div>
+    </Hoverable.Root>
   );
 }
 

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -1,6 +1,7 @@
 import { SvgArrowUpRight, SvgFilterPlus, SvgUserSync } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -22,33 +23,38 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
   const display = value === null ? "\u2014" : value.toLocaleString();
 
   return (
-    <div
-      className={`group/stat relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
-        onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""
-      }`}
-      onClick={onFilter}
-    >
-      <Text as="span" mainUiAction text04>
-        {display}
-      </Text>
-      <Text as="span" secondaryBody text03>
-        {label}
-      </Text>
-      {onFilter && (
-        <IconButton
-          tertiary
-          icon={SvgFilterPlus}
-          tooltip="Add Filter"
-          toolTipPosition="left"
-          tooltipSize="sm"
-          className="absolute right-1 top-1 opacity-0 group-hover/stat:opacity-100 transition-opacity"
-          onClick={(e) => {
-            e.stopPropagation();
-            onFilter();
-          }}
-        />
-      )}
-    </div>
+    <Hoverable.Root group="stat" widthVariant="full">
+      <div
+        className={`relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
+          onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""
+        }`}
+        onClick={onFilter}
+      >
+        <Text as="span" mainUiAction text04>
+          {display}
+        </Text>
+        <Text as="span" secondaryBody text03>
+          {label}
+        </Text>
+        {onFilter && (
+          <div className="absolute right-1 top-1">
+            <Hoverable.Item group="stat" variant="opacity-on-hover">
+              <IconButton
+                tertiary
+                icon={SvgFilterPlus}
+                tooltip="Add Filter"
+                toolTipPosition="left"
+                tooltipSize="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onFilter();
+                }}
+              />
+            </Hoverable.Item>
+          </div>
+        )}
+      </div>
+    </Hoverable.Root>
   );
 }
 

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -11,7 +11,7 @@ import Separator from "@/refresh-components/Separator";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Button } from "@opal/components";
-import { Disabled } from "@opal/core";
+import { Disabled, Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
 import {
   validateToolDefinition,
@@ -243,31 +243,40 @@ function FormContent({
             `Specify an OpenAPI schema that defines the APIs you want to make available as part of this action. Learn more about [OpenAPI actions](${DOCS_ADMINS_PATH}/actions/openapi).`
           )}
         >
-          <div className="group/DefinitionTextAreaField relative w-full">
-            {values.definition.trim() && (
-              <div className="invisible group-hover/DefinitionTextAreaField:visible absolute z-[100000] top-2 right-2 bg-background-tint-00">
-                <CopyIconButton
-                  prominence="tertiary"
-                  size="sm"
-                  getCopyText={() => values.definition}
-                  tooltip="Copy definition"
-                />
-                <Button
-                  prominence="tertiary"
-                  size="sm"
-                  icon={SvgBracketCurly}
-                  tooltip="Format definition"
-                  onClick={handleFormat}
-                />
-              </div>
-            )}
-            <InputTextAreaField
-              name="definition"
-              rows={14}
-              placeholder="Enter your OpenAPI schema here"
-              className="font-main-ui-mono"
-            />
-          </div>
+          <Hoverable.Root group="definitionField" widthVariant="full">
+            <div className="relative w-full">
+              {values.definition.trim() && (
+                <div className="absolute z-[100000] top-2 right-2 bg-background-tint-00">
+                  <Hoverable.Item
+                    group="definitionField"
+                    variant="opacity-on-hover"
+                  >
+                    <div className="flex">
+                      <CopyIconButton
+                        prominence="tertiary"
+                        size="sm"
+                        getCopyText={() => values.definition}
+                        tooltip="Copy definition"
+                      />
+                      <Button
+                        prominence="tertiary"
+                        size="sm"
+                        icon={SvgBracketCurly}
+                        tooltip="Format definition"
+                        onClick={handleFormat}
+                      />
+                    </div>
+                  </Hoverable.Item>
+                </div>
+              )}
+              <InputTextAreaField
+                name="definition"
+                rows={14}
+                placeholder="Enter your OpenAPI schema here"
+                className="font-main-ui-mono"
+              />
+            </div>
+          </Hoverable.Root>
         </InputLayouts.Vertical>
 
         <Separator noPadding />

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -6,7 +6,7 @@ import { UserFileStatus } from "@/app/app/projects/projectsService";
 import { cn, isImageFile } from "@/lib/utils";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { SvgFileText, SvgX } from "@opal/icons";
-import { Interactive } from "@opal/core";
+import { Interactive, Hoverable } from "@opal/core";
 import { AttachmentItemLayout } from "@/layouts/general-layouts";
 import Spacer from "@/refresh-components/Spacer";
 
@@ -21,29 +21,39 @@ function Removable({ onRemove, children }: RemovableProps) {
   }
 
   return (
-    <div className="relative group">
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove();
-        }}
-        title="Remove"
-        aria-label="Remove"
-        className={cn(
-          "absolute -left-2 -top-2 z-10 h-4 w-4",
-          "flex items-center justify-center",
-          "rounded-04 border border-border text-[11px]",
-          "bg-background-neutral-inverted-01 text-text-inverted-05 shadow-sm",
-          "opacity-0 group-hover:opacity-100 focus:opacity-100",
-          "pointer-events-none group-hover:pointer-events-auto focus:pointer-events-auto",
-          "transition-opacity duration-150 hover:opacity-90"
-        )}
-      >
-        <SvgX className="h-3 w-3 stroke-text-inverted-03" />
-      </button>
-      {children}
-    </div>
+    <Hoverable.Root group="fileCard" widthVariant="fit">
+      <div className="relative">
+        <div
+          className={cn(
+            "absolute -left-2 -top-2 z-10",
+            "pointer-events-none focus-within:pointer-events-auto"
+          )}
+        >
+          <Hoverable.Item group="fileCard" variant="opacity-on-hover">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+              title="Remove"
+              aria-label="Remove"
+              className={cn(
+                "h-4 w-4",
+                "flex items-center justify-center",
+                "rounded-04 border border-border text-[11px]",
+                "bg-background-neutral-inverted-01 text-text-inverted-05 shadow-sm",
+                "pointer-events-auto",
+                "hover:opacity-90"
+              )}
+            >
+              <SvgX className="h-3 w-3 stroke-text-inverted-03" />
+            </button>
+          </Hoverable.Item>
+        </div>
+        {children}
+      </div>
+    </Hoverable.Root>
   );
 }
 

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -13,6 +13,7 @@ import InputAvatar from "@/refresh-components/inputs/InputAvatar";
 import { cn } from "@/lib/utils";
 import { SvgCheckCircle, SvgEdit, SvgUser, SvgX } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
+import { Hoverable } from "@opal/core";
 
 export default function NonAdminStep() {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -125,42 +126,41 @@ export default function NonAdminStep() {
           />
         </div>
       ) : (
-        <div
-          className={cn(containerClasses, "group")}
-          aria-label="Edit display name"
-          role="button"
-          tabIndex={0}
-          onClick={() => {
-            setIsEditing(true);
-            setName(savedName);
-          }}
-        >
-          <div className="flex items-center gap-1">
-            <InputAvatar
-              className={cn(
-                "flex items-center justify-center bg-background-neutral-inverted-00",
-                "w-5 h-5"
-              )}
-            >
-              <Text as="p" inverted secondaryBody>
-                {savedName?.[0]?.toUpperCase()}
+        <Hoverable.Root group="nonAdminName" widthVariant="full">
+          <div
+            className={containerClasses}
+            aria-label="Edit display name"
+            role="button"
+            tabIndex={0}
+            onClick={() => {
+              setIsEditing(true);
+              setName(savedName);
+            }}
+          >
+            <div className="flex items-center gap-1">
+              <InputAvatar
+                className={cn(
+                  "flex items-center justify-center bg-background-neutral-inverted-00",
+                  "w-5 h-5"
+                )}
+              >
+                <Text as="p" inverted secondaryBody>
+                  {savedName?.[0]?.toUpperCase()}
+                </Text>
+              </InputAvatar>
+              <Text as="p" text04 mainUiAction>
+                {savedName}
               </Text>
-            </InputAvatar>
-            <Text as="p" text04 mainUiAction>
-              {savedName}
-            </Text>
+            </div>
+            <div className="p-1 flex items-center gap-1">
+              {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+              <Hoverable.Item group="nonAdminName" variant="opacity-on-hover">
+                <IconButton internal icon={SvgEdit} tooltip="Edit" />
+              </Hoverable.Item>
+              <SvgCheckCircle className="w-4 h-4 stroke-status-success-05" />
+            </div>
           </div>
-          <div className="p-1 flex items-center gap-1">
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <IconButton
-              internal
-              icon={SvgEdit}
-              tooltip="Edit"
-              className="opacity-0 group-hover:opacity-100 transition-opacity"
-            />
-            <SvgCheckCircle className="w-4 h-4 stroke-status-success-05" />
-          </div>
-        </div>
+        </Hoverable.Root>
       )}
     </>
   );

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgCheckCircle, SvgEdit, SvgUser } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
+import { Hoverable } from "@opal/core";
 
 export interface NameStepProps {
   state: OnboardingState;
@@ -65,49 +66,48 @@ const NameStep = React.memo(
         />
       </div>
     ) : (
-      <div
-        className={cn(containerClasses, "group")}
-        onClick={() => {
-          setButtonActive(true);
-          goToStep(OnboardingStep.Name);
-        }}
-        aria-label="Edit display name"
-        role="button"
-        tabIndex={0}
-      >
+      <Hoverable.Root group="nameStep" widthVariant="full">
         <div
-          className={cn("flex items-center gap-1", !isActive && "opacity-50")}
+          className={containerClasses}
+          onClick={() => {
+            setButtonActive(true);
+            goToStep(OnboardingStep.Name);
+          }}
+          aria-label="Edit display name"
+          role="button"
+          tabIndex={0}
         >
-          <InputAvatar
-            className={cn(
-              "flex items-center justify-center bg-background-neutral-inverted-00",
-              "w-5 h-5"
-            )}
+          <div
+            className={cn("flex items-center gap-1", !isActive && "opacity-50")}
           >
-            <Text as="p" inverted secondaryBody>
-              {userName?.[0]?.toUpperCase()}
+            <InputAvatar
+              className={cn(
+                "flex items-center justify-center bg-background-neutral-inverted-00",
+                "w-5 h-5"
+              )}
+            >
+              <Text as="p" inverted secondaryBody>
+                {userName?.[0]?.toUpperCase()}
+              </Text>
+            </InputAvatar>
+            <Text as="p" text04 mainUiAction>
+              {userName}
             </Text>
-          </InputAvatar>
-          <Text as="p" text04 mainUiAction>
-            {userName}
-          </Text>
+          </div>
+          <div className="p-1 flex items-center gap-1">
+            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+            <Hoverable.Item group="nameStep" variant="opacity-on-hover">
+              <IconButton internal icon={SvgEdit} tooltip="Edit" />
+            </Hoverable.Item>
+            <SvgCheckCircle
+              className={cn(
+                "w-4 h-4 stroke-status-success-05",
+                !isActive && "opacity-50"
+              )}
+            />
+          </div>
         </div>
-        <div className="p-1 flex items-center gap-1">
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <IconButton
-            internal
-            icon={SvgEdit}
-            tooltip="Edit"
-            className="opacity-0 group-hover:opacity-100 transition-opacity"
-          />
-          <SvgCheckCircle
-            className={cn(
-              "w-4 h-4 stroke-status-success-05",
-              !isActive && "opacity-50"
-            )}
-          />
-        </div>
-      </div>
+      </Hoverable.Root>
     );
   }
 );


### PR DESCRIPTION
## Description

Migrates a handlful of buttons to `Hoverable` for improved a11y

## How Has This Been Tested?

Manually tested each button

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated hover-only UI controls to `Hoverable` from `@opal/core` so they also appear on focus, improving keyboard accessibility across images, files, messages, onboarding, and admin views. No changes to primary actions—just better, consistent a11y.

- **Bug Fixes**
  - Replaced group-hover CSS with `Hoverable.Root`/`Hoverable.Item`.
  - Controls are now tabbable and visible on focus (keyboard-friendly).
  - Fixed hidden/remove buttons to allow keyboard focus and activation.
  - Applied across: message images (download), human messages (copy/edit), project name, image/avatar inputs and agent editor avatar (edit/remove), file tiles/cards (remove), admin forms (SCIM token copy, numeric limit restore, OpenAPI definition toolbar, users stats filter), and onboarding name steps (edit).

<sup>Written for commit ea08f9ecd5f00958e994e5e22985e04ea1c1fc10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

