### PR TITLE
feat(rds): Adding CPU Alerts

### DIFF
--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -65,6 +65,9 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization" {
   threshold           = var.cpu_alarm_threshold
   treat_missing_data  = "missing"
 
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.this.identifier
   }

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -95,16 +95,37 @@ variable "cpu_alarm_threshold" {
   type        = number
   description = "CPU utilization percentage threshold for the CloudWatch alarm"
   default     = 80
+
+  validation {
+    condition     = var.cpu_alarm_threshold >= 0 && var.cpu_alarm_threshold <= 100
+    error_message = "cpu_alarm_threshold must be between 0 and 100 (percentage)."
+  }
 }
 
 variable "cpu_alarm_evaluation_periods" {
   type        = number
   description = "Number of consecutive periods the threshold must be breached before alarming"
   default     = 3
+
+  validation {
+    condition     = var.cpu_alarm_evaluation_periods >= 1
+    error_message = "cpu_alarm_evaluation_periods must be at least 1."
+  }
 }
 
 variable "cpu_alarm_period" {
   type        = number
   description = "Period in seconds over which the CPU metric is evaluated"
   default     = 300
+
+  validation {
+    condition     = var.cpu_alarm_period >= 60 && var.cpu_alarm_period % 60 == 0
+    error_message = "cpu_alarm_period must be a multiple of 60 seconds and at least 60 (CloudWatch requirement)."
+  }
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "List of ARNs to notify when the alarm transitions state (e.g. SNS topic ARNs)"
+  default     = []
 }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding in CPU utilization monitoring for RDS instances

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Deployed to internal RDS instances

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudWatch CPU utilization alerts to the AWS Postgres Terraform module to catch sustained high CPU on RDS instances. Provides sensible defaults with simple variables to tune.

- **New Features**
  - Adds `aws_cloudwatch_metric_alarm` for `AWS/RDS` `CPUUtilization` per DB instance; alarm `${var.identifier}-cpu-utilization`, `Average`, `GreaterThanThreshold`, `treat_missing_data = "missing"`.
  - New variables: `cpu_alarm_threshold` (80), `cpu_alarm_evaluation_periods` (3), `cpu_alarm_period` (300s), `alarm_actions` (with validations).
  - Sets `alarm_actions` and `ok_actions`, inherits tags, and scopes to the instance via `DBInstanceIdentifier`.

<sup>Written for commit 53534557a67900bbae2655189eb384220786203f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

