### PR TITLE
feat(rds): Add Freeable Memory alert

### DIFF
--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -74,3 +74,26 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization" {
 
   tags = var.tags
 }
+
+# CloudWatch alarm for freeable memory monitoring
+resource "aws_cloudwatch_metric_alarm" "freeable_memory" {
+  alarm_name          = "${var.identifier}-freeable-memory"
+  alarm_description   = "RDS freeable memory for ${var.identifier}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = var.memory_alarm_evaluation_periods
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/RDS"
+  period              = var.memory_alarm_period
+  statistic           = "Average"
+  threshold           = var.memory_alarm_threshold
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.this.identifier
+  }
+
+  tags = var.tags
+}

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -124,6 +124,39 @@ variable "cpu_alarm_period" {
   }
 }
 
+variable "memory_alarm_threshold" {
+  type        = number
+  description = "Freeable memory threshold in bytes. Alarm fires when memory drops below this value."
+  default     = 256000000 # 256 MB
+
+  validation {
+    condition     = var.memory_alarm_threshold > 0
+    error_message = "memory_alarm_threshold must be greater than 0."
+  }
+}
+
+variable "memory_alarm_evaluation_periods" {
+  type        = number
+  description = "Number of consecutive periods the threshold must be breached before alarming"
+  default     = 3
+
+  validation {
+    condition     = var.memory_alarm_evaluation_periods >= 1
+    error_message = "memory_alarm_evaluation_periods must be at least 1."
+  }
+}
+
+variable "memory_alarm_period" {
+  type        = number
+  description = "Period in seconds over which the freeable memory metric is evaluated"
+  default     = 300
+
+  validation {
+    condition     = var.memory_alarm_period >= 60 && var.memory_alarm_period % 60 == 0
+    error_message = "memory_alarm_period must be a multiple of 60 seconds and at least 60 (CloudWatch requirement)."
+  }
+}
+
 variable "alarm_actions" {
   type        = list(string)
   description = "List of ARNs to notify when the alarm transitions state (e.g. SNS topic ARNs)"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Following up on the previous PRs. Just doing freeable memory alerts now

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Deployed to internal cluster

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CloudWatch Freeable Memory alarm to the AWS RDS Postgres Terraform module to alert on low memory. Includes new variables to tune threshold, period, and evaluation periods.

- **New Features**
  - Adds CloudWatch alarm for `FreeableMemory` per RDS instance.
  - Fires when average memory < `memory_alarm_threshold` for `memory_alarm_evaluation_periods` over `memory_alarm_period` (defaults: 256MB, 3, 300s).
  - Sends notifications via `alarm_actions`; missing data is treated as "missing".

- **Migration**
  - No breaking changes; alarm is enabled with defaults.
  - Optionally override `memory_alarm_threshold`, `memory_alarm_period`, and `memory_alarm_evaluation_periods`. Ensure `alarm_actions` is set to receive alerts.

<sup>Written for commit 56afa9882f237dad0b9470fd877d8def97b3a8d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

