### PR TITLE
feat(rds): Adding IO Metrics Alarms

### DIFF
--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -75,6 +75,29 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization" {
   tags = var.tags
 }
 
+# CloudWatch alarm for disk IO monitoring
+resource "aws_cloudwatch_metric_alarm" "read_iops" {
+  alarm_name          = "${var.identifier}-read-iops"
+  alarm_description   = "RDS ReadIOPS for ${var.identifier}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.iops_alarm_evaluation_periods
+  metric_name         = "ReadIOPS"
+  namespace           = "AWS/RDS"
+  period              = var.iops_alarm_period
+  statistic           = "Average"
+  threshold           = var.read_iops_alarm_threshold
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.this.identifier
+  }
+
+  tags = var.tags
+}
+
 # CloudWatch alarm for freeable memory monitoring
 resource "aws_cloudwatch_metric_alarm" "freeable_memory" {
   alarm_name          = "${var.identifier}-freeable-memory"

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -157,6 +157,39 @@ variable "memory_alarm_period" {
   }
 }
 
+variable "read_iops_alarm_threshold" {
+  type        = number
+  description = "ReadIOPS threshold. Alarm fires when IOPS exceeds this value."
+  default     = 3000
+
+  validation {
+    condition     = var.read_iops_alarm_threshold > 0
+    error_message = "read_iops_alarm_threshold must be greater than 0."
+  }
+}
+
+variable "iops_alarm_evaluation_periods" {
+  type        = number
+  description = "Number of consecutive periods the IOPS threshold must be breached before alarming"
+  default     = 3
+
+  validation {
+    condition     = var.iops_alarm_evaluation_periods >= 1
+    error_message = "iops_alarm_evaluation_periods must be at least 1."
+  }
+}
+
+variable "iops_alarm_period" {
+  type        = number
+  description = "Period in seconds over which the IOPS metric is evaluated"
+  default     = 300
+
+  validation {
+    condition     = var.iops_alarm_period >= 60 && var.iops_alarm_period % 60 == 0
+    error_message = "iops_alarm_period must be a multiple of 60 seconds and at least 60 (CloudWatch requirement)."
+  }
+}
+
 variable "alarm_actions" {
   type        = list(string)
   description = "List of ARNs to notify when the alarm transitions state (e.g. SNS topic ARNs)"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding IO Metrics Alarms

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested on internal clustter

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CloudWatch `ReadIOPS` alarm to the RDS Postgres module to alert on sustained high read I/O. Configurable thresholds and periods with safe defaults; uses existing `alarm_actions` for notifications.

- **New Features**
  - Adds `ReadIOPS` alarm (Average) on the DB instance; treats missing data as missing.
  - Introduces variables: `read_iops_alarm_threshold` (3000), `iops_alarm_evaluation_periods` (3), `iops_alarm_period` (300) with validation.
  - Reuses `alarm_actions` for alarm/OK states and preserves `tags`.

<sup>Written for commit 31e98e17f4a66217684dce01f833c02fdae576ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

