### PR TITLE
chore: fix batch logging

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -319,9 +319,11 @@ def monitor_indexing_attempt_progress(
     )
 
     current_db_time = get_db_current_time(db_session)
-    total_batches = coordination_status.total_batches
-    if total_batches is None:
-        total_batches = "?"
+    total_batches: int | str = (
+        coordination_status.total_batches
+        if coordination_status.total_batches is not None
+        else "?"
+    )
     if coordination_status.found:
         task_logger.info(
             f"Indexing attempt progress: "


### PR DESCRIPTION
## Description

total batches in the indexing coordination status can be None but can also be 0; these are distinct because when set to 0 it means the attempt actually had no batches of documents to index. Fixed a bug in the logs where we still showed the total batches as '?' in the 0 case.

## How Has This Been Tested?

n/a totally harmless

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix indexing progress logging: show total_batches=0 when no batches, use "?" only when None, and add typing for mypy.

<sup>Written for commit a496d29a2db5e9bb17cbf3466a47e34049ae267c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

