### PR TITLE
chore: fix indexing log2

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -312,6 +312,8 @@ def monitor_indexing_attempt_progress(
         cc_pair.status = ConnectorCredentialPairStatus.INITIAL_INDEXING
         db_session.commit()
 
+    # Get coordination status to track progress
+
     coordination_status = IndexingCoordination.get_coordination_status(
         db_session, attempt.id
     )


### PR DESCRIPTION
## Description

teeny logging fix

## How Has This Been Tested?

n/a harmless
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix indexing completion log to show batch totals of 0 instead of '?', using an explicit None check so 0 logs as 0. No runtime behavior changes.

<sup>Written for commit 03cc4b1de40041ee8f91725f36da0b45d3f38086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

