### PR TITLE
fix(connectors): fix reindex on paused file connectors

### DIFF
--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -208,6 +208,15 @@ export function CCPairStatus({
       );
     } else if (
       lastIndexAttemptStatus &&
+      lastIndexAttemptStatus === "not_started"
+    ) {
+      badge = (
+        <Badge variant="not_started" icon={FiClock}>
+          Scheduled
+        </Badge>
+      );
+    } else if (
+      lastIndexAttemptStatus &&
       lastIndexAttemptStatus === "canceled"
     ) {
       badge = (


### PR DESCRIPTION
## Summary
- Auto-unpause paused connectors when a reindex is explicitly triggered via the UI. Previously, the `indexing_trigger` was set but never consumed because paused cc_pairs are excluded from the indexable query in `check_for_indexing`.
- Handle `not_started` index attempt status in the `CCPairStatus` component so it shows "Scheduled" instead of incorrectly falling through to "Indexed".

[ENG-3817](https://linear.app/onyx-app/issue/ENG-3817/pausing-file-connector)

## Test plan
Tested locally with file connector: pausing, resuming, and reindexing

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check