### PR TITLE
fix: install early exit

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -203,6 +203,7 @@ prompt_or_default() {
     local default_value="$2"
     read_prompt_line "$prompt_text"
     [[ -z "$REPLY" ]] && REPLY="$default_value"
+    return 0
 }
 
 prompt_yn_or_default() {
@@ -210,6 +211,7 @@ prompt_yn_or_default() {
     local default_value="$2"
     read_prompt_char "$prompt_text"
     [[ -z "$REPLY" ]] && REPLY="$default_value"
+    return 0
 }
 
 confirm_action() {


### PR DESCRIPTION
## Description

due to a bash function returning "2" the script was early exiting

## How Has This Been Tested?

tested manually

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented the Docker Compose installer from exiting early by making prompt functions always return success. Added explicit `return 0` in `prompt_or_default` and `prompt_yn_or_default` so a non-zero from `read` doesn’t trigger a `set -e` abort.

<sup>Written for commit d2af2e5a83800e1d1e3ec1db7ecb385060dc0a2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

