### PR TITLE
fix(fe): foldable buttons unfold on tab

### DIFF
--- a/web/lib/opal/src/core/interactive/foldable/styles.css
+++ b/web/lib/opal/src/core/interactive/foldable/styles.css
@@ -1,8 +1,8 @@
 /* ---------------------------------------------------------------------------
    Foldable — CSS grid collapse/expand animation.
 
-   Expands when an ancestor `.interactive` element is hovered or has
-   `data-interaction="hover"` / `data-interaction="active"`.
+   Expands when an ancestor `.interactive` element is hovered, focused
+   within, or has `data-interaction="hover"` / `data-interaction="active"`.
 
    Structure:
      .interactive-foldable-host   — flex parent, gap transitions 0 → 0.25rem
@@ -19,6 +19,7 @@
 }
 
 .interactive:hover:not([data-disabled]) .interactive-foldable-host,
+.interactive:focus-within:not([data-disabled]) .interactive-foldable-host,
 .interactive[data-interaction="hover"]:not([data-disabled])
   .interactive-foldable-host,
 .interactive[data-interaction="active"]:not([data-disabled])
@@ -43,8 +44,9 @@
   min-width: 0;
 }
 
-/* Expanded: hovered or interaction override */
+/* Expanded: hovered, focused within, or interaction override */
 .interactive:hover:not([data-disabled]) .interactive-foldable,
+.interactive:focus-within:not([data-disabled]) .interactive-foldable,
 .interactive[data-interaction="hover"]:not([data-disabled])
   .interactive-foldable,
 .interactive[data-interaction="active"]:not([data-disabled])


### PR DESCRIPTION
## Description



## How Has This Been Tested?

<img width="1176" height="1820" alt="20260401_08h47m58s_grim" src="https://github.com/user-attachments/assets/12a957b4-2eae-44d4-b7ad-6a075c7eb057" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foldable buttons now expand when focused via keyboard (Tab), not just on hover. This improves keyboard navigation and accessibility.

- **Bug Fixes**
  - Added :focus-within to `.interactive` selectors so `.interactive-foldable-host` and `.interactive-foldable` expand on focus.
  - Respects `[data-disabled]` as before and keeps parity with `data-interaction="hover"| "active"`.

<sup>Written for commit 832950706698237446e7a3443cd8f8a5504fb456. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

