### PR TITLE
fix(opensearch): Add Vespa server-side timeout for the migration

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -924,8 +924,19 @@ CUSTOM_ANSWER_VALIDITY_CONDITIONS = json.loads(
 )
 
 VESPA_REQUEST_TIMEOUT = int(os.environ.get("VESPA_REQUEST_TIMEOUT") or "15")
+# This is the timeout for the client side of the Vespa migration task. When
+# exceeded, an exception is raised in our code. This value should be higher than
+# VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT.
 VESPA_MIGRATION_REQUEST_TIMEOUT_S = int(
     os.environ.get("VESPA_MIGRATION_REQUEST_TIMEOUT_S") or "120"
+)
+# This is the timeout Vespa uses on the server side to know when to wrap up its
+# traversal and try to report partial results. This differs from the client
+# timeout above which raises an exception in our code when exceeded. This
+# timeout allows Vespa to return gracefully. This value should be lower than
+# VESPA_MIGRATION_REQUEST_TIMEOUT_S. Formatted as <number of seconds>s.
+VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT = os.environ.get(
+    "VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT", "110s"
 )
 
 SYSTEM_RECURSION_LIMIT = int(os.environ.get("SYSTEM_RECURSION_LIMIT") or "1000")

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -20,6 +20,7 @@ from onyx.background.celery.tasks.opensearch_migration.transformer import (
 from onyx.configs.app_configs import LOG_VESPA_TIMING_INFORMATION
 from onyx.configs.app_configs import VESPA_LANGUAGE_OVERRIDE
 from onyx.configs.app_configs import VESPA_MIGRATION_REQUEST_TIMEOUT_S
+from onyx.configs.app_configs import VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import InferenceChunkUncleaned
 from onyx.document_index.interfaces import VespaChunkRequest
@@ -335,6 +336,11 @@ def get_all_chunks_paginated(
             "format.tensors": "short-value",
             "slices": total_slices,
             "sliceId": slice_id,
+            # When exceeded, Vespa should return gracefully with partial
+            # results. Even if no hits are returned, Vespa should still return a
+            # new continuation token representing a new spot in the linear
+            # traversal.
+            "timeout": VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT,
         }
         if continuation_token is not None:
             params["continuation"] = continuation_token
@@ -343,6 +349,9 @@ def get_all_chunks_paginated(
         start_time = time.monotonic()
         try:
             with get_vespa_http_client(
+                # When exceeded, an exception is raised in our code. No progress
+                # is saved, and the task will retry this spot in the traversal
+                # later.
                 timeout=VESPA_MIGRATION_REQUEST_TIMEOUT_S
             ) as http_client:
                 response = http_client.get(url, params=params)


### PR DESCRIPTION
## Description
This PR adds the `timeout` parameter to the request we make to Vespa to get chunks from the Visit API. Although not documented, in my experiments I found that this parameter allows Vespa to make partial progress through the linear Visit API traversal, even in sparse regions of an index where there are no matching documents. We need this fix because we are seeing some cloud customers whose migrations are stuck from constantly timing out. I believe they are timing out because they are stuck in sparse regions of their respective index with no matching docs, thus they will deterministically time out from our client side, with no graceful partial traversal progress being made by Vespa.

[Relevant Slack thread.](https://onyx-company.slack.com/archives/C0AD06XNMPG/p1774992278461919)

## How Has This Been Tested?
I verified on our cloud Vespa instance that we can traverse a very large and sparse index for a tenant while making incremental progress using this parameter. Also there are existing automated tests which ensure that the migration task still works.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Vespa server-side timeout to migration requests to let the Visit API return partial progress instead of timing out in sparse index regions. This prevents migrations from getting stuck and reduces client-side timeouts.

- **Bug Fixes**
  - Add `timeout` parameter to Vespa Visit API requests so Vespa returns partial results and new continuation tokens even with no hits.
  - Introduce `VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT` (default `110s`) and pass it to Vespa; keep client HTTP timeout via `VESPA_MIGRATION_REQUEST_TIMEOUT_S` higher to allow graceful server returns.

<sup>Written for commit 96e1543d51a4f48112874b04b1bc46316b640553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

