### PR TITLE
fix(opal): guard `opal/interactive`'s `onClick` handlers against React portal event bubbling

### DIFF
--- a/web/lib/opal/src/core/interactive/simple/components.tsx
+++ b/web/lib/opal/src/core/interactive/simple/components.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@opal/utils";
 import { useDisabled } from "@opal/core/disabled/components";
+import { guardPortalClick } from "@opal/core/interactive/utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,7 +92,7 @@ function InteractiveSimple({
           ? href
             ? (e: React.MouseEvent) => e.preventDefault()
             : undefined
-          : onClick
+          : guardPortalClick(onClick)
       }
     />
   );

--- a/web/lib/opal/src/core/interactive/stateful/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateful/components.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@opal/utils";
 import { useDisabled } from "@opal/core/disabled/components";
+import { guardPortalClick } from "@opal/core/interactive/utils";
 import type { ButtonType, WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
@@ -153,7 +154,7 @@ function InteractiveStateful({
           ? href
             ? (e: React.MouseEvent) => e.preventDefault()
             : undefined
-          : onClick
+          : guardPortalClick(onClick)
       }
     />
   );

--- a/web/lib/opal/src/core/interactive/stateless/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateless/components.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@opal/utils";
 import { useDisabled } from "@opal/core/disabled/components";
+import { guardPortalClick } from "@opal/core/interactive/utils";
 import type { ButtonType, WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
@@ -137,7 +138,7 @@ function InteractiveStateless({
           ? href
             ? (e: React.MouseEvent) => e.preventDefault()
             : undefined
-          : onClick
+          : guardPortalClick(onClick)
       }
     />
   );

--- a/web/lib/opal/src/core/interactive/utils.ts
+++ b/web/lib/opal/src/core/interactive/utils.ts
@@ -1,0 +1,28 @@
+import type React from "react";
+
+/**
+ * Guards an onClick handler against React synthetic event bubbling from
+ * portalled children (e.g. Radix Dialog overlays).
+ *
+ * React bubbles synthetic events through the **fiber tree** (component
+ * hierarchy), not the DOM tree. This means a click on a portalled modal
+ * overlay will bubble to a parent component's onClick even though the
+ * overlay is not a DOM descendant. This guard checks that the click
+ * target is actually inside the handler's DOM element before firing.
+ */
+function guardPortalClick<E extends React.MouseEvent>(
+  onClick: ((e: E) => void) | undefined
+): ((e: E) => void) | undefined {
+  if (!onClick) return undefined;
+  return (e: E) => {
+    if (
+      e.currentTarget instanceof Node &&
+      e.target instanceof Node &&
+      e.currentTarget.contains(e.target)
+    ) {
+      onClick(e);
+    }
+  };
+}
+
+export { guardPortalClick };


### PR DESCRIPTION
## Description

React bubbles synthetic events through the **fiber tree** (component hierarchy), not the DOM tree. This means clicks on portalled elements (e.g. Radix Dialog overlays) bubble to ancestor `onClick` handlers even though the portal is not a DOM descendant.

Adds a `guardPortalClick` utility that checks `e.currentTarget.contains(e.target)` before firing `onClick`. Applied to `Interactive.Stateful`, `Interactive.Stateless`, and `Interactive.Simple`.

This prevents a class of bugs where closing a modal (rendered inside a clickable card via a portal) would trigger the card's `onClick`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `Interactive` onClick handlers against React portal event bubbling to stop portalled overlays (e.g., Radix Dialog) from triggering parent clicks. This prevents accidental actions when interacting with modals or overlays inside clickable containers.

- **Bug Fixes**
  - Added `guardPortalClick` in `@opal/core/interactive/utils` to only fire onClick when `e.currentTarget.contains(e.target)` is true.
  - Applied to `Interactive.Stateful`, `Interactive.Stateless`, and `Interactive.Simple`.
  - Fixes cases where closing a modal inside a clickable card triggered the card’s `onClick`.

<sup>Written for commit b9720326a51e29daa2e5ea3cbbd64ecbe611ca64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->