### PR TITLE
feat(chat): add carousel drag interaction for multi-model selection

### DIFF
--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -164,12 +164,12 @@ export default function MultiModelResponseView({
     }
   }, [isGenerating]);
 
-  // Find preferred panel position — used for both the selection guard and carousel layout
+  // Index of the preferred panel in the responses array (-1 if not found)
   const preferredIdx = responses.findIndex(
     (r) => r.modelIndex === preferredIndex
   );
 
-  // Selection mode when preferred is set, found in responses, not generating, and at least 2 visible panels
+  // Selection mode when preferred is set, not generating, and at least 2 visible panels
   const showSelectionMode =
     preferredIndex !== null &&
     preferredIdx !== -1 &&


### PR DESCRIPTION
## Description

Adds drag-to-scroll carousel interaction to the multi-model selection mode view. All changes are in `MultiModelResponseView.tsx`.

- Drag-scroll with pointer capture for smooth carousel panning
- Deferred `setPointerCapture` to drag threshold so panel clicks still work
- Replaced React pointer handlers with window listeners for reliable drag release outside viewport

Stacked on #9855 (PR4b: response panels).

## How Has This Been Tested?

I will fill it in.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check