### PR TITLE
feat(install): add GitHub star prompt at end of install script

### DIFF
--- a/cli/cmd/chat.go
+++ b/cli/cmd/chat.go
@@ -4,6 +4,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/onboarding"
+	"github.com/onyx-dot-app/onyx/cli/internal/starprompt"
 	"github.com/onyx-dot-app/onyx/cli/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,8 @@ func newChatCmd() *cobra.Command {
 				}
 				cfg = *result
 			}
+
+			starprompt.MaybePrompt()
 
 			m := tui.NewModel(cfg)
 			p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())

--- a/cli/internal/starprompt/starprompt.go
+++ b/cli/internal/starprompt/starprompt.go
@@ -1,0 +1,83 @@
+// Package starprompt implements a one-time GitHub star prompt shown before the TUI.
+// Skipped when stdin/stdout is not a TTY, when gh CLI is not installed,
+// or when the user has already been prompted. State is stored in the
+// config directory so it shows at most once per user.
+package starprompt
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/config"
+	"golang.org/x/term"
+)
+
+const repo = "onyx-dot-app/onyx"
+
+func statePath() string {
+	return filepath.Join(config.ConfigDir(), ".star-prompted")
+}
+
+func hasBeenPrompted() bool {
+	_, err := os.Stat(statePath())
+	return err == nil
+}
+
+func markPrompted() {
+	_ = os.MkdirAll(config.ConfigDir(), 0o755)
+	f, err := os.Create(statePath())
+	if err == nil {
+		_ = f.Close()
+	}
+}
+
+func isGHInstalled() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}
+
+// MaybePrompt shows a one-time star prompt if conditions are met.
+// It is safe to call unconditionally — it no-ops when not appropriate.
+func MaybePrompt() {
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return
+	}
+	if hasBeenPrompted() {
+		return
+	}
+	if !isGHInstalled() {
+		return
+	}
+
+	// Mark before asking so Ctrl+C won't cause a re-prompt.
+	markPrompted()
+
+	fmt.Print("Enjoying Onyx? Star the repo on GitHub? [Y/n] ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	if answer == "n" || answer == "no" {
+		return
+	}
+
+	cmd := exec.Command("gh", "api", "-X", "PUT", "/user/starred/"+repo)
+	cmd.Env = append(os.Environ(), "GH_PAGER=")
+	if devnull, err := os.Open(os.DevNull); err == nil {
+		defer func() { _ = devnull.Close() }()
+		cmd.Stdin = devnull
+		cmd.Stdout = devnull
+		cmd.Stderr = devnull
+	}
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Star us at: https://github.com/" + repo)
+	} else {
+		fmt.Println("Thanks for the star!")
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1303,3 +1303,17 @@ print_info "Refer to the README in the ${INSTALL_ROOT} directory for more inform
 echo ""
 print_info "For help or issues, contact: founders@onyx.app"
 echo ""
+
+# --- GitHub star prompt (inspired by oh-my-codex) ---
+# Only prompt in interactive mode and only if gh CLI is available.
+# Uses the GitHub API directly (PUT /user/starred) like oh-my-codex.
+if is_interactive && command -v gh &>/dev/null; then
+    prompt_yn_or_default "Enjoying Onyx? Star the repo on GitHub? [Y/n] " "Y"
+    if [[ ! "$REPLY" =~ ^[Nn] ]]; then
+        if GH_PAGER= gh api -X PUT /user/starred/onyx-dot-app/onyx < /dev/null >/dev/null 2>&1; then
+            print_success "Thanks for the star!"
+        else
+            print_info "Star us at: https://github.com/onyx-dot-app/onyx"
+        fi
+    fi
+fi


### PR DESCRIPTION
## Description

Adds an interactive GitHub star prompt in two places:

1. **Install script** (`deployment/docker_compose/install.sh`) — after installation completes, asks users to star the repo. Uses `gh api -X PUT /user/starred` (matching oh-my-codex's approach). Respects `--no-prompt` for CI/automation.

2. **onyx-cli** (`cli/internal/starprompt/`) — one-time prompt shown before the TUI launches. State persisted to `~/.config/onyx-cli/star-prompt.json` so it only shows once per user. Marks as prompted before asking (so Ctrl+C won't cause re-prompt). Silently skips if not a TTY or if `gh` CLI is not installed.

Inspired by [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex/blob/main/src/cli/star-prompt.ts).

## How Has This Been Tested?

https://github.com/user-attachments/assets/c7ff2d5f-149a-4bdb-b20d-f97cdf8e3d67


https://github.com/user-attachments/assets/e816b399-a048-47e9-9e39-29963ed2df5d

- Go build verified (`go build ./...` passes)
- Manually reviewed install script logic against existing interactive prompt helpers
- Star prompt package follows same patterns as oh-my-codex (one-time state file, TTY check, gh CLI check, mark-before-ask)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check