### PR TITLE
fix(mobile): update sidebar responsiveness

### DIFF
--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
 import { usePathname } from "next/navigation";
 import { useSettingsContext } from "@/providers/SettingsProvider";
@@ -7,6 +8,8 @@ import { ApplicationStatus } from "@/interfaces/settings";
 import { Button } from "@opal/components";
 import { cn } from "@/lib/utils";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import useScreenSize from "@/hooks/useScreenSize";
+import { SvgSidebar } from "@opal/icons";
 
 export interface ClientLayoutProps {
   children: React.ReactNode;
@@ -49,6 +52,8 @@ const SETTINGS_LAYOUT_PREFIXES = [
 ];
 
 export function ClientLayout({ children, enableCloud }: ClientLayoutProps) {
+  const [sidebarFolded, setSidebarFolded] = useState(true);
+  const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
 
@@ -82,7 +87,11 @@ export function ClientLayout({ children, enableCloud }: ClientLayoutProps) {
         <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">{children}</div>
       ) : (
         <>
-          <AdminSidebar enableCloudSS={enableCloud} />
+          <AdminSidebar
+            enableCloudSS={enableCloud}
+            folded={sidebarFolded}
+            onFoldChange={setSidebarFolded}
+          />
           <div
             data-main-container
             className={cn(
@@ -90,6 +99,15 @@ export function ClientLayout({ children, enableCloud }: ClientLayoutProps) {
               !hasOwnLayout && "py-10 px-4 md:px-12"
             )}
           >
+            {isMobile && (
+              <div className="flex items-center px-4 pt-2">
+                <Button
+                  prominence="internal"
+                  icon={SvgSidebar}
+                  onClick={() => setSidebarFolded(false)}
+                />
+              </div>
+            )}
             {children}
           </div>
         </>

--- a/web/src/layouts/sidebar-layouts.tsx
+++ b/web/src/layouts/sidebar-layouts.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * Sidebar Layout Components
+ *
+ * Provides composable layout primitives for app and admin sidebars with mobile
+ * overlay support and optional desktop folding.
+ *
+ * @example
+ * ```tsx
+ * import * as SidebarLayouts from "@/layouts/sidebar-layouts";
+ * import { useSidebarFolded } from "@/layouts/sidebar-layouts";
+ *
+ * function MySidebar() {
+ *   const { folded, setFolded } = useSidebarState();
+ *   const contentFolded = useSidebarFolded();
+ *
+ *   return (
+ *     <SidebarLayouts.Root folded={folded} onFoldChange={setFolded} foldable>
+ *       <SidebarLayouts.Header>
+ *         <NewSessionButton folded={contentFolded} />
+ *       </SidebarLayouts.Header>
+ *       <SidebarLayouts.Body scrollKey="my-sidebar">
+ *         {contentFolded ? null : <SectionContent />}
+ *       </SidebarLayouts.Body>
+ *       <SidebarLayouts.Footer>
+ *         <UserAvatar />
+ *       </SidebarLayouts.Footer>
+ *     </SidebarLayouts.Root>
+ *   );
+ * }
+ * ```
+ */
+
+import {
+  createContext,
+  useContext,
+  useCallback,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { cn } from "@/lib/utils";
+import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
+import OverflowDiv from "@/refresh-components/OverflowDiv";
+import useScreenSize from "@/hooks/useScreenSize";
+
+// ---------------------------------------------------------------------------
+// Fold context
+// ---------------------------------------------------------------------------
+
+const SidebarFoldedContext = createContext(false);
+
+/**
+ * Returns whether the sidebar content should render in its folded (narrow)
+ * state. On mobile, this is always `false` because the overlay pattern handles
+ * visibility — the sidebar content itself is always fully expanded.
+ */
+export function useSidebarFolded(): boolean {
+  return useContext(SidebarFoldedContext);
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+interface SidebarRootProps {
+  /**
+   * Whether the sidebar is currently folded (desktop) or off-screen (mobile).
+   */
+  folded: boolean;
+  /** Callback to update the fold state. Compatible with `useState` setters. */
+  onFoldChange: Dispatch<SetStateAction<boolean>>;
+  /**
+   * Whether the sidebar supports folding on desktop.
+   * When `false` (the default), the sidebar is always expanded on desktop and
+   * the fold button is hidden. Mobile overlay behavior is always enabled
+   * regardless of this prop.
+   */
+  foldable?: boolean;
+  children: React.ReactNode;
+}
+
+function SidebarRoot({
+  folded,
+  onFoldChange,
+  foldable = false,
+  children,
+}: SidebarRootProps) {
+  const { isMobile } = useScreenSize();
+
+  const close = useCallback(() => onFoldChange(true), [onFoldChange]);
+  const toggle = useCallback(
+    () => onFoldChange((prev) => !prev),
+    [onFoldChange]
+  );
+
+  // On mobile the sidebar content is always visually expanded — the overlay
+  // transform handles visibility. On desktop, only foldable sidebars honour
+  // the fold state.
+  const contentFolded = !isMobile && foldable ? folded : false;
+
+  const inner = (
+    <div className="flex flex-col min-h-0 h-full gap-3">{children}</div>
+  );
+
+  if (isMobile) {
+    return (
+      <SidebarFoldedContext.Provider value={false}>
+        <div
+          className={cn(
+            "fixed inset-y-0 left-0 z-50 transition-transform duration-200",
+            folded ? "-translate-x-full" : "translate-x-0"
+          )}
+        >
+          <SidebarWrapper folded={false} onFoldClick={close}>
+            {inner}
+          </SidebarWrapper>
+        </div>
+
+        {/* Backdrop — closes the sidebar when anything outside it is tapped */}
+        <div
+          className={cn(
+            "fixed inset-0 z-40 bg-mask-03 backdrop-blur-03 transition-opacity duration-200",
+            folded
+              ? "opacity-0 pointer-events-none"
+              : "opacity-100 pointer-events-auto"
+          )}
+          onClick={close}
+        />
+      </SidebarFoldedContext.Provider>
+    );
+  }
+
+  return (
+    <SidebarFoldedContext.Provider value={contentFolded}>
+      <SidebarWrapper
+        folded={foldable ? folded : undefined}
+        onFoldClick={foldable ? toggle : undefined}
+      >
+        {inner}
+      </SidebarWrapper>
+    </SidebarFoldedContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header — pinned content above the scroll area
+// ---------------------------------------------------------------------------
+
+interface SidebarHeaderProps {
+  children?: React.ReactNode;
+}
+
+function SidebarHeader({ children }: SidebarHeaderProps) {
+  if (!children) return null;
+  return <div className="px-2">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Body — scrollable content area
+// ---------------------------------------------------------------------------
+
+interface SidebarBodyProps {
+  /**
+   * Unique key to enable scroll position persistence across navigation.
+   * (e.g., "admin-sidebar", "app-sidebar").
+   */
+  scrollKey: string;
+  children?: React.ReactNode;
+}
+
+function SidebarBody({ scrollKey, children }: SidebarBodyProps) {
+  return (
+    <OverflowDiv className="gap-3 px-2" scrollKey={scrollKey}>
+      {children}
+    </OverflowDiv>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Footer — pinned content below the scroll area
+// ---------------------------------------------------------------------------
+
+interface SidebarFooterProps {
+  children?: React.ReactNode;
+}
+
+function SidebarFooter({ children }: SidebarFooterProps) {
+  if (!children) return null;
+  return <div className="px-2">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  SidebarRoot as Root,
+  SidebarHeader as Header,
+  SidebarBody as Body,
+  SidebarFooter as Footer,
+};

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, type Dispatch, type SetStateAction } from "react";
 import { usePathname } from "next/navigation";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import SidebarSection from "@/sections/sidebar/SidebarSection";
-import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
+import * as SidebarLayouts from "@/layouts/sidebar-layouts";
 import { useIsKGExposed } from "@/app/admin/kg/utils";
 import { useCustomAnalyticsEnabled } from "@/lib/hooks/useCustomAnalyticsEnabled";
 import { useUser } from "@/providers/UserProvider";
@@ -12,7 +12,6 @@ import { UserRole } from "@/lib/types";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import { CombinedSettings } from "@/interfaces/settings";
 import { SidebarTab } from "@opal/components";
-import SidebarBody from "@/sections/sidebar/SidebarBody";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Separator from "@/refresh-components/Separator";
 import { SvgArrowUpCircle, SvgUserManage, SvgX } from "@opal/icons";
@@ -191,9 +190,15 @@ function groupBySection(items: SidebarItemEntry[]) {
 
 interface AdminSidebarProps {
   enableCloudSS: boolean;
+  folded: boolean;
+  onFoldChange: Dispatch<SetStateAction<boolean>>;
 }
 
-export default function AdminSidebar({ enableCloudSS }: AdminSidebarProps) {
+export default function AdminSidebar({
+  enableCloudSS,
+  folded,
+  onFoldChange,
+}: AdminSidebarProps) {
   const { kgExposed } = useIsKGExposed();
   const pathname = usePathname();
   const { customAnalyticsEnabled } = useCustomAnalyticsEnabled();
@@ -237,65 +242,27 @@ export default function AdminSidebar({ enableCloudSS }: AdminSidebarProps) {
   const disabledGroups = groupBySection(disabled);
 
   return (
-    <SidebarWrapper>
-      <SidebarBody
-        scrollKey="admin-sidebar"
-        pinnedContent={
-          <div className="flex flex-col w-full">
-            <SidebarTab
-              icon={({ className }) => <SvgX className={className} size={16} />}
-              href="/app"
-              variant="sidebar-light"
-            >
-              Exit Admin Panel
-            </SidebarTab>
-            <InputTypeIn
-              variant="internal"
-              leftSearchIcon
-              placeholder="Search..."
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </div>
-        }
-        footer={
-          <Section gap={0} height="fit" alignItems="start">
-            <div className="p-[0.38rem] w-full">
-              <Content
-                icon={SvgUserManage}
-                title={getUserDisplayName(user)}
-                sizePreset="main-ui"
-                variant="body"
-                prominence="muted"
-                widthVariant="full"
-              />
-            </div>
-            <div className="flex flex-row gap-1 p-[0.38rem] w-full">
-              <Text text03 secondaryAction>
-                <a
-                  className="underline"
-                  href="https://onyx.app"
-                  target="_blank"
-                >
-                  Onyx
-                </a>
-              </Text>
-              <Text text03 secondaryBody>
-                |
-              </Text>
-              {settings.webVersion ? (
-                <Text text03 secondaryBody>
-                  {settings.webVersion}
-                </Text>
-              ) : (
-                <Text text03 secondaryBody>
-                  {APP_SLOGAN}
-                </Text>
-              )}
-            </div>
-          </Section>
-        }
-      >
+    <SidebarLayouts.Root folded={folded} onFoldChange={onFoldChange}>
+      <SidebarLayouts.Header>
+        <div className="flex flex-col w-full">
+          <SidebarTab
+            icon={({ className }) => <SvgX className={className} size={16} />}
+            href="/app"
+            variant="sidebar-light"
+          >
+            Exit Admin Panel
+          </SidebarTab>
+          <InputTypeIn
+            variant="internal"
+            leftSearchIcon
+            placeholder="Search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+      </SidebarLayouts.Header>
+
+      <SidebarLayouts.Body scrollKey="admin-sidebar">
         {enabledGroups.map((group, groupIndex) => {
           const tabs = group.items.map(({ link, icon, name }) => (
             <SidebarTab
@@ -334,7 +301,41 @@ export default function AdminSidebar({ enableCloudSS }: AdminSidebarProps) {
             ))}
           </SidebarSection>
         ))}
-      </SidebarBody>
-    </SidebarWrapper>
+      </SidebarLayouts.Body>
+
+      <SidebarLayouts.Footer>
+        <Section gap={0} height="fit" alignItems="start">
+          <div className="p-[0.38rem] w-full">
+            <Content
+              icon={SvgUserManage}
+              title={getUserDisplayName(user)}
+              sizePreset="main-ui"
+              variant="body"
+              prominence="muted"
+              widthVariant="full"
+            />
+          </div>
+          <div className="flex flex-row gap-1 p-[0.38rem] w-full">
+            <Text text03 secondaryAction>
+              <a className="underline" href="https://onyx.app" target="_blank">
+                Onyx
+              </a>
+            </Text>
+            <Text text03 secondaryBody>
+              |
+            </Text>
+            {settings.webVersion ? (
+              <Text text03 secondaryBody>
+                {settings.webVersion}
+              </Text>
+            ) : (
+              <Text text03 secondaryBody>
+                {APP_SLOGAN}
+              </Text>
+            )}
+          </div>
+        </Section>
+      </SidebarLayouts.Footer>
+    </SidebarLayouts.Root>
   );
 }

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -41,7 +41,8 @@ import MoveCustomAgentChatModal from "@/components/modals/MoveCustomAgentChatMod
 import { useProjectsContext } from "@/providers/ProjectsContext";
 import { removeChatSessionFromProject } from "@/app/app/projects/projectsService";
 import type { Project } from "@/app/app/projects/projectsService";
-import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
+import * as SidebarLayouts from "@/layouts/sidebar-layouts";
+import { useSidebarFolded } from "@/layouts/sidebar-layouts";
 import { Button as OpalButton } from "@opal/components";
 import { cn } from "@/lib/utils";
 import {
@@ -53,12 +54,10 @@ import {
 import { showErrorNotification, handleMoveOperation } from "./sidebarUtils";
 import { SidebarTab } from "@opal/components";
 import { ChatSession } from "@/app/app/interfaces";
-import SidebarBody from "@/sections/sidebar/SidebarBody";
 import { useUser } from "@/providers/UserProvider";
 import useAppFocus from "@/hooks/useAppFocus";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { useModalContext } from "@/components/context/ModalContext";
-import useScreenSize from "@/hooks/useScreenSize";
 import {
   SvgDevKit,
   SvgEditBig,
@@ -196,607 +195,562 @@ function RecentsSection({
   );
 }
 
-interface AppSidebarInnerProps {
-  folded: boolean;
-  onFoldClick: () => void;
-}
+const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
+  const folded = useSidebarFolded();
+  const router = useRouter();
+  const combinedSettings = useSettingsContext();
+  const posthog = usePostHog();
+  const { newTenantInfo, invitationInfo } = useModalContext();
+  const { setAppMode, reset } = useQueryController();
 
-const MemoizedAppSidebarInner = memo(
-  ({ folded, onFoldClick }: AppSidebarInnerProps) => {
-    const router = useRouter();
-    const combinedSettings = useSettingsContext();
-    const posthog = usePostHog();
-    const { newTenantInfo, invitationInfo } = useModalContext();
-    const { setAppMode, reset } = useQueryController();
+  // Use SWR hooks for data fetching
+  const {
+    chatSessions,
+    refreshChatSessions,
+    isLoading: isLoadingChatSessions,
+    hasMore,
+    isLoadingMore,
+    loadMore,
+  } = useChatSessions();
+  const {
+    projects,
+    refreshProjects,
+    isLoading: isLoadingProjects,
+  } = useProjects();
+  const { isLoading: isLoadingAgents } = useAgents();
+  const currentAgent = useCurrentAgent();
+  const {
+    pinnedAgents,
+    updatePinnedAgents,
+    isLoading: isLoadingPinnedAgents,
+  } = usePinnedAgents();
 
-    // Use SWR hooks for data fetching
-    const {
-      chatSessions,
-      refreshChatSessions,
-      isLoading: isLoadingChatSessions,
-      hasMore,
-      isLoadingMore,
-      loadMore,
-    } = useChatSessions();
-    const {
-      projects,
-      refreshProjects,
-      isLoading: isLoadingProjects,
-    } = useProjects();
-    const { isLoading: isLoadingAgents } = useAgents();
-    const currentAgent = useCurrentAgent();
-    const {
-      pinnedAgents,
-      updatePinnedAgents,
-      isLoading: isLoadingPinnedAgents,
-    } = usePinnedAgents();
+  // Wait for ALL dynamic data before showing any sections
+  const isLoadingDynamicContent =
+    isLoadingChatSessions ||
+    isLoadingProjects ||
+    isLoadingAgents ||
+    isLoadingPinnedAgents;
 
-    // Wait for ALL dynamic data before showing any sections
-    const isLoadingDynamicContent =
-      isLoadingChatSessions ||
-      isLoadingProjects ||
-      isLoadingAgents ||
-      isLoadingPinnedAgents;
+  // Still need some context for stateful operations
+  const { refreshCurrentProjectDetails, currentProjectId } =
+    useProjectsContext();
 
-    // Still need some context for stateful operations
-    const { refreshCurrentProjectDetails, currentProjectId } =
-      useProjectsContext();
+  // State for custom agent modal
+  const [pendingMoveChatSession, setPendingMoveChatSession] =
+    useState<ChatSession | null>(null);
+  const [pendingMoveProjectId, setPendingMoveProjectId] = useState<
+    number | null
+  >(null);
+  const [showMoveCustomAgentModal, setShowMoveCustomAgentModal] =
+    useState(false);
 
-    // State for custom agent modal
-    const [pendingMoveChatSession, setPendingMoveChatSession] =
-      useState<ChatSession | null>(null);
-    const [pendingMoveProjectId, setPendingMoveProjectId] = useState<
-      number | null
-    >(null);
-    const [showMoveCustomAgentModal, setShowMoveCustomAgentModal] =
-      useState(false);
+  // Fetch notifications for build mode intro
+  const { data: notifications, mutate: mutateNotifications } = useSWR<
+    Notification[]
+  >(SWR_KEYS.notifications, errorHandlingFetcher);
 
-    // Fetch notifications for build mode intro
-    const { data: notifications, mutate: mutateNotifications } = useSWR<
-      Notification[]
-    >(SWR_KEYS.notifications, errorHandlingFetcher);
+  // Check if Onyx Craft is enabled via settings (backed by PostHog feature flag)
+  // Only explicit true enables the feature; false or undefined = disabled
+  const isOnyxCraftEnabled =
+    combinedSettings?.settings?.onyx_craft_enabled === true;
 
-    // Check if Onyx Craft is enabled via settings (backed by PostHog feature flag)
-    // Only explicit true enables the feature; false or undefined = disabled
-    const isOnyxCraftEnabled =
-      combinedSettings?.settings?.onyx_craft_enabled === true;
+  // Find build_mode feature announcement notification (only if Onyx Craft is enabled)
+  const buildModeNotification = isOnyxCraftEnabled
+    ? notifications?.find(
+        (n) =>
+          n.notif_type === NotificationType.FEATURE_ANNOUNCEMENT &&
+          n.additional_data?.feature === "build_mode" &&
+          !n.dismissed
+      )
+    : undefined;
 
-    // Find build_mode feature announcement notification (only if Onyx Craft is enabled)
-    const buildModeNotification = isOnyxCraftEnabled
-      ? notifications?.find(
-          (n) =>
-            n.notif_type === NotificationType.FEATURE_ANNOUNCEMENT &&
-            n.additional_data?.feature === "build_mode" &&
-            !n.dismissed
-        )
-      : undefined;
+  // State for intro animation overlay
+  const [showIntroAnimation, setShowIntroAnimation] = useState(false);
+  // Track if auto-trigger has fired (prevents race condition during dismiss)
+  const hasAutoTriggeredRef = useRef(false);
 
-    // State for intro animation overlay
-    const [showIntroAnimation, setShowIntroAnimation] = useState(false);
-    // Track if auto-trigger has fired (prevents race condition during dismiss)
-    const hasAutoTriggeredRef = useRef(false);
+  // Auto-show intro once when there's an undismissed notification
+  // Don't show if tenant/invitation modal is open (e.g., "join existing team" modal)
+  // Gated by PostHog feature flag: if `craft-animation-disabled` is true (or
+  // PostHog is unavailable), skip the auto-show entirely.
+  const isCraftAnimationDisabled =
+    posthog?.isFeatureEnabled(FEATURE_FLAGS.CRAFT_ANIMATION_DISABLED) ?? true;
+  const hasTenantModal = !!(newTenantInfo || invitationInfo);
+  useEffect(() => {
+    if (
+      isOnyxCraftEnabled &&
+      buildModeNotification &&
+      !hasAutoTriggeredRef.current &&
+      !hasTenantModal &&
+      !isCraftAnimationDisabled
+    ) {
+      hasAutoTriggeredRef.current = true;
+      setShowIntroAnimation(true);
+    }
+  }, [
+    buildModeNotification,
+    isOnyxCraftEnabled,
+    hasTenantModal,
+    isCraftAnimationDisabled,
+  ]);
 
-    // Auto-show intro once when there's an undismissed notification
-    // Don't show if tenant/invitation modal is open (e.g., "join existing team" modal)
-    // Gated by PostHog feature flag: if `craft-animation-disabled` is true (or
-    // PostHog is unavailable), skip the auto-show entirely.
-    const isCraftAnimationDisabled =
-      posthog?.isFeatureEnabled(FEATURE_FLAGS.CRAFT_ANIMATION_DISABLED) ?? true;
-    const hasTenantModal = !!(newTenantInfo || invitationInfo);
-    useEffect(() => {
-      if (
-        isOnyxCraftEnabled &&
-        buildModeNotification &&
-        !hasAutoTriggeredRef.current &&
-        !hasTenantModal &&
-        !isCraftAnimationDisabled
-      ) {
-        hasAutoTriggeredRef.current = true;
-        setShowIntroAnimation(true);
-      }
-    }, [
-      buildModeNotification,
-      isOnyxCraftEnabled,
-      hasTenantModal,
-      isCraftAnimationDisabled,
-    ]);
+  // Dismiss the build mode notification
+  const dismissBuildModeNotification = useCallback(async () => {
+    if (!buildModeNotification) return;
+    try {
+      await fetch(`/api/notifications/${buildModeNotification.id}/dismiss`, {
+        method: "POST",
+      });
+      mutateNotifications();
+    } catch (error) {
+      console.error("Error dismissing notification:", error);
+    }
+  }, [buildModeNotification, mutateNotifications]);
 
-    // Dismiss the build mode notification
-    const dismissBuildModeNotification = useCallback(async () => {
-      if (!buildModeNotification) return;
-      try {
-        await fetch(`/api/notifications/${buildModeNotification.id}/dismiss`, {
-          method: "POST",
-        });
-        mutateNotifications();
-      } catch (error) {
-        console.error("Error dismissing notification:", error);
-      }
-    }, [buildModeNotification, mutateNotifications]);
+  const [visibleAgents, currentAgentIsPinned] = useMemo(
+    () => buildVisibleAgents(pinnedAgents, currentAgent),
+    [pinnedAgents, currentAgent]
+  );
+  const visibleAgentIds = useMemo(
+    () => visibleAgents.map((agent) => agent.id),
+    [visibleAgents]
+  );
 
-    const [visibleAgents, currentAgentIsPinned] = useMemo(
-      () => buildVisibleAgents(pinnedAgents, currentAgent),
-      [pinnedAgents, currentAgent]
-    );
-    const visibleAgentIds = useMemo(
-      () => visibleAgents.map((agent) => agent.id),
-      [visibleAgents]
-    );
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
 
-    const sensors = useSensors(
-      useSensor(PointerSensor, {
-        activationConstraint: {
-          distance: 8,
-        },
-      }),
-      useSensor(KeyboardSensor, {
-        coordinateGetter: sortableKeyboardCoordinates,
-      })
-    );
+  // Handle agent drag and drop
+  const handleAgentDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over) return;
+      if (active.id === over.id) return;
 
-    // Handle agent drag and drop
-    const handleAgentDragEnd = useCallback(
-      (event: DragEndEvent) => {
-        const { active, over } = event;
-        if (!over) return;
-        if (active.id === over.id) return;
+      const activeIndex = visibleAgentIds.findIndex(
+        (agentId) => agentId === active.id
+      );
+      const overIndex = visibleAgentIds.findIndex(
+        (agentId) => agentId === over.id
+      );
 
-        const activeIndex = visibleAgentIds.findIndex(
-          (agentId) => agentId === active.id
-        );
-        const overIndex = visibleAgentIds.findIndex(
-          (agentId) => agentId === over.id
-        );
+      let newPinnedAgents: MinimalPersonaSnapshot[];
 
-        let newPinnedAgents: MinimalPersonaSnapshot[];
-
-        if (currentAgent && !currentAgentIsPinned) {
-          // This is the case in which the user is dragging the UNPINNED agent and moving it to somewhere else in the list.
-          // This is an indication that we WANT to pin this agent!
-          if (activeIndex === visibleAgentIds.length - 1) {
-            const pinnedWithCurrent = [...pinnedAgents, currentAgent];
-            newPinnedAgents = arrayMove(
-              pinnedWithCurrent,
-              activeIndex,
-              overIndex
-            );
-          } else {
-            // Use visibleAgents to ensure the indices match with `visibleAgentIds`
-            newPinnedAgents = arrayMove(visibleAgents, activeIndex, overIndex);
-          }
+      if (currentAgent && !currentAgentIsPinned) {
+        // This is the case in which the user is dragging the UNPINNED agent and moving it to somewhere else in the list.
+        // This is an indication that we WANT to pin this agent!
+        if (activeIndex === visibleAgentIds.length - 1) {
+          const pinnedWithCurrent = [...pinnedAgents, currentAgent];
+          newPinnedAgents = arrayMove(
+            pinnedWithCurrent,
+            activeIndex,
+            overIndex
+          );
         } else {
           // Use visibleAgents to ensure the indices match with `visibleAgentIds`
           newPinnedAgents = arrayMove(visibleAgents, activeIndex, overIndex);
         }
-
-        updatePinnedAgents(newPinnedAgents);
-      },
-      [
-        visibleAgentIds,
-        visibleAgents,
-        pinnedAgents,
-        updatePinnedAgents,
-        currentAgent,
-        currentAgentIsPinned,
-      ]
-    );
-
-    // Perform the actual move
-    async function performChatMove(
-      targetProjectId: number,
-      chatSession: ChatSession
-    ) {
-      try {
-        await handleMoveOperation({
-          chatSession,
-          targetProjectId,
-          refreshChatSessions,
-          refreshCurrentProjectDetails,
-          fetchProjects: refreshProjects,
-          currentProjectId,
-        });
-        const projectRefreshPromise = currentProjectId
-          ? refreshCurrentProjectDetails()
-          : refreshProjects();
-        await Promise.all([refreshChatSessions(), projectRefreshPromise]);
-      } catch (error) {
-        console.error("Failed to move chat:", error);
-        throw error;
+      } else {
+        // Use visibleAgents to ensure the indices match with `visibleAgentIds`
+        newPinnedAgents = arrayMove(visibleAgents, activeIndex, overIndex);
       }
+
+      updatePinnedAgents(newPinnedAgents);
+    },
+    [
+      visibleAgentIds,
+      visibleAgents,
+      pinnedAgents,
+      updatePinnedAgents,
+      currentAgent,
+      currentAgentIsPinned,
+    ]
+  );
+
+  // Perform the actual move
+  async function performChatMove(
+    targetProjectId: number,
+    chatSession: ChatSession
+  ) {
+    try {
+      await handleMoveOperation({
+        chatSession,
+        targetProjectId,
+        refreshChatSessions,
+        refreshCurrentProjectDetails,
+        fetchProjects: refreshProjects,
+        currentProjectId,
+      });
+      const projectRefreshPromise = currentProjectId
+        ? refreshCurrentProjectDetails()
+        : refreshProjects();
+      await Promise.all([refreshChatSessions(), projectRefreshPromise]);
+    } catch (error) {
+      console.error("Failed to move chat:", error);
+      throw error;
     }
+  }
 
-    // Handle chat to project drag and drop
-    const handleChatProjectDragEnd = useCallback(
-      async (event: DragEndEvent) => {
-        const { active, over } = event;
-        if (!over) return;
+  // Handle chat to project drag and drop
+  const handleChatProjectDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over) return;
 
-        const activeData = active.data.current;
-        const overData = over.data.current;
+      const activeData = active.data.current;
+      const overData = over.data.current;
 
-        if (!activeData || !overData) {
+      if (!activeData || !overData) {
+        return;
+      }
+
+      // Check if we're dragging a chat onto a project
+      if (
+        activeData?.type === DRAG_TYPES.CHAT &&
+        overData?.type === DRAG_TYPES.PROJECT
+      ) {
+        const chatSession = activeData.chatSession as ChatSession;
+        const targetProject = overData.project as Project;
+        const sourceProjectId = activeData.projectId;
+
+        // Don't do anything if dropping on the same project
+        if (sourceProjectId === targetProject.id) {
           return;
         }
 
-        // Check if we're dragging a chat onto a project
-        if (
-          activeData?.type === DRAG_TYPES.CHAT &&
-          overData?.type === DRAG_TYPES.PROJECT
-        ) {
-          const chatSession = activeData.chatSession as ChatSession;
-          const targetProject = overData.project as Project;
-          const sourceProjectId = activeData.projectId;
+        const hideModal =
+          typeof window !== "undefined" &&
+          window.localStorage.getItem(
+            LOCAL_STORAGE_KEYS.HIDE_MOVE_CUSTOM_AGENT_MODAL
+          ) === "true";
 
-          // Don't do anything if dropping on the same project
-          if (sourceProjectId === targetProject.id) {
-            return;
-          }
+        const isChatUsingDefaultAgent =
+          chatSession.persona_id === DEFAULT_PERSONA_ID;
 
-          const hideModal =
-            typeof window !== "undefined" &&
-            window.localStorage.getItem(
-              LOCAL_STORAGE_KEYS.HIDE_MOVE_CUSTOM_AGENT_MODAL
-            ) === "true";
+        if (!isChatUsingDefaultAgent && !hideModal) {
+          setPendingMoveChatSession(chatSession);
+          setPendingMoveProjectId(targetProject.id);
+          setShowMoveCustomAgentModal(true);
+          return;
+        }
 
-          const isChatUsingDefaultAgent =
-            chatSession.persona_id === DEFAULT_PERSONA_ID;
+        try {
+          await performChatMove(targetProject.id, chatSession);
+        } catch (error) {
+          showErrorNotification("Failed to move chat. Please try again.");
+        }
+      }
 
-          if (!isChatUsingDefaultAgent && !hideModal) {
-            setPendingMoveChatSession(chatSession);
-            setPendingMoveProjectId(targetProject.id);
-            setShowMoveCustomAgentModal(true);
-            return;
-          }
+      // Check if we're dragging a chat from a project to the Recents section
+      if (
+        activeData?.type === DRAG_TYPES.CHAT &&
+        overData?.type === DRAG_TYPES.RECENTS
+      ) {
+        const chatSession = activeData.chatSession as ChatSession;
+        const sourceProjectId = activeData.projectId;
 
+        // Only remove from project if it was in a project
+        if (sourceProjectId) {
           try {
-            await performChatMove(targetProject.id, chatSession);
+            await removeChatSessionFromProject(chatSession.id);
+            const projectRefreshPromise = currentProjectId
+              ? refreshCurrentProjectDetails()
+              : refreshProjects();
+            await Promise.all([refreshChatSessions(), projectRefreshPromise]);
           } catch (error) {
-            showErrorNotification("Failed to move chat. Please try again.");
+            console.error("Failed to remove chat from project:", error);
           }
         }
+      }
+    },
+    [
+      currentProjectId,
+      refreshChatSessions,
+      refreshCurrentProjectDetails,
+      refreshProjects,
+    ]
+  );
 
-        // Check if we're dragging a chat from a project to the Recents section
-        if (
-          activeData?.type === DRAG_TYPES.CHAT &&
-          overData?.type === DRAG_TYPES.RECENTS
-        ) {
-          const chatSession = activeData.chatSession as ChatSession;
-          const sourceProjectId = activeData.projectId;
-
-          // Only remove from project if it was in a project
-          if (sourceProjectId) {
-            try {
-              await removeChatSessionFromProject(chatSession.id);
-              const projectRefreshPromise = currentProjectId
-                ? refreshCurrentProjectDetails()
-                : refreshProjects();
-              await Promise.all([refreshChatSessions(), projectRefreshPromise]);
-            } catch (error) {
-              console.error("Failed to remove chat from project:", error);
-            }
-          }
-        }
-      },
-      [
-        currentProjectId,
-        refreshChatSessions,
-        refreshCurrentProjectDetails,
-        refreshProjects,
-      ]
-    );
-
-    const { isAdmin, isCurator, user } = useUser();
-    const activeSidebarTab = useAppFocus();
-    const createProjectModal = useCreateModal();
-    const defaultAppMode =
-      (user?.preferences?.default_app_mode?.toLowerCase() as
-        | "chat"
-        | "search") ?? "chat";
-    const newSessionButton = useMemo(() => {
-      const href =
-        combinedSettings?.settings?.disable_default_assistant && currentAgent
-          ? `/app?agentId=${currentAgent.id}`
-          : "/app";
-      return (
-        <div data-testid="AppSidebar/new-session">
-          <SidebarTab
-            icon={SvgEditBig}
-            folded={folded}
-            href={href}
-            selected={activeSidebarTab.isNewSession()}
-            onClick={() => {
-              if (!activeSidebarTab.isNewSession()) return;
-              setAppMode(defaultAppMode);
-              reset();
-            }}
-          >
-            New Session
-          </SidebarTab>
-        </div>
-      );
-    }, [
-      folded,
-      activeSidebarTab,
-      combinedSettings,
-      currentAgent,
-      defaultAppMode,
-    ]);
-
-    const buildButton = useMemo(
-      () => (
-        <div data-testid="AppSidebar/build">
-          <SidebarTab
-            icon={SvgDevKit}
-            folded={folded}
-            href={CRAFT_PATH}
-            onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
-          >
-            Craft
-          </SidebarTab>
-        </div>
-      ),
-      [folded, posthog]
-    );
-
-    const searchChatsButton = useMemo(
-      () => (
-        <ChatSearchCommandMenu
-          trigger={
-            <SidebarTab icon={SvgSearchMenu} folded={folded}>
-              Search Chats
-            </SidebarTab>
-          }
-        />
-      ),
-      [folded]
-    );
-    const moreAgentsButton = useMemo(
-      () => (
-        <div data-testid="AppSidebar/more-agents">
-          <SidebarTab
-            icon={
-              folded || visibleAgents.length === 0
-                ? SvgOnyxOctagon
-                : SvgMoreHorizontal
-            }
-            href="/app/agents"
-            folded={folded}
-            selected={activeSidebarTab.isMoreAgents()}
-            variant={folded ? "sidebar-heavy" : "sidebar-light"}
-          >
-            {visibleAgents.length === 0 ? "Explore Agents" : "More Agents"}
-          </SidebarTab>
-        </div>
-      ),
-      [folded, activeSidebarTab, visibleAgents]
-    );
-    const newProjectButton = useMemo(
-      () => (
+  const { isAdmin, isCurator, user } = useUser();
+  const activeSidebarTab = useAppFocus();
+  const createProjectModal = useCreateModal();
+  const defaultAppMode =
+    (user?.preferences?.default_app_mode?.toLowerCase() as "chat" | "search") ??
+    "chat";
+  const newSessionButton = useMemo(() => {
+    const href =
+      combinedSettings?.settings?.disable_default_assistant && currentAgent
+        ? `/app?agentId=${currentAgent.id}`
+        : "/app";
+    return (
+      <div data-testid="AppSidebar/new-session">
         <SidebarTab
-          icon={SvgFolderPlus}
-          onClick={() => createProjectModal.toggle(true)}
-          selected={createProjectModal.isOpen}
+          icon={SvgEditBig}
           folded={folded}
+          href={href}
+          selected={activeSidebarTab.isNewSession()}
+          onClick={() => {
+            if (!activeSidebarTab.isNewSession()) return;
+            setAppMode(defaultAppMode);
+            reset();
+          }}
+        >
+          New Session
+        </SidebarTab>
+      </div>
+    );
+  }, [
+    folded,
+    activeSidebarTab,
+    combinedSettings,
+    currentAgent,
+    defaultAppMode,
+  ]);
+
+  const buildButton = useMemo(
+    () => (
+      <div data-testid="AppSidebar/build">
+        <SidebarTab
+          icon={SvgDevKit}
+          folded={folded}
+          href={CRAFT_PATH}
+          onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
+        >
+          Craft
+        </SidebarTab>
+      </div>
+    ),
+    [folded, posthog]
+  );
+
+  const searchChatsButton = useMemo(
+    () => (
+      <ChatSearchCommandMenu
+        trigger={
+          <SidebarTab icon={SvgSearchMenu} folded={folded}>
+            Search Chats
+          </SidebarTab>
+        }
+      />
+    ),
+    [folded]
+  );
+  const moreAgentsButton = useMemo(
+    () => (
+      <div data-testid="AppSidebar/more-agents">
+        <SidebarTab
+          icon={
+            folded || visibleAgents.length === 0
+              ? SvgOnyxOctagon
+              : SvgMoreHorizontal
+          }
+          href="/app/agents"
+          folded={folded}
+          selected={activeSidebarTab.isMoreAgents()}
           variant={folded ? "sidebar-heavy" : "sidebar-light"}
         >
-          New Project
+          {visibleAgents.length === 0 ? "Explore Agents" : "More Agents"}
         </SidebarTab>
-      ),
-      [folded, createProjectModal.toggle, createProjectModal.isOpen]
-    );
-    const handleShowBuildIntro = useCallback(() => {
-      setShowIntroAnimation(true);
-    }, []);
-
-    const settingsButton = useMemo(
-      () => (
-        <div>
-          {(isAdmin || isCurator) && (
-            <SidebarTab
-              href={isCurator ? "/admin/agents" : "/admin/configuration/llm"}
-              icon={SvgSettings}
-              folded={folded}
-            >
-              {isAdmin ? "Admin Panel" : "Curator Panel"}
-            </SidebarTab>
-          )}
-          <UserAvatarPopover
-            folded={folded}
-            onShowBuildIntro={
-              isOnyxCraftEnabled ? handleShowBuildIntro : undefined
-            }
-          />
-        </div>
-      ),
-      [folded, isAdmin, isCurator, handleShowBuildIntro, isOnyxCraftEnabled]
-    );
-
-    return (
-      <>
-        <createProjectModal.Provider>
-          <CreateProjectModal />
-        </createProjectModal.Provider>
-
-        {showMoveCustomAgentModal && (
-          <MoveCustomAgentChatModal
-            onCancel={() => {
-              setShowMoveCustomAgentModal(false);
-              setPendingMoveChatSession(null);
-              setPendingMoveProjectId(null);
-            }}
-            onConfirm={async (doNotShowAgain: boolean) => {
-              if (doNotShowAgain && typeof window !== "undefined") {
-                window.localStorage.setItem(
-                  LOCAL_STORAGE_KEYS.HIDE_MOVE_CUSTOM_AGENT_MODAL,
-                  "true"
-                );
-              }
-              const chat = pendingMoveChatSession;
-              const target = pendingMoveProjectId;
-              setShowMoveCustomAgentModal(false);
-              setPendingMoveChatSession(null);
-              setPendingMoveProjectId(null);
-              if (chat && target != null) {
-                try {
-                  await performChatMove(target, chat);
-                } catch (error) {
-                  showErrorNotification(
-                    "Failed to move chat. Please try again."
-                  );
-                }
-              }
-            }}
-          />
-        )}
-
-        {/* Intro animation overlay */}
-        <AnimatePresence>
-          {showIntroAnimation && (
-            <motion.div
-              className="fixed inset-0 z-[9999]"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.5 }}
-            >
-              <BuildModeIntroBackground />
-              <BuildModeIntroContent
-                onClose={() => {
-                  setShowIntroAnimation(false);
-                  dismissBuildModeNotification();
-                }}
-                onTryBuildMode={() => {
-                  setShowIntroAnimation(false);
-                  dismissBuildModeNotification();
-                  router.push(CRAFT_PATH);
-                }}
-              />
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        <SidebarWrapper folded={folded} onFoldClick={onFoldClick}>
-          <SidebarBody
-            scrollKey="app-sidebar"
-            footer={settingsButton}
-            pinnedContent={
-              <div className="flex flex-col">
-                {newSessionButton}
-                {searchChatsButton}
-                {isOnyxCraftEnabled && buildButton}
-                {folded && moreAgentsButton}
-                {folded && newProjectButton}
-              </div>
-            }
-          >
-            {/* When folded, all nav buttons are in pinnedContent — nothing here */}
-            {folded ? null : isLoadingDynamicContent ? null : (
-              <>
-                {/* Agents */}
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={handleAgentDragEnd}
-                >
-                  <SidebarSection title="Agents">
-                    <SortableContext
-                      items={visibleAgentIds}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      {visibleAgents.map((visibleAgent) => (
-                        <AgentButton
-                          key={visibleAgent.id}
-                          agent={visibleAgent}
-                        />
-                      ))}
-                    </SortableContext>
-                    {moreAgentsButton}
-                  </SidebarSection>
-                </DndContext>
-
-                {/* Wrap Projects and Recents in a shared DndContext for chat-to-project drag */}
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={pointerWithin}
-                  modifiers={[
-                    restrictToFirstScrollableAncestor,
-                    restrictToVerticalAxis,
-                  ]}
-                  onDragEnd={handleChatProjectDragEnd}
-                >
-                  {/* Projects */}
-                  <SidebarSection
-                    title="Projects"
-                    action={
-                      <OpalButton
-                        icon={SvgFolderPlus}
-                        prominence="tertiary"
-                        size="sm"
-                        tooltip="New Project"
-                        onClick={() => createProjectModal.toggle(true)}
-                      />
-                    }
-                  >
-                    {projects.map((project) => (
-                      <ProjectFolderButton key={project.id} project={project} />
-                    ))}
-                    {projects.length === 0 && newProjectButton}
-                  </SidebarSection>
-
-                  {/* Recents */}
-                  <RecentsSection
-                    chatSessions={chatSessions}
-                    hasMore={hasMore}
-                    isLoadingMore={isLoadingMore}
-                    onLoadMore={loadMore}
-                  />
-                </DndContext>
-              </>
-            )}
-          </SidebarBody>
-        </SidebarWrapper>
-      </>
-    );
-  }
-);
-MemoizedAppSidebarInner.displayName = "AppSidebar";
-
-export default function AppSidebar() {
-  const { folded, setFolded } = useAppSidebarContext();
-  const { isMobile } = useScreenSize();
-
-  if (!isMobile)
-    return (
-      <MemoizedAppSidebarInner
+      </div>
+    ),
+    [folded, activeSidebarTab, visibleAgents]
+  );
+  const newProjectButton = useMemo(
+    () => (
+      <SidebarTab
+        icon={SvgFolderPlus}
+        onClick={() => createProjectModal.toggle(true)}
+        selected={createProjectModal.isOpen}
         folded={folded}
-        onFoldClick={() => setFolded((prev) => !prev)}
-      />
-    );
+        variant={folded ? "sidebar-heavy" : "sidebar-light"}
+      >
+        New Project
+      </SidebarTab>
+    ),
+    [folded, createProjectModal.toggle, createProjectModal.isOpen]
+  );
+  const handleShowBuildIntro = useCallback(() => {
+    setShowIntroAnimation(true);
+  }, []);
+
+  const settingsButton = useMemo(
+    () => (
+      <div>
+        {(isAdmin || isCurator) && (
+          <SidebarTab
+            href={isCurator ? "/admin/agents" : "/admin/configuration/llm"}
+            icon={SvgSettings}
+            folded={folded}
+          >
+            {isAdmin ? "Admin Panel" : "Curator Panel"}
+          </SidebarTab>
+        )}
+        <UserAvatarPopover
+          folded={folded}
+          onShowBuildIntro={
+            isOnyxCraftEnabled ? handleShowBuildIntro : undefined
+          }
+        />
+      </div>
+    ),
+    [folded, isAdmin, isCurator, handleShowBuildIntro, isOnyxCraftEnabled]
+  );
 
   return (
     <>
-      <div
-        className={cn(
-          "fixed inset-y-0 left-0 z-50 transition-transform duration-200",
-          folded ? "-translate-x-full" : "translate-x-0"
-        )}
-      >
-        <MemoizedAppSidebarInner
-          folded={false}
-          onFoldClick={() => setFolded(true)}
-        />
-      </div>
+      <createProjectModal.Provider>
+        <CreateProjectModal />
+      </createProjectModal.Provider>
 
-      {/* Hitbox to close the sidebar if anything outside of it is touched */}
-      <div
-        className={cn(
-          "fixed inset-0 z-40 bg-mask-03 backdrop-blur-03 transition-opacity duration-200",
-          folded
-            ? "opacity-0 pointer-events-none"
-            : "opacity-100 pointer-events-auto"
+      {showMoveCustomAgentModal && (
+        <MoveCustomAgentChatModal
+          onCancel={() => {
+            setShowMoveCustomAgentModal(false);
+            setPendingMoveChatSession(null);
+            setPendingMoveProjectId(null);
+          }}
+          onConfirm={async (doNotShowAgain: boolean) => {
+            if (doNotShowAgain && typeof window !== "undefined") {
+              window.localStorage.setItem(
+                LOCAL_STORAGE_KEYS.HIDE_MOVE_CUSTOM_AGENT_MODAL,
+                "true"
+              );
+            }
+            const chat = pendingMoveChatSession;
+            const target = pendingMoveProjectId;
+            setShowMoveCustomAgentModal(false);
+            setPendingMoveChatSession(null);
+            setPendingMoveProjectId(null);
+            if (chat && target != null) {
+              try {
+                await performChatMove(target, chat);
+              } catch (error) {
+                showErrorNotification("Failed to move chat. Please try again.");
+              }
+            }
+          }}
+        />
+      )}
+
+      {/* Intro animation overlay */}
+      <AnimatePresence>
+        {showIntroAnimation && (
+          <motion.div
+            className="fixed inset-0 z-[9999]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <BuildModeIntroBackground />
+            <BuildModeIntroContent
+              onClose={() => {
+                setShowIntroAnimation(false);
+                dismissBuildModeNotification();
+              }}
+              onTryBuildMode={() => {
+                setShowIntroAnimation(false);
+                dismissBuildModeNotification();
+                router.push(CRAFT_PATH);
+              }}
+            />
+          </motion.div>
         )}
-        onClick={() => setFolded(true)}
-      />
+      </AnimatePresence>
+
+      <SidebarLayouts.Header>
+        <div className="flex flex-col">
+          {newSessionButton}
+          {searchChatsButton}
+          {isOnyxCraftEnabled && buildButton}
+          {folded && moreAgentsButton}
+          {folded && newProjectButton}
+        </div>
+      </SidebarLayouts.Header>
+
+      <SidebarLayouts.Body scrollKey="app-sidebar">
+        {/* When folded, all nav buttons are in Header — nothing here */}
+        {folded ? null : isLoadingDynamicContent ? null : (
+          <>
+            {/* Agents */}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleAgentDragEnd}
+            >
+              <SidebarSection title="Agents">
+                <SortableContext
+                  items={visibleAgentIds}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {visibleAgents.map((visibleAgent) => (
+                    <AgentButton key={visibleAgent.id} agent={visibleAgent} />
+                  ))}
+                </SortableContext>
+                {moreAgentsButton}
+              </SidebarSection>
+            </DndContext>
+
+            {/* Wrap Projects and Recents in a shared DndContext for chat-to-project drag */}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={pointerWithin}
+              modifiers={[
+                restrictToFirstScrollableAncestor,
+                restrictToVerticalAxis,
+              ]}
+              onDragEnd={handleChatProjectDragEnd}
+            >
+              {/* Projects */}
+              <SidebarSection
+                title="Projects"
+                action={
+                  <OpalButton
+                    icon={SvgFolderPlus}
+                    prominence="tertiary"
+                    size="sm"
+                    tooltip="New Project"
+                    onClick={() => createProjectModal.toggle(true)}
+                  />
+                }
+              >
+                {projects.map((project) => (
+                  <ProjectFolderButton key={project.id} project={project} />
+                ))}
+                {projects.length === 0 && newProjectButton}
+              </SidebarSection>
+
+              {/* Recents */}
+              <RecentsSection
+                chatSessions={chatSessions}
+                hasMore={hasMore}
+                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMore}
+              />
+            </DndContext>
+          </>
+        )}
+      </SidebarLayouts.Body>
+
+      <SidebarLayouts.Footer>{settingsButton}</SidebarLayouts.Footer>
     </>
+  );
+});
+
+export default function AppSidebar() {
+  const { folded, setFolded } = useAppSidebarContext();
+
+  return (
+    <SidebarLayouts.Root folded={folded} onFoldChange={setFolded} foldable>
+      <MemoizedAppSidebarInner />
+    </SidebarLayouts.Root>
   );
 }


### PR DESCRIPTION
## Description

Refactors the Sidebar into a layout components.

Notable functional change, the admin sidebar can now folded on mobile/small screens while on medium/large screens size still disallows the sidebar to be folded.

Related to https://linear.app/onyx-app/issue/ENG-3890/sidebar-breakpoints

## How Has This Been Tested?

Expecting minimal behavior on large screens which is captured by playwright.

mobile behavior:
<img width="1136" height="1820" alt="20260402_10h02m12s_grim" src="https://github.com/user-attachments/assets/91ceff45-a02f-43b7-825f-59311bdadc4b" />

The whitespace is a little off on mobile, but this change is already quite large and resolve that is likely related to a longstanding TODO to standardize the admin pages layout, so will follow up with the change to address this.

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the App and Admin sidebars slide in on mobile with a backdrop; desktop behavior is unchanged (App sidebar remains foldable). Matches Linear ENG-3890 sidebar breakpoints.

- **Bug Fixes**
  - Mobile overlay for both sidebars with a backdrop; tap backdrop or fold button to dismiss.
  - Added a mobile toggle button on admin pages in `ClientLayout` to open the sidebar.

- **Refactors**
  - Introduced shared `SidebarLayouts` (`Root`, `Header`, `Body`, `Footer`) and `useSidebarFolded` in `@/layouts/sidebar-layouts` to unify overlay and desktop folding.
  - Rewrote `AppSidebar` and `AdminSidebar` to use `SidebarLayouts`; `ClientLayout` now owns admin fold state and passes `folded`/`onFoldChange`.

<sup>Written for commit 7ca87cdf36ee3244ca24295b38f244bfda0999fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



