### PR TITLE
fix(federated): prevent masked credentials from corrupting stored secrets

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -12,6 +12,11 @@ SLACK_USER_TOKEN_PREFIX = "xoxp-"
 SLACK_BOT_TOKEN_PREFIX = "xoxb-"
 ONYX_EMAILABLE_LOGO_MAX_DIM = 512
 
+# The mask_string() function in encryption.py uses "•" (U+2022 BULLET) to mask secrets.
+MASK_CREDENTIAL_CHAR = "\u2022"
+# Pattern produced by mask_string for strings >= 14 chars: "abcd...wxyz" (exactly 11 chars)
+MASK_CREDENTIAL_LONG_RE = re.compile(r"^.{4}\.{3}.{4}$")
+
 SOURCE_TYPE = "source_type"
 # stored in the `metadata` of a chunk. Used to signify that this chunk should
 # not be used for QA. For example, Google Drive file types which can't be parsed

--- a/backend/onyx/db/federated.py
+++ b/backend/onyx/db/federated.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FederatedConnectorSource
+from onyx.configs.constants import MASK_CREDENTIAL_CHAR
+from onyx.configs.constants import MASK_CREDENTIAL_LONG_RE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import DocumentSet
 from onyx.db.models import FederatedConnector
@@ -45,16 +47,18 @@ def fetch_all_federated_connectors_parallel() -> list[FederatedConnector]:
         return fetch_all_federated_connectors(db_session)
 
 
-# The mask_string() function in encryption.py uses "•" (U+2022 BULLET) to mask secrets.
-# If any credential value contains this character, it's a masked placeholder that must
-# never be persisted — doing so permanently corrupts the real secret.
-MASK_CHAR = "\u2022"
-
-
 def _reject_masked_credentials(credentials: dict[str, Any]) -> None:
-    """Raise if any credential string value contains mask placeholder characters."""
+    """Raise if any credential string value contains mask placeholder characters.
+
+    mask_string() has two output formats:
+    - Short strings (< 14 chars): "••••••••••••" (U+2022 BULLET)
+    - Long strings (>= 14 chars): "abcd...wxyz" (first4 + "..." + last4)
+    Both must be rejected.
+    """
     for key, val in credentials.items():
-        if isinstance(val, str) and MASK_CHAR in val:
+        if isinstance(val, str) and (
+            MASK_CREDENTIAL_CHAR in val or MASK_CREDENTIAL_LONG_RE.match(val)
+        ):
             raise ValueError(
                 f"Credential field '{key}' contains masked placeholder characters. Please provide the actual credential value."
             )

--- a/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
+++ b/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
@@ -1,27 +1,28 @@
 import pytest
 
+from onyx.configs.constants import MASK_CREDENTIAL_CHAR
 from onyx.db.federated import _reject_masked_credentials
-from onyx.db.federated import MASK_CHAR
 
 
 class TestRejectMaskedCredentials:
     """Verify that masked credential values are never accepted for DB writes.
 
-    The mask_string() utility replaces secrets with "••••••••••••" (U+2022 BULLET).
-    If these masked placeholders reach create/update, the real secret is permanently
-    lost. _reject_masked_credentials is a backend safety-net for this.
+    mask_string() has two output formats:
+    - Short strings (< 14 chars): "••••••••••••" (U+2022 BULLET)
+    - Long strings (>= 14 chars): "abcd...wxyz" (first4 + "..." + last4)
+    _reject_masked_credentials must catch both.
     """
 
     def test_rejects_fully_masked_value(self) -> None:
-        masked = MASK_CHAR * 12  # "••••••••••••"
+        masked = MASK_CREDENTIAL_CHAR * 12  # "••••••••••••"
         with pytest.raises(ValueError, match="masked placeholder"):
             _reject_masked_credentials({"client_id": masked})
 
-    def test_rejects_partially_masked_value(self) -> None:
-        """mask_string returns 'first4...last4' for long strings — but the
-        short-string branch returns pure bullets. Both must be caught."""
+    def test_rejects_long_string_masked_value(self) -> None:
+        """mask_string returns 'first4...last4' for long strings — the real
+        format used for OAuth credentials like client_id and client_secret."""
         with pytest.raises(ValueError, match="masked placeholder"):
-            _reject_masked_credentials({"client_id": f"abcd{MASK_CHAR * 6}wxyz"})
+            _reject_masked_credentials({"client_id": "1234...7890"})
 
     def test_rejects_when_any_field_is_masked(self) -> None:
         """Even if client_id is real, a masked client_secret must be caught."""
@@ -29,7 +30,7 @@ class TestRejectMaskedCredentials:
             _reject_masked_credentials(
                 {
                     "client_id": "1234567890.1234567890",
-                    "client_secret": MASK_CHAR * 12,
+                    "client_secret": MASK_CREDENTIAL_CHAR * 12,
                 }
             )
 
@@ -51,7 +52,7 @@ class TestRejectMaskedCredentials:
         _reject_masked_credentials(
             {
                 "client_id": "real_value",
-                "redirect_uri": None,  # type: ignore[dict-item]
-                "some_flag": True,  # type: ignore[dict-item]
+                "redirect_uri": None,
+                "some_flag": True,
             }
         )

--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -358,6 +358,11 @@ export function FederatedConnectorForm({
 
   const handleValidateCredentials = async () => {
     if (!formState.schema) return;
+    if (isEditMode && !credentialsModified) {
+      setSubmitMessage("Enter new credential values before validating.");
+      setSubmitSuccess(false);
+      return;
+    }
 
     setIsValidating(true);
     setSubmitMessage(null);


### PR DESCRIPTION
## Description

When an admin edits a federated connector, the `GET /api/federated/{id}` endpoint returns credentials with `apply_mask=True`, replacing secrets with `••••••••••••` (U+2022 BULLET). The edit form loaded these masked values into state. On save, `PUT /api/federated/{id}` stored the masked string as the real credentials — permanently corrupting both `client_id` and `client_secret`. This caused Slack OAuth to fail with "Invalid client_id parameter" because the URL contained masked bullets instead of the real client ID.

### Frontend fix

Edit form no longer pre-fills credential fields with masked values in edit mode. A `credentialsModified` flag tracks whether the user has actually typed into any credential field:

- **If credentials are not modified:** `null` is passed to `updateFederatedConnector`, which serializes as `undefined` (omitted from the JSON body). The Pydantic model defaults `credentials` to `None`. The API endpoint passes `None` to the DB function. The DB function's `if credentials is not None:` guard skips the entire credential update block — existing credentials are untouched.
- **If credentials are modified:** The new values are sent and validated normally.

### Backend fix (defense-in-depth)

Both `create_federated_connector` and `update_federated_connector` now reject any credential value containing the mask character (U+2022 BULLET), preventing masked placeholders from ever being persisted.

**Linear:** [CS-55](https://linear.app/onyx-app/issue/CS-55/slack-oauth-fails-with-invalid-client-id-masked-credentials-corrupted)

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check