### PR TITLE
fix(fe): projects buttons transition in like other sidebar items

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -127,7 +127,7 @@ function SidebarTab({
               rightChildren={truncationSpacer}
             />
           ) : (
-            <div className="flex flex-row items-center gap-2 flex-1">
+            <div className="flex flex-row items-center gap-2 w-full">
               {Icon && (
                 <div className="flex items-center justify-center p-0.5">
                   <Icon className="h-[1rem] w-[1rem] text-text-03" />


### PR DESCRIPTION
## Description

Currently, the Projects buttons transition in from outside the viewport. This fixes it so that the projects buttons transition in similarly to the other buttons in the sidebar.

Per Claude,

> The fix: changed flex-1 to w-full on the non-string children wrapper in SidebarTab. flex-1 (with basis 0) inside a justify-center container doesn't guarantee full width during dynamic resizing. w-full explicitly fills the container, so the icon stays pinned to the left edge regardless of the sidebar's width transition.

## How Has This Been Tested?

Opened the sidebar and confirmed transition is smooth

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Projects buttons so they animate like other sidebar items. The buttons no longer slide in from off-screen during sidebar resize.

- **Bug Fixes**
  - In `SidebarTab`, replaced `flex-1` with `w-full` on the non-string children wrapper to ensure full-width during transitions. Icons stay pinned left and the animation is smooth.

<sup>Written for commit 2af6a2d00b3caf45c217d9abe7385da129677487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

