### PR TITLE
fix(fe): closed sidebar button tooltip text color

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -153,7 +153,7 @@ function SidebarTab({
             side="right"
             sideOffset={4}
           >
-            <Text>{children}</Text>
+            {children}
           </TooltipPrimitive.Content>
         </TooltipPrimitive.Portal>
       </TooltipPrimitive.Root>


### PR DESCRIPTION
## How Has This Been Tested?

**before**
<img width="1317" height="2085" alt="20260402_15h18m12s_grim" src="https://github.com/user-attachments/assets/9c6cd3ce-27d9-44c6-9ead-b67a5f0c260a" />

**after**
<img width="1317" height="2085" alt="20260402_15h18m03s_grim" src="https://github.com/user-attachments/assets/f653cc97-3f9d-4131-bc8e-86fe9675e21d" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the closed sidebar button tooltip text color. Removes the Text wrapper so the tooltip content inherits the correct theme styles.

<sup>Written for commit db8ca7e132f780f4623ec09e508b81e4d7a28cec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

