### PR TITLE
feat(hook): UI improve disconnect error popover

### DIFF
--- a/web/src/ee/refresh-pages/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookLogsModal.tsx
@@ -5,6 +5,7 @@ import { SvgDownload, SvgTextLines } from "@opal/icons";
 import Modal from "@/refresh-components/Modal";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
+import { Hoverable } from "@opal/core";
 import { useHookExecutionLogs } from "@/ee/hooks/useHookExecutionLogs";
 import { formatDateTimeLog } from "@/lib/dateUtils";
 import { downloadFile } from "@/lib/download";
@@ -40,33 +41,40 @@ function SectionHeader({ label }: { label: string }) {
   );
 }
 
-function LogRow({ log }: { log: HookExecutionRecord }) {
+function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
   return (
-    <Section
-      flexDirection="row"
-      justifyContent="start"
-      alignItems="start"
-      gap={0.5}
-      height="fit"
-      className="py-2"
-    >
-      {/* 1. Timestamp */}
-      <span className="shrink-0 text-code-code">
-        <Text font="secondary-mono-label" color="inherit" nowrap>
-          {formatDateTimeLog(log.created_at)}
-        </Text>
-      </span>
-      {/* 2. Error message */}
-      <span className="flex-1 min-w-0 break-all whitespace-pre-wrap text-code-code">
-        <Text font="secondary-mono" color="inherit">
-          {log.error_message ?? "Unknown error"}
-        </Text>
-      </span>
-      {/* 3. Copy button */}
-      <Section width="fit" height="fit" alignItems="center">
-        <CopyIconButton size="xs" getCopyText={() => log.error_message ?? ""} />
+    <Hoverable.Root group={group}>
+      <Section
+        flexDirection="row"
+        justifyContent="start"
+        alignItems="start"
+        gap={0.5}
+        height="fit"
+        className="py-2"
+      >
+        {/* 1. Timestamp */}
+        <span className="shrink-0 text-code-code">
+          <Text font="secondary-mono-label" color="inherit" nowrap>
+            {formatDateTimeLog(log.created_at)}
+          </Text>
+        </span>
+        {/* 2. Error message */}
+        <span className="flex-1 min-w-0 break-all whitespace-pre-wrap text-code-code">
+          <Text font="secondary-mono" color="inherit">
+            {log.error_message ?? "Unknown error"}
+          </Text>
+        </span>
+        {/* 3. Copy button */}
+        <Section width="fit" height="fit" alignItems="center">
+          <Hoverable.Item group={group} variant="opacity-on-hover">
+            <CopyIconButton
+              size="xs"
+              getCopyText={() => log.error_message ?? ""}
+            />
+          </Hoverable.Item>
+        </Section>
       </Section>
-    </Section>
+    </Hoverable.Root>
   );
 }
 
@@ -126,7 +134,11 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
                 <>
                   <SectionHeader label="Past Hour" />
                   {recentErrors.map((log, idx) => (
-                    <LogRow key={log.created_at + String(idx)} log={log} />
+                    <LogRow
+                      key={log.created_at + String(idx)}
+                      log={log}
+                      group={log.created_at + String(idx)}
+                    />
                   ))}
                 </>
               )}
@@ -134,7 +146,11 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
                 <>
                   <SectionHeader label="Older" />
                   {olderErrors.map((log, idx) => (
-                    <LogRow key={log.created_at + String(idx)} log={log} />
+                    <LogRow
+                      key={log.created_at + String(idx)}
+                      log={log}
+                      group={log.created_at + String(idx)}
+                    />
                   ))}
                 </>
               )}

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { noProp } from "@/lib/utils";
-import { formatTimeOnly } from "@/lib/dateUtils";
+import { formatDateTimeLog } from "@/lib/dateUtils";
 import { Button, Text } from "@opal/components";
 import { Content } from "@opal/layouts";
 import LineItem from "@/refresh-components/buttons/LineItem";
@@ -18,6 +18,7 @@ import {
   SvgXOctagon,
 } from "@opal/icons";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
+import { Hoverable } from "@opal/core";
 import { useHookExecutionLogs } from "@/ee/hooks/useHookExecutionLogs";
 import HookLogsModal from "@/ee/refresh-pages/admin/HooksPage/HookLogsModal";
 import type {
@@ -25,6 +26,52 @@ import type {
   HookResponse,
 } from "@/ee/refresh-pages/admin/HooksPage/interfaces";
 import { cn } from "@opal/utils";
+
+function ErrorLogRow({
+  log,
+  group,
+}: {
+  log: { created_at: string; error_message: string | null };
+  group: string;
+}) {
+  return (
+    <Hoverable.Root group={group}>
+      <Section
+        flexDirection="column"
+        justifyContent="start"
+        alignItems="start"
+        gap={0.25}
+        padding={0.25}
+        height="fit"
+      >
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="center"
+          gap={0}
+          height="fit"
+        >
+          <span className="text-code-code">
+            <Text font="secondary-mono-label" color="inherit">
+              {formatDateTimeLog(log.created_at)}
+            </Text>
+          </span>
+          <Hoverable.Item group={group} variant="opacity-on-hover">
+            <CopyIconButton
+              size="xs"
+              getCopyText={() => log.error_message ?? ""}
+            />
+          </Hoverable.Item>
+        </Section>
+        <span className="break-all">
+          <Text font="secondary-mono" color="text-03">
+            {log.error_message ?? "Unknown error"}
+          </Text>
+        </span>
+      </Section>
+    </Hoverable.Root>
+  );
+}
 
 interface HookStatusPopoverProps {
   hook: HookResponse;
@@ -43,8 +90,15 @@ export default function HookStatusPopover({
   const [clickOpened, setClickOpened] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { hasRecentErrors, recentErrors, isLoading, error } =
+  const { hasRecentErrors, recentErrors, olderErrors, isLoading, error } =
     useHookExecutionLogs(hook.id);
+
+  const topErrors = [...recentErrors, ...olderErrors]
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )
+    .slice(0, 3);
 
   useEffect(() => {
     return () => {
@@ -162,7 +216,15 @@ export default function HookStatusPopover({
             justifyContent="start"
             alignItems="start"
             height="fit"
-            width={hasRecentErrors ? 20 : 12.5}
+            width={
+              hook.is_reachable === false
+                ? topErrors.length > 0
+                  ? 20
+                  : 12.5
+                : hasRecentErrors
+                  ? 20
+                  : 12.5
+            }
             padding={0.125}
             gap={0.25}
           >
@@ -174,13 +236,70 @@ export default function HookStatusPopover({
               <Text font="secondary-body" color="text-03">
                 Failed to load logs.
               </Text>
+            ) : hook.is_reachable === false ? (
+              <>
+                <div className="p-1">
+                  <Content
+                    sizePreset="secondary"
+                    variant="section"
+                    icon={(props) => (
+                      <SvgXOctagon
+                        {...props}
+                        className="text-status-error-05"
+                      />
+                    )}
+                    title="Most Recent Errors"
+                  />
+                </div>
+
+                {topErrors.length > 0 ? (
+                  <>
+                    <Separator noPadding className="px-2" />
+
+                    <Section
+                      flexDirection="column"
+                      justifyContent="start"
+                      alignItems="start"
+                      gap={0.25}
+                      padding={0.25}
+                      height="fit"
+                    >
+                      {topErrors.map((log, idx) => (
+                        <ErrorLogRow
+                          key={log.created_at + String(idx)}
+                          log={log}
+                          group={log.created_at + String(idx)}
+                        />
+                      ))}
+                    </Section>
+                  </>
+                ) : (
+                  <Separator noPadding className="px-2" />
+                )}
+
+                <LineItem
+                  muted
+                  icon={SvgMaximize2}
+                  onClick={noProp(() => {
+                    handleOpenChange(false);
+                    logsModal.toggle(true);
+                  })}
+                >
+                  View More Lines
+                </LineItem>
+              </>
             ) : hasRecentErrors ? (
               <>
                 <div className="p-1">
                   <Content
                     sizePreset="secondary"
                     variant="section"
-                    icon={SvgXOctagon}
+                    icon={(props) => (
+                      <SvgXOctagon
+                        {...props}
+                        className="text-status-error-05"
+                      />
+                    )}
                     title={
                       recentErrors.length <= 3
                         ? `${recentErrors.length} ${
@@ -204,38 +323,11 @@ export default function HookStatusPopover({
                   height="fit"
                 >
                   {recentErrors.slice(0, 3).map((log, idx) => (
-                    <Section
+                    <ErrorLogRow
                       key={log.created_at + String(idx)}
-                      flexDirection="column"
-                      justifyContent="start"
-                      alignItems="start"
-                      gap={0.25}
-                      padding={0.25}
-                      height="fit"
-                    >
-                      <Section
-                        flexDirection="row"
-                        justifyContent="between"
-                        alignItems="center"
-                        gap={0}
-                        height="fit"
-                      >
-                        <span className="text-code-code">
-                          <Text font="secondary-mono-label" color="inherit">
-                            {formatTimeOnly(log.created_at)}
-                          </Text>
-                        </span>
-                        <CopyIconButton
-                          size="xs"
-                          getCopyText={() => log.error_message ?? ""}
-                        />
-                      </Section>
-                      <span className="break-all">
-                        <Text font="secondary-mono" color="text-03">
-                          {log.error_message ?? "Unknown error"}
-                        </Text>
-                      </span>
-                    </Section>
+                      log={log}
+                      group={log.created_at + String(idx)}
+                    />
                   ))}
                 </Section>
 

--- a/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
@@ -41,6 +41,7 @@ import {
   activateHook,
   deactivateHook,
   deleteHook,
+  getHook,
   validateHook,
 } from "@/ee/refresh-pages/admin/HooksPage/svc";
 import type {
@@ -319,8 +320,15 @@ function ConnectedHookCard({
       toast.error(
         err instanceof Error ? err.message : "Failed to validate hook."
       );
+      return;
     } finally {
       setIsBusy(false);
+    }
+    try {
+      const updated = await getHook(hook.id);
+      onToggled(updated);
+    } catch (err) {
+      console.error("Failed to refresh hook after validation:", err);
     }
   }
 

--- a/web/src/ee/refresh-pages/admin/HooksPage/svc.ts
+++ b/web/src/ee/refresh-pages/admin/HooksPage/svc.ts
@@ -87,6 +87,14 @@ export async function deactivateHook(id: number): Promise<HookResponse> {
   return res.json();
 }
 
+export async function getHook(id: number): Promise<HookResponse> {
+  const res = await fetch(`/api/admin/hooks/${id}`);
+  if (!res.ok) {
+    throw await parseError(res, "Failed to fetch hook");
+  }
+  return res.json();
+}
+
 export async function validateHook(id: number): Promise<HookValidateResponse> {
   const res = await fetch(`/api/admin/hooks/${id}/validate`, {
     method: "POST",


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Summary 

- Unreachable popover: when is_reachable === false, shows up to 3 most recent errors from the last 30 days with timestamps (previously no error details were shown)
- Post-validate refresh: after "Test Connection", the hook card re-fetches the latest state so is_reachable updates immediately in the UI
- Hover-only copy button: CopyIconButton on each error row (popover + logs modal) is hidden until hovering that row, using Hoverable.Root /Hoverable.Item

Motivation: We want to support customer to inject function into certain point in our pipeline.
Eng Doc: https://docs.google.com/document/d/1wCQ4jcuscDLBIuVwzG8yT6UnHVWgIi5gdteOhe1SqhU/edit?tab=t.0
Linear: https://linear.app/onyx-app/project/hooks-14fc5597dc91/overview
UI mocks:
https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=4756-763808&p=f&m=dev

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

<img width="887" height="441" alt="Screenshot 2026-04-02 at 3 19 37 PM" src="https://github.com/user-attachments/assets/2bc04892-eebc-40d8-9106-5964991fbadb" />
<img width="666" height="656" alt="Screenshot 2026-04-02 at 3 20 05 PM" src="https://github.com/user-attachments/assets/1ae1a25a-7716-4b66-abc2-bc076185bfa8" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
