### PR TITLE
fix(desktop): prefer native scrollbar styling

### DIFF
--- a/web/src/app/css/colors.css
+++ b/web/src/app/css/colors.css
@@ -471,7 +471,6 @@
   /* Scrollbar */
   --scrollbar-track: transparent;
   --scrollbar-thumb: var(--alpha-grey-100-20);
-  --scrollbar-thumb-hover: var(--alpha-grey-100-40);
 }
 
 /* Dark Colors */
@@ -680,5 +679,4 @@
   /* Scrollbar */
   --scrollbar-track: transparent;
   --scrollbar-thumb: var(--alpha-grey-00-20);
-  --scrollbar-thumb-hover: var(--alpha-grey-00-40);
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -370,8 +370,10 @@
 }
 
 /* Ensure native scrollbars are visible */
-* {
-  scrollbar-width: auto;
+@layer base {
+  * {
+    scrollbar-width: auto;
+  }
 }
 
 /* TEXTAREA */


### PR DESCRIPTION
## Description

The custom scrollbar styling isn't working on at least the Desktop Linux build, so remove in favor of the native scrollbars. They look and behave mostly similar to the custom app scrollbars anyways.

## How Has This Been Tested?

Expecting no change on Chrome/Firefox

<img width="2880" height="1920" alt="20260402_17h05m14s_grim" src="https://github.com/user-attachments/assets/9f96b3e5-178e-48cf-b4fb-97ca92489e54" />

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to native scrollbar styling to fix broken scrollbars on Desktop Linux. No visual change expected on Chrome/Firefox.

- **Bug Fixes**
  - Removed all `::-webkit-scrollbar` rules and hidden hacks; set global `scrollbar-width: auto` to use OS defaults.
  - Added `--scrollbar-track` and `--scrollbar-thumb` tokens; applied `scrollbar-color`/`scrollbar-width: thin` to `textarea` and `.default-scrollbar`.
  - Dropped `overflow: overlay` and simplified `.inputscroll`, `.no-scrollbar`, and `.default-scrollbar` to avoid platform quirks.

<sup>Written for commit 21869e82d7dffeb1af97f72668de0705a094f5d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

