### PR TITLE
fix(fe): fix sticky sidebar headers overlapping scrollbars

### DIFF
--- a/web/src/sections/sidebar/SidebarSection.tsx
+++ b/web/src/sections/sidebar/SidebarSection.tsx
@@ -19,7 +19,10 @@ export default function SidebarSection({
 }: SidebarSectionProps) {
   return (
     <div className={cn("flex flex-col group/SidebarSection", className)}>
-      <div className="pl-2 pr-1.5 py-1 sticky top-[0rem] bg-background-tint-02 z-10 flex flex-row items-center justify-between min-h-[2rem]">
+      {/* NOTE: mr-1.5 is intentionally used instead of padding to avoid the background color
+          from overlapping with scrollbars on Safari.
+      */}
+      <div className="pl-2 mr-1.5 py-1 sticky top-0 bg-background-tint-02 z-10 flex flex-row items-center justify-between min-h-[2rem]">
         <Text as="p" secondaryBody text02>
           {title}
         </Text>


### PR DESCRIPTION
## Description
The sticky headers have a background color and z-index so they mask the content that goes behind them and on Safari, this is including the scrollbar gutter now that the desktop has scrollbars.

Using margin instead of padding means the actual element size and therefore background do not extend into this area. This is also the same `pr-2` region applied to the underlying content, so we're never expecting sidebar content to appear here and not get masked.

## How Has This Been Tested?

**before**
<img width="2880" height="1920" alt="20260403_08h49m55s_grim" src="https://github.com/user-attachments/assets/a02d30a0-2485-4107-ba19-a67b7ef39571" />

**after**
<img width="2880" height="1920" alt="20260403_08h50m22s_grim" src="https://github.com/user-attachments/assets/8112ad08-745e-4988-b624-def6ee485c06" />

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sticky sidebar headers overlapping the scrollbar gutter in Safari. Switch the header’s right spacing from padding to margin (`pr-1.5` → `mr-1.5`) so the background doesn’t cover the scrollbar.

<sup>Written for commit 47a0b77723877cd4b26e3e2c9c27b84c5db12e94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

