### PR TITLE
fix: disable reactCompiler to fix citation clicks during streaming

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -21,7 +21,6 @@ const nextConfig = {
   output: "standalone",
   transpilePackages: ["@onyx/opal"],
   typedRoutes: true,
-  reactCompiler: true,
   images: {
     // Used to fetch favicons
     remotePatterns: [


### PR DESCRIPTION
## Summary

Disables the experimental React Compiler in next.config.js. The compiler was causing issues with event handlers on citation links during rapid re-renders while answers were streaming.

## Changes

- **web/next.config.js**: Removed reactCompiler: true to fix click events on citations during streaming.

## Related Issue

Closes #5745