### PR TITLE
chore: bump sleep time in flaky test

### DIFF
--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -186,7 +186,7 @@ class TestDocumentIndexNew:
             )
             document_index.index(chunks=[pre_chunk], indexing_metadata=pre_metadata)
 
-            time.sleep(1)
+            time.sleep(2)
 
             # Now index a batch with the existing doc and a new doc.
             chunks = [


### PR DESCRIPTION
## Description

seeing some occasional failures like https://github.com/onyx-dot-app/onyx/actions/runs/23958007757/job/69880966255?pr=9890 so we're going to increase the sleep time to hopefully avoid the race condition (arguably if it takes 2s for the next step to be ready the test _should_ fail...)

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the wait in the document index test from 1s to 2s to reduce intermittent failures caused by a race between pre-indexing and batch indexing. This ensures the pre-seeded chunk is fully indexed before the mixed-doc batch runs.

<sup>Written for commit 12a91da07e0376a93aa5df07af59e3d06a9ae6e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

