### PR TITLE
chore(deps): bump litellm from 1.81.6 to 1.83.0 (#9898) to release v2.12

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -520,7 +520,7 @@ lazy-imports==1.0.1
     # via onyx
 legacy-cgi==2.6.4 ; python_full_version >= '3.13'
     # via ddtrace
-litellm==1.81.6
+litellm==1.83.0
     # via onyx
 locket==1.0.0
     # via

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -272,7 +272,7 @@ kiwisolver==1.4.9
     # via matplotlib
 kubernetes==31.0.0
     # via onyx
-litellm==1.81.6
+litellm==1.83.0
     # via onyx
 mako==1.2.4
     # via alembic

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -207,7 +207,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 kubernetes==31.0.0
     # via onyx
-litellm==1.81.6
+litellm==1.83.0
     # via onyx
 markupsafe==3.0.3
     # via jinja2

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -242,7 +242,7 @@ kombu==5.5.4
     # via celery
 kubernetes==31.0.0
     # via onyx
-litellm==1.81.6
+litellm==1.83.0
     # via onyx
 markupsafe==3.0.3
     # via jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "fastapi==0.128.0",
     "google-cloud-aiplatform==1.121.0",
     "google-genai==1.52.0",
-    "litellm==1.81.6",
+    "litellm==1.83.0",
     "openai==2.14.0",
     "pydantic==2.11.7",
     "prometheus_client>=0.21.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3369,7 +3369,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.81.6"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3385,9 +3385,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f3/194a2dca6cb3eddb89f4bc2920cf5e27542256af907c23be13c61fe7e021/litellm-1.81.6.tar.gz", hash = "sha256:f02b503dfb7d66d1c939f82e4db21aeec1d6e2ed1fe3f5cd02aaec3f792bc4ae", size = 13878107, upload-time = "2026-02-01T04:02:27.36Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/05/3516cc7386b220d388aa0bd833308c677e94eceb82b2756dd95e06f6a13f/litellm-1.81.6-py3-none-any.whl", hash = "sha256:573206ba194d49a1691370ba33f781671609ac77c35347f8a0411d852cf6341a", size = 12224343, upload-time = "2026-02-01T04:02:23.704Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
 ]
 
 [[package]]
@@ -4747,7 +4747,7 @@ requires-dist = [
     { name = "langchainhub", marker = "extra == 'backend'", specifier = "==0.1.21" },
     { name = "langfuse", marker = "extra == 'backend'", specifier = "==3.10.0" },
     { name = "lazy-imports", marker = "extra == 'backend'", specifier = "==1.0.1" },
-    { name = "litellm", specifier = "==1.81.6" },
+    { name = "litellm", specifier = "==1.83.0" },
     { name = "lxml", marker = "extra == 'backend'", specifier = "==5.3.0" },
     { name = "mako", marker = "extra == 'backend'", specifier = "==1.2.4" },
     { name = "manygo", marker = "extra == 'dev'", specifier = "==0.2.0" },


### PR DESCRIPTION
Cherry-pick of commit ae343c718b572bf08a2d8a0d3559687c17f9c082 to release/v2.12 branch.

Original PR: #9898

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `litellm` from 1.81.6 to 1.83.0 across the codebase to align the v2.12 release with the latest upstream fixes.

- **Dependencies**
  - Updated pins in `backend/requirements/*`, `pyproject.toml`, and `uv.lock`.

<sup>Written for commit 75a3c5d7c86ea497c1adfb6ba585e8fd59797e42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

