### PR TITLE
fix: Edit `AccountPopover` + `Separator`'s appearances when folded

### DIFF
--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -33,7 +33,6 @@ import { ADMIN_ROUTES, sidebarItem } from "@/lib/admin-routes";
 import useFilter from "@/hooks/useFilter";
 import { IconFunctionComponent } from "@opal/types";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
-import useScreenSize from "@/hooks/useScreenSize";
 
 const SECTIONS = {
   UNLABELED: "",
@@ -212,7 +211,6 @@ function AdminSidebarInner({
   const folded = useSidebarFolded();
   const searchRef = useRef<HTMLInputElement>(null);
   const [focusSearch, setFocusSearch] = useState(false);
-  const { isMobile } = useScreenSize();
 
   useEffect(() => {
     if (focusSearch && !folded && searchRef.current) {


### PR DESCRIPTION
## Screenshots + Videos

### Before

<img width="96" height="135" alt="image" src="https://github.com/user-attachments/assets/eb651b0a-3916-47ac-92c1-154c7134542f" />

### After

<img width="161" height="104" alt="image" src="https://github.com/user-attachments/assets/41c556d0-e618-4b45-a8f3-ca8bf4a404f2" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix collapsed admin sidebar visuals by hiding the footer `Separator`/spacing and making `AccountPopover` render in folded mode. Also removes dead code in `AdminSidebar`.

- **Bug Fixes**
  - Hide `Separator` and `Spacer` when the sidebar is folded to prevent extra padding/lines.
  - Pass `folded` to `AccountPopover` so it displays the compact variant correctly.

<sup>Written for commit 0e2b55bf73a3494548316e60bdca7c7e3eb00217. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

