### PR TITLE
chore(devtools): `ods web` installs node_modules on init

### DIFF
--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -48,6 +48,19 @@ func runWebScript(args []string) {
 		log.Fatalf("Failed to find web directory: %v", err)
 	}
 
+	nodeModules := filepath.Join(webDir, "node_modules")
+	if _, err := os.Stat(nodeModules); os.IsNotExist(err) {
+		log.Info("node_modules not found, running npm install --no-save...")
+		installCmd := exec.Command("npm", "install", "--no-save")
+		installCmd.Dir = webDir
+		installCmd.Stdout = os.Stdout
+		installCmd.Stderr = os.Stderr
+		installCmd.Stdin = os.Stdin
+		if err := installCmd.Run(); err != nil {
+			log.Fatalf("Failed to run npm install: %v", err)
+		}
+	}
+
 	scriptName := args[0]
 	scriptArgs := args[1:]
 	if len(scriptArgs) > 0 && scriptArgs[0] == "--" {


### PR DESCRIPTION
## Description

`ods web` detects when there are no `web/node_modules/` and does an install before running commands.

## How Has This Been Tested?

`prek run`

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running `ods web` now auto-installs web dependencies if `web/node_modules/` is missing. It runs `npm install --no-save` before your script to prevent failures on fresh clones and clean CI runs.

<sup>Written for commit 63da8a5b89b9738a72decf4e4ea59279c067cd08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

