### PR TITLE
fix(fe): Query History table has constrained column size

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -59,9 +59,9 @@ function QueryHistoryTableRow({
   return (
     <TableRow
       key={chatSessionMinimal.id}
-      className="hover:bg-accent-background cursor-pointer relative select-none"
+      className="hover:bg-accent-background cursor-pointer relative select-none max-h-32 overflow-hidden"
     >
-      <TableCell>
+      <TableCell className="max-w-xs">
         <Text className="whitespace-normal line-clamp-5">
           {chatSessionMinimal.first_user_message ||
             chatSessionMinimal.name ||

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -59,7 +59,7 @@ function QueryHistoryTableRow({
   return (
     <TableRow
       key={chatSessionMinimal.id}
-      className="hover:bg-accent-background cursor-pointer relative select-none max-h-32 overflow-hidden"
+      className="hover:bg-accent-background cursor-pointer relative select-none"
     >
       <TableCell className="max-w-xs">
         <Text className="whitespace-normal line-clamp-5">


### PR DESCRIPTION
## Description

Closes https://linear.app/onyx-app/issue/ENG-3253/the-query-history-table-should-probably-have-a-column-max-width

## How Has This Been Tested?

**before**
<img width="1497" height="2085" alt="20260409_17h03m50s_grim" src="https://github.com/user-attachments/assets/c7c10f3f-bc8d-4b49-81f4-b4c5e097ec49" />

**after**
<img width="1497" height="2085" alt="20260409_17h03m59s_grim" src="https://github.com/user-attachments/assets/3a65e68f-7c46-4f20-9de7-31b7a05852b2" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain the first column of the Query History table with `max-w-xs` so long queries don’t stretch the layout, improving readability and meeting Linear ENG-3253.

<sup>Written for commit e4bd493df25affb1d6869e3484962e3af9b40312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

