### PR TITLE
fix(scim): add advisory lock to prevent seat limit race condition

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -11,6 +11,7 @@ require a valid SCIM bearer token.
 
 from __future__ import annotations
 
+import hashlib
 from uuid import UUID
 
 from fastapi import APIRouter
@@ -242,7 +243,7 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     # Uses the two-argument form so each tenant gets its own lock and
     # unrelated tenants never block each other.
     tenant_id = get_current_tenant_id()
-    tenant_key = hash(tenant_id) & 0x7FFFFFFF
+    tenant_key = int(hashlib.sha256(tenant_id.encode()).hexdigest(), 16) & 0x7FFFFFFF
     dal.session.execute(
         text("SELECT pg_advisory_xact_lock(:key1, :key2)"),
         {"key1": _SEAT_LOCK_KEY1, "key2": tenant_key},

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -22,6 +22,7 @@ from fastapi import Response
 from fastapi.responses import JSONResponse
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import func
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -70,6 +71,10 @@ logger = setup_logger()
 
 # Group names reserved for system default groups (seeded by migration).
 _RESERVED_GROUP_NAMES = frozenset({"Admin", "Basic"})
+
+# Arbitrary fixed ID for the pg_advisory_xact_lock that serializes
+# seat-allocation checks during concurrent SCIM provisioning requests.
+_SEAT_LOCK_ID = 294837
 
 
 class ScimJSONResponse(JSONResponse):
@@ -208,8 +213,33 @@ def _apply_exclusions(
     return data
 
 
+def _acquire_seat_lock(dal: ScimDAL) -> None:
+    """Acquire a transaction-scoped advisory lock for seat allocation.
+
+    IdPs (Okta, Azure AD) send SCIM provisioning requests in parallel
+    batches.  Without serialization the seat-availability check is
+    vulnerable to a TOCTOU race: N concurrent requests each see "seats
+    available", all insert, and the tenant ends up over its seat limit.
+
+    ``pg_advisory_xact_lock`` serializes these checks within the same
+    database transaction and is released automatically on COMMIT /
+    ROLLBACK — no explicit cleanup needed.
+    """
+    dal.session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_id)"),
+        {"lock_id": _SEAT_LOCK_ID},
+    )
+
+
 def _check_seat_availability(dal: ScimDAL) -> str | None:
-    """Return an error message if seat limit is reached, else None."""
+    """Return an error message if seat limit is reached, else None.
+
+    Acquires a transaction-scoped advisory lock first so that
+    concurrent SCIM requests are serialized — the lock is held until
+    the caller commits or rolls back, preventing over-allocation.
+    """
+    _acquire_seat_lock(dal)
+
     check_fn = fetch_ee_implementation_or_noop(
         "onyx.db.license", "check_seat_availability", None
     )

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -12,6 +12,7 @@ require a valid SCIM bearer token.
 from __future__ import annotations
 
 import hashlib
+import struct
 from uuid import UUID
 
 from fastapi import APIRouter
@@ -74,11 +75,17 @@ logger = setup_logger()
 # Group names reserved for system default groups (seeded by migration).
 _RESERVED_GROUP_NAMES = frozenset({"Admin", "Basic"})
 
-# First key for the two-argument pg_advisory_xact_lock that serializes
-# seat-allocation checks during concurrent SCIM provisioning requests.
-# The second key is derived from the tenant ID so that different tenants
-# do not block each other.
-_SEAT_LOCK_KEY1 = 294837
+# Namespace prefix for the seat-allocation advisory lock. Hashed together
+# with the tenant ID so the lock is scoped per-tenant (unrelated tenants
+# never block each other) and cannot collide with unrelated advisory locks.
+_SEAT_LOCK_NAMESPACE = "onyx_scim_seat_lock"
+
+
+def _seat_lock_id_for_tenant(tenant_id: str) -> int:
+    """Derive a stable 64-bit signed int lock id for this tenant's seat lock."""
+    digest = hashlib.sha256(f"{_SEAT_LOCK_NAMESPACE}:{tenant_id}".encode()).digest()
+    # pg_advisory_xact_lock takes a signed 8-byte int; unpack as such.
+    return struct.unpack("q", digest[:8])[0]
 
 
 class ScimJSONResponse(JSONResponse):
@@ -240,13 +247,13 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
         return None
 
     # Transaction-scoped advisory lock — released on dal.commit() / dal.rollback().
-    # Uses the two-argument form so each tenant gets its own lock and
-    # unrelated tenants never block each other.
-    tenant_id = get_current_tenant_id()
-    tenant_key = int(hashlib.sha256(tenant_id.encode()).hexdigest(), 16) & 0x7FFFFFFF
+    # The lock id is derived from the tenant so unrelated tenants never block
+    # each other, and from a namespace string so it cannot collide with
+    # unrelated advisory locks elsewhere in the codebase.
+    lock_id = _seat_lock_id_for_tenant(get_current_tenant_id())
     dal.session.execute(
-        text("SELECT pg_advisory_xact_lock(:key1, :key2)"),
-        {"key1": _SEAT_LOCK_KEY1, "key2": tenant_key},
+        text("SELECT pg_advisory_xact_lock(:lock_id)"),
+        {"lock_id": lock_id},
     )
 
     result = check_fn(dal.session, seats_needed=1)

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -66,15 +66,18 @@ from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
 # Group names reserved for system default groups (seeded by migration).
 _RESERVED_GROUP_NAMES = frozenset({"Admin", "Basic"})
 
-# Arbitrary fixed ID for the pg_advisory_xact_lock that serializes
+# First key for the two-argument pg_advisory_xact_lock that serializes
 # seat-allocation checks during concurrent SCIM provisioning requests.
-_SEAT_LOCK_ID = 294837
+# The second key is derived from the tenant ID so that different tenants
+# do not block each other.
+_SEAT_LOCK_KEY1 = 294837
 
 
 class ScimJSONResponse(JSONResponse):
@@ -213,38 +216,38 @@ def _apply_exclusions(
     return data
 
 
-def _acquire_seat_lock(dal: ScimDAL) -> None:
-    """Acquire a transaction-scoped advisory lock for seat allocation.
-
-    IdPs (Okta, Azure AD) send SCIM provisioning requests in parallel
-    batches.  Without serialization the seat-availability check is
-    vulnerable to a TOCTOU race: N concurrent requests each see "seats
-    available", all insert, and the tenant ends up over its seat limit.
-
-    ``pg_advisory_xact_lock`` serializes these checks within the same
-    database transaction and is released automatically on COMMIT /
-    ROLLBACK — no explicit cleanup needed.
-    """
-    dal.session.execute(
-        text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": _SEAT_LOCK_ID},
-    )
-
-
 def _check_seat_availability(dal: ScimDAL) -> str | None:
     """Return an error message if seat limit is reached, else None.
 
-    Acquires a transaction-scoped advisory lock first so that
-    concurrent SCIM requests are serialized — the lock is held until
-    the caller commits or rolls back, preventing over-allocation.
-    """
-    _acquire_seat_lock(dal)
+    Acquires a transaction-scoped advisory lock so that concurrent
+    SCIM requests are serialized.  IdPs like Okta send provisioning
+    requests in parallel batches — without serialization the check is
+    vulnerable to a TOCTOU race where N concurrent requests each see
+    "seats available", all insert, and the tenant ends up over its
+    seat limit.
 
+    The lock is held until the caller's next COMMIT or ROLLBACK, which
+    means the seat count cannot change between the check here and the
+    subsequent INSERT/UPDATE.  Each call site in this module follows
+    the pattern: _check_seat_availability → write → dal.commit()
+    (which releases the lock for the next waiting request).
+    """
     check_fn = fetch_ee_implementation_or_noop(
         "onyx.db.license", "check_seat_availability", None
     )
     if check_fn is None:
         return None
+
+    # Transaction-scoped advisory lock — released on dal.commit() / dal.rollback().
+    # Uses the two-argument form so each tenant gets its own lock and
+    # unrelated tenants never block each other.
+    tenant_id = get_current_tenant_id()
+    tenant_key = hash(tenant_id) & 0x7FFFFFFF
+    dal.session.execute(
+        text("SELECT pg_advisory_xact_lock(:key1, :key2)"),
+        {"key1": _SEAT_LOCK_KEY1, "key2": tenant_key},
+    )
+
     result = check_fn(dal.session, seats_needed=1)
     if not result.available:
         return result.error_message or "Seat limit reached"

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -802,7 +803,10 @@ class TestSeatLock:
         mock_dal.session.execute.assert_called_once()
         params = mock_dal.session.execute.call_args[0][1]
         assert params["key1"] == _SEAT_LOCK_KEY1
-        assert params["key2"] == hash("tenant_xyz") & 0x7FFFFFFF
+        assert (
+            params["key2"]
+            == int(hashlib.sha256(b"tenant_xyz").hexdigest(), 16) & 0x7FFFFFFF
+        )
 
     def test_no_lock_when_ee_absent(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from uuid import uuid4
@@ -9,7 +10,10 @@ from uuid import uuid4
 from fastapi import Response
 from sqlalchemy.exc import IntegrityError
 
+from ee.onyx.server.scim.api import _acquire_seat_lock
+from ee.onyx.server.scim.api import _check_seat_availability
 from ee.onyx.server.scim.api import _scim_name_to_str
+from ee.onyx.server.scim.api import _SEAT_LOCK_ID
 from ee.onyx.server.scim.api import create_user
 from ee.onyx.server.scim.api import delete_user
 from ee.onyx.server.scim.api import get_user
@@ -741,3 +745,52 @@ class TestEmailCasePreservation:
         resource = parse_scim_user(result)
         assert resource.userName == "Alice@Example.COM"
         assert resource.emails[0].value == "Alice@Example.COM"
+
+
+class TestSeatLock:
+    """Tests for the advisory lock in _check_seat_availability."""
+
+    def test_acquires_advisory_lock_before_checking(
+        self,
+        mock_dal: MagicMock,
+    ) -> None:
+        """The advisory lock must be acquired before the seat check runs."""
+        call_order: list[str] = []
+
+        def track_execute(stmt: Any, _params: Any = None) -> None:
+            if "pg_advisory_xact_lock" in str(stmt):
+                call_order.append("lock")
+
+        mock_dal.session.execute.side_effect = track_execute
+
+        with patch(
+            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop"
+        ) as mock_fetch:
+            mock_result = MagicMock()
+            mock_result.available = True
+            mock_fn = MagicMock(return_value=mock_result)
+            mock_fetch.return_value = mock_fn
+
+            def track_check(*_args: Any, **_kwargs: Any) -> Any:
+                call_order.append("check")
+                return mock_result
+
+            mock_fn.side_effect = track_check
+
+            _check_seat_availability(mock_dal)
+
+        assert call_order == ["lock", "check"]
+
+    def test_lock_uses_correct_lock_id(
+        self,
+        mock_dal: MagicMock,
+    ) -> None:
+        """The lock ID must match the module constant."""
+        _acquire_seat_lock(mock_dal)
+
+        mock_dal.session.execute.assert_called_once()
+        call_args = mock_dal.session.execute.call_args
+        params = (
+            call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
+        )
+        assert params == {"lock_id": _SEAT_LOCK_ID}

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -13,7 +12,7 @@ from sqlalchemy.exc import IntegrityError
 
 from ee.onyx.server.scim.api import _check_seat_availability
 from ee.onyx.server.scim.api import _scim_name_to_str
-from ee.onyx.server.scim.api import _SEAT_LOCK_KEY1
+from ee.onyx.server.scim.api import _seat_lock_id_for_tenant
 from ee.onyx.server.scim.api import create_user
 from ee.onyx.server.scim.api import delete_user
 from ee.onyx.server.scim.api import get_user
@@ -789,7 +788,7 @@ class TestSeatLock:
         _mock_tenant: MagicMock,
         mock_dal: MagicMock,
     ) -> None:
-        """The lock must use the two-arg form with a tenant-derived key."""
+        """The lock id must be derived from the tenant via _seat_lock_id_for_tenant."""
         mock_result = MagicMock()
         mock_result.available = True
         mock_check = MagicMock(return_value=mock_result)
@@ -802,11 +801,12 @@ class TestSeatLock:
 
         mock_dal.session.execute.assert_called_once()
         params = mock_dal.session.execute.call_args[0][1]
-        assert params["key1"] == _SEAT_LOCK_KEY1
-        assert (
-            params["key2"]
-            == int(hashlib.sha256(b"tenant_xyz").hexdigest(), 16) & 0x7FFFFFFF
-        )
+        assert params["lock_id"] == _seat_lock_id_for_tenant("tenant_xyz")
+
+    def test_seat_lock_id_is_stable_and_tenant_scoped(self) -> None:
+        """Lock id must be deterministic and differ across tenants."""
+        assert _seat_lock_id_for_tenant("t1") == _seat_lock_id_for_tenant("t1")
+        assert _seat_lock_id_for_tenant("t1") != _seat_lock_id_for_tenant("t2")
 
     def test_no_lock_when_ee_absent(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -10,10 +10,9 @@ from uuid import uuid4
 from fastapi import Response
 from sqlalchemy.exc import IntegrityError
 
-from ee.onyx.server.scim.api import _acquire_seat_lock
 from ee.onyx.server.scim.api import _check_seat_availability
 from ee.onyx.server.scim.api import _scim_name_to_str
-from ee.onyx.server.scim.api import _SEAT_LOCK_ID
+from ee.onyx.server.scim.api import _SEAT_LOCK_KEY1
 from ee.onyx.server.scim.api import create_user
 from ee.onyx.server.scim.api import delete_user
 from ee.onyx.server.scim.api import get_user
@@ -750,8 +749,10 @@ class TestEmailCasePreservation:
 class TestSeatLock:
     """Tests for the advisory lock in _check_seat_availability."""
 
+    @patch("ee.onyx.server.scim.api.get_current_tenant_id", return_value="tenant_abc")
     def test_acquires_advisory_lock_before_checking(
         self,
+        _mock_tenant: MagicMock,
         mock_dal: MagicMock,
     ) -> None:
         """The advisory lock must be acquired before the seat check runs."""
@@ -781,16 +782,38 @@ class TestSeatLock:
 
         assert call_order == ["lock", "check"]
 
-    def test_lock_uses_correct_lock_id(
+    @patch("ee.onyx.server.scim.api.get_current_tenant_id", return_value="tenant_xyz")
+    def test_lock_uses_tenant_scoped_key(
+        self,
+        _mock_tenant: MagicMock,
+        mock_dal: MagicMock,
+    ) -> None:
+        """The lock must use the two-arg form with a tenant-derived key."""
+        mock_result = MagicMock()
+        mock_result.available = True
+        mock_check = MagicMock(return_value=mock_result)
+
+        with patch(
+            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
+            return_value=mock_check,
+        ):
+            _check_seat_availability(mock_dal)
+
+        mock_dal.session.execute.assert_called_once()
+        params = mock_dal.session.execute.call_args[0][1]
+        assert params["key1"] == _SEAT_LOCK_KEY1
+        assert params["key2"] == hash("tenant_xyz") & 0x7FFFFFFF
+
+    def test_no_lock_when_ee_absent(
         self,
         mock_dal: MagicMock,
     ) -> None:
-        """The lock ID must match the module constant."""
-        _acquire_seat_lock(mock_dal)
+        """No advisory lock should be acquired when the EE check is absent."""
+        with patch(
+            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
+            return_value=None,
+        ):
+            result = _check_seat_availability(mock_dal)
 
-        mock_dal.session.execute.assert_called_once()
-        call_args = mock_dal.session.execute.call_args
-        params = (
-            call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
-        )
-        assert params == {"lock_id": _SEAT_LOCK_ID}
+        assert result is None
+        mock_dal.session.execute.assert_not_called()


### PR DESCRIPTION
## Description

IdPs like Okta send SCIM provisioning requests in parallel batches during user sync. The seat-availability check in `_check_seat_availability` was vulnerable to a TOCTOU race condition: N concurrent requests could each see "seats available", all insert, and push the tenant over its seat limit.

Adds a `pg_advisory_xact_lock` in `_check_seat_availability` that serializes concurrent seat checks within the same DB transaction. The lock is automatically released on COMMIT/ROLLBACK, so it only holds for the duration of the check + insert — no manual cleanup needed.

## How Has This Been Tested?

unit tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check