### PR TITLE
fix(chat): hide ModelSelector in search mode

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -871,15 +871,20 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         agent={liveAgent}
                         isDefaultAgent={isDefaultAgent}
                       />
-                      {liveAgent && !llmManager.isLoadingProviders && (
-                        <ModelSelector
-                          llmManager={llmManager}
-                          selectedModels={multiModel.selectedModels}
-                          onAdd={multiModel.addModel}
-                          onRemove={multiModel.removeModel}
-                          onReplace={multiModel.replaceModel}
-                        />
-                      )}
+                      {!isSearch &&
+                        !(
+                          state.phase === "idle" && state.appMode === "search"
+                        ) &&
+                        liveAgent &&
+                        !llmManager.isLoadingProviders && (
+                          <ModelSelector
+                            llmManager={llmManager}
+                            selectedModels={multiModel.selectedModels}
+                            onAdd={multiModel.addModel}
+                            onRemove={multiModel.removeModel}
+                            onReplace={multiModel.replaceModel}
+                          />
+                        )}
                     </Section>
                     <Spacer rem={1.5} />
                   </Fade>


### PR DESCRIPTION
## Description

The ModelSelector was visible on the welcome screen even when the app mode dropdown was set to "Search". Model selection is only relevant for chat, not search.

Hides the welcome screen ModelSelector when:
- App mode is set to Search while idle (`state.phase === "idle" && state.appMode === "search"`)
- Active search is in progress (`searching` / `search-results` phase)

The chat-mode ModelSelector (above the input bar) was already gated by `appFocus.isChat()`.

## How Has This Been Tested?

![2026-04-09 17 32 49](https://github.com/user-attachments/assets/29cdcd03-7ee2-4f49-9643-049fabbe8240)


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check