### PR TITLE
fix(license): exclude service account users from seat count

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -13,6 +13,7 @@ from ee.onyx.server.license.models import LicenseSource
 from onyx.auth.schemas import UserRole
 from onyx.cache.factory import get_cache_backend
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
+from onyx.db.enums import AccountType
 from onyx.db.models import License
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
@@ -107,12 +108,11 @@ def get_used_seats(tenant_id: str | None = None) -> int:
     Get current seat usage directly from database.
 
     For multi-tenant: counts users in UserTenantMapping for this tenant.
-    For self-hosted: counts all active users (excludes EXT_PERM_USER role
-    and the anonymous system user).
+    For self-hosted: counts all active users.
 
-    TODO: Exclude API key dummy users from seat counting. API keys create
-    users with emails like `__DANSWER_API_KEY_*` that should not count toward
-    seat limits. See: https://linear.app/onyx-app/issue/ENG-3518
+    Only human interactive accounts count toward seat limits.
+    SERVICE_ACCOUNT (API key dummy users), BOT (Slack users),
+    EXT_PERM_USER, and the anonymous system user are excluded.
     """
     if MULTI_TENANT:
         from ee.onyx.server.tenants.user_mapping import get_tenant_count
@@ -129,6 +129,9 @@ def get_used_seats(tenant_id: str | None = None) -> int:
                     User.is_active == True,  # type: ignore  # noqa: E712
                     User.role != UserRole.EXT_PERM_USER,
                     User.email != ANONYMOUS_USER_EMAIL,  # type: ignore
+                    User.account_type.notin_(  # type: ignore
+                        [AccountType.SERVICE_ACCOUNT, AccountType.BOT]
+                    ),
                 )
             )
             return result.scalar() or 0

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -110,9 +110,11 @@ def get_used_seats(tenant_id: str | None = None) -> int:
     For multi-tenant: counts users in UserTenantMapping for this tenant.
     For self-hosted: counts all active users.
 
-    Only human interactive accounts count toward seat limits.
-    SERVICE_ACCOUNT (API key dummy users), BOT (Slack users),
-    EXT_PERM_USER, and the anonymous system user are excluded.
+    Only human accounts count toward seat limits.
+    SERVICE_ACCOUNT (API key dummy users), EXT_PERM_USER, and the
+    anonymous system user are excluded. BOT (Slack users) ARE counted
+    because they represent real humans and get upgraded to STANDARD
+    when they log in via web.
     """
     if MULTI_TENANT:
         from ee.onyx.server.tenants.user_mapping import get_tenant_count
@@ -129,9 +131,7 @@ def get_used_seats(tenant_id: str | None = None) -> int:
                     User.is_active == True,  # type: ignore  # noqa: E712
                     User.role != UserRole.EXT_PERM_USER,
                     User.email != ANONYMOUS_USER_EMAIL,  # type: ignore
-                    User.account_type.notin_(  # type: ignore
-                        [AccountType.SERVICE_ACCOUNT, AccountType.BOT]
-                    ),
+                    User.account_type != AccountType.SERVICE_ACCOUNT,
                 )
             )
             return result.scalar() or 0

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -320,10 +320,12 @@ def get_tenant_count(tenant_id: str) -> int:
     1. They have an active mapping to this tenant (UserTenantMapping.active == True)
     2. AND the User is active (User.is_active == True)
     3. AND the User is not the anonymous system user
-    4. AND the User is not a SERVICE_ACCOUNT (API key dummy user)
+
+    TODO: Exclude API key dummy users from seat counting. API keys create
+    users with emails like `__DANSWER_API_KEY_*` that should not count toward
+    seat limits. See: https://linear.app/onyx-app/issue/ENG-3518
     """
     from onyx.configs.constants import ANONYMOUS_USER_EMAIL
-    from onyx.db.enums import AccountType
     from onyx.db.models import User
 
     # First get all emails with active mappings to this tenant
@@ -349,7 +351,6 @@ def get_tenant_count(tenant_id: str) -> int:
             .filter(
                 User.email.in_(emails),  # type: ignore
                 User.is_active == True,  # type: ignore  # noqa: E712
-                User.account_type != AccountType.SERVICE_ACCOUNT,  # type: ignore
             )
             .count()
         )

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -320,7 +320,7 @@ def get_tenant_count(tenant_id: str) -> int:
     1. They have an active mapping to this tenant (UserTenantMapping.active == True)
     2. AND the User is active (User.is_active == True)
     3. AND the User is not the anonymous system user
-    4. AND the User is a human interactive account (not SERVICE_ACCOUNT or BOT)
+    4. AND the User is not a SERVICE_ACCOUNT (API key dummy user)
     """
     from onyx.configs.constants import ANONYMOUS_USER_EMAIL
     from onyx.db.enums import AccountType
@@ -349,9 +349,7 @@ def get_tenant_count(tenant_id: str) -> int:
             .filter(
                 User.email.in_(emails),  # type: ignore
                 User.is_active == True,  # type: ignore  # noqa: E712
-                User.account_type.notin_(  # type: ignore
-                    [AccountType.SERVICE_ACCOUNT, AccountType.BOT]
-                ),
+                User.account_type != AccountType.SERVICE_ACCOUNT,  # type: ignore
             )
             .count()
         )

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -320,12 +320,10 @@ def get_tenant_count(tenant_id: str) -> int:
     1. They have an active mapping to this tenant (UserTenantMapping.active == True)
     2. AND the User is active (User.is_active == True)
     3. AND the User is not the anonymous system user
-
-    TODO: Exclude API key dummy users from seat counting. API keys create
-    users with emails like `__DANSWER_API_KEY_*` that should not count toward
-    seat limits. See: https://linear.app/onyx-app/issue/ENG-3518
+    4. AND the User is a human interactive account (not SERVICE_ACCOUNT or BOT)
     """
     from onyx.configs.constants import ANONYMOUS_USER_EMAIL
+    from onyx.db.enums import AccountType
     from onyx.db.models import User
 
     # First get all emails with active mappings to this tenant
@@ -351,6 +349,9 @@ def get_tenant_count(tenant_id: str) -> int:
             .filter(
                 User.email.in_(emails),  # type: ignore
                 User.is_active == True,  # type: ignore  # noqa: E712
+                User.account_type.notin_(  # type: ignore
+                    [AccountType.SERVICE_ACCOUNT, AccountType.BOT]
+                ),
             )
             .count()
         )

--- a/backend/tests/unit/ee/onyx/db/test_license.py
+++ b/backend/tests/unit/ee/onyx/db/test_license.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from ee.onyx.db.license import check_seat_availability
 from ee.onyx.db.license import delete_license
 from ee.onyx.db.license import get_license
+from ee.onyx.db.license import get_used_seats
 from ee.onyx.db.license import upsert_license
 from ee.onyx.server.license.models import LicenseMetadata
 from ee.onyx.server.license.models import LicenseSource
@@ -214,3 +215,43 @@ class TestCheckSeatAvailabilityMultiTenant:
         assert result.available is False
         assert result.error_message is not None
         mock_tenant_count.assert_called_once_with("tenant-abc")
+
+
+class TestGetUsedSeatsAccountTypeFiltering:
+    """Verify get_used_seats query excludes SERVICE_ACCOUNT but includes BOT."""
+
+    @patch("ee.onyx.db.license.MULTI_TENANT", False)
+    @patch("onyx.db.engine.sql_engine.get_session_with_current_tenant")
+    def test_excludes_service_accounts(self, mock_get_session: MagicMock) -> None:
+        """SERVICE_ACCOUNT users should not count toward seats."""
+        mock_session = MagicMock()
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.execute.return_value.scalar.return_value = 5
+
+        result = get_used_seats()
+
+        assert result == 5
+        # Inspect the compiled query to verify account_type filter
+        call_args = mock_session.execute.call_args
+        query = call_args[0][0]
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "SERVICE_ACCOUNT" in compiled
+        # BOT should NOT be excluded
+        assert "BOT" not in compiled
+
+    @patch("ee.onyx.db.license.MULTI_TENANT", False)
+    @patch("onyx.db.engine.sql_engine.get_session_with_current_tenant")
+    def test_still_excludes_ext_perm_user(self, mock_get_session: MagicMock) -> None:
+        """EXT_PERM_USER exclusion should still be present."""
+        mock_session = MagicMock()
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.execute.return_value.scalar.return_value = 3
+
+        get_used_seats()
+
+        call_args = mock_session.execute.call_args
+        query = call_args[0][0]
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "EXT_PERM_USER" in compiled


### PR DESCRIPTION
## Description

Adds `SERVICE_ACCOUNT` filter to the self-hosted seat-counting query in `get_used_seats` and updates the docstring to accurately document which account types are excluded.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check