### PR TITLE
chore(devtools): improve devcontainer usability w/ rootless docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:26.04@sha256:cc925e589b7543b910fea57a240468940003fbfc0515245a495dd0ad8fe7cef1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  acl \
   curl \
   fd-find \
   fzf \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -14,12 +14,6 @@ A containerized development environment for working on Onyx.
 
 ## Usage
 
-### VS Code
-
-1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Open this repo in VS Code
-3. "Reopen in Container" when prompted
-
 ### CLI (`ods dev`)
 
 The [`ods` devtools CLI](../tools/ods/README.md) provides workspace-aware wrappers
@@ -39,24 +33,7 @@ ods dev exec npm test
 ods dev stop
 ```
 
-If you don't have `ods` installed, use the `devcontainer` CLI directly:
-
-```bash
-npm install -g @devcontainers/cli
-
-devcontainer up --workspace-folder .
-devcontainer exec --workspace-folder . zsh
-```
-
 ## Restarting the container
-
-### VS Code
-
-Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run:
-
-- **Dev Containers: Reopen in Container** — restarts the container without rebuilding
-
-### CLI
 
 ```bash
 # Restart the container
@@ -64,12 +41,6 @@ ods dev restart
 
 # Pull the latest published image and recreate
 ods dev rebuild
-```
-
-Or without `ods`:
-
-```bash
-devcontainer up --workspace-folder . --remove-existing-container
 ```
 
 ## Image
@@ -99,14 +70,6 @@ user has read/write access to the bind-mounted workspace:
   maps back to your host user via the user namespace. New files are owned by your
   host UID and no ACL workarounds are needed.
 
-  If you use the `devcontainer` CLI directly (without `ods`), export the variable
-  yourself:
-
-  ```bash
-  export DEVCONTAINER_REMOTE_USER=root
-  devcontainer up --workspace-folder .
-  ```
-
   To override the auto-detection, set `DEVCONTAINER_REMOTE_USER` before running
   `ods dev up`.
 
@@ -121,9 +84,7 @@ from inside. `ods dev` auto-detects the socket path and sets `DOCKER_SOCK`:
 | macOS (Docker Desktop)  | `~/.docker/run/docker.sock`    |
 | Linux (standard Docker) | `/var/run/docker.sock`         |
 
-To override, set `DOCKER_SOCK` before running `ods dev up`. When using the
-VS Code extension or `devcontainer` CLI directly (without `ods`), you must set
-`DOCKER_SOCK` yourself.
+To override, set `DOCKER_SOCK` before running `ods dev up`.
 
 ## Firewall
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -88,15 +88,27 @@ The `devcontainer` target is defined in `docker-bake.hcl` at the repo root.
 ## User & permissions
 
 The container runs as the `dev` user by default (`remoteUser` in devcontainer.json).
-An init script (`init-dev-user.sh`) runs at container start to ensure `dev` has
-read/write access to the bind-mounted workspace:
+An init script (`init-dev-user.sh`) runs at container start to ensure the active
+user has read/write access to the bind-mounted workspace:
 
 - **Standard Docker** — `dev`'s UID/GID is remapped to match the workspace owner,
   so file permissions work seamlessly.
 - **Rootless Docker** — The workspace appears as root-owned (UID 0) inside the
-  container due to user-namespace mapping. The init script grants `dev` access via
-  POSIX ACLs (`setfacl`), which adds a few seconds to the first container start on
-  large repos.
+  container due to user-namespace mapping. `ods dev up` auto-detects rootless Docker
+  and sets `DEVCONTAINER_REMOTE_USER=root` so the container runs as root — which
+  maps back to your host user via the user namespace. New files are owned by your
+  host UID and no ACL workarounds are needed.
+
+  If you use the `devcontainer` CLI directly (without `ods`), export the variable
+  yourself:
+
+  ```bash
+  export DEVCONTAINER_REMOTE_USER=root
+  devcontainer up --workspace-folder .
+  ```
+
+  To override the auto-detection, set `DEVCONTAINER_REMOTE_USER` before running
+  `ods dev up`.
 
 ## Docker socket
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,13 @@
     "source=${localEnv:HOME}/.claude.json,target=/home/dev/.claude.json,type=bind",
     "source=${localEnv:HOME}/.zshrc,target=/home/dev/.zshrc.host,type=bind,readonly",
     "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig.host,type=bind,readonly",
-    "source=${localEnv:HOME}/.ssh,target=/home/dev/.ssh,type=bind",
     "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
   ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock"
+  },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",
   "updateRemoteUserUID": false,
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "source=${localEnv:HOME}/.claude,target=/home/dev/.claude,type=bind",
     "source=${localEnv:HOME}/.claude.json,target=/home/dev/.claude.json,type=bind",
     "source=${localEnv:HOME}/.zshrc,target=/home/dev/.zshrc.host,type=bind,readonly",
-    "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig.host,type=bind,readonly",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig,type=bind,readonly",
     "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
     "source=${localEnv:HOME}/.claude.json,target=/home/dev/.claude.json,type=bind",
     "source=${localEnv:HOME}/.zshrc,target=/home/dev/.zshrc.host,type=bind,readonly",
     "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig.host,type=bind,readonly",
-    "source=${localEnv:HOME}/.ssh,target=/home/dev/.ssh.host,type=bind,readonly",
-    "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim.host,type=bind,readonly",
+    "source=${localEnv:HOME}/.ssh,target=/home/dev/.ssh,type=bind",
+    "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
   ],
-  "remoteUser": "dev",
+  "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",
   "updateRemoteUserUID": false,
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -8,12 +8,14 @@ set -euo pipefail
 #                    We remap dev to that UID -- fast and seamless.
 #
 # Rootless Docker:   Workspace appears as root-owned (UID 0) inside the
-#                    container due to user-namespace mapping.  We can't remap
-#                    dev to UID 0 (that's root), so we grant access with
-#                    POSIX ACLs instead.
+#                    container due to user-namespace mapping.
+#                    • remoteUser=root  → symlink bind-mounts into /root
+#                      (container root IS the host user; no permission tricks)
+#                    • remoteUser=dev   → grant access with POSIX ACLs
 
 WORKSPACE=/workspace
 TARGET_USER=dev
+REMOTE_USER="${SUDO_USER:-$TARGET_USER}"
 
 WS_UID=$(stat -c '%u' "$WORKSPACE")
 WS_GID=$(stat -c '%g' "$WORKSPACE")
@@ -22,24 +24,61 @@ DEV_GID=$(id -g "$TARGET_USER")
 
 DEV_HOME=/home/"$TARGET_USER"
 
-# Ensure directories that tools expect exist under ~dev.
-# ~/.local and ~/.cache are named Docker volumes -- ensure they are owned by dev.
+if [ "$REMOTE_USER" = "root" ]; then
+    ACTIVE_HOME="/root"
+else
+    ACTIVE_HOME="$DEV_HOME"
+fi
+
+# ── Phase 1: home directory setup ───────────────────────────────────
+
+# ~/.local and ~/.cache are named Docker volumes mounted under ~dev.
 mkdir -p "$DEV_HOME"/.local/state "$DEV_HOME"/.local/share
 chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME"/.local
 chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME"/.cache
 
-# Copy host configs mounted as *.host into their real locations.
-# This gives the dev user owned copies without touching host originals.
+# Copy host configs mounted as *.host into the active user's home.
+# Sources are always under ~dev (that's where devcontainer.json mounts them).
 if [ -d "$DEV_HOME/.ssh.host" ]; then
-    cp -a "$DEV_HOME/.ssh.host" "$DEV_HOME/.ssh"
-    chmod 700 "$DEV_HOME/.ssh"
-    chmod 600 "$DEV_HOME"/.ssh/id_* 2>/dev/null || true
-    chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME/.ssh"
+    cp -a "$DEV_HOME/.ssh.host" "$ACTIVE_HOME/.ssh"
+    chmod 700 "$ACTIVE_HOME/.ssh"
+    chmod 600 "$ACTIVE_HOME"/.ssh/id_* 2>/dev/null || true
+    chown -R "$REMOTE_USER":"$REMOTE_USER" "$ACTIVE_HOME/.ssh"
 fi
 if [ -d "$DEV_HOME/.config/nvim.host" ]; then
-    mkdir -p "$DEV_HOME/.config"
-    cp -a "$DEV_HOME/.config/nvim.host" "$DEV_HOME/.config/nvim"
-    chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME/.config/nvim"
+    mkdir -p "$ACTIVE_HOME/.config"
+    cp -a "$DEV_HOME/.config/nvim.host" "$ACTIVE_HOME/.config/nvim"
+    chown -R "$REMOTE_USER":"$REMOTE_USER" "$ACTIVE_HOME/.config/nvim"
+fi
+
+# When running as root, symlink bind-mounts and named volumes into /root
+# so that $HOME-relative tools (Claude Code, git, etc.) find them.
+if [ "$REMOTE_USER" = "root" ] && [ "$ACTIVE_HOME" != "$DEV_HOME" ]; then
+    for item in .claude .cache .local; do
+        [ -d "$DEV_HOME/$item" ] || continue
+        [ -L "/root/$item" ] || rm -rf "/root/$item"
+        ln -sfn "$DEV_HOME/$item" "/root/$item"
+    done
+    [ -f "$DEV_HOME/.claude.json" ] && ln -sf "$DEV_HOME/.claude.json" /root/.claude.json
+
+    # Git: include the host gitconfig and mark the workspace safe.
+    printf '[include]\n\tpath = %s/.gitconfig.host\n[safe]\n\tdirectory = %s\n' \
+        "$DEV_HOME" "$WORKSPACE" > /root/.gitconfig
+
+    GIT_COMMON_DIR=$(git -C "$WORKSPACE" rev-parse --git-common-dir 2>/dev/null || true)
+    if [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ]; then
+        [ ! -d "$GIT_COMMON_DIR" ] && GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR"
+        if [ -d "$GIT_COMMON_DIR" ]; then
+            git config -f /root/.gitconfig --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
+        fi
+    fi
+fi
+
+# ── Phase 2: workspace access ───────────────────────────────────────
+
+# Root always has workspace access; Phase 1 handled home setup.
+if [ "$REMOTE_USER" = "root" ]; then
+    exit 0
 fi
 
 # Already matching -- nothing to do.
@@ -100,6 +139,6 @@ else
             setfacl -m "u:${TARGET_USER}:rw" /home/"$TARGET_USER"/.claude.json
     else
         echo "warning: setfacl not found; dev user may not have write access to workspace" >&2
-        echo "         install the 'acl' package or set remoteUser to root" >&2
+        echo "         install the 'acl' package or set DEVCONTAINER_REMOTE_USER=root" >&2
     fi
 fi

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -49,7 +49,10 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
         fi
         ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"
     done
-    [ -f "$MOUNT_HOME/.claude.json" ] && ln -sf "$MOUNT_HOME/.claude.json" "$ACTIVE_HOME/.claude.json"
+    # Symlink files (not directories).
+    for file in .claude.json .gitconfig; do
+        [ -f "$MOUNT_HOME/$file" ] && ln -sf "$MOUNT_HOME/$file" "$ACTIVE_HOME/$file"
+    done
 
     # Nested mount: .config/nvim
     if [ -d "$MOUNT_HOME/.config/nvim" ]; then
@@ -59,23 +62,6 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
             rm -rf "$ACTIVE_HOME/.config/nvim"
         fi
         ln -sfn "$MOUNT_HOME/.config/nvim" "$ACTIVE_HOME/.config/nvim"
-    fi
-
-    # Git: include the host gitconfig and mark the workspace safe.
-    printf '[include]\n\tpath = %s/.gitconfig.host\n[safe]\n\tdirectory = %s\n' \
-        "$MOUNT_HOME" "$WORKSPACE" > "$ACTIVE_HOME/.gitconfig"
-
-    GIT_COMMON_DIR=$(git -C "$WORKSPACE" rev-parse --git-common-dir 2>/dev/null || true)
-    if [ -n "$GIT_COMMON_DIR" ]; then
-        # Resolve to absolute before comparing — git returns a relative path
-        # for regular repos (.git) but absolute for worktrees.
-        case "$GIT_COMMON_DIR" in
-            /*) ;;
-            *)  GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR" ;;
-        esac
-        if [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ] && [ -d "$GIT_COMMON_DIR" ]; then
-            git config -f "$ACTIVE_HOME/.gitconfig" --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
-        fi
     fi
 fi
 

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -43,7 +43,10 @@ mkdir -p "$MOUNT_HOME"/.local/state "$MOUNT_HOME"/.local/share
 if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
     for item in .claude .cache .local; do
         [ -d "$MOUNT_HOME/$item" ] || continue
-        [ -L "$ACTIVE_HOME/$item" ] || rm -rf "$ACTIVE_HOME/$item"
+        if [ -e "$ACTIVE_HOME/$item" ] && [ ! -L "$ACTIVE_HOME/$item" ]; then
+            echo "warning: replacing $ACTIVE_HOME/$item with symlink to $MOUNT_HOME/$item" >&2
+            rm -rf "$ACTIVE_HOME/$item"
+        fi
         ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"
     done
     [ -f "$MOUNT_HOME/.claude.json" ] && ln -sf "$MOUNT_HOME/.claude.json" "$ACTIVE_HOME/.claude.json"
@@ -51,7 +54,10 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
     # Nested mount: .config/nvim
     if [ -d "$MOUNT_HOME/.config/nvim" ]; then
         mkdir -p "$ACTIVE_HOME/.config"
-        [ -L "$ACTIVE_HOME/.config/nvim" ] || rm -rf "$ACTIVE_HOME/.config/nvim"
+        if [ -e "$ACTIVE_HOME/.config/nvim" ] && [ ! -L "$ACTIVE_HOME/.config/nvim" ]; then
+            echo "warning: replacing $ACTIVE_HOME/.config/nvim with symlink" >&2
+            rm -rf "$ACTIVE_HOME/.config/nvim"
+        fi
         ln -sfn "$MOUNT_HOME/.config/nvim" "$ACTIVE_HOME/.config/nvim"
     fi
 
@@ -60,9 +66,14 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
         "$MOUNT_HOME" "$WORKSPACE" > "$ACTIVE_HOME/.gitconfig"
 
     GIT_COMMON_DIR=$(git -C "$WORKSPACE" rev-parse --git-common-dir 2>/dev/null || true)
-    if [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ]; then
-        [ ! -d "$GIT_COMMON_DIR" ] && GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR"
-        if [ -d "$GIT_COMMON_DIR" ]; then
+    if [ -n "$GIT_COMMON_DIR" ]; then
+        # Resolve to absolute before comparing — git returns a relative path
+        # for regular repos (.git) but absolute for worktrees.
+        case "$GIT_COMMON_DIR" in
+            /*) ;;
+            *)  GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR" ;;
+        esac
+        if [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ] && [ -d "$GIT_COMMON_DIR" ]; then
             git config -f "$ACTIVE_HOME/.gitconfig" --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
         fi
     fi

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -39,9 +39,9 @@ fi
 mkdir -p "$MOUNT_HOME"/.local/state "$MOUNT_HOME"/.local/share
 
 # When running as root, symlink bind-mounts and named volumes into /root
-# so that $HOME-relative tools (Claude Code, git, ssh, etc.) find them.
+# so that $HOME-relative tools (Claude Code, git, etc.) find them.
 if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
-    for item in .claude .ssh .cache .local; do
+    for item in .claude .cache .local; do
         [ -d "$MOUNT_HOME/$item" ] || continue
         [ -L "$ACTIVE_HOME/$item" ] || rm -rf "$ACTIVE_HOME/$item"
         ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -22,54 +22,52 @@ WS_GID=$(stat -c '%g' "$WORKSPACE")
 DEV_UID=$(id -u "$TARGET_USER")
 DEV_GID=$(id -g "$TARGET_USER")
 
-DEV_HOME=/home/"$TARGET_USER"
+# devcontainer.json bind-mounts and named volumes target /home/dev regardless
+# of remoteUser.  When running as root ($HOME=/root), Phase 1 bridges the gap
+# with symlinks from ACTIVE_HOME → MOUNT_HOME.
+MOUNT_HOME=/home/"$TARGET_USER"
 
 if [ "$REMOTE_USER" = "root" ]; then
     ACTIVE_HOME="/root"
 else
-    ACTIVE_HOME="$DEV_HOME"
+    ACTIVE_HOME="$MOUNT_HOME"
 fi
 
 # ── Phase 1: home directory setup ───────────────────────────────────
 
-# ~/.local and ~/.cache are named Docker volumes mounted under ~dev.
-mkdir -p "$DEV_HOME"/.local/state "$DEV_HOME"/.local/share
-chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME"/.local
-chown -R "$TARGET_USER":"$TARGET_USER" "$DEV_HOME"/.cache
+# ~/.local and ~/.cache are named Docker volumes mounted under MOUNT_HOME.
+mkdir -p "$MOUNT_HOME"/.local/state "$MOUNT_HOME"/.local/share
 
 # Copy host configs mounted as *.host into the active user's home.
-# Sources are always under ~dev (that's where devcontainer.json mounts them).
-if [ -d "$DEV_HOME/.ssh.host" ]; then
-    cp -a "$DEV_HOME/.ssh.host" "$ACTIVE_HOME/.ssh"
+if [ -d "$MOUNT_HOME/.ssh.host" ]; then
+    cp -a "$MOUNT_HOME/.ssh.host" "$ACTIVE_HOME/.ssh"
     chmod 700 "$ACTIVE_HOME/.ssh"
     chmod 600 "$ACTIVE_HOME"/.ssh/id_* 2>/dev/null || true
-    chown -R "$REMOTE_USER":"$REMOTE_USER" "$ACTIVE_HOME/.ssh"
 fi
-if [ -d "$DEV_HOME/.config/nvim.host" ]; then
+if [ -d "$MOUNT_HOME/.config/nvim.host" ]; then
     mkdir -p "$ACTIVE_HOME/.config"
-    cp -a "$DEV_HOME/.config/nvim.host" "$ACTIVE_HOME/.config/nvim"
-    chown -R "$REMOTE_USER":"$REMOTE_USER" "$ACTIVE_HOME/.config/nvim"
+    cp -a "$MOUNT_HOME/.config/nvim.host" "$ACTIVE_HOME/.config/nvim"
 fi
 
 # When running as root, symlink bind-mounts and named volumes into /root
 # so that $HOME-relative tools (Claude Code, git, etc.) find them.
-if [ "$REMOTE_USER" = "root" ] && [ "$ACTIVE_HOME" != "$DEV_HOME" ]; then
+if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
     for item in .claude .cache .local; do
-        [ -d "$DEV_HOME/$item" ] || continue
-        [ -L "/root/$item" ] || rm -rf "/root/$item"
-        ln -sfn "$DEV_HOME/$item" "/root/$item"
+        [ -d "$MOUNT_HOME/$item" ] || continue
+        [ -L "$ACTIVE_HOME/$item" ] || rm -rf "$ACTIVE_HOME/$item"
+        ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"
     done
-    [ -f "$DEV_HOME/.claude.json" ] && ln -sf "$DEV_HOME/.claude.json" /root/.claude.json
+    [ -f "$MOUNT_HOME/.claude.json" ] && ln -sf "$MOUNT_HOME/.claude.json" "$ACTIVE_HOME/.claude.json"
 
     # Git: include the host gitconfig and mark the workspace safe.
     printf '[include]\n\tpath = %s/.gitconfig.host\n[safe]\n\tdirectory = %s\n' \
-        "$DEV_HOME" "$WORKSPACE" > /root/.gitconfig
+        "$MOUNT_HOME" "$WORKSPACE" > "$ACTIVE_HOME/.gitconfig"
 
     GIT_COMMON_DIR=$(git -C "$WORKSPACE" rev-parse --git-common-dir 2>/dev/null || true)
     if [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ]; then
         [ ! -d "$GIT_COMMON_DIR" ] && GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR"
         if [ -d "$GIT_COMMON_DIR" ]; then
-            git config -f /root/.gitconfig --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
+            git config -f "$ACTIVE_HOME/.gitconfig" --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
         fi
     fi
 fi
@@ -80,6 +78,10 @@ fi
 if [ "$REMOTE_USER" = "root" ]; then
     exit 0
 fi
+
+# Ensure ~dev owns its own home (volumes may have been created as root).
+chown -R "$TARGET_USER":"$TARGET_USER" "$MOUNT_HOME"/.local
+chown -R "$TARGET_USER":"$TARGET_USER" "$MOUNT_HOME"/.cache
 
 # Already matching -- nothing to do.
 if [ "$WS_UID" = "$DEV_UID" ] && [ "$WS_GID" = "$DEV_GID" ]; then
@@ -100,8 +102,8 @@ if [ "$WS_UID" != "0" ]; then
             echo "warning: failed to remap $TARGET_USER UID to $WS_UID" >&2
         fi
     fi
-    if ! chown -R "$TARGET_USER":"$TARGET_USER" /home/"$TARGET_USER" 2>&1; then
-        echo "warning: failed to chown /home/$TARGET_USER" >&2
+    if ! chown -R "$TARGET_USER":"$TARGET_USER" "$MOUNT_HOME" 2>&1; then
+        echo "warning: failed to chown $MOUNT_HOME" >&2
     fi
 else
     # ── Rootless Docker ──────────────────────────────────────────────

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -38,26 +38,22 @@ fi
 # ~/.local and ~/.cache are named Docker volumes mounted under MOUNT_HOME.
 mkdir -p "$MOUNT_HOME"/.local/state "$MOUNT_HOME"/.local/share
 
-# Copy host configs mounted as *.host into the active user's home.
-if [ -d "$MOUNT_HOME/.ssh.host" ]; then
-    cp -a "$MOUNT_HOME/.ssh.host" "$ACTIVE_HOME/.ssh"
-    chmod 700 "$ACTIVE_HOME/.ssh"
-    chmod 600 "$ACTIVE_HOME"/.ssh/id_* 2>/dev/null || true
-fi
-if [ -d "$MOUNT_HOME/.config/nvim.host" ]; then
-    mkdir -p "$ACTIVE_HOME/.config"
-    cp -a "$MOUNT_HOME/.config/nvim.host" "$ACTIVE_HOME/.config/nvim"
-fi
-
 # When running as root, symlink bind-mounts and named volumes into /root
-# so that $HOME-relative tools (Claude Code, git, etc.) find them.
+# so that $HOME-relative tools (Claude Code, git, ssh, etc.) find them.
 if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
-    for item in .claude .cache .local; do
+    for item in .claude .ssh .cache .local; do
         [ -d "$MOUNT_HOME/$item" ] || continue
         [ -L "$ACTIVE_HOME/$item" ] || rm -rf "$ACTIVE_HOME/$item"
         ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"
     done
     [ -f "$MOUNT_HOME/.claude.json" ] && ln -sf "$MOUNT_HOME/.claude.json" "$ACTIVE_HOME/.claude.json"
+
+    # Nested mount: .config/nvim
+    if [ -d "$MOUNT_HOME/.config/nvim" ]; then
+        mkdir -p "$ACTIVE_HOME/.config"
+        [ -L "$ACTIVE_HOME/.config/nvim" ] || rm -rf "$ACTIVE_HOME/.config/nvim"
+        ln -sfn "$MOUNT_HOME/.config/nvim" "$ACTIVE_HOME/.config/nvim"
+    fi
 
     # Git: include the host gitconfig and mark the workspace safe.
     printf '[include]\n\tpath = %s/.gitconfig.host\n[safe]\n\tdirectory = %s\n' \

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 #                    We remap dev to that UID -- fast and seamless.
 #
 # Rootless Docker:   Workspace appears as root-owned (UID 0) inside the
-#                    container due to user-namespace mapping.
-#                    • remoteUser=root  → symlink bind-mounts into /root
-#                      (container root IS the host user; no permission tricks)
-#                    • remoteUser=dev   → grant access with POSIX ACLs
+#                    container due to user-namespace mapping.  Requires
+#                    DEVCONTAINER_REMOTE_USER=root (set automatically by
+#                    ods dev up).  Container root IS the host user, so
+#                    bind-mounts and named volumes are symlinked into /root.
 
 WORKSPACE=/workspace
 TARGET_USER=dev
@@ -105,40 +105,12 @@ if [ "$WS_UID" != "0" ]; then
     fi
 else
     # ── Rootless Docker ──────────────────────────────────────────────
-    # Workspace is root-owned inside the container.  Grant dev access
-    # via POSIX ACLs (preserves ownership, works across the namespace
-    # boundary).
-    if command -v setfacl &>/dev/null; then
-        setfacl -Rm  "u:${TARGET_USER}:rwX" "$WORKSPACE"
-        setfacl -Rdm "u:${TARGET_USER}:rwX" "$WORKSPACE"   # default ACL for new files
-
-        # Git refuses to operate in repos owned by a different UID.
-        # Host gitconfig is mounted readonly as ~/.gitconfig.host.
-        # Create a real ~/.gitconfig that includes it plus container overrides.
-        printf '[include]\n\tpath = %s/.gitconfig.host\n[safe]\n\tdirectory = %s\n' \
-            "$DEV_HOME" "$WORKSPACE" > "$DEV_HOME/.gitconfig"
-        chown "$TARGET_USER":"$TARGET_USER" "$DEV_HOME/.gitconfig"
-
-        # If this is a worktree, the main .git dir is bind-mounted at its
-        # host absolute path. Grant dev access so git operations work.
-        GIT_COMMON_DIR=$(git -C "$WORKSPACE" rev-parse --git-common-dir 2>/dev/null || true)
-        if [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_COMMON_DIR" != "$WORKSPACE/.git" ]; then
-            [ ! -d "$GIT_COMMON_DIR" ] && GIT_COMMON_DIR="$WORKSPACE/$GIT_COMMON_DIR"
-            if [ -d "$GIT_COMMON_DIR" ]; then
-                setfacl -Rm "u:${TARGET_USER}:rwX" "$GIT_COMMON_DIR"
-                setfacl -Rdm "u:${TARGET_USER}:rwX" "$GIT_COMMON_DIR"
-                git config -f "$DEV_HOME/.gitconfig" --add safe.directory "$(dirname "$GIT_COMMON_DIR")"
-            fi
-        fi
-
-        # Also fix bind-mounted dirs under ~dev that appear root-owned.
-        for dir in /home/"$TARGET_USER"/.claude; do
-            [ -d "$dir" ] && setfacl -Rm "u:${TARGET_USER}:rwX" "$dir" && setfacl -Rdm "u:${TARGET_USER}:rwX" "$dir"
-        done
-        [ -f /home/"$TARGET_USER"/.claude.json ] && \
-            setfacl -m "u:${TARGET_USER}:rw" /home/"$TARGET_USER"/.claude.json
-    else
-        echo "warning: setfacl not found; dev user may not have write access to workspace" >&2
-        echo "         install the 'acl' package or set DEVCONTAINER_REMOTE_USER=root" >&2
-    fi
+    # Workspace is root-owned (UID 0) due to user-namespace mapping.
+    # The supported path is remoteUser=root (set DEVCONTAINER_REMOTE_USER=root),
+    # which is handled above.  If we reach here, the user is running as dev
+    # under rootless Docker without the override.
+    echo "error: rootless Docker detected but remoteUser is not root." >&2
+    echo "       Set DEVCONTAINER_REMOTE_USER=root before starting the container," >&2
+    echo "       or use 'ods dev up' which sets it automatically." >&2
+    exit 1
 fi

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -50,7 +50,7 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
         ln -sfn "$MOUNT_HOME/$item" "$ACTIVE_HOME/$item"
     done
     # Symlink files (not directories).
-    for file in .claude.json .gitconfig; do
+    for file in .claude.json .gitconfig .zshrc.host; do
         [ -f "$MOUNT_HOME/$file" ] && ln -sf "$MOUNT_HOME/$file" "$ACTIVE_HOME/$file"
     done
 

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -75,10 +75,6 @@ if [ "$REMOTE_USER" = "root" ]; then
     exit 0
 fi
 
-# Ensure ~dev owns its own home (volumes may have been created as root).
-chown -R "$TARGET_USER":"$TARGET_USER" "$MOUNT_HOME"/.local
-chown -R "$TARGET_USER":"$TARGET_USER" "$MOUNT_HOME"/.cache
-
 # Already matching -- nothing to do.
 if [ "$WS_UID" = "$DEV_UID" ] && [ "$WS_GID" = "$DEV_GID" ]; then
     exit 0

--- a/tools/ods/cmd/dev_into.go
+++ b/tools/ods/cmd/dev_into.go
@@ -29,6 +29,8 @@ Examples:
 // runDevExec executes "devcontainer exec --workspace-folder <root> <command...>".
 func runDevExec(command []string) {
 	checkDevcontainerCLI()
+	ensureDockerSock()
+	ensureRemoteUser()
 
 	root, err := paths.GitRoot()
 	if err != nil {

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -148,6 +148,24 @@ func worktreeGitMount(root string) (string, bool) {
 	return mount, true
 }
 
+// sshAgentMount returns a --mount flag value that forwards the host's SSH agent
+// socket into the container.  Returns ("", false) when SSH_AUTH_SOCK is unset or
+// the socket is not accessible.
+func sshAgentMount() (string, bool) {
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		log.Debug("SSH_AUTH_SOCK not set — skipping SSH agent forwarding")
+		return "", false
+	}
+	if _, err := os.Stat(sock); err != nil {
+		log.Debugf("SSH_AUTH_SOCK=%s not accessible: %v", sock, err)
+		return "", false
+	}
+	mount := fmt.Sprintf("type=bind,source=%s,target=/tmp/ssh-agent.sock", sock)
+	log.Debugf("Forwarding SSH agent: %s", sock)
+	return mount, true
+}
+
 // ensureRemoteUser sets DEVCONTAINER_REMOTE_USER when rootless Docker is
 // detected.  Container root maps to the host user in rootless mode, so running
 // as root inside the container avoids the UID mismatch on new files.
@@ -182,6 +200,9 @@ func runDevcontainer(action string, extraArgs []string) {
 
 	args := []string{action, "--workspace-folder", root}
 	if mount, ok := worktreeGitMount(root); ok {
+		args = append(args, "--mount", mount)
+	}
+	if mount, ok := sshAgentMount(); ok {
 		args = append(args, "--mount", mount)
 	}
 	args = append(args, extraArgs...)

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -148,10 +148,32 @@ func worktreeGitMount(root string) (string, bool) {
 	return mount, true
 }
 
+// ensureRemoteUser sets DEVCONTAINER_REMOTE_USER when rootless Docker is
+// detected.  Container root maps to the host user in rootless mode, so running
+// as root inside the container avoids the UID mismatch on new files.
+// Must be called after ensureDockerSock.
+func ensureRemoteUser() {
+	if os.Getenv("DEVCONTAINER_REMOTE_USER") != "" {
+		return
+	}
+
+	if runtime.GOOS == "linux" {
+		sock := os.Getenv("DOCKER_SOCK")
+		xdg := os.Getenv("XDG_RUNTIME_DIR")
+		if xdg != "" && strings.HasPrefix(sock, xdg) {
+			log.Debug("Rootless Docker detected — setting DEVCONTAINER_REMOTE_USER=root")
+			if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {
+				log.Warnf("Failed to set DEVCONTAINER_REMOTE_USER: %v", err)
+			}
+		}
+	}
+}
+
 // runDevcontainer executes "devcontainer <action> --workspace-folder <root> [extraArgs...]".
 func runDevcontainer(action string, extraArgs []string) {
 	checkDevcontainerCLI()
 	ensureDockerSock()
+	ensureRemoteUser()
 
 	root, err := paths.GitRoot()
 	if err != nil {

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -178,6 +178,9 @@ func ensureRemoteUser() {
 	if runtime.GOOS == "linux" {
 		sock := os.Getenv("DOCKER_SOCK")
 		xdg := os.Getenv("XDG_RUNTIME_DIR")
+		// Heuristic: rootless Docker on Linux typically places its socket
+		// under $XDG_RUNTIME_DIR. If DOCKER_SOCK was set to a custom path
+		// outside XDG_RUNTIME_DIR, set DEVCONTAINER_REMOTE_USER=root manually.
 		if xdg != "" && strings.HasPrefix(sock, xdg) {
 			log.Debug("Rootless Docker detected — setting DEVCONTAINER_REMOTE_USER=root")
 			if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {


### PR DESCRIPTION
## Description

tl;dr when docker is rootless, run the devcontainer as `root` (but `root` in the container is rootless anyways).

Right now, we're using the `dev` user inside the devcontainer regardless of docker setup. This makes sense when docker is rootful to avoid allowing the user permissions granted to the host's `root`. With rootless docker (my case), this is done at the docker daemon level -- `root` in the container is basically the host user, not host `root`.

Otherwise, `dev` in my rootless container maps to UID `10100` and requires jank `setfacl` which is proving to be quite annoying for me.

## How Has This Been Tested?

Should only affect rootless docker users of the devcontainer (me)

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve devcontainer usability with rootless Docker by running the container as `root` in that mode and removing ACL workarounds. `ods dev up` and `ods dev exec` auto-detect rootless Docker, set `DEVCONTAINER_REMOTE_USER=root`, and forward SSH agent; `devcontainer.json` respects this with a fallback to `dev`.

- **New Features**
  - Rootless auto-detect in `ods dev up` and `ods dev exec` sets `DEVCONTAINER_REMOTE_USER=root`; `devcontainer.json` uses `"${localEnv:DEVCONTAINER_REMOTE_USER:dev}"`.
  - SSH agent forwarding: `ods dev up` mounts `SSH_AUTH_SOCK` to `/tmp/ssh-agent.sock`; `devcontainer.json` sets `SSH_AUTH_SOCK` for in-container use.
  - `init-dev-user.sh` supports running as `root`: symlinks `/home/dev` mounts into `/root` and warns before replacing non-symlink dirs; exits with guidance if rootless but not running as `root`.

- **Refactors**
  - Remove `acl` and all POSIX ACL logic; drop `.ssh` bind/copy and bind `~/.config/nvim` + `~/.gitconfig` read-only.
  - Simplify docs to focus on `ods dev` and the `DOCKER_SOCK` override; document the Linux rootless detection heuristic (`XDG_RUNTIME_DIR`).

<sup>Written for commit 7ea78635c63b6e3ac9e58d120718f7c056242996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

