### PR TITLE
feat: opalified `Divider`

### DIFF
--- a/web/lib/opal/src/components/divider/Divider.stories.tsx
+++ b/web/lib/opal/src/components/divider/Divider.stories.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Divider } from "@opal/components/divider/components";
+
+const meta: Meta<typeof Divider> = {
+  title: "opal/components/Divider",
+  component: Divider,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+export const Plain: Story = {
+  render: () => <Divider />,
+};
+
+export const WithTitle: Story = {
+  render: () => <Divider title="Section" />,
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <Divider description="Additional configuration options for power users." />
+  ),
+};
+
+export const Foldable: Story = {
+  render: () => (
+    <Divider title="Advanced Options" foldable defaultOpen={false}>
+      <div style={{ padding: "0.5rem 0" }}>
+        <p>This content is revealed when the divider is expanded.</p>
+      </div>
+    </Divider>
+  ),
+};
+
+export const FoldableDefaultOpen: Story = {
+  render: () => (
+    <Divider title="Details" foldable defaultOpen>
+      <div style={{ padding: "0.5rem 0" }}>
+        <p>This starts open by default.</p>
+      </div>
+    </Divider>
+  ),
+};

--- a/web/lib/opal/src/components/divider/README.md
+++ b/web/lib/opal/src/components/divider/README.md
@@ -1,0 +1,62 @@
+# Divider
+
+**Import:** `import { Divider } from "@opal/components";`
+
+A horizontal rule that optionally displays a title, description, or foldable content section.
+
+## Props
+
+The component uses a discriminated union with four variants. `title` and `description` are mutually exclusive; `foldable` requires `title`.
+
+### Bare divider
+
+No props — renders a plain horizontal line.
+
+### Titled divider
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string \| RichStr` | **(required)** | Label to the left of the line |
+
+### Described divider
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `description` | `string \| RichStr` | **(required)** | Text below the line |
+
+### Foldable divider
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string \| RichStr` | **(required)** | Label to the left of the line |
+| `foldable` | `true` | **(required)** | Enables fold/expand behavior |
+| `open` | `boolean` | — | Controlled open state |
+| `defaultOpen` | `boolean` | `false` | Uncontrolled initial open state |
+| `onOpenChange` | `(open: boolean) => void` | — | Callback when toggled |
+| `children` | `ReactNode` | — | Content revealed when open |
+
+## Usage Examples
+
+```tsx
+import { Divider } from "@opal/components";
+
+// Plain line
+<Divider />
+
+// With title
+<Divider title="Advanced" />
+
+// With description
+<Divider description="Additional configuration options." />
+
+// Foldable
+<Divider title="Advanced Options" foldable>
+  <p>Hidden content here</p>
+</Divider>
+
+// Controlled foldable
+const [open, setOpen] = useState(false);
+<Divider title="Details" foldable open={open} onOpenChange={setOpen}>
+  <p>Controlled content</p>
+</Divider>
+```

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import "@opal/components/divider/styles.css";
+import { useState, useCallback } from "react";
+import type { RichStr } from "@opal/types";
+import { Button, Text } from "@opal/components";
+import { SvgChevronRight } from "@opal/icons";
+import { Interactive } from "@opal/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DividerNeverFields {
+  open?: never;
+  defaultOpen?: never;
+  onOpenChange?: never;
+  children?: never;
+}
+
+/** Plain line — no title, no description. */
+interface DividerBareProps extends DividerNeverFields {
+  title?: never;
+  description?: never;
+  foldable?: false;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/** Line with a title to the left. */
+interface DividerTitledProps extends DividerNeverFields {
+  title: string | RichStr;
+  description?: never;
+  foldable?: false;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/** Line with a description below. */
+interface DividerDescribedProps extends DividerNeverFields {
+  title?: never;
+  /** Description rendered below the divider line. */
+  description: string | RichStr;
+  foldable?: false;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/** Foldable — requires title, reveals children. */
+interface DividerFoldableProps {
+  /** Title is required when foldable. */
+  title: string | RichStr;
+  foldable: true;
+  description?: never;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Uncontrolled default open state. */
+  defaultOpen?: boolean;
+  /** Callback when open state changes. */
+  onOpenChange?: (open: boolean) => void;
+  /** Content revealed when open. */
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+type DividerProps =
+  | DividerBareProps
+  | DividerTitledProps
+  | DividerDescribedProps
+  | DividerFoldableProps;
+
+// ---------------------------------------------------------------------------
+// Divider
+// ---------------------------------------------------------------------------
+
+function Divider(props: DividerProps) {
+  if (props.foldable) {
+    return <FoldableDivider {...props} />;
+  }
+
+  const { ref } = props;
+  const title = "title" in props ? props.title : undefined;
+  const description = "description" in props ? props.description : undefined;
+
+  return (
+    <div ref={ref} className="opal-divider">
+      <div className="opal-divider-row">
+        {title && (
+          <div className="opal-divider-title">
+            <Text font="secondary-body" color="text-03" nowrap>
+              {title}
+            </Text>
+          </div>
+        )}
+        <div className="opal-divider-line" />
+      </div>
+      {description && (
+        <div className="opal-divider-description">
+          <Text font="secondary-body" color="text-03">
+            {description}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FoldableDivider (internal)
+// ---------------------------------------------------------------------------
+
+function FoldableDivider({
+  title,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  children,
+}: DividerFoldableProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+
+  const toggle = useCallback(() => {
+    const next = !isOpen;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  }, [isOpen, isControlled, onOpenChange]);
+
+  return (
+    <>
+      <Interactive.Stateless
+        variant="default"
+        prominence="tertiary"
+        interaction={isOpen ? "hover" : "rest"}
+        onClick={toggle}
+      >
+        <Interactive.Container
+          roundingVariant="sm"
+          heightVariant="fit"
+          widthVariant="full"
+        >
+          <div className="opal-divider">
+            <div className="opal-divider-row">
+              <div className="opal-divider-title">
+                <Text font="secondary-body" color="inherit" nowrap>
+                  {title}
+                </Text>
+              </div>
+              <div className="opal-divider-line" />
+              <div className="opal-divider-chevron" data-open={isOpen}>
+                <Button
+                  icon={SvgChevronRight}
+                  size="sm"
+                  prominence="tertiary"
+                />
+              </div>
+            </div>
+          </div>
+        </Interactive.Container>
+      </Interactive.Stateless>
+      {isOpen && children}
+    </>
+  );
+}
+
+export { Divider, type DividerProps };

--- a/web/lib/opal/src/components/divider/styles.css
+++ b/web/lib/opal/src/components/divider/styles.css
@@ -1,0 +1,38 @@
+/* ---------------------------------------------------------------------------
+   Divider
+
+   A horizontal rule with optional title, foldable chevron, or description.
+   --------------------------------------------------------------------------- */
+
+.opal-divider {
+  @apply flex flex-col w-full;
+  padding: 0.25rem 0.5rem;
+  gap: 0.75rem;
+}
+
+.opal-divider-row {
+  @apply flex flex-row items-center w-full;
+  gap: 2px;
+  padding: 0px;
+}
+
+.opal-divider-title {
+  @apply flex flex-col justify-center;
+  padding: 0px 2px;
+}
+
+.opal-divider-line {
+  @apply flex-1 h-px bg-border-01;
+}
+
+.opal-divider-description {
+  padding: 0px 2px;
+}
+
+.opal-divider-chevron {
+  @apply transition-transform duration-200 ease-in-out;
+}
+
+.opal-divider-chevron[data-open="true"] {
+  transform: rotate(90deg);
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -54,6 +54,12 @@ export {
   type TagColor,
 } from "@opal/components/tag/components";
 
+/* Divider */
+export {
+  Divider,
+  type DividerProps,
+} from "@opal/components/divider/components";
+
 /* Card */
 export {
   Card,


### PR DESCRIPTION
## Description

New `Divider` component in the Opal design system (`@opal/components`). Fully compliant with the mocks: https://www.figma.com/design/Fms9uHkizpBuDEfsB8ujCc/Onyx-UI-Library?node-id=1574-64153&m=dev. The `title` and `description` also support rich markdown via `RichStr`.

## Screenshots + Videos

https://github.com/user-attachments/assets/42cebdb9-7e52-47cf-8801-93925b6b94cd

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check