### PR TITLE
refactor: migrate `refresh-components/Separator` and `refresh-components/Divider` to `@opal/components.Divider`

### DIFF
--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -3,10 +3,9 @@
 import { useState, useMemo, useEffect } from "react";
 import { Section } from "@/layouts/general-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
-import Separator from "@/refresh-components/Separator";
 import { SvgUsers, SvgCheck } from "@opal/icons";
 import { createCheckoutSession } from "@/lib/billing/svc";
 import { useUser } from "@/providers/UserProvider";
@@ -218,7 +217,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
             </Section>
           </InputLayouts.Horizontal>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           {/* Seats */}
           <InputLayouts.Horizontal

--- a/web/src/app/admin/bots/SlackTokensForm.tsx
+++ b/web/src/app/admin/bots/SlackTokensForm.tsx
@@ -4,8 +4,7 @@ import { TextFormField } from "@/components/Field";
 import { Form, Formik } from "formik";
 import * as Yup from "yup";
 import { createSlackBot, updateSlackBot } from "./new/lib";
-import { Button } from "@opal/components";
-import Separator from "@/refresh-components/Separator";
+import { Button, Divider } from "@opal/components";
 import { useEffect } from "react";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
 import { toast } from "@/hooks/useToast";
@@ -96,7 +95,7 @@ export const SlackTokensForm = ({
 
           {!isUpdate && (
             <div className="mt-4">
-              <Separator />
+              <Divider />
               Please refer to our{" "}
               <a
                 className="text-blue-500 hover:underline"

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -11,7 +11,7 @@ import {
   TextArrayField,
   TextFormField,
 } from "@/components/Field";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import DocumentSetCard from "@/sections/cards/DocumentSetCard";
 import CollapsibleSection from "@/app/admin/agents/CollapsibleSection";
@@ -39,7 +39,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import Separator from "@/refresh-components/Separator";
 import { CheckboxField } from "@/refresh-components/form/LabeledCheckboxField";
 
 export interface SlackChannelConfigFormFieldsProps {
@@ -452,7 +451,7 @@ export function SlackChannelConfigFormFields({
           </div>
         )}
       </div>
-      <Separator className="my-4" />
+      <Divider />
       <Accordion type="multiple" className="gap-y-2 w-full">
         {values.knowledge_source !== "non_search_agent" && (
           <AccordionItem value="search-options">

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -5,8 +5,7 @@ import { useState } from "react";
 import { ValidSources } from "@/lib/types";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
-import Separator from "@/refresh-components/Separator";
+import { Button, Divider } from "@opal/components";
 import { SvgChevronUp, SvgChevronDown, SvgEdit } from "@opal/icons";
 import Truncated from "@/refresh-components/texts/Truncated";
 
@@ -228,7 +227,9 @@ export function AdvancedConfigDisplay({
               onEdit={item.onEdit}
             />
           </div>
-          {index < items.length - 1 && <Separator noPadding />}
+          {index < items.length - 1 && (
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          )}
         </div>
       ))}
     </Section>
@@ -255,7 +256,9 @@ export function ConfigDisplay({
               onEdit={onEdit ? () => onEdit(key) : undefined}
             />
           </div>
-          {index < entries.length - 1 && <Separator noPadding />}
+          {index < entries.length - 1 && (
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          )}
         </div>
       ))}
     </Section>

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { triggerIndexing } from "@/app/admin/connector/[ccPairId]/lib";
 import Modal from "@/refresh-components/Modal";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
 import { SvgRefreshCw } from "@opal/icons";
 // Hook to handle re-indexing functionality
 export function useReIndexModal(
@@ -119,7 +118,7 @@ export default function ReIndexModal({ hide, onRunIndex }: ReIndexModalProps) {
             Run Update
           </Button>
 
-          <Separator />
+          <Divider />
 
           <Text as="p">
             This will cause a complete re-indexing of all documents from the

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -10,11 +10,10 @@ import {
   TableBody,
   TableCell,
 } from "@/components/ui/table";
-import { Text } from "@opal/components";
+import { Divider, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
 import Spacer from "@/refresh-components/Spacer";
 import Title from "@/components/ui/title";
-import Separator from "@/refresh-components/Separator";
 import { DocumentSetSummary } from "@/lib/types";
 import { useState } from "react";
 import { useDocumentSets } from "./hooks";
@@ -412,7 +411,7 @@ function Main() {
 
       {documentSets.length > 0 && (
         <>
-          <Separator />
+          <Divider />
           <DocumentSetTable
             documentSets={documentSets}
             editableDocumentSets={editableDocumentSets}

--- a/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useState } from "react";
 import Modal from "@/refresh-components/Modal";
 import { Callout } from "@/components/ui/callout";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import Button from "@/refresh-components/buttons/Button";
 import { Label } from "@/components/Field";
 import {
@@ -278,7 +278,7 @@ export default function ChangeCredentialsModal({
                   Update Configuration
                 </Button>
 
-                <Separator />
+                <Divider />
               </div>
             </>
           )}

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -2,9 +2,8 @@ import { SvgCheckCircle, SvgClock, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
 import { timeAgo } from "@/lib/time";
 
 // ---------------------------------------------------------------------------
@@ -66,7 +65,7 @@ export default function ScimSyncCard({
 
       {hasToken && (
         <>
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           <Section
             flexDirection="row"

--- a/web/src/app/app/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/app/components/projects/ProjectContextPanel.tsx
@@ -2,12 +2,11 @@
 
 import React, { useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
-import Separator from "@/refresh-components/Separator";
 import { useProjectsContext } from "@/providers/ProjectsContext";
 import FilePickerPopover from "@/refresh-components/popovers/FilePickerPopover";
 import type { ProjectFile } from "../../projects/projectsService";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 
 import AddInstructionModal from "@/components/modals/AddInstructionModal";
 import UserFilesModal from "@/components/modals/UserFilesModal";
@@ -170,7 +169,7 @@ export default function ProjectContextPanel({
           </Hoverable.Root>
         </div>
 
-        <Separator className="py-0" />
+        <Divider paddingPerpendicular="fit" />
         <div className="flex flex-row gap-2 justify-between">
           <div className="min-w-0 flex-1">
             <Text as="p" headingH3 text04>

--- a/web/src/app/craft/v1/configure/components/ComingSoonConnectors.tsx
+++ b/web/src/app/craft/v1/configure/components/ComingSoonConnectors.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Card from "@/refresh-components/cards/Card";
 import Text from "@/refresh-components/texts/Text";
 import { Content } from "@opal/layouts";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { ValidSources } from "@/lib/types";
 import { getSourceMetadata } from "@/lib/sources";
 import RequestConnectorModal from "@/app/craft/v1/configure/components/RequestConnectorModal";
@@ -66,7 +66,7 @@ export default function ComingSoonConnectors() {
 
   return (
     <>
-      <Separator />
+      <Divider />
       <div className="w-full flex items-center justify-between pb-2">
         <div className="flex flex-col gap-0.25">
           <Text mainContentEmphasis text04>

--- a/web/src/app/craft/v1/configure/components/ConnectorConfigStep.tsx
+++ b/web/src/app/craft/v1/configure/components/ConnectorConfigStep.tsx
@@ -3,11 +3,10 @@
 import { useState } from "react";
 import { Formik, Form, useFormikContext } from "formik";
 import { Section } from "@/layouts/general-layouts";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { toast } from "@/hooks/useToast";
 import { ValidSources } from "@/lib/types";
 import { Credential } from "@/lib/connectors/credentials";
-import Separator from "@/refresh-components/Separator";
 import {
   connectorConfigs,
   createConnectorInitialValues,
@@ -82,7 +81,7 @@ function ConnectorConfigForm({
               currentCredential={credential}
             />
           ))}
-        <Separator />
+        <Divider />
         {config?.advanced_values &&
           config.advanced_values.length > 0 &&
           config.advanced_values.map((field) => (

--- a/web/src/app/craft/v1/configure/page.tsx
+++ b/web/src/app/craft/v1/configure/page.tsx
@@ -35,13 +35,12 @@ import {
 import { ConfirmEntityModal } from "@/components/modals/ConfirmEntityModal";
 import { getSourceMetadata } from "@/lib/sources";
 import { deleteConnector } from "@/app/craft/services/apiServices";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import {
   OAUTH_STATE_KEY,
   getDemoDataEnabled,
   setDemoDataCookie,
 } from "@/app/craft/v1/constants";
-import Separator from "@/refresh-components/Separator";
 import Switch from "@/refresh-components/inputs/Switch";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import NotAllowedModal from "@/app/craft/onboarding/components/NotAllowedModal";
@@ -487,7 +486,7 @@ export default function BuildConfigPage() {
                     </InputLayouts.Horizontal>
                   </div>
                 </Card>
-                <Separator />
+                <Divider />
                 <div className="w-full flex items-center justify-between">
                   <div className="flex flex-col gap-0.25">
                     <Text mainContentEmphasis text04>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -1,4 +1,3 @@
-import Separator from "@/refresh-components/Separator";
 import {
   Table,
   TableHead,
@@ -41,7 +40,7 @@ import {
 } from "@/app/ee/admin/performance/query-history/constants";
 import { humanReadableFormatWithTime } from "@/lib/time";
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { Badge } from "@/components/ui/badge";
 import {
   SvgDownloadCloud,
@@ -329,7 +328,7 @@ export function QueryHistoryTable() {
             </Button>
           </div>
         </div>
-        <Separator />
+        <Divider />
         <Section>
           <Table className="mt-5">
             <TableHeader>

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 import { use } from "react";
 
-import { Text } from "@opal/components";
+import { Divider, Text } from "@opal/components";
 import Title from "@/components/ui/title";
-import Separator from "@/refresh-components/Separator";
 import Spacer from "@/refresh-components/Spacer";
 import { ChatSessionSnapshot, MessageSnapshot } from "../../usage/types";
 import { FiBook } from "react-icons/fi";
@@ -61,7 +60,7 @@ function MessageDisplay({ message }: { message: MessageSnapshot }) {
           </div>
         </div>
       )}
-      <Separator />
+      <Divider />
     </div>
   );
 }
@@ -112,7 +111,7 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
           }`}
         </Text>
 
-        <Separator />
+        <Divider />
 
         <div className="flex flex-col">
           {chatSessionSnapshot.messages.map((message) => {

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -26,7 +26,7 @@ import Link from "next/link";
 import { humanReadableFormat, humanReadableFormatWithTime } from "@/lib/time";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { PageSelector } from "@/components/PageSelector";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { DateRangePickerValue } from "../../../../../components/dateRangeSelectors/AdminDateRangeSelector";
 import Popover from "@/refresh-components/Popover";
 import Calendar from "@/refresh-components/Calendar";
@@ -442,7 +442,7 @@ export default function UsageReports() {
             </div>
           </div>
         )}
-        <Separator />
+        <Divider />
         <UsageReportsTable
           refreshTrigger={refreshTrigger}
           isWaitingForReport={isWaitingForReport}

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -7,7 +7,7 @@ import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPer
 import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { useAdminPersonas } from "@/hooks/useAdminPersonas";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
@@ -33,7 +33,7 @@ export default function AnalyticsPage() {
           availablePersonas={personas}
           timeRange={timeRange}
         />
-        <Separator />
+        <Divider />
         <UsageReports />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -5,7 +5,7 @@ import { toast } from "@/hooks/useToast";
 import { useStandardAnswers, useStandardAnswerCategories } from "./hooks";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import {
   Table,
   TableHead,
@@ -407,7 +407,7 @@ function Main() {
         New Standard Answer
       </CreateButton>
 
-      <Separator />
+      <Divider />
 
       <div>
         <StandardAnswersTable

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -3,13 +3,12 @@
 import { FormField } from "@/refresh-components/form/FormField";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Tabs from "@/refresh-components/Tabs";
-import Separator from "@/refresh-components/Separator";
 import { Preview } from "./Preview";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import Switch from "@/refresh-components/inputs/Switch";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import InputImage from "@/refresh-components/inputs/InputImage";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { useFormikContext } from "formik";
 import {
   forwardRef,
@@ -325,7 +324,7 @@ export const AppearanceThemeSettings = forwardRef<
         </FormField>
       </div>
 
-      <Separator className="my-4" />
+      <Divider />
 
       <Preview
         className="mb-8"
@@ -442,7 +441,7 @@ export const AppearanceThemeSettings = forwardRef<
         />
       </FormField>
 
-      <Separator className="my-4" />
+      <Divider />
 
       <div className="flex flex-col gap-4 p-4 bg-background-tint-00 rounded-16">
         <FormField state="idle" className="gap-0">

--- a/web/src/components/admin/Title.tsx
+++ b/web/src/components/admin/Title.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { JSX } from "react";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import type { IconProps } from "@opal/types";
 import Text from "@/refresh-components/texts/Text";
 
@@ -33,7 +33,7 @@ export function AdminPageTitle({
         </div>
         {farRightElement}
       </div>
-      {includeDivider ? <Separator /> : <div className="mb-6" />}
+      {includeDivider ? <Divider /> : <div className="mb-6" />}
     </div>
   );
 }

--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -2,8 +2,7 @@ import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidE
 import React, { useState, useEffect } from "react";
 import { FieldArray, ArrayHelpers, ErrorMessage, useField } from "formik";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
-import Separator from "@/refresh-components/Separator";
+import { Button, Divider } from "@opal/components";
 import { UserGroup, UserRole } from "@/lib/types";
 import { useUserGroups } from "@/lib/hooks";
 import {
@@ -108,7 +107,7 @@ export function AccessTypeGroupSelector({
         userGroups &&
         userGroups?.length > 0 && (
           <>
-            <Separator />
+            <Divider />
             <div className="flex flex-col gap-3 pt-4">
               <Text as="p" mainUiAction text05>
                 Assign group access for this Connector

--- a/web/src/components/admin/connectors/AutoSyncOptions.tsx
+++ b/web/src/components/admin/connectors/AutoSyncOptions.tsx
@@ -1,6 +1,6 @@
 import { TextFormField } from "@/components/Field";
 import { ValidAutoSyncSource } from "@/lib/types";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { autoSyncConfigBySource } from "@/lib/connectors/AutoSyncOptionFields";
 
 export function AutoSyncOptions({
@@ -16,7 +16,7 @@ export function AutoSyncOptions({
 
   return (
     <div>
-      <Separator />
+      <Divider />
       {Object.entries(autoSyncConfig).map(([key, config]) => (
         <div key={key} className="mb-4">
           <TextFormField

--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
+import { Button as OpalButton, Divider } from "@opal/components";
 import {
   ConfigurableSources,
   CredentialFieldSpec,
@@ -33,7 +33,6 @@ import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
-import Separator from "@/refresh-components/Separator";
 import { SvgSettings } from "@opal/icons";
 
 export interface FederatedConnectorFormProps {
@@ -833,7 +832,7 @@ export function FederatedConnectorForm({
               Enter the credentials for this connector.
             </Text>
             <div className="space-y-4">{renderCredentialFields()}</div>
-            <Separator />
+            <Divider />
             <Text as="p" headingH3>
               Configuration
             </Text>

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
@@ -4,12 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { noProp } from "@/lib/utils";
 import { formatDateTimeLog } from "@/lib/dateUtils";
-import { Button, Text } from "@opal/components";
+import { Button, Divider, Text } from "@opal/components";
 import { Content } from "@opal/layouts";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import Popover from "@/refresh-components/Popover";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-import Separator from "@/refresh-components/Separator";
 import { Section } from "@/layouts/general-layouts";
 import {
   SvgAlertTriangle,
@@ -254,7 +253,7 @@ export default function HookStatusPopover({
 
                 {topErrors.length > 0 ? (
                   <>
-                    <Separator noPadding className="px-2" />
+                    <Divider paddingPerpendicular="fit" />
 
                     <Section
                       flexDirection="column"
@@ -274,7 +273,7 @@ export default function HookStatusPopover({
                     </Section>
                   </>
                 ) : (
-                  <Separator noPadding className="px-2" />
+                  <Divider paddingPerpendicular="fit" />
                 )}
 
                 <LineItem
@@ -311,7 +310,7 @@ export default function HookStatusPopover({
                   />
                 </div>
 
-                <Separator noPadding className="px-2" />
+                <Divider paddingPerpendicular="fit" />
 
                 {/* Log rows — at most 3, timestamp first then error message */}
                 <Section
@@ -356,7 +355,7 @@ export default function HookStatusPopover({
                   />
                 </div>
 
-                <Separator noPadding className="px-2" />
+                <Divider paddingPerpendicular="fit" />
 
                 {/* View Older Errors */}
                 <LineItem

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -7,8 +7,7 @@ import {
   SourceMetadata,
 } from "@/lib/search/interfaces";
 import SearchCard from "@/ee/sections/SearchCard";
-import { Pagination } from "@opal/components";
-import Separator from "@/refresh-components/Separator";
+import { Divider, Pagination } from "@opal/components";
 import EmptyMessage from "@/refresh-components/EmptyMessage";
 import { IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
@@ -310,7 +309,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
             </Popover>
           </div>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
         </div>
 
         {!showEmpty && (
@@ -321,7 +320,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
               </Text>
             </Section>
 
-            <Separator noPadding />
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
           </div>
         )}
       </div>

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -3,7 +3,7 @@
 import type { RichStr, WithoutStyles } from "@opal/types";
 import { resolveStr } from "@opal/components/text/InlineMarkdown";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { SvgXOctagon, SvgAlertCircle } from "@opal/icons";
 import { useField, useFormikContext } from "formik";
 import { Section } from "@/layouts/general-layouts";
@@ -234,7 +234,7 @@ function ErrorTextLayout({ children, type = "error" }: ErrorTextLayoutProps) {
  * FieldSeparator - A horizontal rule with inline padding, used to visually separate field groups.
  */
 function FieldSeparator() {
-  return <Separator noPadding className="p-2" />;
+  return <Divider paddingParallel="sm" paddingPerpendicular="sm" />;
 }
 
 /**

--- a/web/src/layouts/settings-layouts.tsx
+++ b/web/src/layouts/settings-layouts.tsx
@@ -35,7 +35,7 @@
 
 import BackButton from "@/refresh-components/buttons/BackButton";
 import { cn } from "@/lib/utils";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import { WithoutStyles } from "@/types";
 import { IconFunctionComponent } from "@opal/types";
 import { HtmlHTMLAttributes, useEffect, useRef, useState } from "react";
@@ -252,7 +252,7 @@ function SettingsHeader({
       {separator ? (
         <>
           <Spacer vertical rem={1.5} />
-          <Separator noPadding className="px-4" />
+          <Divider paddingParallel="md" paddingPerpendicular="fit" />
         </>
       ) : (
         <Spacer vertical rem={0.5} />

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -6,9 +6,8 @@ import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import CharacterCount from "@/refresh-components/CharacterCount";
-import Separator from "@/refresh-components/Separator";
 import TextSeparator from "@/refresh-components/TextSeparator";
 import { toast } from "@/hooks/useToast";
 import { useModalClose } from "@/refresh-components/contexts/ModalContext";
@@ -323,7 +322,9 @@ export default function MemoriesModal({
                       setHighlightMemoryId(null);
                     }}
                   />
-                  {memory.isNew && <Separator noPadding />}
+                  {memory.isNew && (
+                    <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                  )}
                 </Fragment>
               ))}
             </Section>

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
+import { Button as OpalButton, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
@@ -16,7 +16,6 @@ import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import InputTypeInElementField from "@/refresh-components/form/InputTypeInElementField";
 import InputDatePickerField from "@/refresh-components/form/InputDatePickerField";
 import Message from "@/refresh-components/messages/Message";
-import Separator from "@/refresh-components/Separator";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { useFormikContext } from "formik";
 import LLMSelector from "@/components/llm/LLMSelector";
@@ -1289,7 +1288,10 @@ export default function AgentEditorPage({
                         </GeneralLayouts.Section>
                       </GeneralLayouts.Section>
 
-                      <Separator noPadding />
+                      <Divider
+                        paddingParallel="fit"
+                        paddingPerpendicular="fit"
+                      />
 
                       <GeneralLayouts.Section>
                         <InputLayouts.Vertical
@@ -1314,7 +1316,10 @@ export default function AgentEditorPage({
                         </InputLayouts.Vertical>
                       </GeneralLayouts.Section>
 
-                      <Separator noPadding />
+                      <Divider
+                        paddingParallel="fit"
+                        paddingPerpendicular="fit"
+                      />
 
                       <AgentKnowledgePane
                         enableKnowledge={values.enable_knowledge}
@@ -1359,7 +1364,10 @@ export default function AgentEditorPage({
                         vectorDbEnabled={vectorDbEnabled}
                       />
 
-                      <Separator noPadding />
+                      <Divider
+                        paddingParallel="fit"
+                        paddingPerpendicular="fit"
+                      />
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
@@ -1448,7 +1456,10 @@ export default function AgentEditorPage({
                               {/* render the separator if there is at least one mcp-server or open-api-tool */}
                               {(mcpServers.length > 0 ||
                                 openApiTools.length > 0) && (
-                                <Separator noPadding className="py-1" />
+                                <Divider
+                                  paddingPerpendicular="xs"
+                                  paddingParallel="fit"
+                                />
                               )}
 
                               {/* MCP tools */}
@@ -1483,7 +1494,10 @@ export default function AgentEditorPage({
                         </SimpleCollapsible.Content>
                       </SimpleCollapsible>
 
-                      <Separator noPadding />
+                      <Divider
+                        paddingParallel="fit"
+                        paddingPerpendicular="fit"
+                      />
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
@@ -1591,7 +1605,10 @@ export default function AgentEditorPage({
 
                       {existingAgent && (
                         <>
-                          <Separator noPadding />
+                          <Divider
+                            paddingParallel="fit"
+                            paddingPerpendicular="fit"
+                          />
 
                           <Card>
                             <InputLayouts.Horizontal

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -37,12 +37,11 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useFilter from "@/hooks/useFilter";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import useFederatedOAuthStatus from "@/hooks/useFederatedOAuthStatus";
 import useCCPairs from "@/hooks/useCCPairs";
 import { ValidSources } from "@/lib/types";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
-import Separator from "@/refresh-components/Separator";
 import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import Code from "@/refresh-components/Code";
@@ -429,7 +428,7 @@ function GeneralSettings() {
           </Card>
         </Section>
 
-        <Separator noPadding />
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
         <Section gap={0.75}>
           <Content

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -11,7 +11,6 @@ import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
-import Separator from "@/refresh-components/Separator";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import SwitchField from "@/refresh-components/form/SwitchField";
@@ -47,7 +46,7 @@ import {
   PYTHON_TOOL_ID,
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
-import { Button, Text, Card as OpalCard } from "@opal/components";
+import { Button, Divider, Text, Card as OpalCard } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
 import Switch from "@/refresh-components/inputs/Switch";
 import useMcpServersForAgentEditor from "@/hooks/useMcpServersForAgentEditor";
@@ -580,7 +579,7 @@ function ChatPreferencesForm() {
             </Button>
           </InputLayouts.Horizontal>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           {/* Features */}
           <Section gap={0.75}>
@@ -641,7 +640,7 @@ function ChatPreferencesForm() {
             </Card>
           </Section>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           <Disabled disabled={values.disable_default_assistant}>
             <div>
@@ -823,7 +822,10 @@ function ChatPreferencesForm() {
                     {/* Separator between built-in tools and MCP/OpenAPI tools */}
                     {(mcpServersWithTools.length > 0 ||
                       openApiTools.length > 0) && (
-                      <Separator noPadding className="py-3" />
+                      <Divider
+                        paddingPerpendicular="sm"
+                        paddingParallel="fit"
+                      />
                     )}
 
                     {/* MCP Servers & OpenAPI Tools */}
@@ -862,7 +864,7 @@ function ChatPreferencesForm() {
             </div>
           </Disabled>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           {/* Advanced Options */}
           <SimpleCollapsible defaultOpen={false}>

--- a/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Table, Button } from "@opal/components";
+import { Table, Button, Divider } from "@opal/components";
 import { IllustrationContent } from "@opal/layouts";
 import { SvgUsers } from "@opal/icons";
 import SvgNoResult from "@opal/illustrations/no-result";
@@ -11,7 +11,6 @@ import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-import Separator from "@/refresh-components/Separator";
 import { toast } from "@/hooks/useToast";
 import useGroupMemberCandidates from "./useGroupMemberCandidates";
 import {
@@ -110,7 +109,7 @@ function CreateGroupPage() {
           />
         </Section>
 
-        <Separator noPadding />
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
         {/* Members table */}
         {isLoading && <SimpleLoader />}

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import useGroupMemberCandidates from "./useGroupMemberCandidates";
-import { Table, Button } from "@opal/components";
+import { Table, Button, Divider } from "@opal/components";
 import { IllustrationContent } from "@opal/layouts";
 import { SvgUsers, SvgTrash, SvgMinusCircle, SvgPlusCircle } from "@opal/icons";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -17,7 +17,6 @@ import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
-import Separator from "@/refresh-components/Separator";
 import { toast } from "@/hooks/useToast";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
@@ -347,7 +346,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 />
               </Section>
 
-              <Separator noPadding />
+              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
               {/* Members table */}
               <Section

--- a/web/src/refresh-pages/admin/GroupsPage/GroupsList.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupsList.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import type { UserGroup } from "@/lib/types";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import GroupCard from "./GroupCard";
 import { isBuiltInGroup } from "./utils";
 import { Section } from "@/layouts/general-layouts";
@@ -41,7 +41,7 @@ function GroupsList({ groups, searchQuery }: GroupsListProps) {
       ))}
 
       {builtInGroups.length > 0 && customGroups.length > 0 && (
-        <Separator paddingYRem={0.5} />
+        <Divider paddingPerpendicular="sm" paddingParallel="fit" />
       )}
 
       {customGroups.map((group) => (

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -5,7 +5,7 @@ import { SvgEmpty } from "@opal/icons";
 import { Content } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Popover from "@/refresh-components/Popover";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
@@ -68,7 +68,10 @@ function ResourcePopover({
                         <Text secondaryBody text03 className="shrink-0">
                           {section.label}
                         </Text>
-                        <Separator noPadding className="flex-1" />
+                        <Divider
+                          paddingParallel="fit"
+                          paddingPerpendicular="fit"
+                        />
                       </Section>
                     )}
                     <Section

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -7,7 +7,7 @@ import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import { useConnectorStatus } from "@/lib/hooks";
@@ -340,7 +340,7 @@ function SharedGroupResources({
               )}
             </Section>
 
-            <Separator noPadding />
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
             {/* Agents */}
             <Section

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/hooks/useLLMProviders";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { Content, Card as CardLayout } from "@opal/layouts";
-import { Button, SelectCard, Text, Card } from "@opal/components";
+import { Button, Divider, SelectCard, Text, Card } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { SvgArrowExchange, SvgSettings, SvgTrash } from "@opal/icons";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
@@ -23,7 +23,6 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Message from "@/refresh-components/messages/Message";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
-import Separator from "@/refresh-components/Separator";
 import {
   LLMProviderName,
   LLMProviderView,
@@ -407,7 +406,7 @@ export default function LLMConfigurationPage() {
               </div>
             </GeneralLayouts.Section>
 
-            <Separator noPadding />
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
           </>
         )}
 

--- a/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { SvgUsers, SvgUser, SvgLogOut, SvgCheck } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import Modal from "@/refresh-components/Modal";
@@ -9,7 +9,6 @@ import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Popover from "@/refresh-components/Popover";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import Separator from "@/refresh-components/Separator";
 import ShadowDiv from "@/refresh-components/ShadowDiv";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { Section } from "@/layouts/general-layouts";
@@ -291,7 +290,7 @@ export default function EditUserModal({
             </Section>
             {user.role && (
               <>
-                <Separator noPadding />
+                <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
                 <ContentAction
                   title="User Role"

--- a/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import {
   SvgMoreHorizontal,
   SvgUsers,
@@ -14,7 +14,6 @@ import {
 import { Disabled } from "@opal/core";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import Popover from "@/refresh-components/Popover";
-import Separator from "@/refresh-components/Separator";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import { UserStatus } from "@/lib/types";
@@ -91,7 +90,7 @@ export default function UserRowActions({
               Deactivate User
             </LineItem>
           </Disabled>
-          <Separator paddingXRem={0.5} />
+          <Divider paddingPerpendicular="md" />
           <Text as="p" secondaryBody text03 className="px-3 py-1">
             This is a synced SCIM user managed by your identity provider.
           </Text>
@@ -151,7 +150,7 @@ export default function UserRowActions({
             >
               Reset Password
             </LineItem>
-            <Separator paddingXRem={0.5} />
+            <Divider paddingPerpendicular="md" />
             <LineItem
               danger
               icon={SvgUserX}
@@ -179,14 +178,14 @@ export default function UserRowActions({
             >
               Reset Password
             </LineItem>
-            <Separator paddingXRem={0.5} />
+            <Divider paddingPerpendicular="md" />
             <LineItem
               icon={SvgUserPlus}
               onClick={() => openModal(Modal.ACTIVATE)}
             >
               Activate User
             </LineItem>
-            <Separator paddingXRem={0.5} />
+            <Divider paddingPerpendicular="md" />
             <LineItem
               danger
               icon={SvgUserX}

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -7,7 +7,7 @@ import InputKeyValue, {
 } from "@/refresh-components/inputs/InputKeyValue";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Text from "@/refresh-components/texts/Text";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import type { MCPAuthFormValues } from "@/sections/actions/modals/MCPAuthenticationModal";
 import { SvgUser } from "@opal/icons";
 
@@ -134,7 +134,7 @@ export function PerUserAuthConfig({
       {/* Only show user credentials section if there are required fields */}
       {requiredFields.length > 0 && (
         <>
-          <Separator className="-my-2" />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           <div className="flex flex-col gap-4">
             <div className="flex items-start gap-1">

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -14,8 +14,7 @@ import {
   MCPServer,
 } from "@/lib/tools/interfaces";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
-import Separator from "@/refresh-components/Separator";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { toast } from "@/hooks/useToast";
 import { ModalCreationInterface } from "@/refresh-components/contexts/ModalContext";
 import { SvgCheckCircle, SvgServer, SvgUnplug } from "@opal/icons";
@@ -166,7 +165,7 @@ export default function AddMCPServerModal({
                   />
                 </InputLayouts.Vertical>
 
-                <Separator noPadding />
+                <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
                 <InputLayouts.Vertical
                   name="server_url"

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -7,10 +7,9 @@ import Text from "@/refresh-components/texts/Text";
 import * as InputLayouts from "@/layouts/input-layouts";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
-import Separator from "@/refresh-components/Separator";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
 import {
@@ -279,7 +278,7 @@ function FormContent({
           </Hoverable.Root>
         </InputLayouts.Vertical>
 
-        <Separator noPadding />
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
         {methodSpecs && methodSpecs.length > 0 ? (
           <>
@@ -297,7 +296,7 @@ function FormContent({
                 description="URL found in the schema. Only connect to servers you trust."
               />
             )}
-            <Separator noPadding />
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
             <Section gap={0.5}>
               {methodSpecs.map((method) => (
                 <ToolItem

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -9,7 +9,7 @@ import { FormField } from "@/refresh-components/form/FormField";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { markdown } from "@opal/utils";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import Text from "@/refresh-components/texts/Text";
@@ -24,7 +24,6 @@ import {
   MCPServer,
   MCPServersResponse,
 } from "@/lib/tools/interfaces";
-import Separator from "@/refresh-components/Separator";
 import Tabs from "@/refresh-components/Tabs";
 import { PerUserAuthConfig } from "@/sections/actions/PerUserAuthConfig";
 import { updateMCPServerStatus, upsertMCPServer } from "@/lib/tools/mcpService";
@@ -432,7 +431,7 @@ export default function MCPAuthenticationModal({
                         }}
                       />
                     </FormField>
-                    <Separator className="py-0" />
+                    <Divider paddingPerpendicular="fit" />
                   </div>
 
                   {/* OAuth Section */}

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -4,12 +4,11 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Formik, Form, FormikHelpers } from "formik";
 import * as Yup from "yup";
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
 import { FormField } from "@/refresh-components/form/FormField";
-import Separator from "@/refresh-components/Separator";
 import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import KeyValueInput, {
@@ -414,7 +413,7 @@ export default function OpenAPIAuthenticationModal({
                       </FormField>
                     </div>
 
-                    <Separator className="py-0" />
+                    <Divider paddingPerpendicular="fit" />
 
                     {values.authMethod === "oauth" && (
                       <section className="flex flex-col gap-4 rounded-12 bg-background-tint-00 border border-border-01 p-4">

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -10,9 +10,8 @@ import {
   useSelectedNodeForDocDisplay,
 } from "@/app/app/stores/useChatSessionStore";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import { SvgSearchMenu, SvgX } from "@opal/icons";
-import Separator from "@/refresh-components/Separator";
 
 // Build an OnyxDocument from basic file info
 const buildOnyxDocumentFromFile = (
@@ -60,7 +59,7 @@ function Header({ children, onClose }: HeaderProps) {
           tooltip="Close Sidebar"
         />
       </div>
-      <Separator noPadding />
+      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
     </div>
   );
 }

--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -13,10 +13,9 @@ import { Content } from "@opal/layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { Card } from "@/refresh-components/cards";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import Separator from "@/refresh-components/Separator";
 import Switch from "@/refresh-components/inputs/Switch";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
@@ -116,7 +115,7 @@ function KnowledgeSidebar({
             Document Set
           </LineItem>
 
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           {connectedSources.map((connectedSource) => {
             const sourceMetadata = getSourceMetadata(connectedSource.source);
@@ -241,7 +240,7 @@ function KnowledgeTable<T>({
         ))}
       </TableLayouts.TableRow>
 
-      <Separator noPadding />
+      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
       {/* Table body */}
       {items.length === 0 ? (

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -9,10 +9,9 @@ import React, {
 } from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
-import { Button } from "@opal/components";
+import { Button, Divider as OpalDivider } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
-import Separator from "@/refresh-components/Separator";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import Popover from "@/refresh-components/Popover";
@@ -826,7 +825,7 @@ export default function SourceHierarchyBrowser({
         </TableLayouts.TableCell>
       </TableLayouts.TableRow>
 
-      <Separator noPadding />
+      <OpalDivider paddingParallel="fit" paddingPerpendicular="fit" />
 
       {/* Scrollable table body */}
       <div

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -10,7 +10,7 @@ import { Section } from "@/layouts/general-layouts";
 import { Content, ContentAction } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
-import Separator from "@/refresh-components/Separator";
+import { Divider } from "@opal/components";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import {
   SvgActions,
@@ -283,7 +283,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {agent.description && <Text text03>{agent.description}</Text>}
 
           {/* Knowledge */}
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
           <Section gap={0.5} alignItems="start">
             <Content
               title="Knowledge"
@@ -336,7 +336,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           </SimpleCollapsible>
 
           {/* More Info (Collapsible) */}
-          <Separator noPadding />
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
           <SimpleCollapsible>
             <SimpleCollapsible.Header title="More Info" />
             <SimpleCollapsible.Content>
@@ -386,7 +386,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {/* Prompt Reminders */}
           {agent.task_prompt && (
             <>
-              <Separator noPadding />
+              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
               <Content
                 title="Prompt Reminders"
                 description={agent.task_prompt}
@@ -399,7 +399,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {/* Conversation Starters */}
           {agent.starter_messages && agent.starter_messages.length > 0 && (
             <>
-              <Separator noPadding />
+              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
               <Content
                 title="Conversation Starters"
                 sizePreset="main-content"

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -2,8 +2,7 @@
 
 import { memo, useState, useCallback } from "react";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
-import Separator from "@/refresh-components/Separator";
+import { Button, Divider } from "@opal/components";
 import LLMProviderCard from "@/sections/onboarding/components/LLMProviderCard";
 import {
   OnboardingActions,
@@ -169,7 +168,7 @@ const LLMStep = memo(
                 </Button>
               }
             />
-            <Separator />
+            <Divider />
             <div className="flex flex-wrap gap-1 [&>*:last-child:nth-child(odd)]:basis-full">
               {isLoading ? (
                 Array.from({ length: 8 }).map((_, idx) => (

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -19,9 +19,8 @@ import { useUser } from "@/providers/UserProvider";
 import { UserRole } from "@/lib/types";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import { CombinedSettings } from "@/interfaces/settings";
-import { SidebarTab } from "@opal/components";
+import { Divider, SidebarTab } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import Separator from "@/refresh-components/Separator";
 import Spacer from "@/refresh-components/Spacer";
 import { SvgArrowUpCircle, SvgSearch, SvgX } from "@opal/icons";
 import {
@@ -310,7 +309,7 @@ function AdminSidebarInner({
           );
         })}
 
-        {disabledGroups.length > 0 && <Separator noPadding className="px-2" />}
+        {disabledGroups.length > 0 && <Divider paddingPerpendicular="fit" />}
 
         {disabledGroups.map((group, groupIndex) => (
           <SidebarSection
@@ -330,7 +329,7 @@ function AdminSidebarInner({
       <SidebarLayouts.Footer>
         {!folded && (
           <>
-            <Separator noPadding className="px-2" />
+            <Divider paddingPerpendicular="fit" />
             <Spacer rem={0.5} />
           </>
         )}

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -11,10 +11,9 @@ import Text from "@/refresh-components/texts/Text";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { SvgSparkle, SvgRefreshCw, SvgX } from "@opal/icons";
 import { IconProps } from "@opal/types";
-import { Button } from "@opal/components";
+import { Button, Divider } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
-import Separator from "@/refresh-components/Separator";
 
 function getNotificationIcon(
   notifType: string
@@ -108,7 +107,7 @@ export default function NotificationsPopover({
         <Button icon={SvgX} prominence="tertiary" size="sm" onClick={onClose} />
       </Section>
 
-      <Separator noPadding className="px-2" />
+      <Divider paddingPerpendicular="fit" />
 
       <Section>
         {isLoading ? (


### PR DESCRIPTION
## Description

Migrates `SettingsLayouts.Header` from the legacy `Separator` component to the new Opal `Divider`.

- Replace `Separator` import with `Divider` from `@opal/components` in `settings-layouts.tsx`
- Rename the `separator` prop to `divider` in `SettingsHeaderProps`
- Update all ~43 callsites across the codebase

## Screenshots + Videos

No UI changes; screenshots / videos not needed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized separators by migrating legacy `Separator` usages to the `@opal/components` `Divider`. Applied correct per‑axis padding across callsites, including settings headers and form/table separators.

- **Refactors**
  - Replaced `Separator` → `Divider` across admin/app/EE pages, sidebars, modals, tables, and popovers; mapped `noPadding` to `paddingParallel="fit" paddingPerpendicular="fit"` and removed spacing hacks.
  - Updated `SettingsLayouts.Header` to render a `Divider` when `separator` is set with `paddingParallel="md" paddingPerpendicular="fit"`; set `InputLayouts.FieldSeparator` to `Divider paddingParallel="sm" paddingPerpendicular="sm"`.
  - Deprecated `web/src/refresh-components/Divider.tsx`; three refresh internals still use it (`ModelSelector`, `Popover`, `InputSelect`) for vertical/wrapper patterns.

- **New Features**
  - Per‑axis padding via `paddingParallel`/`paddingPerpendicular` (defaults `sm`/`xs`); use `"fit"` to remove padding. `Divider` supports `orientation="vertical"`.

<sup>Written for commit e9c55eece3f7780c3f0366f7cf8fa962c1176461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

