### PR TITLE
fix(mcp): prevent masked OAuth credentials from being stored on re-auth

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -392,6 +392,29 @@ async def _connect_oauth(
             detail=f"Server was configured with authentication type {auth_type_str}",
         )
 
+    # If the frontend sent back masked credentials (unchanged by the user),
+    # restore the real stored values so we don't overwrite them with masks.
+    if mcp_server.admin_connection_config:
+        existing_data = extract_connection_data(
+            mcp_server.admin_connection_config, apply_mask=False
+        )
+        existing_client_raw = existing_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        if existing_client_raw:
+            existing_client = OAuthClientInformationFull.model_validate(
+                existing_client_raw
+            )
+            if request.oauth_client_id and request.oauth_client_id == mask_string(
+                existing_client.client_id
+            ):
+                request.oauth_client_id = existing_client.client_id
+            if (
+                request.oauth_client_secret
+                and existing_client.client_secret
+                and request.oauth_client_secret
+                == mask_string(existing_client.client_secret)
+            ):
+                request.oauth_client_secret = existing_client.client_secret
+
     # Create admin config with client info if provided
     config_data = MCPConnectionData(headers={})
     if request.oauth_client_id and request.oauth_client_secret:
@@ -1355,6 +1378,22 @@ def _upsert_mcp_server(
             )
             if client_info_raw:
                 client_info = OAuthClientInformationFull.model_validate(client_info_raw)
+
+        # If the frontend sent back masked credentials (unchanged by the user),
+        # restore the real stored values so the comparison below sees no change
+        # and the credentials aren't overwritten with masked strings.
+        if client_info and request.auth_type == MCPAuthenticationType.OAUTH:
+            if request.oauth_client_id and request.oauth_client_id == mask_string(
+                client_info.client_id
+            ):
+                request.oauth_client_id = client_info.client_id
+            if (
+                request.oauth_client_secret
+                and client_info.client_secret
+                and request.oauth_client_secret
+                == mask_string(client_info.client_secret)
+            ):
+                request.oauth_client_secret = client_info.client_secret
 
         changing_connection_config = (
             not mcp_server.admin_connection_config

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -96,6 +96,27 @@ def _truncate_description(description: str | None, max_length: int = 500) -> str
     return description[: max_length - 3] + "..."
 
 
+def _restore_masked_oauth_credentials(
+    request_client_id: str | None,
+    request_client_secret: str | None,
+    existing_client: OAuthClientInformationFull,
+) -> tuple[str | None, str | None]:
+    """If the frontend sent back masked credentials, restore the real stored values."""
+    if (
+        request_client_id
+        and existing_client.client_id
+        and request_client_id == mask_string(existing_client.client_id)
+    ):
+        request_client_id = existing_client.client_id
+    if (
+        request_client_secret
+        and existing_client.client_secret
+        and request_client_secret == mask_string(existing_client.client_secret)
+    ):
+        request_client_secret = existing_client.client_secret
+    return request_client_id, request_client_secret
+
+
 router = APIRouter(prefix="/mcp")
 admin_router = APIRouter(prefix="/admin/mcp")
 STATE_TTL_SECONDS = 60 * 5  # 5 minutes
@@ -403,17 +424,14 @@ async def _connect_oauth(
             existing_client = OAuthClientInformationFull.model_validate(
                 existing_client_raw
             )
-            if request.oauth_client_id and request.oauth_client_id == mask_string(
-                existing_client.client_id
-            ):
-                request.oauth_client_id = existing_client.client_id
-            if (
-                request.oauth_client_secret
-                and existing_client.client_secret
-                and request.oauth_client_secret
-                == mask_string(existing_client.client_secret)
-            ):
-                request.oauth_client_secret = existing_client.client_secret
+            (
+                request.oauth_client_id,
+                request.oauth_client_secret,
+            ) = _restore_masked_oauth_credentials(
+                request.oauth_client_id,
+                request.oauth_client_secret,
+                existing_client,
+            )
 
     # Create admin config with client info if provided
     config_data = MCPConnectionData(headers={})
@@ -1383,17 +1401,14 @@ def _upsert_mcp_server(
         # restore the real stored values so the comparison below sees no change
         # and the credentials aren't overwritten with masked strings.
         if client_info and request.auth_type == MCPAuthenticationType.OAUTH:
-            if request.oauth_client_id and request.oauth_client_id == mask_string(
-                client_info.client_id
-            ):
-                request.oauth_client_id = client_info.client_id
-            if (
-                request.oauth_client_secret
-                and client_info.client_secret
-                and request.oauth_client_secret
-                == mask_string(client_info.client_secret)
-            ):
-                request.oauth_client_secret = client_info.client_secret
+            (
+                request.oauth_client_id,
+                request.oauth_client_secret,
+            ) = _restore_masked_oauth_credentials(
+                request.oauth_client_id,
+                request.oauth_client_secret,
+                client_info,
+            )
 
         changing_connection_config = (
             not mcp_server.admin_connection_config

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -96,6 +96,11 @@ def _truncate_description(description: str | None, max_length: int = 500) -> str
     return description[: max_length - 3] + "..."
 
 
+# TODO: Replace mask-comparison approach with an explicit Unset sentinel from the
+# frontend indicating whether each credential field was actually modified. The current
+# approach is brittle (e.g. short credentials produce a fixed-length mask that could
+# collide) and mutates request values, which is surprising. The frontend should signal
+# "unchanged" vs "new value" directly rather than relying on masked-string equality.
 def _restore_masked_oauth_credentials(
     request_client_id: str | None,
     request_client_secret: str | None,


### PR DESCRIPTION
## Description

Closes https://discord.com/channels/1119886360506023946/1491443877092135044

## How Has This Been Tested?

Testing locally. ~~Maybe playwright? TBD~~

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents masked OAuth credentials from overwriting real secrets during MCP re-auth and server updates. Restores stored values when masks are detected to avoid false config changes.

- **Bug Fixes**
  - Added _restore_masked_oauth_credentials and used it in _connect_oauth and _upsert_mcp_server to swap masked client_id/client_secret with stored values before save/compare, preventing masked writes and unnecessary updates.

<sup>Written for commit 15093dba44940e53d1e3acf0adb897f9d3f34a69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



