### PR TITLE
fix(mcp): route OAuth callback to web server instead of MCP server

### DIFF
--- a/deployment/data/nginx/mcp.conf.inc.template
+++ b/deployment/data/nginx/mcp.conf.inc.template
@@ -1,3 +1,17 @@
+# OAuth callback page must be served by the web server (Next.js),
+# not the MCP server. Exact match takes priority over the regex below.
+location = /mcp/oauth/callback {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_redirect off;
+    proxy_pass http://web_server;
+}
+
 # MCP Server - Model Context Protocol for LLM integrations
 # Match /mcp, /mcp/, or /mcp/* but NOT /mcpserver, /mcpapi, etc.
 location ~ ^/mcp(/.*)?$ {

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.42
+version: 0.4.43
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -42,6 +42,22 @@ data:
         client_max_body_size 5G;
         {{- if .Values.mcpServer.enabled }}
 
+        # OAuth callback page must be served by the web server (Next.js),
+        # not the MCP server. Exact match takes priority over the regex below.
+        location = /mcp/oauth/callback {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Host $host;
+            proxy_http_version 1.1;
+            proxy_redirect off;
+            proxy_connect_timeout {{ .Values.nginx.timeouts.connect }}s;
+            proxy_send_timeout {{ .Values.nginx.timeouts.send }}s;
+            proxy_read_timeout {{ .Values.nginx.timeouts.read }}s;
+            proxy_pass http://web_server;
+        }
+
         # MCP Server - Model Context Protocol for LLM integrations
         # Match /mcp, /mcp/, or /mcp/* but NOT /mcpserver, /mcpapi, etc.
         location ~ ^/mcp(/.*)?$ {

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -296,7 +296,7 @@ nginx:
     # The ingress-nginx subchart doesn't auto-detect our custom ConfigMap changes.
     # Workaround: Helm upgrade will restart if the following annotation value changes.
     podAnnotations:
-      onyx.app/nginx-config-version: "3"
+      onyx.app/nginx-config-version: "4"
 
     # Propagate DOMAIN into nginx so server_name continues to use the same env var
     extraEnvs:


### PR DESCRIPTION
## Description

Routes the `/mcp/oauth/callback` to the frontend rather than directly to the MCP server. Otherwise, this returns a 404

Closes https://discord.com/channels/1119886360506023946/1491443877092135044

## How Has This Been Tested?

TODO

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the `/mcp/oauth/callback` endpoint to the web server (Next.js) instead of the MCP server to prevent 404s during the OAuth flow. Add an exact-match Nginx location (with proxy headers/timeouts) that takes precedence over the `/mcp` regex, bump the Helm chart to 0.4.43, and update the `nginx-config-version` annotation to trigger a reload.

<sup>Written for commit ece9a1bb133dbef408b7855b478404bbd6ca3bc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

