### PR TITLE
fix(mcp): add Ingress route for OAuth callback to reach web server

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.43
+version: 0.4.44
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/ingress-mcp-oauth-callback.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-mcp-oauth-callback.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.ingress.enabled .Values.mcpServer.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "onyx.fullname" . }}-ingress-mcp-oauth-callback
+  annotations:
+    {{- if not .Values.ingress.className }}
+    kubernetes.io/ingress.class: nginx
+    {{- end }}
+    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.api.host }}
+      http:
+        paths:
+          - path: /mcp/oauth/callback
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "onyx.fullname" . }}-webserver
+                port:
+                  number: {{ .Values.webserver.service.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.api.host }}
+      secretName: {{ include "onyx.fullname" . }}-ingress-mcp-oauth-callback-tls
+{{- end }}


### PR DESCRIPTION
## Description



## How Has This Been Tested?

:shrug: 

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Kubernetes Ingress for the MCP OAuth callback so it reaches the web server. This fixes the OAuth flow behind ingress.

- **Bug Fixes**
  - Exact path `/mcp/oauth/callback` on the API host.
  - Routes to the web server service with TLS via `cert-manager`; honors `ingressClassName` (defaults to `nginx`).
  - Bumped Helm chart to 0.4.44.

<sup>Written for commit 7d8e155034d3b90d0de3daabeaa8fe2d82a1b7c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

