### PR TITLE
feat(chat): smooth character-level streaming

### DIFF
--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -305,7 +305,7 @@ const AgentMessage = React.memo(function AgentMessage({
                     onRenderComplete();
                   }
                 }}
-                animate={false}
+                animate={!stopPacketSeen}
                 stopPacketSeen={stopPacketSeen}
                 stopReason={stopReason}
               >

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import Text from "@/refresh-components/texts/Text";
+import React, { useEffect, useMemo, useRef } from "react";
+import ReactMarkdown, { Components } from "react-markdown";
+import type { PluggableList } from "unified";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeHighlight from "rehype-highlight";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
 
+import { useTypewriter } from "@/hooks/useTypewriter";
+import Text from "@/refresh-components/texts/Text";
 import {
   ChatPacket,
   PacketType,
@@ -8,16 +16,22 @@ import {
 } from "../../../services/streamingModels";
 import { MessageRenderer, FullChatState } from "../interfaces";
 import { isFinalAnswerComplete } from "../../../services/packetUtils";
-import { useMarkdownRenderer } from "../markdownUtils";
+import { processContent } from "../markdownUtils";
 import { BlinkingBar } from "../../BlinkingBar";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
+import {
+  MemoizedAnchor,
+  MemoizedParagraph,
+} from "@/app/app/message/MemoizedTextComponents";
+import { extractCodeText } from "@/app/app/message/codeUtils";
+import { CodeBlock } from "@/app/app/message/CodeBlock";
+import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
+import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
+import { cn, transformLinkUri } from "@/lib/utils";
 
-/**
- * Maps a cleaned character position to the corresponding position in markdown text.
- * This allows progressive reveal to work with markdown formatting.
- */
+/** Maps a visible-char count to a markdown index (skips formatting chars,
+ *  extends to word boundary). Used by the voice-sync reveal path only. */
 function getRevealPosition(markdown: string, cleanChars: number): number {
-  // Skip patterns that don't contribute to visible character count
   const skipChars = new Set(["*", "`", "#"]);
   let cleanIndex = 0;
   let mdIndex = 0;
@@ -25,13 +39,11 @@ function getRevealPosition(markdown: string, cleanChars: number): number {
   while (cleanIndex < cleanChars && mdIndex < markdown.length) {
     const char = markdown[mdIndex];
 
-    // Skip markdown formatting characters
     if (char !== undefined && skipChars.has(char)) {
       mdIndex++;
       continue;
     }
 
-    // Handle link syntax [text](url) - skip the (url) part but count the text
     if (
       char === "]" &&
       mdIndex + 1 < markdown.length &&
@@ -48,7 +60,6 @@ function getRevealPosition(markdown: string, cleanChars: number): number {
     mdIndex++;
   }
 
-  // Extend to word boundary to avoid cutting mid-word
   while (
     mdIndex < markdown.length &&
     markdown[mdIndex] !== " " &&
@@ -60,8 +71,15 @@ function getRevealPosition(markdown: string, cleanChars: number): number {
   return mdIndex;
 }
 
-// Control the rate of packet streaming (packets per second)
-const PACKET_DELAY_MS = 10;
+// Cheap streaming plugins (gfm only) → cheap per-frame parse. Full
+// pipeline flips in once, at the end, for syntax highlighting + math.
+const STREAMING_REMARK_PLUGINS: PluggableList = [remarkGfm];
+const STREAMING_REHYPE_PLUGINS: PluggableList = [];
+const FULL_REMARK_PLUGINS: PluggableList = [
+  remarkGfm,
+  [remarkMath, { singleDollarTextMath: true }],
+];
+const FULL_REHYPE_PLUGINS: PluggableList = [rehypeHighlight, rehypeKatex];
 
 export const MessageTextRenderer: MessageRenderer<
   ChatPacket,
@@ -78,19 +96,9 @@ export const MessageTextRenderer: MessageRenderer<
   stopReason,
   children,
 }) => {
-  // If we're animating and the final answer is already complete, show more packets initially
-  const initialPacketCount = animate
-    ? packets.length > 0
-      ? 1 // Otherwise start with 1 packet
-      : 0
-    : -1; // Show all if not animating
-
-  const [displayedPacketCount, setDisplayedPacketCount] =
-    useState(initialPacketCount);
   const lastStableSyncedContentRef = useRef("");
   const lastVisibleContentRef = useRef("");
 
-  // Get voice mode context for progressive text reveal synced with audio
   const {
     revealedCharCount,
     autoPlayback,
@@ -99,7 +107,6 @@ export const MessageTextRenderer: MessageRenderer<
     isAwaitingAutoPlaybackStart,
   } = useVoiceMode();
 
-  // Get the full content from all packets
   const fullContent = packets
     .map((packet) => {
       if (
@@ -117,114 +124,40 @@ export const MessageTextRenderer: MessageRenderer<
     typeof messageNodeId === "number" &&
     activeMessageNodeId === messageNodeId;
 
-  // Animation effect - gradually increase displayed packets at controlled rate
-  useEffect(() => {
-    if (!animate) {
-      setDisplayedPacketCount(-1); // Show all packets
-      return;
-    }
-
-    if (displayedPacketCount >= 0 && displayedPacketCount < packets.length) {
-      const timer = setTimeout(() => {
-        setDisplayedPacketCount((prev) => Math.min(prev + 1, packets.length));
-      }, PACKET_DELAY_MS);
-
-      return () => clearTimeout(timer);
-    }
-  }, [animate, displayedPacketCount, packets.length]);
-
-  // Reset displayed count when packet array changes significantly (e.g., new message)
-  useEffect(() => {
-    if (animate && packets.length < displayedPacketCount) {
-      const resetCount = isFinalAnswerComplete(packets)
-        ? Math.min(10, packets.length)
-        : packets.length > 0
-          ? 1
-          : 0;
-      setDisplayedPacketCount(resetCount);
-    }
-  }, [animate, packets.length, displayedPacketCount]);
-
-  // Only mark as complete when all packets are received AND displayed
-  useEffect(() => {
-    if (isFinalAnswerComplete(packets)) {
-      // If animating, wait until all packets are displayed
-      if (
-        animate &&
-        displayedPacketCount >= 0 &&
-        displayedPacketCount < packets.length
-      ) {
-        return;
-      }
-      onComplete();
-    }
-  }, [packets, onComplete, animate, displayedPacketCount]);
-
-  // Get content based on displayed packet count or audio progress
+  // Normal streaming hands full text to the typewriter. Voice-sync and
+  // cancel paths pre-slice and bypass.
   const computedContent = useMemo(() => {
-    // Hold response in "thinking" state only while autoplay startup is pending.
     if (shouldUseAutoPlaybackSync && isAwaitingAutoPlaybackStart) {
       return "";
     }
 
-    // Sync text with audio only for the message currently being spoken.
     if (shouldUseAutoPlaybackSync && isAudioSyncActive) {
       const MIN_REVEAL_CHARS = 12;
       if (revealedCharCount < MIN_REVEAL_CHARS) {
         return "";
       }
-
-      // Reveal text progressively based on audio progress
       const revealPos = getRevealPosition(fullContent, revealedCharCount);
       return fullContent.slice(0, Math.max(revealPos, 0));
     }
 
-    // During an active synced turn, if sync temporarily drops, keep current reveal
-    // instead of jumping to full content or blanking.
     if (shouldUseAutoPlaybackSync && !stopPacketSeen) {
       return lastStableSyncedContentRef.current;
     }
 
-    // Standard behavior when auto-playback is off
-    if (!animate || displayedPacketCount === -1) {
-      return fullContent; // Show all content
-    }
-
-    // Packet-based reveal (when auto-playback is disabled)
-    return packets
-      .slice(0, displayedPacketCount)
-      .map((packet) => {
-        if (
-          packet.obj.type === PacketType.MESSAGE_DELTA ||
-          packet.obj.type === PacketType.MESSAGE_START
-        ) {
-          return packet.obj.content;
-        }
-        return "";
-      })
-      .join("");
+    return fullContent;
   }, [
-    animate,
-    displayedPacketCount,
-    fullContent,
-    packets,
-    revealedCharCount,
-    autoPlayback,
-    isAudioSyncActive,
-    activeMessageNodeId,
-    isAwaitingAutoPlaybackStart,
-    messageNodeId,
     shouldUseAutoPlaybackSync,
+    isAwaitingAutoPlaybackStart,
+    isAudioSyncActive,
+    revealedCharCount,
+    fullContent,
     stopPacketSeen,
   ]);
 
-  // Keep synced text monotonic: once visible, never regress or disappear between chunks.
+  // Monotonic guard for voice sync + freeze on user cancel.
   const content = useMemo(() => {
     const wasUserCancelled = stopReason === StopReason.USER_CANCELLED;
 
-    // On user cancel during live streaming, freeze at exactly what was already
-    // visible to prevent flicker. On history reload (animate=false), the ref
-    // starts empty so we must use computedContent directly.
     if (wasUserCancelled && animate) {
       return lastVisibleContentRef.current;
     }
@@ -242,13 +175,10 @@ export const MessageTextRenderer: MessageRenderer<
       return computedContent;
     }
 
-    // If content shape changed unexpectedly mid-stream, prefer the stable version
-    // to avoid flicker/dumps.
     if (!stopPacketSeen || wasUserCancelled) {
       return last;
     }
 
-    // For normal completed responses, allow final full content.
     return computedContent;
   }, [
     computedContent,
@@ -258,7 +188,6 @@ export const MessageTextRenderer: MessageRenderer<
     animate,
   ]);
 
-  // Sync the stable ref outside of useMemo to avoid side effects during render.
   useEffect(() => {
     if (stopReason === StopReason.USER_CANCELLED) {
       return;
@@ -270,12 +199,127 @@ export const MessageTextRenderer: MessageRenderer<
     }
   }, [content, shouldUseAutoPlaybackSync, stopReason]);
 
-  // Track last actually rendered content so cancel can freeze without dumping buffered text.
   useEffect(() => {
     if (content.length > 0) {
       lastVisibleContentRef.current = content;
     }
   }, [content]);
+
+  const isStreamingAnimationEnabled =
+    animate &&
+    !shouldUseAutoPlaybackSync &&
+    stopReason !== StopReason.USER_CANCELLED;
+
+  const isStreamFinished = isFinalAnswerComplete(packets);
+
+  const displayedContent = useTypewriter(content, isStreamingAnimationEnabled);
+
+  // One-way signal: stream done AND typewriter caught up. Do NOT derive
+  // this from "typewriter currently behind" — it oscillates mid-stream
+  // between packet bursts and would thrash the plugin pipeline.
+  const streamFullyDisplayed =
+    isStreamFinished && displayedContent.length >= content.length;
+
+  // Fire onComplete exactly once per mount. `onComplete` is an inline
+  // arrow in AgentMessage so its identity changes on every parent render;
+  // without this guard, each new identity would re-fire the effect once
+  // `streamFullyDisplayed` is true.
+  const onCompleteFiredRef = useRef(false);
+  useEffect(() => {
+    if (streamFullyDisplayed && !onCompleteFiredRef.current) {
+      onCompleteFiredRef.current = true;
+      onComplete();
+    }
+  }, [streamFullyDisplayed, onComplete]);
+
+  const processedContent = useMemo(
+    () => processContent(displayedContent),
+    [displayedContent]
+  );
+
+  // Stable-identity components for ReactMarkdown. Dynamic data (`state`,
+  // `processedContent`) flows through refs so the callback identities
+  // never change — otherwise every typewriter tick would invalidate
+  // React reconciliation on the markdown subtree.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const processedContentRef = useRef(processedContent);
+  processedContentRef.current = processedContent;
+
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      a: ({ href, children }) => {
+        const s = stateRef.current;
+        const imageFileId = extractChatImageFileId(
+          href,
+          String(children ?? "")
+        );
+        if (imageFileId) {
+          return (
+            <InMessageImage
+              fileId={imageFileId}
+              fileName={String(children ?? "")}
+            />
+          );
+        }
+        return (
+          <MemoizedAnchor
+            updatePresentingDocument={s?.setPresentingDocument || (() => {})}
+            docs={s?.docs || []}
+            userFiles={s?.userFiles || []}
+            citations={s?.citations}
+            href={href}
+          >
+            {children}
+          </MemoizedAnchor>
+        );
+      },
+      p: ({ children }) => (
+        <MemoizedParagraph className="font-main-content-body">
+          {children}
+        </MemoizedParagraph>
+      ),
+      pre: ({ children }) => <>{children}</>,
+      b: ({ className, children }) => (
+        <span className={className}>{children}</span>
+      ),
+      ul: ({ className, children, ...rest }) => (
+        <ul className={className} {...rest}>
+          {children}
+        </ul>
+      ),
+      ol: ({ className, children, ...rest }) => (
+        <ol className={className} {...rest}>
+          {children}
+        </ol>
+      ),
+      li: ({ className, children, ...rest }) => (
+        <li className={className} {...rest}>
+          {children}
+        </li>
+      ),
+      table: ({ className, children, ...rest }) => (
+        <div className="markdown-table-breakout">
+          <table className={cn(className, "min-w-full")} {...rest}>
+            {children}
+          </table>
+        </div>
+      ),
+      code: ({ node, className, children }) => {
+        const codeText = extractCodeText(
+          node,
+          processedContentRef.current,
+          children
+        );
+        return (
+          <CodeBlock className={className} codeText={codeText}>
+            {children}
+          </CodeBlock>
+        );
+      },
+    }),
+    []
+  );
 
   const shouldShowThinkingPlaceholder =
     shouldUseAutoPlaybackSync &&
@@ -292,16 +336,16 @@ export const MessageTextRenderer: MessageRenderer<
     !stopPacketSeen;
 
   const shouldShowCursor =
-    content.length > 0 &&
-    (!stopPacketSeen ||
+    displayedContent.length > 0 &&
+    ((isStreamingAnimationEnabled && !streamFullyDisplayed) ||
+      (!isStreamingAnimationEnabled && !stopPacketSeen) ||
       (shouldUseAutoPlaybackSync && content.length < fullContent.length));
 
-  const { renderedContent } = useMarkdownRenderer(
-    // the [*]() is a hack to show a blinking dot when the packet is not complete
-    shouldShowCursor ? content + " [*]() " : content,
-    state,
-    "font-main-content-body"
-  );
+  // `[*]() ` is rendered by the anchor component as an inline blinking
+  // caret, keeping it flush with the trailing character.
+  const markdownInput = shouldShowCursor
+    ? processedContent + " [*]() "
+    : processedContent;
 
   return children([
     {
@@ -312,8 +356,26 @@ export const MessageTextRenderer: MessageRenderer<
           <Text as="span" secondaryBody text04 className="italic">
             Thinking
           </Text>
-        ) : content.length > 0 ? (
-          <>{renderedContent}</>
+        ) : displayedContent.length > 0 ? (
+          <div dir="auto">
+            <ReactMarkdown
+              className="prose font-main-content-body max-w-full"
+              components={markdownComponents}
+              remarkPlugins={
+                streamFullyDisplayed
+                  ? FULL_REMARK_PLUGINS
+                  : STREAMING_REMARK_PLUGINS
+              }
+              rehypePlugins={
+                streamFullyDisplayed
+                  ? FULL_REHYPE_PLUGINS
+                  : STREAMING_REHYPE_PLUGINS
+              }
+              urlTransform={transformLinkUri}
+            >
+              {markdownInput}
+            </ReactMarkdown>
+          </div>
         ) : (
           <BlinkingBar addMargin />
         ),

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -711,6 +711,13 @@ export default function useChatController({
         ? selectedModels?.map((m) => m.displayName) ?? []
         : [];
 
+      // rAF-batched flush state. One Zustand write per frame instead of
+      // one per packet.
+      const dirtyModelIndices = new Set<number>();
+      let singleModelDirty = false;
+      let userNodeDirty = false;
+      let pendingFlush = false;
+
       /** Build a non-errored multi-model assistant node for upsert. */
       function buildAssistantNodeUpdate(
         idx: number,
@@ -740,14 +747,122 @@ export default function useChatController({
         };
       }
 
-      /** Build updated nodes for all non-errored models. */
-      function buildNonErroredNodes(overrides?: Partial<Message>): Message[] {
+      /** With `onlyDirty`, rebuilds only those model nodes — unchanged
+       *  siblings keep their stable Message ref so React memo short-circuits. */
+      function buildNonErroredNodes(
+        overrides?: Partial<Message>,
+        onlyDirty?: Set<number> | null
+      ): Message[] {
         const nodes: Message[] = [];
         for (let idx = 0; idx < initialAssistantNodes.length; idx++) {
           if (erroredModelIndices.has(idx)) continue;
+          if (onlyDirty && !onlyDirty.has(idx)) continue;
           nodes.push(buildAssistantNodeUpdate(idx, overrides));
         }
         return nodes;
+      }
+
+      /** Flush accumulated packet state into the tree as one Zustand
+       *  update. No-op when nothing is pending. */
+      function flushPendingUpdates() {
+        if (!pendingFlush) return;
+        pendingFlush = false;
+
+        parentMessage =
+          parentMessage || currentMessageTreeLocal?.get(SYSTEM_NODE_ID)!;
+
+        let messagesToUpsert: Message[];
+
+        if (isMultiModel) {
+          if (dirtyModelIndices.size === 0 && !userNodeDirty) return;
+
+          const dirtySnapshot = new Set(dirtyModelIndices);
+          dirtyModelIndices.clear();
+          const dirtyNodes = buildNonErroredNodes(undefined, dirtySnapshot);
+
+          if (userNodeDirty) {
+            userNodeDirty = false;
+            // Read current user node to preserve childrenNodeIds
+            // (initialUserNode's are stale from creation time).
+            const currentUserNode =
+              currentMessageTreeLocal.get(initialUserNode.nodeId) ||
+              initialUserNode;
+            const updatedUserNode: Message = {
+              ...currentUserNode,
+              messageId: newUserMessageId ?? undefined,
+              files: files,
+            };
+            messagesToUpsert = [updatedUserNode, ...dirtyNodes];
+          } else {
+            messagesToUpsert = dirtyNodes;
+          }
+
+          if (messagesToUpsert.length === 0) return;
+        } else {
+          if (!singleModelDirty) return;
+          singleModelDirty = false;
+
+          messagesToUpsert = [
+            {
+              ...initialUserNode,
+              messageId: newUserMessageId ?? undefined,
+              files: files,
+            },
+            {
+              ...initialAgentNode,
+              messageId: newAgentMessageId ?? undefined,
+              message: error || answer,
+              type: error ? "error" : "assistant",
+              retrievalType,
+              query: finalMessage?.rephrased_query || query,
+              documents: documents,
+              citations: finalMessage?.citations || citations || {},
+              files: finalMessage?.files || aiMessageImages || [],
+              toolCall: finalMessage?.tool_call || toolCall,
+              stackTrace: stackTrace,
+              overridden_model: finalMessage?.overridden_model,
+              stopReason: stopReason,
+              packets: packets,
+              packetCount: packets.length,
+              processingDurationSeconds:
+                finalMessage?.processing_duration_seconds ??
+                (() => {
+                  const startTime = useChatSessionStore
+                    .getState()
+                    .getStreamingStartTime(frozenSessionId);
+                  return startTime
+                    ? Math.floor((Date.now() - startTime) / 1000)
+                    : undefined;
+                })(),
+            },
+          ];
+        }
+
+        currentMessageTreeLocal = upsertToCompleteMessageTree({
+          messages: messagesToUpsert,
+          completeMessageTreeOverride: currentMessageTreeLocal,
+          chatSessionId: frozenSessionId!,
+        });
+      }
+
+      /** Awaits next animation frame (or a setTimeout fallback when the
+       *  tab is hidden — rAF is paused in background tabs, which would
+       *  otherwise hang the stream loop here), then flushes. Aligns
+       *  React updates with the paint cycle when visible. */
+      function flushViaRAF(): Promise<void> {
+        return new Promise<void>((resolve) => {
+          let done = false;
+          const flush = () => {
+            if (done) return;
+            done = true;
+            flushPendingUpdates();
+            resolve();
+          };
+          requestAnimationFrame(flush);
+          // Fallback for hidden tabs where rAF is paused. Throttled to
+          // ~1s by browsers, matching the previous setTimeout(500) cadence.
+          setTimeout(flush, 100);
+        });
       }
 
       let streamSucceeded = false;
@@ -836,7 +951,12 @@ export default function useChatController({
         await delay(50);
         while (!stack.isComplete || !stack.isEmpty()) {
           if (stack.isEmpty()) {
-            await delay(0.5);
+            // Flush the burst on the next paint, or idle briefly.
+            if (pendingFlush) {
+              await flushViaRAF();
+            } else {
+              await delay(0.5);
+            }
           }
 
           if (!stack.isEmpty() && !controller.signal.aborted) {
@@ -860,6 +980,7 @@ export default function useChatController({
             if ((packet as MessageResponseIDInfo).user_message_id) {
               newUserMessageId = (packet as MessageResponseIDInfo)
                 .user_message_id;
+              userNodeDirty = true;
 
               // Track extension queries in PostHog (reuses isExtension/extensionContext from above)
               if (isExtension) {
@@ -898,6 +1019,8 @@ export default function useChatController({
                   modelDisplayNames[mi] = slot.model_name;
                 }
               }
+              userNodeDirty = true;
+              pendingFlush = true;
               continue;
             }
 
@@ -909,6 +1032,7 @@ export default function useChatController({
                   !files.some((existingFile) => existingFile.id === newFile.id)
               );
               files = files.concat(newUserFiles);
+              if (newUserFiles.length > 0) userNodeDirty = true;
             }
 
             if (Object.hasOwn(packet, "file_ids")) {
@@ -937,6 +1061,7 @@ export default function useChatController({
                 ) {
                   const errorNode = initialAssistantNodes[errorModelIndex]!;
                   erroredModelIndices.add(errorModelIndex);
+                  dirtyModelIndices.delete(errorModelIndex);
                   currentMessageTreeLocal = upsertToCompleteMessageTree({
                     messages: [
                       {
@@ -993,19 +1118,21 @@ export default function useChatController({
 
               if (isMultiModel) {
                 // Multi-model: route packet by placement.model_index.
-                // OverallStop (type "stop") has model_index=null — it's a global
-                // terminal packet that must be delivered to ALL models so each
-                // panel's AgentMessage sees the stop and exits "Thinking..." state.
+                // OverallStop (type "stop") has model_index=null — it's a
+                // global terminal packet that must be delivered to ALL
+                // models so each panel's AgentMessage sees the stop and
+                // exits "Thinking..." state.
                 const isGlobalStop =
                   packetObj.type === "stop" &&
                   typedPacket.placement?.model_index == null;
 
                 if (isGlobalStop) {
                   for (let mi = 0; mi < packetsPerModel.length; mi++) {
-                    packetsPerModel[mi] = [
-                      ...packetsPerModel[mi]!,
-                      typedPacket,
-                    ];
+                    // Mutated in place — change detection uses packetCount, not array identity.
+                    packetsPerModel[mi]!.push(typedPacket);
+                    if (!erroredModelIndices.has(mi)) {
+                      dirtyModelIndices.add(mi);
+                    }
                   }
                 }
 
@@ -1015,10 +1142,10 @@ export default function useChatController({
                   modelIndex >= 0 &&
                   modelIndex < packetsPerModel.length
                 ) {
-                  packetsPerModel[modelIndex] = [
-                    ...packetsPerModel[modelIndex]!,
-                    typedPacket,
-                  ];
+                  packetsPerModel[modelIndex]!.push(typedPacket);
+                  if (!erroredModelIndices.has(modelIndex)) {
+                    dirtyModelIndices.add(modelIndex);
+                  }
 
                   if (packetObj.type === "citation_info") {
                     const citationInfo = packetObj as {
@@ -1048,6 +1175,7 @@ export default function useChatController({
                 // Single-model
                 packets.push(typedPacket);
                 packetsVersion++;
+                singleModelDirty = true;
 
                 if (packetObj.type === "citation_info") {
                   const citationInfo = packetObj as {
@@ -1074,73 +1202,16 @@ export default function useChatController({
               console.warn("Unknown packet:", JSON.stringify(packet));
             }
 
-            // on initial message send, we insert a dummy system message
-            // set this as the parent here if no parent is set
-            parentMessage =
-              parentMessage || currentMessageTreeLocal?.get(SYSTEM_NODE_ID)!;
-
-            // Build the messages to upsert based on single vs multi-model mode
-            let messagesToUpsertInLoop: Message[];
-
-            if (isMultiModel) {
-              // Read the current user node from the tree to preserve childrenNodeIds
-              // (initialUserNode has stale/empty children from creation time).
-              const currentUserNode =
-                currentMessageTreeLocal.get(initialUserNode.nodeId) ||
-                initialUserNode;
-              const updatedUserNode: Message = {
-                ...currentUserNode,
-                messageId: newUserMessageId ?? undefined,
-                files: files,
-              };
-              messagesToUpsertInLoop = [
-                updatedUserNode,
-                ...buildNonErroredNodes(),
-              ];
-            } else {
-              messagesToUpsertInLoop = [
-                {
-                  ...initialUserNode,
-                  messageId: newUserMessageId ?? undefined,
-                  files: files,
-                },
-                {
-                  ...initialAgentNode,
-                  messageId: newAgentMessageId ?? undefined,
-                  message: error || answer,
-                  type: error ? "error" : "assistant",
-                  retrievalType,
-                  query: finalMessage?.rephrased_query || query,
-                  documents: documents,
-                  citations: finalMessage?.citations || citations || {},
-                  files: finalMessage?.files || aiMessageImages || [],
-                  toolCall: finalMessage?.tool_call || toolCall,
-                  stackTrace: stackTrace,
-                  overridden_model: finalMessage?.overridden_model,
-                  stopReason: stopReason,
-                  packets: packets,
-                  packetCount: packets.length,
-                  processingDurationSeconds:
-                    finalMessage?.processing_duration_seconds ??
-                    (() => {
-                      const startTime = useChatSessionStore
-                        .getState()
-                        .getStreamingStartTime(frozenSessionId);
-                      return startTime
-                        ? Math.floor((Date.now() - startTime) / 1000)
-                        : undefined;
-                    })(),
-                },
-              ];
-            }
-
-            currentMessageTreeLocal = upsertToCompleteMessageTree({
-              messages: messagesToUpsertInLoop,
-              completeMessageTreeOverride: currentMessageTreeLocal,
-              chatSessionId: frozenSessionId!,
-            });
+            // Mark dirty — flushViaRAF coalesces bursts into one React update per frame.
+            if (!isMultiModel) singleModelDirty = true;
+            pendingFlush = true;
           }
         }
+        // Flush any tail state from the final packet(s) before declaring
+        // the stream complete. Without this, the last ≤1 frame of packets
+        // could get stranded in local state.
+        flushPendingUpdates();
+
         // Surface FIFO errors (e.g. 429 before any packets arrive) so the
         // catch block replaces the thinking placeholder with an error message.
         if (stack.error) {

--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+// Fixed reveal rate — NOT adaptive. Any ceil(delta/N) formula produces
+// visible chunks on burst packet arrivals. 1 = 60 cps, 2 = 120 cps.
+const CHARS_PER_FRAME = 2;
+
+/**
+ * Reveals `target` one character at a time on each animation frame.
+ * When `enabled` is false (historical messages), snaps to full on mount.
+ * The rAF loop pauses once caught up and resumes when `target` grows.
+ */
+export function useTypewriter(target: string, enabled: boolean): string {
+  // Ref so the rAF loop reads latest length without restarting.
+  const targetRef = useRef(target);
+  targetRef.current = target;
+
+  // Mirror `enabled` so the restart effect can short-circuit when the
+  // caller has turned animation off (e.g. voice-mode, where display is
+  // driven by audio position — the typewriter must stay idle and not
+  // animate a jump after audio ends).
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  // `enabled` controls initial state: animate from 0 vs snap to full for
+  // history/voice. Transitions mid-stream are handled via enabledRef in
+  // the restart effect so a flip to false doesn't dump the buffered tail
+  // *and* doesn't spin up the rAF loop on later growth.
+  const [displayedLength, setDisplayedLength] = useState<number>(
+    enabled ? 0 : target.length
+  );
+
+  // Mirror displayedLength in a ref so the rAF loop can read the latest
+  // value without stale-closure issues AND without needing a functional
+  // state updater (which must be pure — no ref mutations inside).
+  const displayedLengthRef = useRef(displayedLength);
+
+  // Clamp (not reset) on target shrink — preserves already-revealed chars
+  // across user-cancel freeze and regeneration.
+  const prevTargetLengthRef = useRef(target.length);
+  useEffect(() => {
+    if (target.length < prevTargetLengthRef.current) {
+      const clamped = Math.min(displayedLengthRef.current, target.length);
+      displayedLengthRef.current = clamped;
+      setDisplayedLength(clamped);
+    }
+    prevTargetLengthRef.current = target.length;
+  }, [target.length]);
+
+  // Self-scheduling rAF loop. Pauses when caught up so idle/historical
+  // messages don't run a 60fps no-op updater for their entire lifetime.
+  const rafIdRef = useRef<number | null>(null);
+  const runningRef = useRef(false);
+  const startLoopRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const tick = () => {
+      const targetLen = targetRef.current.length;
+      const prev = displayedLengthRef.current;
+      if (prev >= targetLen) {
+        // Caught up — pause the loop. The sibling effect below will
+        // restart it when `target` grows.
+        runningRef.current = false;
+        rafIdRef.current = null;
+        return;
+      }
+      const next = Math.min(prev + CHARS_PER_FRAME, targetLen);
+      displayedLengthRef.current = next;
+      setDisplayedLength(next);
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      if (runningRef.current) return;
+      // Animation disabled — snap to full and stay idle. This is the
+      // voice-mode path where content is driven by audio position, and
+      // any "gap" (e.g. user stops audio early) must jump instantly
+      // instead of animating a 1500-char typewriter burst.
+      if (!enabledRef.current) {
+        const targetLen = targetRef.current.length;
+        if (displayedLengthRef.current !== targetLen) {
+          displayedLengthRef.current = targetLen;
+          setDisplayedLength(targetLen);
+        }
+        return;
+      }
+      runningRef.current = true;
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+
+    startLoopRef.current = start;
+
+    if (targetRef.current.length > displayedLengthRef.current) {
+      start();
+    }
+
+    return () => {
+      runningRef.current = false;
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      startLoopRef.current = null;
+    };
+  }, []);
+
+  // Restart the loop when target grows past what's currently displayed.
+  useEffect(() => {
+    if (target.length > displayedLength && startLoopRef.current) {
+      startLoopRef.current();
+    }
+  }, [target.length, displayedLength]);
+
+  return useMemo(
+    () => target.slice(0, Math.min(displayedLength, target.length)),
+    [target, displayedLength]
+  );
+}

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -213,9 +213,12 @@ const ChatScrollContainer = React.memo(
         }
       }, [updateScrollState, getScrollState]);
 
-      // Watch for content changes (MutationObserver + ResizeObserver)
+      // MutationObserver (structural) + ResizeObserver (height growth).
+      // NOT characterData — typewriter reveals don't change scrollHeight
+      // and firing per-char thrashed auto-scroll.
       useEffect(() => {
         const container = scrollContainerRef.current;
+        const contentWrapper = contentWrapperRef.current;
         if (!container) return;
 
         let rafId: number | null = null;
@@ -244,17 +247,17 @@ const ChatScrollContainer = React.memo(
           });
         };
 
-        // MutationObserver for content changes
         const mutationObserver = new MutationObserver(onContentChange);
         mutationObserver.observe(container, {
           childList: true,
           subtree: true,
-          characterData: true,
         });
 
-        // ResizeObserver for container size changes
         const resizeObserver = new ResizeObserver(onContentChange);
         resizeObserver.observe(container);
+        if (contentWrapper) {
+          resizeObserver.observe(contentWrapper);
+        }
 
         return () => {
           mutationObserver.disconnect();


### PR DESCRIPTION
## Description

Character-level smooth streaming for chat responses, plus fixes for scroll jitter and post-stop content dumps.

**What changed:**
- Custom `useTypewriter` hook with a self-scheduling `requestAnimationFrame` loop reveals 2 chars/frame (~120 cps) regardless of packet arrival cadence.
- `useChatController` batches packet → Zustand writes via rAF so bursts coalesce into one React update per frame.
- `MessageTextRenderer` uses stable-identity markdown components (refs for dynamic data) and only runs the full remark/rehype pipeline once the stream finishes — streaming passes use `remark-gfm` only.
- `ChatScrollContainer` drops `characterData` mutation tracking and uses a `ResizeObserver` on the content wrapper, so per-char reveals no longer trigger auto-scroll.
- `AgentMessage` passes `animate={!stopPacketSeen}` so the typewriter continues draining buffered content after the stop packet instead of dumping it all at once.

## How Has This Been Tested?


https://github.com/user-attachments/assets/8a80e375-f442-4fbb-b189-2c86397b668d



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check