### PR TITLE
feat: add padding API to `Divider`

### DIFF
--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -1,6 +1,6 @@
 import "@opal/components/cards/card/styles.css";
 import type { PaddingVariants, RoundingVariants } from "@opal/types";
-import { cardPaddingVariants, cardRoundingVariants } from "@opal/shared";
+import { paddingVariants, cardRoundingVariants } from "@opal/shared";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -79,7 +79,7 @@ function Card({
   ref,
   children,
 }: CardProps) {
-  const padding = cardPaddingVariants[paddingProp];
+  const padding = paddingVariants[paddingProp];
   const rounding = cardRoundingVariants[roundingProp];
 
   return (

--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -1,6 +1,6 @@
 import "@opal/components/cards/select-card/styles.css";
 import type { PaddingVariants, RoundingVariants } from "@opal/types";
-import { cardPaddingVariants, cardRoundingVariants } from "@opal/shared";
+import { paddingVariants, cardRoundingVariants } from "@opal/shared";
 import { cn } from "@opal/utils";
 import { Interactive, type InteractiveStatefulProps } from "@opal/core";
 
@@ -78,7 +78,7 @@ function SelectCard({
   children,
   ...statefulProps
 }: SelectCardProps) {
-  const padding = cardPaddingVariants[paddingProp];
+  const padding = paddingVariants[paddingProp];
   const rounding = cardRoundingVariants[roundingProp];
 
   return (

--- a/web/lib/opal/src/components/divider/Divider.stories.tsx
+++ b/web/lib/opal/src/components/divider/Divider.stories.tsx
@@ -27,17 +27,21 @@ export const Vertical: Story = {
   ),
 };
 
-export const FitPadding: Story = {
-  render: () => <Divider padding="fit" />,
+export const NoPadding: Story = {
+  render: () => <Divider paddingX="fit" paddingY="fit" />,
 };
 
-export const VerticalFitPadding: Story = {
+export const CustomPadding: Story = {
+  render: () => <Divider paddingX="lg" paddingY="sm" />,
+};
+
+export const VerticalNoPadding: Story = {
   render: () => (
     <div
       style={{ display: "flex", alignItems: "stretch", height: 64, gap: 16 }}
     >
       <span>Left</span>
-      <Divider orientation="vertical" padding="fit" />
+      <Divider orientation="vertical" paddingX="fit" paddingY="fit" />
       <span>Right</span>
     </div>
   ),

--- a/web/lib/opal/src/components/divider/Divider.stories.tsx
+++ b/web/lib/opal/src/components/divider/Divider.stories.tsx
@@ -15,6 +15,34 @@ export const Plain: Story = {
   render: () => <Divider />,
 };
 
+export const Vertical: Story = {
+  render: () => (
+    <div
+      style={{ display: "flex", alignItems: "stretch", height: 64, gap: 16 }}
+    >
+      <span>Left</span>
+      <Divider orientation="vertical" />
+      <span>Right</span>
+    </div>
+  ),
+};
+
+export const FitPadding: Story = {
+  render: () => <Divider padding="fit" />,
+};
+
+export const VerticalFitPadding: Story = {
+  render: () => (
+    <div
+      style={{ display: "flex", alignItems: "stretch", height: 64, gap: 16 }}
+    >
+      <span>Left</span>
+      <Divider orientation="vertical" padding="fit" />
+      <span>Right</span>
+    </div>
+  ),
+};
+
 export const WithTitle: Story = {
   render: () => <Divider title="Section" />,
 };

--- a/web/lib/opal/src/components/divider/Divider.stories.tsx
+++ b/web/lib/opal/src/components/divider/Divider.stories.tsx
@@ -28,11 +28,11 @@ export const Vertical: Story = {
 };
 
 export const NoPadding: Story = {
-  render: () => <Divider paddingX="fit" paddingY="fit" />,
+  render: () => <Divider paddingParallel="fit" paddingPerpendicular="fit" />,
 };
 
 export const CustomPadding: Story = {
-  render: () => <Divider paddingX="lg" paddingY="sm" />,
+  render: () => <Divider paddingParallel="lg" paddingPerpendicular="sm" />,
 };
 
 export const VerticalNoPadding: Story = {
@@ -41,7 +41,11 @@ export const VerticalNoPadding: Story = {
       style={{ display: "flex", alignItems: "stretch", height: 64, gap: 16 }}
     >
       <span>Left</span>
-      <Divider orientation="vertical" paddingX="fit" paddingY="fit" />
+      <Divider
+        orientation="vertical"
+        paddingParallel="fit"
+        paddingPerpendicular="fit"
+      />
       <span>Right</span>
     </div>
   ),

--- a/web/lib/opal/src/components/divider/README.md
+++ b/web/lib/opal/src/components/divider/README.md
@@ -10,7 +10,12 @@ The component uses a discriminated union with four variants. `title` and `descri
 
 ### Bare divider
 
-No props — renders a plain horizontal line.
+A plain line with no title or description.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the line |
+| `padding` | `"md" \| "fit"` | `"md"` | `"md"` adds standard padding, `"fit"` removes it |
 
 ### Titled divider
 
@@ -40,8 +45,14 @@ No props — renders a plain horizontal line.
 ```tsx
 import { Divider } from "@opal/components";
 
-// Plain line
+// Plain horizontal line
 <Divider />
+
+// Vertical line
+<Divider orientation="vertical" />
+
+// No padding
+<Divider padding="fit" />
 
 // With title
 <Divider title="Advanced" />

--- a/web/lib/opal/src/components/divider/README.md
+++ b/web/lib/opal/src/components/divider/README.md
@@ -15,10 +15,8 @@ A plain line with no title or description.
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the line |
-| `paddingX` | `PaddingVariants` | `"sm"` | Horizontal padding (0.5rem) |
-| `paddingY` | `PaddingVariants` | `"xs"` | Vertical padding (0.25rem) |
-
-> **Note:** For `orientation="vertical"`, `paddingX` and `paddingY` are swapped so they remain relative to the line direction — `paddingX` controls spacing along the line, `paddingY` controls spacing perpendicular to it.
+| `paddingParallel` | `PaddingVariants` | `"sm"` | Padding along the line direction (0.5rem) |
+| `paddingPerpendicular` | `PaddingVariants` | `"xs"` | Padding perpendicular to the line (0.25rem) |
 
 ### Titled divider
 
@@ -55,10 +53,10 @@ import { Divider } from "@opal/components";
 <Divider orientation="vertical" />
 
 // No padding
-<Divider paddingX="fit" paddingY="fit" />
+<Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
 // Custom padding
-<Divider paddingX="lg" paddingY="sm" />
+<Divider paddingParallel="lg" paddingPerpendicular="sm" />
 
 // With title
 <Divider title="Advanced" />

--- a/web/lib/opal/src/components/divider/README.md
+++ b/web/lib/opal/src/components/divider/README.md
@@ -15,7 +15,10 @@ A plain line with no title or description.
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the line |
-| `padding` | `"md" \| "fit"` | `"md"` | `"md"` adds standard padding, `"fit"` removes it |
+| `paddingX` | `PaddingVariants` | `"sm"` | Horizontal padding (0.5rem) |
+| `paddingY` | `PaddingVariants` | `"xs"` | Vertical padding (0.25rem) |
+
+> **Note:** For `orientation="vertical"`, `paddingX` and `paddingY` are swapped so they remain relative to the line direction — `paddingX` controls spacing along the line, `paddingY` controls spacing perpendicular to it.
 
 ### Titled divider
 
@@ -52,7 +55,10 @@ import { Divider } from "@opal/components";
 <Divider orientation="vertical" />
 
 // No padding
-<Divider padding="fit" />
+<Divider paddingX="fit" paddingY="fit" />
+
+// Custom padding
+<Divider paddingX="lg" paddingY="sm" />
 
 // With title
 <Divider title="Advanced" />

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -19,8 +19,8 @@ interface DividerSharedProps {
   description?: never;
   foldable?: false;
   orientation?: never;
-  paddingX?: never;
-  paddingY?: never;
+  paddingParallel?: never;
+  paddingPerpendicular?: never;
   open?: never;
   defaultOpen?: never;
   onOpenChange?: never;
@@ -30,14 +30,14 @@ interface DividerSharedProps {
 /** Plain line — no title, no description. */
 type DividerBareProps = Omit<
   DividerSharedProps,
-  "orientation" | "paddingX" | "paddingY"
+  "orientation" | "paddingParallel" | "paddingPerpendicular"
 > & {
   /** Orientation of the line. Default: `"horizontal"`. */
   orientation?: "horizontal" | "vertical";
-  /** Horizontal padding. Default: `"sm"` (0.5rem). */
-  paddingX?: PaddingVariants;
-  /** Vertical padding. Default: `"xs"` (0.25rem). */
-  paddingY?: PaddingVariants;
+  /** Padding along the line direction. Default: `"sm"` (0.5rem). */
+  paddingParallel?: PaddingVariants;
+  /** Padding perpendicular to the line. Default: `"xs"` (0.25rem). */
+  paddingPerpendicular?: PaddingVariants;
 };
 
 /** Line with a title to the left. */
@@ -89,8 +89,8 @@ function Divider(props: DividerProps) {
     title,
     description,
     orientation = "horizontal",
-    paddingX = "sm",
-    paddingY = "xs",
+    paddingParallel = "sm",
+    paddingPerpendicular = "xs",
   } = props;
 
   if (orientation === "vertical") {
@@ -99,8 +99,8 @@ function Divider(props: DividerProps) {
         ref={ref}
         className={cn(
           "opal-divider-vertical",
-          paddingXVariants[paddingY],
-          paddingYVariants[paddingX]
+          paddingXVariants[paddingPerpendicular],
+          paddingYVariants[paddingParallel]
         )}
       >
         <div className="opal-divider-line-vertical" />
@@ -113,8 +113,8 @@ function Divider(props: DividerProps) {
       ref={ref}
       className={cn(
         "opal-divider",
-        paddingXVariants[paddingX],
-        paddingYVariants[paddingY]
+        paddingXVariants[paddingParallel],
+        paddingYVariants[paddingPerpendicular]
       )}
     >
       <div className="opal-divider-row">

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -2,10 +2,12 @@
 
 import "@opal/components/divider/styles.css";
 import { useState, useCallback } from "react";
-import type { RichStr } from "@opal/types";
+import type { PaddingVariants, RichStr } from "@opal/types";
 import { Button, Text } from "@opal/components";
 import { SvgChevronRight } from "@opal/icons";
 import { Interactive } from "@opal/core";
+import { cn } from "@opal/utils";
+import { paddingXVariants, paddingYVariants } from "@opal/shared";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,6 +25,12 @@ interface DividerBareProps extends DividerNeverFields {
   title?: never;
   description?: never;
   foldable?: false;
+  /** Orientation of the line. Default: `"horizontal"`. */
+  orientation?: "horizontal" | "vertical";
+  /** Horizontal padding. Default: `"sm"` (0.5rem). */
+  paddingX?: PaddingVariants;
+  /** Vertical padding. Default: `"xs"` (0.25rem). */
+  paddingY?: PaddingVariants;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -78,9 +86,35 @@ function Divider(props: DividerProps) {
   const { ref } = props;
   const title = "title" in props ? props.title : undefined;
   const description = "description" in props ? props.description : undefined;
+  const orientation =
+    "orientation" in props ? props.orientation ?? "horizontal" : "horizontal";
+  const paddingX = "paddingX" in props ? props.paddingX ?? "sm" : "sm";
+  const paddingY = "paddingY" in props ? props.paddingY ?? "xs" : "xs";
+
+  if (orientation === "vertical") {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "opal-divider-vertical",
+          paddingXVariants[paddingY],
+          paddingYVariants[paddingX]
+        )}
+      >
+        <div className="opal-divider-line-vertical" />
+      </div>
+    );
+  }
 
   return (
-    <div ref={ref} className="opal-divider">
+    <div
+      ref={ref}
+      className={cn(
+        "opal-divider",
+        paddingXVariants[paddingX],
+        paddingYVariants[paddingY]
+      )}
+    >
       <div className="opal-divider-row">
         {title && (
           <div className="opal-divider-title">

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -13,7 +13,14 @@ import { paddingXVariants, paddingYVariants } from "@opal/shared";
 // Types
 // ---------------------------------------------------------------------------
 
-interface DividerNeverFields {
+interface DividerSharedProps {
+  ref?: React.Ref<HTMLDivElement>;
+  title?: never;
+  description?: never;
+  foldable?: false;
+  orientation?: never;
+  paddingX?: never;
+  paddingY?: never;
   open?: never;
   defaultOpen?: never;
   onOpenChange?: never;
@@ -21,42 +28,37 @@ interface DividerNeverFields {
 }
 
 /** Plain line — no title, no description. */
-interface DividerBareProps extends DividerNeverFields {
-  title?: never;
-  description?: never;
-  foldable?: false;
+type DividerBareProps = Omit<
+  DividerSharedProps,
+  "orientation" | "paddingX" | "paddingY"
+> & {
   /** Orientation of the line. Default: `"horizontal"`. */
   orientation?: "horizontal" | "vertical";
   /** Horizontal padding. Default: `"sm"` (0.5rem). */
   paddingX?: PaddingVariants;
   /** Vertical padding. Default: `"xs"` (0.25rem). */
   paddingY?: PaddingVariants;
-  ref?: React.Ref<HTMLDivElement>;
-}
+};
 
 /** Line with a title to the left. */
-interface DividerTitledProps extends DividerNeverFields {
+type DividerTitledProps = Omit<DividerSharedProps, "title"> & {
   title: string | RichStr;
-  description?: never;
-  foldable?: false;
-  ref?: React.Ref<HTMLDivElement>;
-}
+};
 
 /** Line with a description below. */
-interface DividerDescribedProps extends DividerNeverFields {
-  title?: never;
+type DividerDescribedProps = Omit<DividerSharedProps, "description"> & {
   /** Description rendered below the divider line. */
   description: string | RichStr;
-  foldable?: false;
-  ref?: React.Ref<HTMLDivElement>;
-}
+};
 
 /** Foldable — requires title, reveals children. */
-interface DividerFoldableProps {
+type DividerFoldableProps = Omit<
+  DividerSharedProps,
+  "title" | "foldable" | "open" | "defaultOpen" | "onOpenChange" | "children"
+> & {
   /** Title is required when foldable. */
   title: string | RichStr;
   foldable: true;
-  description?: never;
   /** Controlled open state. */
   open?: boolean;
   /** Uncontrolled default open state. */
@@ -65,8 +67,7 @@ interface DividerFoldableProps {
   onOpenChange?: (open: boolean) => void;
   /** Content revealed when open. */
   children?: React.ReactNode;
-  ref?: React.Ref<HTMLDivElement>;
-}
+};
 
 type DividerProps =
   | DividerBareProps
@@ -83,13 +84,14 @@ function Divider(props: DividerProps) {
     return <FoldableDivider {...props} />;
   }
 
-  const { ref } = props;
-  const title = "title" in props ? props.title : undefined;
-  const description = "description" in props ? props.description : undefined;
-  const orientation =
-    "orientation" in props ? props.orientation ?? "horizontal" : "horizontal";
-  const paddingX = "paddingX" in props ? props.paddingX ?? "sm" : "sm";
-  const paddingY = "paddingY" in props ? props.paddingY ?? "xs" : "xs";
+  const {
+    ref,
+    title,
+    description,
+    orientation = "horizontal",
+    paddingX = "sm",
+    paddingY = "xs",
+  } = props;
 
   if (orientation === "vertical") {
     return (

--- a/web/lib/opal/src/components/divider/styles.css
+++ b/web/lib/opal/src/components/divider/styles.css
@@ -2,11 +2,13 @@
    Divider
 
    A horizontal rule with optional title, foldable chevron, or description.
+   Padding is controlled via Tailwind classes applied by the component.
    --------------------------------------------------------------------------- */
+
+/* ── Horizontal ─────────────────────────────────────────────────────────────── */
 
 .opal-divider {
   @apply flex flex-col w-full;
-  padding: 0.25rem 0.5rem;
   gap: 0.75rem;
 }
 
@@ -28,6 +30,18 @@
 .opal-divider-description {
   padding: 0px 2px;
 }
+
+/* ── Vertical orientation ───────────────────────────────────────────────────── */
+
+.opal-divider-vertical {
+  @apply flex flex-row h-full;
+}
+
+.opal-divider-line-vertical {
+  @apply flex-1 w-px bg-border-01;
+}
+
+/* ── Foldable chevron ───────────────────────────────────────────────────────── */
 
 .opal-divider-chevron {
   @apply transition-transform duration-200 ease-in-out;

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -100,13 +100,31 @@ const heightVariants: Record<ExtremaSizeVariants, string> = {
 //   - SelectCard    (paddingVariant, roundingVariant)
 // ---------------------------------------------------------------------------
 
-const cardPaddingVariants: Record<PaddingVariants, string> = {
+const paddingVariants: Record<PaddingVariants, string> = {
   lg: "p-6",
   md: "p-4",
   sm: "p-2",
   xs: "p-1",
   "2xs": "p-0.5",
   fit: "p-0",
+};
+
+const paddingXVariants: Record<PaddingVariants, string> = {
+  lg: "px-6",
+  md: "px-4",
+  sm: "px-2",
+  xs: "px-1",
+  "2xs": "px-0.5",
+  fit: "px-0",
+};
+
+const paddingYVariants: Record<PaddingVariants, string> = {
+  lg: "py-6",
+  md: "py-4",
+  sm: "py-2",
+  xs: "py-1",
+  "2xs": "py-0.5",
+  fit: "py-0",
 };
 
 const cardRoundingVariants: Record<RoundingVariants, string> = {
@@ -122,7 +140,9 @@ export {
   type OverridableExtremaSizeVariants,
   type SizeVariants,
   containerSizeVariants,
-  cardPaddingVariants,
+  paddingVariants,
+  paddingXVariants,
+  paddingYVariants,
   cardRoundingVariants,
   widthVariants,
   heightVariants,


### PR DESCRIPTION
## Description

API changes to the `@opal/components.Divider` component and shared padding maps:

- Replace single `padding` prop with separate `paddingParallel` and `paddingPerpendicular` props (`PaddingVariants`) on the bare `Divider` variant. Defaults: `paddingParallel="sm"` (0.5rem), `paddingPerpendicular="xs"` (0.25rem). Vertical orientation swaps axes.
- Add `paddingXVariants` and `paddingYVariants` maps to `@opal/shared` (same scale as existing padding variants).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direction-based padding to the `Divider` with `paddingParallel`/`paddingPerpendicular` and vertical orientation support. Centralizes padding utilities in `@opal/shared`, updates cards to use `paddingVariants`, removes hardcoded padding, and simplifies types.

- **New Features**
  - Bare `Divider`: `paddingParallel`/`paddingPerpendicular` props (defaults `sm`/`xs`); `orientation="vertical"` supported; padding is relative to the line direction (no axis-swap).
  - Shared padding maps: `paddingXVariants` and `paddingYVariants` in `@opal/shared`.

- **Refactors**
  - Renamed `cardPaddingVariants` → `paddingVariants`; updated `Card` and `SelectCard`.
  - Removed fixed padding from `Divider` CSS; apply via variant classes; added vertical styles.
  - Updated stories and README for the new props and examples.
  - Simplified prop types using `Omit` to avoid conflicts.

<sup>Written for commit 5f5f901385793293a3a90adb954133ed580f5d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->