### PR TITLE
fix(copy-button): fall back when Clipboard API unavailable

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,6 +47,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "cookies-next": "^5.1.0",
+        "copy-to-clipboard": "^3.3.3",
         "date-fns": "^3.6.0",
         "docx-preview": "^0.3.7",
         "favicon-fetch": "^1.0.0",
@@ -8843,6 +8844,15 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.46.0",
       "hasInstallScript": true,
@@ -17425,6 +17435,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/toposort": {
       "version": "2.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -65,6 +65,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "cookies-next": "^5.1.0",
+    "copy-to-clipboard": "^3.3.3",
     "date-fns": "^3.6.0",
     "docx-preview": "^0.3.7",
     "favicon-fetch": "^1.0.0",

--- a/web/src/refresh-components/buttons/CopyIconButton.tsx
+++ b/web/src/refresh-components/buttons/CopyIconButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import copy from "copy-to-clipboard";
 import { Button, ButtonProps } from "@opal/components";
 import { SvgAlertTriangle, SvgCheck, SvgCopy } from "@opal/icons";
 
@@ -40,26 +41,17 @@ export default function CopyIconButton({
     }
 
     try {
-      // Check if Clipboard API is available
-      if (!navigator.clipboard) {
-        throw new Error("Clipboard API not available");
-      }
-
-      // If HTML content getter is provided, copy both HTML and plain text
-      if (getHtmlContent) {
+      if (navigator.clipboard && getHtmlContent) {
         const htmlContent = getHtmlContent();
         const clipboardItem = new ClipboardItem({
           "text/html": new Blob([htmlContent], { type: "text/html" }),
           "text/plain": new Blob([text], { type: "text/plain" }),
         });
         await navigator.clipboard.write([clipboardItem]);
-      }
-      // Default: plain text only
-      else {
-        await navigator.clipboard.writeText(text);
+      } else if (!copy(text)) {
+        throw new Error("copy-to-clipboard returned false");
       }
 
-      // Show "copied" state
       setCopyState("copied");
     } catch (err) {
       console.error("Failed to copy:", err);

--- a/web/src/refresh-components/buttons/CopyIconButton.tsx
+++ b/web/src/refresh-components/buttons/CopyIconButton.tsx
@@ -48,6 +48,8 @@ export default function CopyIconButton({
           "text/plain": new Blob([text], { type: "text/plain" }),
         });
         await navigator.clipboard.write([clipboardItem]);
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
       } else if (!copy(text)) {
         throw new Error("copy-to-clipboard returned false");
       }


### PR DESCRIPTION
## Description

Closes https://github.com/onyx-dot-app/onyx/issues/10072

## How Has This Been Tested?

Not really

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fallback for the copy button: if `navigator.clipboard` isn’t available, use `copy-to-clipboard` to copy plain text. When the Clipboard API is available, copy HTML+text when `getHtmlContent` is provided; otherwise copy plain text.

- **Bug Fixes**
  - Fallback to `copy-to-clipboard` when the Clipboard API is missing and surface errors if it fails; preserve HTML+text copy via Clipboard API when available.

- **Dependencies**
  - Add `copy-to-clipboard` v3.3.3.

<sup>Written for commit 49aac471317bc8d3bc3f2249c2c94a4b424562e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

