### PR TITLE
chore(indexing): Add kind enum to Section model

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 from typing import cast
+from typing import Literal
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -34,8 +35,7 @@ class ConnectorMissingCredentialError(PermissionError):
 
 
 class SectionKind(str, Enum):
-    """Discriminator for Section subclasses.
-    """
+    """Discriminator for Section subclasses."""
 
     TEXT = "text"
     IMAGE = "image"
@@ -53,7 +53,7 @@ class Section(BaseModel):
 class TextSection(Section):
     """Section containing text content"""
 
-    kind: SectionKind = SectionKind.TEXT
+    kind: Literal[SectionKind.TEXT] = SectionKind.TEXT
     text: str
 
     def __sizeof__(self) -> int:
@@ -63,7 +63,7 @@ class TextSection(Section):
 class ImageSection(Section):
     """Section containing an image reference"""
 
-    kind: SectionKind = SectionKind.IMAGE
+    kind: Literal[SectionKind.IMAGE] = SectionKind.IMAGE
     image_file_id: str
 
     def __sizeof__(self) -> int:

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -33,9 +33,18 @@ class ConnectorMissingCredentialError(PermissionError):
         )
 
 
+class SectionKind(str, Enum):
+    """Discriminator for Section subclasses.
+    """
+
+    TEXT = "text"
+    IMAGE = "image"
+
+
 class Section(BaseModel):
     """Base section class with common attributes"""
 
+    kind: SectionKind
     link: str | None = None
     text: str | None = None
     image_file_id: str | None = None
@@ -44,6 +53,7 @@ class Section(BaseModel):
 class TextSection(Section):
     """Section containing text content"""
 
+    kind: SectionKind = SectionKind.TEXT
     text: str
 
     def __sizeof__(self) -> int:
@@ -53,6 +63,7 @@ class TextSection(Section):
 class ImageSection(Section):
     """Section containing an image reference"""
 
+    kind: SectionKind = SectionKind.IMAGE
     image_file_id: str
 
     def __sizeof__(self) -> int:

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -34,7 +34,7 @@ class ConnectorMissingCredentialError(PermissionError):
         )
 
 
-class SectionKind(str, Enum):
+class SectionType(str, Enum):
     """Discriminator for Section subclasses."""
 
     TEXT = "text"
@@ -44,7 +44,7 @@ class SectionKind(str, Enum):
 class Section(BaseModel):
     """Base section class with common attributes"""
 
-    kind: SectionKind
+    type: SectionType
     link: str | None = None
     text: str | None = None
     image_file_id: str | None = None
@@ -53,7 +53,7 @@ class Section(BaseModel):
 class TextSection(Section):
     """Section containing text content"""
 
-    kind: Literal[SectionKind.TEXT] = SectionKind.TEXT
+    type: Literal[SectionType.TEXT] = SectionType.TEXT
     text: str
 
     def __sizeof__(self) -> int:
@@ -63,7 +63,7 @@ class TextSection(Section):
 class ImageSection(Section):
     """Section containing an image reference"""
 
-    kind: Literal[SectionKind.IMAGE] = SectionKind.IMAGE
+    type: Literal[SectionType.IMAGE] = SectionType.IMAGE
     image_file_id: str
 
     def __sizeof__(self) -> int:

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -542,7 +542,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                 **document.model_dump(),
                 processed_sections=[
                     Section(
-                        kind=section.kind,
+                        type=section.type,
                         text=section.text if isinstance(section, TextSection) else "",
                         link=section.link,
                         image_file_id=(
@@ -567,7 +567,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             if isinstance(section, ImageSection):
                 # Default section with image path preserved - ensure text is always a string
                 processed_section = Section(
-                    kind=section.kind,
+                    type=section.type,
                     link=section.link,
                     image_file_id=section.image_file_id,
                     text="",  # Initialize with empty string
@@ -611,7 +611,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             # For TextSection, create a base Section with text and link
             elif isinstance(section, TextSection):
                 processed_section = Section(
-                    kind=section.kind,
+                    type=section.type,
                     text=section.text or "",  # Ensure text is always a string, not None
                     link=section.link,
                     image_file_id=None,

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -542,6 +542,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                 **document.model_dump(),
                 processed_sections=[
                     Section(
+                        kind=section.kind,
                         text=section.text if isinstance(section, TextSection) else "",
                         link=section.link,
                         image_file_id=(
@@ -566,6 +567,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             if isinstance(section, ImageSection):
                 # Default section with image path preserved - ensure text is always a string
                 processed_section = Section(
+                    kind=section.kind,
                     link=section.link,
                     image_file_id=section.image_file_id,
                     text="",  # Initialize with empty string
@@ -609,6 +611,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             # For TextSection, create a base Section with text and link
             elif isinstance(section, TextSection):
                 processed_section = Section(
+                    kind=section.kind,
                     text=section.text or "",  # Ensure text is always a string, not None
                     link=section.link,
                     image_file_id=None,

--- a/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
+++ b/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
@@ -1,7 +1,6 @@
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
-from onyx.connectors.models import SectionType
 
 
 FINAL_CONTEXT_DOCUMENTS_ID = "final_context_documents"

--- a/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
+++ b/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
@@ -1,7 +1,7 @@
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
-from onyx.connectors.models import SectionKind
+from onyx.connectors.models import SectionType
 
 
 FINAL_CONTEXT_DOCUMENTS_ID = "final_context_documents"
@@ -18,7 +18,7 @@ def documents_to_indexing_documents(
         processed_sections = []
         for section in document.sections:
             processed_section = Section(
-                kind=section.kind,
+                type=section.type,
                 text=section.text or "",
                 link=section.link,
                 image_file_id=None,

--- a/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
+++ b/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
@@ -18,7 +18,7 @@ def documents_to_indexing_documents(
         processed_sections = []
         for section in document.sections:
             processed_section = Section(
-                kind=SectionKind.TEXT,
+                kind=section.kind,
                 text=section.text or "",
                 link=section.link,
                 image_file_id=None,

--- a/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
+++ b/backend/onyx/tools/tool_implementations/search_like_tool_utils.py
@@ -1,6 +1,7 @@
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
+from onyx.connectors.models import SectionKind
 
 
 FINAL_CONTEXT_DOCUMENTS_ID = "final_context_documents"
@@ -17,6 +18,7 @@ def documents_to_indexing_documents(
         processed_sections = []
         for section in document.sections:
             processed_section = Section(
+                kind=SectionKind.TEXT,
                 text=section.text or "",
                 link=section.link,
                 image_file_id=None,

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -4,7 +4,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import SECTION_SEPARATOR
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
-from onyx.connectors.models import SectionKind
+from onyx.connectors.models import SectionType
 from onyx.indexing import chunker as chunker_module
 from onyx.indexing.chunker import Chunker
 from onyx.natural_language_processing.utils import BaseTokenizer
@@ -90,7 +90,7 @@ def test_empty_section_on_first_position_without_title_is_skipped() -> None:
     `(not document.title or section_idx > 0)` means it IS skipped."""
     chunker = _make_chunker()
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text="", link="l0")],
+        sections=[Section(type=SectionType.TEXT, text="", link="l0")],
         title=None,
     )
 
@@ -113,9 +113,9 @@ def test_empty_section_on_later_position_is_skipped_even_with_title() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="Alpha.", link="l0"),
-            Section(kind=SectionKind.TEXT, text="", link="l1"),  # should be skipped
-            Section(kind=SectionKind.TEXT, text="Beta.", link="l2"),
+            Section(type=SectionType.TEXT, text="Alpha.", link="l0"),
+            Section(type=SectionType.TEXT, text="", link="l1"),  # should be skipped
+            Section(type=SectionType.TEXT, text="Beta.", link="l2"),
         ],
     )
 
@@ -141,7 +141,7 @@ def test_empty_section_on_later_position_is_skipped_even_with_title() -> None:
 def test_single_small_text_section_becomes_one_chunk() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text="Hello world.", link="https://a")]
+        sections=[Section(type=SectionType.TEXT, text="Hello world.", link="https://a")]
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -170,9 +170,9 @@ def test_single_small_text_section_becomes_one_chunk() -> None:
 def test_multiple_small_sections_combine_into_one_chunk() -> None:
     chunker = _make_chunker()
     sections = [
-        Section(kind=SectionKind.TEXT, text="Part one.", link="l1"),
-        Section(kind=SectionKind.TEXT, text="Part two.", link="l2"),
-        Section(kind=SectionKind.TEXT, text="Part three.", link="l3"),
+        Section(type=SectionType.TEXT, text="Part one.", link="l1"),
+        Section(type=SectionType.TEXT, text="Part two.", link="l2"),
+        Section(type=SectionType.TEXT, text="Part three.", link="l3"),
     ]
     doc = _make_doc(sections=sections)
 
@@ -207,8 +207,8 @@ def test_sections_overflow_into_second_chunk() -> None:
     b = "B" * 120
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text=a, link="la"),
-            Section(kind=SectionKind.TEXT, text=b, link="lb"),
+            Section(type=SectionType.TEXT, text=a, link="la"),
+            Section(type=SectionType.TEXT, text=b, link="lb"),
         ],
     )
 
@@ -243,7 +243,7 @@ def test_image_only_section_produces_single_chunk_with_image_id() -> None:
     doc = _make_doc(
         sections=[
             Section(
-                kind=SectionKind.IMAGE,
+                type=SectionType.IMAGE,
                 text="summary of image",
                 link="https://img",
                 image_file_id="img-abc",
@@ -272,14 +272,14 @@ def test_image_section_flushes_pending_text_and_creates_its_own_chunk() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="Pending text.", link="ltext"),
+            Section(type=SectionType.TEXT, text="Pending text.", link="ltext"),
             Section(
-                kind=SectionKind.IMAGE,
+                type=SectionType.IMAGE,
                 text="image summary",
                 link="limage",
                 image_file_id="img-1",
             ),
-            Section(kind=SectionKind.TEXT, text="Trailing text.", link="ltail"),
+            Section(type=SectionType.TEXT, text="Trailing text.", link="ltail"),
         ],
     )
 
@@ -316,7 +316,7 @@ def test_image_section_without_link_gets_empty_links_dict() -> None:
     doc = _make_doc(
         sections=[
             Section(
-                kind=SectionKind.IMAGE,
+                type=SectionType.IMAGE,
                 text="img",
                 link=None,
                 image_file_id="img-xyz",
@@ -359,7 +359,7 @@ def test_oversized_section_is_split_across_multiple_chunks() -> None:
     assert len(section_text) > CHUNK_LIMIT
 
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text=section_text, link="big-link")],
+        sections=[Section(type=SectionType.TEXT, text=section_text, link="big-link")],
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -401,8 +401,8 @@ def test_oversized_section_flushes_pending_text_first() -> None:
 
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text=pending, link="l-pending"),
-            Section(kind=SectionKind.TEXT, text=big, link="l-big"),
+            Section(type=SectionType.TEXT, text=pending, link="l-pending"),
+            Section(type=SectionType.TEXT, text=big, link="l-big"),
         ],
     )
 
@@ -438,8 +438,8 @@ def test_title_prefix_and_metadata_propagate_to_all_chunks() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
-            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
+            Section(type=SectionType.TEXT, text="A" * 120, link="la"),
+            Section(type=SectionType.TEXT, text="B" * 120, link="lb"),
         ],
     )
 
@@ -466,9 +466,9 @@ def test_chunk_ids_are_sequential_starting_at_zero() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
-            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
-            Section(kind=SectionKind.TEXT, text="C" * 120, link="lc"),
+            Section(type=SectionType.TEXT, text="A" * 120, link="la"),
+            Section(type=SectionType.TEXT, text="B" * 120, link="lb"),
+            Section(type=SectionType.TEXT, text="C" * 120, link="lc"),
         ],
     )
 
@@ -495,9 +495,9 @@ def test_overflow_flush_then_subsequent_section_joins_new_chunk() -> None:
     # Third section is small (20 chars) → should fit with second.
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
-            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
-            Section(kind=SectionKind.TEXT, text="C" * 20, link="lc"),
+            Section(type=SectionType.TEXT, text="A" * 120, link="la"),
+            Section(type=SectionType.TEXT, text="B" * 120, link="lb"),
+            Section(type=SectionType.TEXT, text="C" * 20, link="lc"),
         ],
     )
 
@@ -531,8 +531,8 @@ def test_small_section_after_oversized_starts_a_fresh_chunk() -> None:
     assert len(big) > CHUNK_LIMIT
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text=big, link="l-big"),
-            Section(kind=SectionKind.TEXT, text="Tail text.", link="l-tail"),
+            Section(type=SectionType.TEXT, text=big, link="l-big"),
+            Section(type=SectionType.TEXT, text="Tail text.", link="l-tail"),
         ],
     )
 
@@ -571,7 +571,7 @@ def test_strict_chunk_token_limit_subdivides_oversized_split(
     # return it as one oversized piece (>200) which triggers the fallback.
     run = "a" * 500
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text=run, link="l-run")]
+        sections=[Section(type=SectionType.TEXT, text=run, link="l-run")]
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -608,7 +608,7 @@ def test_strict_chunk_token_limit_disabled_allows_oversized_split(
     chunker = _make_chunker()
     run = "a" * 500
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text=run, link="l-run")]
+        sections=[Section(type=SectionType.TEXT, text=run, link="l-run")]
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -636,8 +636,8 @@ def test_first_empty_section_with_title_is_processed_not_skipped() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="", link="l0"),  # empty first section, kept
-            Section(kind=SectionKind.TEXT, text="Real content.", link="l1"),
+            Section(type=SectionType.TEXT, text="", link="l0"),  # empty first section, kept
+            Section(type=SectionType.TEXT, text="Real content.", link="l1"),
         ],
         title="Has A Title",
     )
@@ -670,7 +670,7 @@ def test_clean_text_strips_control_chars_from_section_content() -> None:
     # stripped by clean_text.
     dirty = "Hello\x00 World\x07!"
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text=dirty, link="l1")]
+        sections=[Section(type=SectionType.TEXT, text=dirty, link="l1")]
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -696,9 +696,9 @@ def test_section_with_none_text_behaves_like_empty_string() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="Alpha.", link="la"),
-            Section(kind=SectionKind.TEXT, text=None, link="lnone"),  # idx 1 → skipped
-            Section(kind=SectionKind.TEXT, text="Beta.", link="lb"),
+            Section(type=SectionType.TEXT, text="Alpha.", link="la"),
+            Section(type=SectionType.TEXT, text=None, link="lnone"),  # idx 1 → skipped
+            Section(type=SectionType.TEXT, text="Beta.", link="lb"),
         ],
     )
 
@@ -727,9 +727,9 @@ def test_no_trailing_empty_chunk_when_last_section_was_image() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(kind=SectionKind.TEXT, text="Leading text.", link="ltext"),
+            Section(type=SectionType.TEXT, text="Leading text.", link="ltext"),
             Section(
-                kind=SectionKind.IMAGE,
+                type=SectionType.IMAGE,
                 text="img summary",
                 link="limg",
                 image_file_id="img-final",
@@ -766,7 +766,7 @@ def test_no_trailing_empty_chunk_when_last_section_was_oversized() -> None:
     )
     assert len(big) > CHUNK_LIMIT
     doc = _make_doc(
-        sections=[Section(kind=SectionKind.TEXT, text=big, link="l-big")]
+        sections=[Section(type=SectionType.TEXT, text=big, link="l-big")]
     )
 
     chunks = chunker._chunk_document_with_sections(

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -4,6 +4,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import SECTION_SEPARATOR
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
+from onyx.connectors.models import SectionKind
 from onyx.indexing import chunker as chunker_module
 from onyx.indexing.chunker import Chunker
 from onyx.natural_language_processing.utils import BaseTokenizer
@@ -89,7 +90,7 @@ def test_empty_section_on_first_position_without_title_is_skipped() -> None:
     `(not document.title or section_idx > 0)` means it IS skipped."""
     chunker = _make_chunker()
     doc = _make_doc(
-        sections=[Section(text="", link="l0")],
+        sections=[Section(kind=SectionKind.TEXT, text="", link="l0")],
         title=None,
     )
 
@@ -112,9 +113,9 @@ def test_empty_section_on_later_position_is_skipped_even_with_title() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="Alpha.", link="l0"),
-            Section(text="", link="l1"),  # should be skipped
-            Section(text="Beta.", link="l2"),
+            Section(kind=SectionKind.TEXT, text="Alpha.", link="l0"),
+            Section(kind=SectionKind.TEXT, text="", link="l1"),  # should be skipped
+            Section(kind=SectionKind.TEXT, text="Beta.", link="l2"),
         ],
     )
 
@@ -139,7 +140,9 @@ def test_empty_section_on_later_position_is_skipped_even_with_title() -> None:
 
 def test_single_small_text_section_becomes_one_chunk() -> None:
     chunker = _make_chunker()
-    doc = _make_doc(sections=[Section(text="Hello world.", link="https://a")])
+    doc = _make_doc(
+        sections=[Section(kind=SectionKind.TEXT, text="Hello world.", link="https://a")]
+    )
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -167,9 +170,9 @@ def test_single_small_text_section_becomes_one_chunk() -> None:
 def test_multiple_small_sections_combine_into_one_chunk() -> None:
     chunker = _make_chunker()
     sections = [
-        Section(text="Part one.", link="l1"),
-        Section(text="Part two.", link="l2"),
-        Section(text="Part three.", link="l3"),
+        Section(kind=SectionKind.TEXT, text="Part one.", link="l1"),
+        Section(kind=SectionKind.TEXT, text="Part two.", link="l2"),
+        Section(kind=SectionKind.TEXT, text="Part three.", link="l3"),
     ]
     doc = _make_doc(sections=sections)
 
@@ -204,8 +207,8 @@ def test_sections_overflow_into_second_chunk() -> None:
     b = "B" * 120
     doc = _make_doc(
         sections=[
-            Section(text=a, link="la"),
-            Section(text=b, link="lb"),
+            Section(kind=SectionKind.TEXT, text=a, link="la"),
+            Section(kind=SectionKind.TEXT, text=b, link="lb"),
         ],
     )
 
@@ -240,6 +243,7 @@ def test_image_only_section_produces_single_chunk_with_image_id() -> None:
     doc = _make_doc(
         sections=[
             Section(
+                kind=SectionKind.IMAGE,
                 text="summary of image",
                 link="https://img",
                 image_file_id="img-abc",
@@ -268,13 +272,14 @@ def test_image_section_flushes_pending_text_and_creates_its_own_chunk() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="Pending text.", link="ltext"),
+            Section(kind=SectionKind.TEXT, text="Pending text.", link="ltext"),
             Section(
+                kind=SectionKind.IMAGE,
                 text="image summary",
                 link="limage",
                 image_file_id="img-1",
             ),
-            Section(text="Trailing text.", link="ltail"),
+            Section(kind=SectionKind.TEXT, text="Trailing text.", link="ltail"),
         ],
     )
 
@@ -310,7 +315,12 @@ def test_image_section_without_link_gets_empty_links_dict() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="img", link=None, image_file_id="img-xyz"),
+            Section(
+                kind=SectionKind.IMAGE,
+                text="img",
+                link=None,
+                image_file_id="img-xyz",
+            ),
         ],
     )
 
@@ -349,7 +359,7 @@ def test_oversized_section_is_split_across_multiple_chunks() -> None:
     assert len(section_text) > CHUNK_LIMIT
 
     doc = _make_doc(
-        sections=[Section(text=section_text, link="big-link")],
+        sections=[Section(kind=SectionKind.TEXT, text=section_text, link="big-link")],
     )
 
     chunks = chunker._chunk_document_with_sections(
@@ -391,8 +401,8 @@ def test_oversized_section_flushes_pending_text_first() -> None:
 
     doc = _make_doc(
         sections=[
-            Section(text=pending, link="l-pending"),
-            Section(text=big, link="l-big"),
+            Section(kind=SectionKind.TEXT, text=pending, link="l-pending"),
+            Section(kind=SectionKind.TEXT, text=big, link="l-big"),
         ],
     )
 
@@ -428,8 +438,8 @@ def test_title_prefix_and_metadata_propagate_to_all_chunks() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="A" * 120, link="la"),
-            Section(text="B" * 120, link="lb"),
+            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
+            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
         ],
     )
 
@@ -456,9 +466,9 @@ def test_chunk_ids_are_sequential_starting_at_zero() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="A" * 120, link="la"),
-            Section(text="B" * 120, link="lb"),
-            Section(text="C" * 120, link="lc"),
+            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
+            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
+            Section(kind=SectionKind.TEXT, text="C" * 120, link="lc"),
         ],
     )
 
@@ -485,9 +495,9 @@ def test_overflow_flush_then_subsequent_section_joins_new_chunk() -> None:
     # Third section is small (20 chars) → should fit with second.
     doc = _make_doc(
         sections=[
-            Section(text="A" * 120, link="la"),
-            Section(text="B" * 120, link="lb"),
-            Section(text="C" * 20, link="lc"),
+            Section(kind=SectionKind.TEXT, text="A" * 120, link="la"),
+            Section(kind=SectionKind.TEXT, text="B" * 120, link="lb"),
+            Section(kind=SectionKind.TEXT, text="C" * 20, link="lc"),
         ],
     )
 
@@ -521,8 +531,8 @@ def test_small_section_after_oversized_starts_a_fresh_chunk() -> None:
     assert len(big) > CHUNK_LIMIT
     doc = _make_doc(
         sections=[
-            Section(text=big, link="l-big"),
-            Section(text="Tail text.", link="l-tail"),
+            Section(kind=SectionKind.TEXT, text=big, link="l-big"),
+            Section(kind=SectionKind.TEXT, text="Tail text.", link="l-tail"),
         ],
     )
 
@@ -560,7 +570,9 @@ def test_strict_chunk_token_limit_subdivides_oversized_split(
     # 500 non-whitespace chars with no sentence boundaries — chonkie will
     # return it as one oversized piece (>200) which triggers the fallback.
     run = "a" * 500
-    doc = _make_doc(sections=[Section(text=run, link="l-run")])
+    doc = _make_doc(
+        sections=[Section(kind=SectionKind.TEXT, text=run, link="l-run")]
+    )
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -595,7 +607,9 @@ def test_strict_chunk_token_limit_disabled_allows_oversized_split(
     monkeypatch.setattr(chunker_module, "STRICT_CHUNK_TOKEN_LIMIT", False)
     chunker = _make_chunker()
     run = "a" * 500
-    doc = _make_doc(sections=[Section(text=run, link="l-run")])
+    doc = _make_doc(
+        sections=[Section(kind=SectionKind.TEXT, text=run, link="l-run")]
+    )
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -622,8 +636,8 @@ def test_first_empty_section_with_title_is_processed_not_skipped() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="", link="l0"),  # empty first section, kept
-            Section(text="Real content.", link="l1"),
+            Section(kind=SectionKind.TEXT, text="", link="l0"),  # empty first section, kept
+            Section(kind=SectionKind.TEXT, text="Real content.", link="l1"),
         ],
         title="Has A Title",
     )
@@ -655,7 +669,9 @@ def test_clean_text_strips_control_chars_from_section_content() -> None:
     # NUL + BEL are control chars below 0x20 and not \n or \t → should be
     # stripped by clean_text.
     dirty = "Hello\x00 World\x07!"
-    doc = _make_doc(sections=[Section(text=dirty, link="l1")])
+    doc = _make_doc(
+        sections=[Section(kind=SectionKind.TEXT, text=dirty, link="l1")]
+    )
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -680,9 +696,9 @@ def test_section_with_none_text_behaves_like_empty_string() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="Alpha.", link="la"),
-            Section(text=None, link="lnone"),  # idx 1 → skipped
-            Section(text="Beta.", link="lb"),
+            Section(kind=SectionKind.TEXT, text="Alpha.", link="la"),
+            Section(kind=SectionKind.TEXT, text=None, link="lnone"),  # idx 1 → skipped
+            Section(kind=SectionKind.TEXT, text="Beta.", link="lb"),
         ],
     )
 
@@ -711,8 +727,13 @@ def test_no_trailing_empty_chunk_when_last_section_was_image() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(text="Leading text.", link="ltext"),
-            Section(text="img summary", link="limg", image_file_id="img-final"),
+            Section(kind=SectionKind.TEXT, text="Leading text.", link="ltext"),
+            Section(
+                kind=SectionKind.IMAGE,
+                text="img summary",
+                link="limg",
+                image_file_id="img-final",
+            ),
         ],
     )
 
@@ -744,7 +765,9 @@ def test_no_trailing_empty_chunk_when_last_section_was_oversized() -> None:
         "Ten eleven twelve. Thirteen fourteen fifteen. Sixteen seventeen."
     )
     assert len(big) > CHUNK_LIMIT
-    doc = _make_doc(sections=[Section(text=big, link="l-big")])
+    doc = _make_doc(
+        sections=[Section(kind=SectionKind.TEXT, text=big, link="l-big")]
+    )
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -570,9 +570,7 @@ def test_strict_chunk_token_limit_subdivides_oversized_split(
     # 500 non-whitespace chars with no sentence boundaries — chonkie will
     # return it as one oversized piece (>200) which triggers the fallback.
     run = "a" * 500
-    doc = _make_doc(
-        sections=[Section(type=SectionType.TEXT, text=run, link="l-run")]
-    )
+    doc = _make_doc(sections=[Section(type=SectionType.TEXT, text=run, link="l-run")])
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -607,9 +605,7 @@ def test_strict_chunk_token_limit_disabled_allows_oversized_split(
     monkeypatch.setattr(chunker_module, "STRICT_CHUNK_TOKEN_LIMIT", False)
     chunker = _make_chunker()
     run = "a" * 500
-    doc = _make_doc(
-        sections=[Section(type=SectionType.TEXT, text=run, link="l-run")]
-    )
+    doc = _make_doc(sections=[Section(type=SectionType.TEXT, text=run, link="l-run")])
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -636,7 +632,9 @@ def test_first_empty_section_with_title_is_processed_not_skipped() -> None:
     chunker = _make_chunker()
     doc = _make_doc(
         sections=[
-            Section(type=SectionType.TEXT, text="", link="l0"),  # empty first section, kept
+            Section(
+                type=SectionType.TEXT, text="", link="l0"
+            ),  # empty first section, kept
             Section(type=SectionType.TEXT, text="Real content.", link="l1"),
         ],
         title="Has A Title",
@@ -669,9 +667,7 @@ def test_clean_text_strips_control_chars_from_section_content() -> None:
     # NUL + BEL are control chars below 0x20 and not \n or \t → should be
     # stripped by clean_text.
     dirty = "Hello\x00 World\x07!"
-    doc = _make_doc(
-        sections=[Section(type=SectionType.TEXT, text=dirty, link="l1")]
-    )
+    doc = _make_doc(sections=[Section(type=SectionType.TEXT, text=dirty, link="l1")])
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,
@@ -765,9 +761,7 @@ def test_no_trailing_empty_chunk_when_last_section_was_oversized() -> None:
         "Ten eleven twelve. Thirteen fourteen fifteen. Sixteen seventeen."
     )
     assert len(big) > CHUNK_LIMIT
-    doc = _make_doc(
-        sections=[Section(type=SectionType.TEXT, text=big, link="l-big")]
-    )
+    doc = _make_doc(sections=[Section(type=SectionType.TEXT, text=big, link="l-big")])
 
     chunks = chunker._chunk_document_with_sections(
         document=doc,


### PR DESCRIPTION
## Description
Adds a new kind attribute to the section model.
Allows for differentiation between sections without relying on base-class.

Will be used for section type specific chunk dispatching.

## How Has This Been Tested?
Unit

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a required `type` enum to `Section` (`text` or `image`) and propagate it through indexing and tool conversions for type-aware chunking. Normalize `text` to "" so downstream code never sees `None`.

- **Refactors**
  - Added `SectionType` and required `type` on `Section`; `TextSection`/`ImageSection` set it via `Literal`.
  - Propagated `type` when constructing base `Section`s in indexing (`process_image_sections`) and in search-like tool conversion.
  - Ensured `text` is always a string for both text and image sections; updated unit tests to cover new typing and image chunk cases.

- **Migration**
  - When creating a `Section`, set `type` (`SectionType.TEXT`/`SectionType.IMAGE`) or use `TextSection`/`ImageSection` which set it by default.

<sup>Written for commit d0d22bc115c3abc5c34e94c8aa44ca15fd12461f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

