### PR TITLE
fix: welcome message alignment in chrome extension/desktop

### DIFF
--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -516,8 +516,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
               ref={inputRef}
               className={cn(
                 "w-full flex flex-col",
-                !isSidePanel &&
-                  "max-w-[var(--app-page-main-content-width)] px-4"
+                !isSidePanel && "max-w-[var(--app-page-main-content-width)]"
               )}
             >
               {hasMessages && liveAgent && !llmManager.isLoadingProviders && (


### PR DESCRIPTION
## Description

fixes welcome message alignment in chrome extension and desktop

## How Has This Been Tested?
<img width="1266" height="591" alt="Screenshot 2026-04-12 at 3 39 50 PM" src="https://github.com/user-attachments/assets/37238eb4-2381-4c32-9e4d-027b1d3824ac" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
