### PR TITLE
feat(chat): scrollable tables with overflow fade

### DIFF
--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -258,23 +258,102 @@ pre[class*="language-"] {
   scrollbar-color: #4b5563 #1f2937;
 }
 
+/* Card wrapper — holds the background, border-radius, padding, and fade overlay.
+   Does NOT scroll — the inner .markdown-table-breakout handles that. */
+.markdown-table-card {
+  position: relative;
+  background: var(--background-neutral-01);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0;
+}
+
 /*
- * Table breakout container - allows tables to extend beyond their parent's
- * constrained width to use the full container query width (100cqw).
- *
- * Requires an ancestor element with `container-type: inline-size` (@container in Tailwind).
- *
- * How the math works:
- * - width: 100cqw → expand to full container query width
- * - marginLeft: calc((100% - 100cqw) / 2) → negative margin pulls element left
- *   (100% is parent width, 100cqw is larger, so result is negative)
- * - paddingLeft/Right: calc((100cqw - 100%) / 2) → padding keeps content aligned
- *   with original position while allowing scroll area to extend
+ * Scrollable table container — sits inside the card.
  */
 .markdown-table-breakout {
   overflow-x: auto;
-  width: 100cqw;
-  margin-left: calc((100% - 100cqw) / 2);
-  padding-left: calc((100cqw - 100%) / 2);
-  padding-right: calc((100cqw - 100%) / 2);
+
+  /* Always reserve scrollbar height so hover doesn't shift content.
+     Thumb is transparent by default, revealed on hover. */
+  scrollbar-width: thin; /* Firefox — always shows track */
+  scrollbar-color: transparent transparent; /* invisible thumb + track */
+}
+.markdown-table-breakout::-webkit-scrollbar {
+  height: 6px;
+}
+.markdown-table-breakout::-webkit-scrollbar-track {
+  background: transparent;
+}
+.markdown-table-breakout::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+.markdown-table-breakout:hover {
+  scrollbar-color: var(--border-03) transparent; /* Firefox — reveal thumb */
+}
+.markdown-table-breakout:hover::-webkit-scrollbar-thumb {
+  background: var(--border-03);
+}
+
+/* Fade the right edge via an ::after overlay on the non-scrolling card.
+   Stays pinned while table scrolls; doesn't affect the sticky column. */
+.markdown-table-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 2rem;
+  pointer-events: none;
+  z-index: 2;
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--background-neutral-01)
+  );
+  border-radius: 0 0.5rem 0.5rem 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.markdown-table-card[data-overflows="true"]::after {
+  opacity: 1;
+}
+
+/* Sticky first column — inherits the container's background so it
+   matches regardless of theme or custom wallpaper. */
+.markdown-table-breakout th:first-child,
+.markdown-table-breakout td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  padding-left: 0.75rem;
+  background: var(--background-neutral-01);
+}
+.markdown-table-breakout th:last-child,
+.markdown-table-breakout td:last-child {
+  padding-right: 0.75rem;
+}
+
+/* Shadow on sticky column when scrolled. Uses an ::after pseudo-element
+   so it isn't clipped by the overflow container or the mask-image fade. */
+.markdown-table-breakout th:first-child::after,
+.markdown-table-breakout td:first-child::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -6px;
+  bottom: 0;
+  width: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-25);
+}
+.dark .markdown-table-breakout th:first-child::after,
+.dark .markdown-table-breakout td:first-child::after {
+  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-60);
+}
+.markdown-table-breakout[data-scrolled="true"] th:first-child::after,
+.markdown-table-breakout[data-scrolled="true"] td:first-child::after {
+  opacity: 1;
 }

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, JSX } from "react";
+import React, { useCallback, useEffect, useRef, useMemo, JSX } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -16,6 +16,66 @@ import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { transformLinkUri, cn } from "@/lib/utils";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
+
+/** Table wrapper that detects horizontal overflow and shows a fade + scrollbar. */
+interface ScrollableTableProps
+  extends React.TableHTMLAttributes<HTMLTableElement> {
+  children: React.ReactNode;
+}
+
+export function ScrollableTable({
+  className,
+  children,
+  ...props
+}: ScrollableTableProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    const wrap = wrapRef.current;
+    const table = tableRef.current;
+    if (!el || !wrap) return;
+
+    const check = () => {
+      const overflows = el.scrollWidth > el.clientWidth;
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 2;
+      wrap.dataset.overflows = overflows && !atEnd ? "true" : "false";
+      el.dataset.scrolled = el.scrollLeft > 0 ? "true" : "false";
+    };
+
+    check();
+    el.addEventListener("scroll", check, { passive: true });
+    // Observe both the scroll container (parent resize) and the table
+    // itself (content growth during streaming).
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    if (table) ro.observe(table);
+
+    return () => {
+      el.removeEventListener("scroll", check);
+      ro.disconnect();
+    };
+  }, []);
+
+  return (
+    <div ref={wrapRef} className="markdown-table-card">
+      <div ref={scrollRef} className="markdown-table-breakout">
+        <table
+          ref={tableRef}
+          className={cn(
+            className,
+            "min-w-full !my-0 [&_th]:whitespace-nowrap [&_td]:whitespace-nowrap"
+          )}
+          {...props}
+        >
+          {children}
+        </table>
+      </div>
+    </div>
+  );
+}
 
 /**
  * Processes content for markdown rendering by handling code blocks and LaTeX
@@ -127,11 +187,9 @@ export const useMarkdownComponents = (
       },
       table: ({ node, className, children, ...props }: any) => {
         return (
-          <div className="markdown-table-breakout">
-            <table className={cn(className, "min-w-full")} {...props}>
-              {children}
-            </table>
-          </div>
+          <ScrollableTable className={className} {...props}>
+            {children}
+          </ScrollableTable>
         );
       },
       code: ({ node, className, children }: any) => {

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../../services/streamingModels";
 import { MessageRenderer, FullChatState } from "../interfaces";
 import { isFinalAnswerComplete } from "../../../services/packetUtils";
-import { processContent } from "../markdownUtils";
+import { processContent, ScrollableTable } from "../markdownUtils";
 import { BlinkingBar } from "../../BlinkingBar";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import {
@@ -338,11 +338,9 @@ export const MessageTextRenderer: MessageRenderer<
         </li>
       ),
       table: ({ className, children, ...rest }) => (
-        <div className="markdown-table-breakout">
-          <table className={cn(className, "min-w-full")} {...rest}>
-            {children}
-          </table>
-        </div>
+        <ScrollableTable className={className} {...rest}>
+          {children}
+        </ScrollableTable>
       ),
       code: ({ node, className, children }) => {
         const codeText = extractCodeText(


### PR DESCRIPTION
## Description

Tables in chat messages now stay within their panel width instead of breaking out via container queries (`100cqw`). When a table's content exceeds the available width, a subtle fade appears on the right edge and a scrollbar reveals on hover. Columns size to their widest content (`whitespace-nowrap` on `th`/`td`) so nothing truncates — the user scrolls horizontally instead.

**Changes:**
- `custom-code-styles.css`: Replaced `100cqw` breakout with contained `overflow-x: auto`, hover-reveal scrollbar, and a `::after` fade pseudo-element driven by `data-overflows`
- `markdownUtils.tsx`: New `ScrollableTable` component wraps tables, detects overflow via `ResizeObserver` + scroll listener, and toggles the fade when content extends past the right edge (hidden when scrolled to end)

## How Has This Been Tested?


https://github.com/user-attachments/assets/8c37a5e1-b47c-4d3b-a2d4-e119a72a4ef2

Dark/light modes + custom backgrounds
![2026-04-13 11 44 36](https://github.com/user-attachments/assets/417f803d-895d-4ec3-8a36-7548a90528e4)
![2026-04-13 11 44 52](https://github.com/user-attachments/assets/765ba143-c779-4294-a359-2c098a88a787)
![2026-04-13 11 45 07](https://github.com/user-attachments/assets/71c4bd5a-c438-4510-95ed-a4434f76bc17)
![2026-04-13 11 45 22](https://github.com/user-attachments/assets/21f8554d-bf84-45eb-8763-7146912d7c03)



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check