### PR TITLE
chore: [Running GitHub actions for #9807]

### DIFF
--- a/backend/onyx/connectors/canvas/client.py
+++ b/backend/onyx/connectors/canvas/client.py
@@ -27,16 +27,19 @@ _STATUS_TO_ERROR_CODE: dict[int, OnyxErrorCode] = {
     401: OnyxErrorCode.CREDENTIAL_EXPIRED,
     403: OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
     404: OnyxErrorCode.BAD_GATEWAY,
-    429: OnyxErrorCode.RATE_LIMITED,
 }
 
 
 def _error_code_for_status(status_code: int) -> OnyxErrorCode:
     """Map an HTTP status code to the appropriate OnyxErrorCode.
 
-    Expects a >= 400 status code. Known codes (401, 403, 404, 429) are
+    Expects a >= 400 status code. Known codes (401, 403, 404) are
     mapped to specific error codes; all other codes (unrecognised 4xx
     and 5xx) map to BAD_GATEWAY as unexpected upstream errors.
+
+    Note: 429 is intentionally omitted — the rl_requests wrapper
+    handles rate limits transparently at the HTTP layer, so 429
+    responses never reach this function.
     """
     if status_code in _STATUS_TO_ERROR_CODE:
         return _STATUS_TO_ERROR_CODE[status_code]

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -463,10 +463,18 @@ class CanvasConnector(
 
         # Fetch one page of API results for the current stage.
         # If next_url is set, we're resuming mid-pagination.
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
         stage_config: dict[str, dict[str, Any]] = {
             "pages": {
                 "endpoint": f"courses/{course_id}/pages",
-                "params": {"per_page": "100", "include[]": "body", "published": "true"},
+                "params": {
+                    "per_page": "100",
+                    "include[]": "body",
+                    "published": "true",
+                    "sort": "updated_at",
+                    "order": "desc",
+                },
             },
             "assignments": {
                 "endpoint": f"courses/{course_id}/assignments",
@@ -478,6 +486,8 @@ class CanvasConnector(
                     "per_page": "100",
                     "context_codes[]": f"course_{course_id}",
                     "active_only": "true",
+                    "start_date": start_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "end_date": end_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 },
             },
         }
@@ -515,11 +525,28 @@ class CanvasConnector(
             return new_checkpoint
 
         # Process fetched items
+        early_exit = False
         for item in response or []:
             try:
                 if stage == "pages":
                     page = CanvasPage.from_api(item, course_id=course_id)
-                    if not page.updated_at or not _in_time_window(page.updated_at):
+                    if not page.updated_at:
+                        continue
+                    # Pages are sorted by updated_at desc — once we see
+                    # an item at or before `start`, all remaining items
+                    # on this and subsequent pages are older too.
+                    if not _in_time_window(page.updated_at):
+                        ts = (
+                            datetime.fromisoformat(
+                                page.updated_at.replace("Z", "+00:00")
+                            )
+                            .astimezone(timezone.utc)
+                            .timestamp()
+                        )
+                        if ts <= start:
+                            early_exit = True
+                            break
+                        # ts > end: page is newer than our window, skip it
                         continue
                     doc = self._convert_page_to_document(page)
                     yield _maybe_attach_permissions(doc)
@@ -565,6 +592,11 @@ class CanvasConnector(
                     failure_message=f"Failed to process {stage.removesuffix('s')}: {e}",
                     exception=e,
                 )
+
+        # If we hit an item older than our window (pages sorted desc),
+        # skip remaining pagination and advance to the next stage.
+        if early_exit:
+            result_next_url = None
 
         # If there are more pages, save the cursor and return
         if result_next_url:

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -25,8 +25,10 @@ from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.error_handling.exceptions import OnyxError
@@ -54,6 +56,25 @@ def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
     elif e.status_code >= 500:
         raise UnexpectedValidationError(
             f"Unexpected Canvas HTTP error (status={e.status_code}): {e}"
+        )
+    else:
+        raise ConnectorValidationError(
+            f"Canvas API error (status={e.status_code}): {e}"
+        )
+
+def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
+    """Map Canvas API errors to connector framework exceptions."""
+    if e.status_code == 401:
+        raise CredentialExpiredError(
+            "Canvas API token is invalid or expired (HTTP 401)."
+        )
+    elif e.status_code == 403:
+        raise InsufficientPermissionsError(
+            "Canvas API token does not have sufficient permissions (HTTP 403)."
+        )
+    elif e.status_code == 429:
+        raise ConnectorValidationError(
+            "Canvas rate-limit exceeded (HTTP 429). Please try again later."
         )
     else:
         raise ConnectorValidationError(
@@ -400,6 +421,223 @@ class CanvasConnector(
         self._canvas_client = client
         return None
 
+    def _load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: CanvasConnectorCheckpoint,
+        include_permissions: bool = False,
+    ) -> CheckpointOutput[CanvasConnectorCheckpoint]:
+        """Shared implementation for load_from_checkpoint and load_from_checkpoint_with_perm_sync."""
+        new_checkpoint = checkpoint.model_copy(deep=True)
+
+        # First call: materialize the list of course IDs
+        if not new_checkpoint.course_ids:
+            try:
+                courses = self._list_courses()
+            except Exception as e:
+                logger.warning(f"Failed to list Canvas courses: {e}")
+                new_checkpoint.has_more = True
+                return new_checkpoint
+            new_checkpoint.course_ids = [c.id for c in courses]
+            new_checkpoint.current_course_index = 0
+            new_checkpoint.stage = "pages"
+            logger.info(
+                f"Found {len(courses)} Canvas courses to process"
+            )
+            new_checkpoint.has_more = len(new_checkpoint.course_ids) > 0
+            return new_checkpoint
+
+        # All courses done
+        if new_checkpoint.current_course_index >= len(
+            new_checkpoint.course_ids
+        ):
+            new_checkpoint.has_more = False
+            return new_checkpoint
+
+        course_id = new_checkpoint.course_ids[
+            new_checkpoint.current_course_index
+        ]
+        stage = new_checkpoint.stage
+
+        if stage not in ("pages", "assignments", "announcements"):
+            raise ValueError(
+                f"Invalid checkpoint stage: {stage!r}"
+            )
+
+        def _in_time_window(timestamp_str: str) -> bool:
+            ts = (
+                datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+                .astimezone(timezone.utc)
+                .timestamp()
+            )
+            return start < ts <= end
+
+        def _maybe_attach_permissions(document: Document) -> Document:
+            if include_permissions:
+                document.external_access = self._get_course_permissions(
+                    course_id
+                )
+            return document
+
+        # Fetch one page of API results for the current stage.
+        # If next_url is set, we're resuming mid-pagination.
+        stage_config: dict[str, dict[str, Any]] = {
+            "pages": {
+                "endpoint": f"courses/{course_id}/pages",
+                "params": {"per_page": "100", "include[]": "body", "published": "true"},
+            },
+            "assignments": {
+                "endpoint": f"courses/{course_id}/assignments",
+                "params": {"per_page": "100", "published": "true"},
+            },
+            "announcements": {
+                "endpoint": "announcements",
+                "params": {
+                    "per_page": "100",
+                    "context_codes[]": f"course_{course_id}",
+                    "active_only": "true",
+                },
+            },
+        }
+        config = stage_config[stage]
+
+        try:
+            if new_checkpoint.next_url:
+                response, result_next_url = self.canvas_client.get(
+                    full_url=new_checkpoint.next_url
+                )
+            else:
+                response, result_next_url = self.canvas_client.get(
+                    config["endpoint"], params=config["params"]
+                )
+        except OnyxError as oe:
+            # Re-raise security errors from _parse_next_link (host/scheme
+            # mismatch on pagination URLs) — these must not be silenced.
+            # Security errors have no HTTP status code override (they are
+            # raised locally, not from an API response).
+            is_api_error = oe._status_code_override is not None
+            if not is_api_error:
+                raise
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {oe}"
+            )
+            new_checkpoint.has_more = True
+            return new_checkpoint
+        except Exception as e:
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {e}"
+            )
+            new_checkpoint.has_more = True
+            return new_checkpoint
+
+        # Process fetched items
+        for item in response or []:
+            try:
+                if stage == "pages":
+                    page = CanvasPage.from_api(item, course_id=course_id)
+                    if not page.updated_at or not _in_time_window(page.updated_at):
+                        continue
+                    doc = self._convert_page_to_document(page)
+                    yield _maybe_attach_permissions(doc)
+
+                elif stage == "assignments":
+                    assignment = CanvasAssignment.from_api(
+                        item, course_id=course_id
+                    )
+                    if not assignment.updated_at or not _in_time_window(assignment.updated_at):
+                        continue
+                    doc = self._convert_assignment_to_document(assignment)
+                    yield _maybe_attach_permissions(doc)
+
+                elif stage == "announcements":
+                    announcement = CanvasAnnouncement.from_api(
+                        item, course_id=course_id
+                    )
+                    if not announcement.posted_at:
+                        logger.debug(
+                            f"Skipping announcement {announcement.id} in "
+                            f"course {course_id}: no posted_at"
+                        )
+                        continue
+                    if not _in_time_window(announcement.posted_at):
+                        continue
+                    doc = self._convert_announcement_to_document(announcement)
+                    yield _maybe_attach_permissions(doc)
+
+            except Exception as e:
+                item_id = item.get("id") or item.get("page_id", "unknown")
+                if stage == "pages":
+                    doc_link = (
+                        f"{self.canvas_base_url}/courses/{course_id}"
+                        f"/pages/{item.get('url', '')}"
+                    )
+                else:
+                    doc_link = item.get("html_url", "")
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=f"canvas-{stage.removesuffix('s')}-{course_id}-{item_id}",
+                        document_link=doc_link,
+                    ),
+                    failure_message=f"Failed to process {stage.removesuffix('s')}: {e}",
+                    exception=e,
+                )
+
+        # If there are more pages, save the cursor and return
+        if result_next_url:
+            new_checkpoint.next_url = result_next_url
+        else:
+            # Stage complete — advance to next stage
+            new_checkpoint.next_url = None
+            next_stages: dict[str, CanvasStage | None] = {
+                "pages": "assignments",
+                "assignments": "announcements",
+                "announcements": None,
+            }
+            next_stage = next_stages[stage]
+            if next_stage:
+                new_checkpoint.stage = next_stage
+            else:
+                new_checkpoint.advance_course()
+
+        new_checkpoint.has_more = new_checkpoint.current_course_index < len(
+            new_checkpoint.course_ids
+        )
+        return new_checkpoint
+
+    @override
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: CanvasConnectorCheckpoint,
+    ) -> CheckpointOutput[CanvasConnectorCheckpoint]:
+        return self._load_from_checkpoint(
+            start, end, checkpoint, include_permissions=False
+        )
+
+    @override
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: CanvasConnectorCheckpoint,
+    ) -> CheckpointOutput[CanvasConnectorCheckpoint]:
+        """Load documents from checkpoint with permission information included."""
+        return self._load_from_checkpoint(
+            start, end, checkpoint, include_permissions=True
+        )
+
+    @override
+    def build_dummy_checkpoint(self) -> CanvasConnectorCheckpoint:
+        return CanvasConnectorCheckpoint(has_more=True)
+
+    @override
+    def validate_checkpoint_json(
+        self, checkpoint_json: str
+    ) -> CanvasConnectorCheckpoint:
+        return CanvasConnectorCheckpoint.model_validate_json(checkpoint_json)
+
     @override
     def validate_connector_settings(self) -> None:
         """Validate Canvas connector settings by testing API access."""
@@ -414,38 +652,6 @@ class CanvasConnector(
             raise UnexpectedValidationError(
                 f"Unexpected error during Canvas settings validation: {exc}"
             )
-
-    @override
-    def load_from_checkpoint(
-        self,
-        start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
-        checkpoint: CanvasConnectorCheckpoint,
-    ) -> CheckpointOutput[CanvasConnectorCheckpoint]:
-        # TODO(benwu408): implemented in PR3 (checkpoint)
-        raise NotImplementedError
-
-    @override
-    def load_from_checkpoint_with_perm_sync(
-        self,
-        start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
-        checkpoint: CanvasConnectorCheckpoint,
-    ) -> CheckpointOutput[CanvasConnectorCheckpoint]:
-        # TODO(benwu408): implemented in PR3 (checkpoint)
-        raise NotImplementedError
-
-    @override
-    def build_dummy_checkpoint(self) -> CanvasConnectorCheckpoint:
-        # TODO(benwu408): implemented in PR3 (checkpoint)
-        raise NotImplementedError
-
-    @override
-    def validate_checkpoint_json(
-        self, checkpoint_json: str
-    ) -> CanvasConnectorCheckpoint:
-        # TODO(benwu408): implemented in PR3 (checkpoint)
-        raise NotImplementedError
 
     @override
     def retrieve_all_slim_docs_perm_sync(

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -62,25 +62,6 @@ def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
             f"Canvas API error (status={e.status_code}): {e}"
         )
 
-def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
-    """Map Canvas API errors to connector framework exceptions."""
-    if e.status_code == 401:
-        raise CredentialExpiredError(
-            "Canvas API token is invalid or expired (HTTP 401)."
-        )
-    elif e.status_code == 403:
-        raise InsufficientPermissionsError(
-            "Canvas API token does not have sufficient permissions (HTTP 403)."
-        )
-    elif e.status_code == 429:
-        raise ConnectorValidationError(
-            "Canvas rate-limit exceeded (HTTP 429). Please try again later."
-        )
-    else:
-        raise ConnectorValidationError(
-            f"Canvas API error (status={e.status_code}): {e}"
-        )
-
 
 class CanvasCourse(BaseModel):
     id: int
@@ -519,6 +500,8 @@ class CanvasConnector(
             is_api_error = oe._status_code_override is not None
             if not is_api_error:
                 raise
+            if oe.status_code in (401, 403):
+                _handle_canvas_api_error(oe)
             logger.warning(
                 f"Failed to fetch {stage} for course {course_id}: {oe}"
             )

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -98,9 +98,9 @@ def _parse_canvas_dt(timestamp_str: str) -> datetime:
     Canvas returns timestamps with a trailing 'Z' instead of '+00:00',
     so we normalise before parsing.
     """
-    return datetime.fromisoformat(
-        timestamp_str.replace("Z", "+00:00")
-    ).astimezone(timezone.utc)
+    return datetime.fromisoformat(timestamp_str.replace("Z", "+00:00")).astimezone(
+        timezone.utc
+    )
 
 
 def _unix_to_canvas_time(epoch: float) -> str:
@@ -108,9 +108,7 @@ def _unix_to_canvas_time(epoch: float) -> str:
     return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _in_time_window(
-    timestamp_str: str, start: float, end: float
-) -> bool:
+def _in_time_window(timestamp_str: str, start: float, end: float) -> bool:
     """Check whether a Canvas ISO-8601 timestamp falls within (start, end]."""
     return start < _parse_canvas_dt(timestamp_str).timestamp() <= end
 
@@ -361,9 +359,7 @@ class CanvasConnector(
         if body_text:
             text_parts.append(body_text)
 
-        doc_updated_at = (
-            _parse_canvas_dt(page.updated_at) if page.updated_at else None
-        )
+        doc_updated_at = _parse_canvas_dt(page.updated_at) if page.updated_at else None
 
         document = self._build_document(
             doc_id=f"canvas-page-{page.course_id}-{page.page_id}",
@@ -391,9 +387,7 @@ class CanvasConnector(
             text_parts.append(f"Due: {due_dt.strftime('%B %d, %Y %H:%M UTC')}")
 
         doc_updated_at = (
-            _parse_canvas_dt(assignment.updated_at)
-            if assignment.updated_at
-            else None
+            _parse_canvas_dt(assignment.updated_at) if assignment.updated_at else None
         )
 
         document = self._build_document(
@@ -419,9 +413,7 @@ class CanvasConnector(
             text_parts.append(msg_text)
 
         doc_updated_at = (
-            _parse_canvas_dt(announcement.posted_at)
-            if announcement.posted_at
-            else None
+            _parse_canvas_dt(announcement.posted_at) if announcement.posted_at else None
         )
 
         document = self._build_document(
@@ -470,9 +462,7 @@ class CanvasConnector(
         if next_url:
             # Resuming mid-pagination: the next_url from Canvas's
             # Link header already contains endpoint + query params.
-            response, result_next_url = self.canvas_client.get(
-                full_url=next_url
-            )
+            response, result_next_url = self.canvas_client.get(full_url=next_url)
         else:
             # First request for this stage: build from endpoint + params.
             response, result_next_url = self.canvas_client.get(
@@ -521,9 +511,7 @@ class CanvasConnector(
                     )
 
                 elif stage == CanvasStage.ASSIGNMENTS:
-                    assignment = CanvasAssignment.from_api(
-                        item, course_id=course_id
-                    )
+                    assignment = CanvasAssignment.from_api(item, course_id=course_id)
                     if not assignment.updated_at or not _in_time_window(
                         assignment.updated_at, start, end
                     ):
@@ -545,9 +533,7 @@ class CanvasConnector(
                             f"course {course_id}: no posted_at"
                         )
                         continue
-                    if not _in_time_window(
-                        announcement.posted_at, start, end
-                    ):
+                    if not _in_time_window(announcement.posted_at, start, end):
                         continue
                     doc = self._convert_announcement_to_document(announcement)
                     results.append(
@@ -610,37 +596,28 @@ class CanvasConnector(
                     _handle_canvas_api_error(e)  # NoReturn — always raises
                 raise
             new_checkpoint.course_ids = [c.id for c in courses]
-            logger.info(
-                f"Found {len(courses)} Canvas courses to process"
-            )
+            logger.info(f"Found {len(courses)} Canvas courses to process")
             new_checkpoint.has_more = len(new_checkpoint.course_ids) > 0
             return new_checkpoint
 
         # All courses done.
-        if new_checkpoint.current_course_index >= len(
-            new_checkpoint.course_ids
-        ):
+        if new_checkpoint.current_course_index >= len(new_checkpoint.course_ids):
             new_checkpoint.has_more = False
             return new_checkpoint
 
-        course_id = new_checkpoint.course_ids[
-            new_checkpoint.current_course_index
-        ]
-        stage = new_checkpoint.stage
-
-        if stage not in CanvasStage:
+        course_id = new_checkpoint.course_ids[new_checkpoint.current_course_index]
+        try:
+            stage = CanvasStage(new_checkpoint.stage)
+        except ValueError as e:
             raise ValueError(
-                f"Invalid checkpoint stage: {stage!r}. "
+                f"Invalid checkpoint stage: {new_checkpoint.stage!r}. "
                 f"Valid stages: {[s.value for s in CanvasStage]}"
-            )
+            ) from e
 
         # Build endpoint + params from the static template.
         config = _STAGE_CONFIG[stage]
         endpoint = config["endpoint"].format(course_id=course_id)
-        params = {
-            k: v.format(course_id=course_id)
-            for k, v in config["params"].items()
-        }
+        params = {k: v.format(course_id=course_id) for k, v in config["params"].items()}
         # Only the announcements API supports server-side date filtering
         # (start_date/end_date). Pages support server-side sorting
         # (sort=updated_at desc) enabling early exit, but not date
@@ -678,9 +655,7 @@ class CanvasConnector(
                     failed_entity=EntityFailure(
                         entity_id=f"canvas-course-{course_id}",
                     ),
-                    failure_message=(
-                        f"Canvas course {course_id} not found: {oe}"
-                    ),
+                    failure_message=(f"Canvas course {course_id} not found: {oe}"),
                     exception=oe,
                 )
                 new_checkpoint.advance_course()

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 from datetime import timezone
+from enum import StrEnum
 from typing import Any
 from typing import cast
-from typing import Literal
 from typing import NoReturn
-from typing import TypeAlias
 
 from pydantic import BaseModel
 from retry import retry
@@ -61,6 +60,51 @@ def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
         raise ConnectorValidationError(
             f"Canvas API error (status={e.status_code}): {e}"
         )
+
+
+_STAGE_CONFIG: dict[CanvasStage, dict[str, Any]] = {
+    CanvasStage.PAGES: {
+        "endpoint": "courses/{course_id}/pages",
+        "params": {
+            "per_page": "100",
+            "include[]": "body",
+            "published": "true",
+            "sort": "updated_at",
+            "order": "desc",
+        },
+    },
+    CanvasStage.ASSIGNMENTS: {
+        "endpoint": "courses/{course_id}/assignments",
+        "params": {"per_page": "100", "published": "true"},
+    },
+    CanvasStage.ANNOUNCEMENTS: {
+        "endpoint": "announcements",
+        "params": {
+            "per_page": "100",
+            "context_codes[]": "course_{course_id}",
+            "active_only": "true",
+        },
+    },
+}
+
+
+def _parse_canvas_dt(timestamp_str: str) -> datetime:
+    """Parse a Canvas ISO-8601 timestamp (e.g. '2025-06-15T12:00:00Z')
+    into a timezone-aware UTC datetime.
+
+    Canvas returns timestamps with a trailing 'Z' instead of '+00:00',
+    so we normalise before parsing.
+    """
+    return datetime.fromisoformat(
+        timestamp_str.replace("Z", "+00:00")
+    ).astimezone(timezone.utc)
+
+
+def _in_time_window(
+    timestamp_str: str, start: float, end: float
+) -> bool:
+    """Check whether a Canvas ISO-8601 timestamp falls within (start, end]."""
+    return start < _parse_canvas_dt(timestamp_str).timestamp() <= end
 
 
 class CanvasCourse(BaseModel):
@@ -147,7 +191,10 @@ class CanvasAnnouncement(BaseModel):
         )
 
 
-CanvasStage: TypeAlias = Literal["pages", "assignments", "announcements"]
+class CanvasStage(StrEnum):
+    PAGES = "pages"
+    ASSIGNMENTS = "assignments"
+    ANNOUNCEMENTS = "announcements"
 
 
 class CanvasConnectorCheckpoint(ConnectorCheckpoint):
@@ -167,13 +214,13 @@ class CanvasConnectorCheckpoint(ConnectorCheckpoint):
 
     course_ids: list[int] = []
     current_course_index: int = 0
-    stage: CanvasStage = "pages"
+    stage: CanvasStage = CanvasStage.PAGES
     next_url: str | None = None
 
     def advance_course(self) -> None:
         """Move to the next course and reset within-course state."""
         self.current_course_index += 1
-        self.stage = "pages"
+        self.stage = CanvasStage.PAGES
         self.next_url = None
 
 
@@ -298,11 +345,7 @@ class CanvasConnector(
             text_parts.append(body_text)
 
         doc_updated_at = (
-            datetime.fromisoformat(page.updated_at.replace("Z", "+00:00")).astimezone(
-                timezone.utc
-            )
-            if page.updated_at
-            else None
+            _parse_canvas_dt(page.updated_at) if page.updated_at else None
         )
 
         document = self._build_document(
@@ -327,15 +370,11 @@ class CanvasConnector(
         if desc_text:
             text_parts.append(desc_text)
         if assignment.due_at:
-            due_dt = datetime.fromisoformat(
-                assignment.due_at.replace("Z", "+00:00")
-            ).astimezone(timezone.utc)
+            due_dt = _parse_canvas_dt(assignment.due_at)
             text_parts.append(f"Due: {due_dt.strftime('%B %d, %Y %H:%M UTC')}")
 
         doc_updated_at = (
-            datetime.fromisoformat(
-                assignment.updated_at.replace("Z", "+00:00")
-            ).astimezone(timezone.utc)
+            _parse_canvas_dt(assignment.updated_at)
             if assignment.updated_at
             else None
         )
@@ -363,9 +402,7 @@ class CanvasConnector(
             text_parts.append(msg_text)
 
         doc_updated_at = (
-            datetime.fromisoformat(
-                announcement.posted_at.replace("Z", "+00:00")
-            ).astimezone(timezone.utc)
+            _parse_canvas_dt(announcement.posted_at)
             if announcement.posted_at
             else None
         )
@@ -402,6 +439,61 @@ class CanvasConnector(
         self._canvas_client = client
         return None
 
+    def _fetch_stage_page(
+        self,
+        next_url: str | None,
+        endpoint: str,
+        params: dict[str, Any],
+        stage: str,
+        course_id: int,
+    ) -> tuple[list[Any], str | None]:
+        """Fetch one page of API results for the current stage.
+
+        Returns (items, next_url). Raises on auth/security errors;
+        logs and re-raises a ValueError on transient failures so the
+        caller can handle checkpoint retry.
+        """
+        try:
+            if next_url:
+                # Resuming mid-pagination: the next_url from Canvas's
+                # Link header already contains endpoint + query params.
+                response, result_next_url = self.canvas_client.get(
+                    full_url=next_url
+                )
+            else:
+                # First request for this stage: build from endpoint + params.
+                response, result_next_url = self.canvas_client.get(
+                    endpoint, params=params
+                )
+        except OnyxError as oe:
+            # Re-raise security errors from _parse_next_link (host/scheme
+            # mismatch on pagination URLs) — these must not be silenced.
+            is_api_error = oe._status_code_override is not None
+            if not is_api_error:
+                raise
+            if oe.status_code in (401, 403):
+                _handle_canvas_api_error(oe)
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {oe}"
+            )
+            raise
+        except Exception as e:
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {e}"
+            )
+            raise
+        return response or [], result_next_url
+
+    def _maybe_attach_permissions(
+        self,
+        document: Document,
+        course_id: int,
+        include_permissions: bool,
+    ) -> Document:
+        if include_permissions:
+            document.external_access = self._get_course_permissions(course_id)
+        return document
+
     def _load_from_checkpoint(
         self,
         start: SecondsSinceUnixEpoch,
@@ -421,8 +513,6 @@ class CanvasConnector(
                 new_checkpoint.has_more = True
                 return new_checkpoint
             new_checkpoint.course_ids = [c.id for c in courses]
-            new_checkpoint.current_course_index = 0
-            new_checkpoint.stage = "pages"
             logger.info(
                 f"Found {len(courses)} Canvas courses to process"
             )
@@ -441,126 +531,72 @@ class CanvasConnector(
         ]
         stage = new_checkpoint.stage
 
-        if stage not in ("pages", "assignments", "announcements"):
+        if stage not in CanvasStage:
             raise ValueError(
                 f"Invalid checkpoint stage: {stage!r}"
             )
 
-        def _in_time_window(timestamp_str: str) -> bool:
-            ts = (
-                datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
-                .astimezone(timezone.utc)
-                .timestamp()
-            )
-            return start < ts <= end
-
-        def _maybe_attach_permissions(document: Document) -> Document:
-            if include_permissions:
-                document.external_access = self._get_course_permissions(
-                    course_id
-                )
-            return document
-
-        # Fetch one page of API results for the current stage.
-        # If next_url is set, we're resuming mid-pagination.
-        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
-        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-        stage_config: dict[str, dict[str, Any]] = {
-            "pages": {
-                "endpoint": f"courses/{course_id}/pages",
-                "params": {
-                    "per_page": "100",
-                    "include[]": "body",
-                    "published": "true",
-                    "sort": "updated_at",
-                    "order": "desc",
-                },
-            },
-            "assignments": {
-                "endpoint": f"courses/{course_id}/assignments",
-                "params": {"per_page": "100", "published": "true"},
-            },
-            "announcements": {
-                "endpoint": "announcements",
-                "params": {
-                    "per_page": "100",
-                    "context_codes[]": f"course_{course_id}",
-                    "active_only": "true",
-                    "start_date": start_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "end_date": end_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                },
-            },
+        # Build endpoint + params from the static template.
+        config = _STAGE_CONFIG[stage]
+        endpoint = config["endpoint"].format(course_id=course_id)
+        params = {
+            k: v.format(course_id=course_id)
+            for k, v in config["params"].items()
         }
-        config = stage_config[stage]
+        if stage == CanvasStage.ANNOUNCEMENTS:
+            start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+            end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+            params["start_date"] = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["end_date"] = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         try:
-            if new_checkpoint.next_url:
-                response, result_next_url = self.canvas_client.get(
-                    full_url=new_checkpoint.next_url
-                )
-            else:
-                response, result_next_url = self.canvas_client.get(
-                    config["endpoint"], params=config["params"]
-                )
-        except OnyxError as oe:
-            # Re-raise security errors from _parse_next_link (host/scheme
-            # mismatch on pagination URLs) — these must not be silenced.
-            # Security errors have no HTTP status code override (they are
-            # raised locally, not from an API response).
-            is_api_error = oe._status_code_override is not None
-            if not is_api_error:
-                raise
-            if oe.status_code in (401, 403):
-                _handle_canvas_api_error(oe)
-            logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {oe}"
+            response, result_next_url = self._fetch_stage_page(
+                next_url=new_checkpoint.next_url,
+                endpoint=endpoint,
+                params=params,
+                stage=stage,
+                course_id=course_id,
             )
-            new_checkpoint.has_more = True
-            return new_checkpoint
-        except Exception as e:
-            logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {e}"
-            )
+        except Exception:
             new_checkpoint.has_more = True
             return new_checkpoint
 
         # Process fetched items
         early_exit = False
-        for item in response or []:
+        for item in response:
             try:
-                if stage == "pages":
+                if stage == CanvasStage.PAGES:
                     page = CanvasPage.from_api(item, course_id=course_id)
                     if not page.updated_at:
                         continue
                     # Pages are sorted by updated_at desc — once we see
                     # an item at or before `start`, all remaining items
                     # on this and subsequent pages are older too.
-                    if not _in_time_window(page.updated_at):
-                        ts = (
-                            datetime.fromisoformat(
-                                page.updated_at.replace("Z", "+00:00")
-                            )
-                            .astimezone(timezone.utc)
-                            .timestamp()
-                        )
-                        if ts <= start:
+                    if not _in_time_window(page.updated_at, start, end):
+                        if _parse_canvas_dt(page.updated_at).timestamp() <= start:
                             early_exit = True
                             break
                         # ts > end: page is newer than our window, skip it
                         continue
                     doc = self._convert_page_to_document(page)
-                    yield _maybe_attach_permissions(doc)
+                    yield self._maybe_attach_permissions(
+                        doc, course_id, include_permissions
+                    )
 
-                elif stage == "assignments":
+                elif stage == CanvasStage.ASSIGNMENTS:
                     assignment = CanvasAssignment.from_api(
                         item, course_id=course_id
                     )
-                    if not assignment.updated_at or not _in_time_window(assignment.updated_at):
+                    if not assignment.updated_at or not _in_time_window(
+                        assignment.updated_at, start, end
+                    ):
                         continue
                     doc = self._convert_assignment_to_document(assignment)
-                    yield _maybe_attach_permissions(doc)
+                    yield self._maybe_attach_permissions(
+                        doc, course_id, include_permissions
+                    )
 
-                elif stage == "announcements":
+                elif stage == CanvasStage.ANNOUNCEMENTS:
                     announcement = CanvasAnnouncement.from_api(
                         item, course_id=course_id
                     )
@@ -570,14 +606,18 @@ class CanvasConnector(
                             f"course {course_id}: no posted_at"
                         )
                         continue
-                    if not _in_time_window(announcement.posted_at):
+                    if not _in_time_window(
+                        announcement.posted_at, start, end
+                    ):
                         continue
                     doc = self._convert_announcement_to_document(announcement)
-                    yield _maybe_attach_permissions(doc)
+                    yield self._maybe_attach_permissions(
+                        doc, course_id, include_permissions
+                    )
 
             except Exception as e:
                 item_id = item.get("id") or item.get("page_id", "unknown")
-                if stage == "pages":
+                if stage == CanvasStage.PAGES:
                     doc_link = (
                         f"{self.canvas_base_url}/courses/{course_id}"
                         f"/pages/{item.get('url', '')}"
@@ -604,14 +644,10 @@ class CanvasConnector(
         else:
             # Stage complete — advance to next stage
             new_checkpoint.next_url = None
-            next_stages: dict[str, CanvasStage | None] = {
-                "pages": "assignments",
-                "assignments": "announcements",
-                "announcements": None,
-            }
-            next_stage = next_stages[stage]
-            if next_stage:
-                new_checkpoint.stage = next_stage
+            stages = list(CanvasStage)
+            idx = stages.index(stage)
+            if idx + 1 < len(stages):
+                new_checkpoint.stage = stages[idx + 1]
             else:
                 new_checkpoint.advance_course()
 

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -62,6 +62,12 @@ def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
         )
 
 
+class CanvasStage(StrEnum):
+    PAGES = "pages"
+    ASSIGNMENTS = "assignments"
+    ANNOUNCEMENTS = "announcements"
+
+
 _STAGE_CONFIG: dict[CanvasStage, dict[str, Any]] = {
     CanvasStage.PAGES: {
         "endpoint": "courses/{course_id}/pages",
@@ -189,12 +195,6 @@ class CanvasAnnouncement(BaseModel):
             posted_at=payload.get("posted_at"),
             course_id=course_id,
         )
-
-
-class CanvasStage(StrEnum):
-    PAGES = "pages"
-    ASSIGNMENTS = "assignments"
-    ANNOUNCEMENTS = "announcements"
 
 
 class CanvasConnectorCheckpoint(ConnectorCheckpoint):
@@ -557,6 +557,15 @@ class CanvasConnector(
                 stage=stage,
                 course_id=course_id,
             )
+        except (CredentialExpiredError, InsufficientPermissionsError):
+            raise
+        except OnyxError as e:
+            # Security validation errors from pagination URL parsing must
+            # fail fast; upstream HTTP errors remain retryable.
+            if e._status_code_override is None:
+                raise
+            new_checkpoint.has_more = True
+            return new_checkpoint
         except Exception:
             new_checkpoint.has_more = True
             return new_checkpoint

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -231,7 +231,7 @@ class CanvasConnectorCheckpoint(ConnectorCheckpoint):
         the next call starts fresh on the new stage.
         """
         self.next_url = None
-        stages = list(CanvasStage)
+        stages: list[CanvasStage] = list(CanvasStage)
         next_idx = stages.index(self.stage) + 1
         if next_idx < len(stages):
             self.stage = stages[next_idx]

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -28,6 +28,7 @@ from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.error_handling.exceptions import OnyxError
@@ -47,10 +48,6 @@ def _handle_canvas_api_error(e: OnyxError) -> NoReturn:
     elif e.status_code == 403:
         raise InsufficientPermissionsError(
             "Canvas API token does not have sufficient permissions (HTTP 403)."
-        )
-    elif e.status_code == 429:
-        raise ConnectorValidationError(
-            "Canvas rate-limit exceeded (HTTP 429). Please try again later."
         )
     elif e.status_code >= 500:
         raise UnexpectedValidationError(
@@ -227,6 +224,21 @@ class CanvasConnectorCheckpoint(ConnectorCheckpoint):
         self.current_course_index += 1
         self.stage = CanvasStage.PAGES
         self.next_url = None
+
+    def advance_stage(self) -> None:
+        """Advance past the current stage.
+
+        Moves to the next stage within the same course, or to the next
+        course if the current stage is the last one. Resets next_url so
+        the next call starts fresh on the new stage.
+        """
+        self.next_url = None
+        stages = list(CanvasStage)
+        next_idx = stages.index(self.stage) + 1
+        if next_idx < len(stages):
+            self.stage = stages[next_idx]
+        else:
+            self.advance_course()
 
 
 class CanvasConnector(
@@ -481,7 +493,7 @@ class CanvasConnector(
 
         Returns (docs, early_exit). early_exit is True when pages
         (sorted desc by updated_at) hit an item older than start,
-        signalling that pagination should stop.
+        signaling that pagination should stop.
         """
         results: list[Document | ConnectorFailure] = []
         early_exit = False
@@ -586,20 +598,17 @@ class CanvasConnector(
         """Shared implementation for load_from_checkpoint and load_from_checkpoint_with_perm_sync."""
         new_checkpoint = checkpoint.model_copy(deep=True)
 
-        # First call: materialize the list of course IDs
+        # First call: materialize the list of course IDs.
+        # On failure, let the exception propagate so the framework fails the
+        # attempt cleanly. Swallowing errors here would leave the checkpoint
+        # state unchanged and cause an infinite retry loop.
         if not new_checkpoint.course_ids:
             try:
                 courses = self._list_courses()
             except OnyxError as e:
                 if e.status_code in (401, 403):
-                    _handle_canvas_api_error(e)
-                logger.warning(f"Failed to list Canvas courses: {e}")
-                new_checkpoint.has_more = True
-                return new_checkpoint
-            except Exception as e:
-                logger.warning(f"Failed to list Canvas courses: {e}")
-                new_checkpoint.has_more = True
-                return new_checkpoint
+                    _handle_canvas_api_error(e)  # NoReturn — always raises
+                raise
             new_checkpoint.course_ids = [c.id for c in courses]
             logger.info(
                 f"Found {len(courses)} Canvas courses to process"
@@ -655,17 +664,64 @@ class CanvasConnector(
             if not is_api_error:
                 raise
             if oe.status_code in (401, 403):
-                _handle_canvas_api_error(oe)
-            logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {oe}"
+                _handle_canvas_api_error(oe)  # NoReturn — always raises
+
+            # 404 means the course itself is gone or inaccessible. The
+            # other stages on this course will hit the same 404, so skip
+            # the whole course rather than burning API calls on each stage.
+            if oe.status_code == 404:
+                logger.warning(
+                    f"Canvas course {course_id} not found while fetching "
+                    f"{stage} (HTTP 404). Skipping course."
+                )
+                yield ConnectorFailure(
+                    failed_entity=EntityFailure(
+                        entity_id=f"canvas-course-{course_id}",
+                    ),
+                    failure_message=(
+                        f"Canvas course {course_id} not found: {oe}"
+                    ),
+                    exception=oe,
+                )
+                new_checkpoint.advance_course()
+            else:
+                logger.warning(
+                    f"Failed to fetch {stage} for course {course_id}: {oe}. "
+                    f"Skipping remainder of this stage."
+                )
+                yield ConnectorFailure(
+                    failed_entity=EntityFailure(
+                        entity_id=f"canvas-{stage}-{course_id}",
+                    ),
+                    failure_message=(
+                        f"Failed to fetch {stage} for course {course_id}: {oe}"
+                    ),
+                    exception=oe,
+                )
+                new_checkpoint.advance_stage()
+            new_checkpoint.has_more = new_checkpoint.current_course_index < len(
+                new_checkpoint.course_ids
             )
-            new_checkpoint.has_more = True
             return new_checkpoint
         except Exception as e:
+            # Unknown error — skip the stage and try to continue.
             logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {e}"
+                f"Failed to fetch {stage} for course {course_id}: {e}. "
+                f"Skipping remainder of this stage."
             )
-            new_checkpoint.has_more = True
+            yield ConnectorFailure(
+                failed_entity=EntityFailure(
+                    entity_id=f"canvas-{stage}-{course_id}",
+                ),
+                failure_message=(
+                    f"Failed to fetch {stage} for course {course_id}: {e}"
+                ),
+                exception=e,
+            )
+            new_checkpoint.advance_stage()
+            new_checkpoint.has_more = new_checkpoint.current_course_index < len(
+                new_checkpoint.course_ids
+            )
             return new_checkpoint
 
         # Process fetched items
@@ -684,16 +740,8 @@ class CanvasConnector(
         if result_next_url:
             new_checkpoint.next_url = result_next_url
         else:
-            # Stage complete — advance to next stage
-            new_checkpoint.next_url = None
-            stages = list(CanvasStage)
-            # Advance to the next stage (e.g. pages → assignments → announcements),
-            # or to the next course if all stages are done.
-            next_idx = stages.index(stage) + 1
-            if next_idx < len(stages):
-                new_checkpoint.stage = stages[next_idx]
-            else:
-                new_checkpoint.advance_course()
+            # Stage complete — advance to next stage (or next course if last).
+            new_checkpoint.advance_stage()
 
         new_checkpoint.has_more = new_checkpoint.current_course_index < len(
             new_checkpoint.course_ids

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -106,6 +106,11 @@ def _parse_canvas_dt(timestamp_str: str) -> datetime:
     ).astimezone(timezone.utc)
 
 
+def _unix_to_canvas_time(epoch: float) -> str:
+    """Convert a Unix timestamp to Canvas ISO-8601 format (e.g. '2025-06-15T12:00:00Z')."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _in_time_window(
     timestamp_str: str, start: float, end: float
 ) -> bool:
@@ -444,45 +449,122 @@ class CanvasConnector(
         next_url: str | None,
         endpoint: str,
         params: dict[str, Any],
-        stage: str,
-        course_id: int,
     ) -> tuple[list[Any], str | None]:
         """Fetch one page of API results for the current stage.
 
-        Returns (items, next_url). Raises on auth/security errors;
-        logs and re-raises a ValueError on transient failures so the
-        caller can handle checkpoint retry.
+        Returns (items, next_url).  All error handling is done by the
+        caller (_load_from_checkpoint).
         """
-        try:
-            if next_url:
-                # Resuming mid-pagination: the next_url from Canvas's
-                # Link header already contains endpoint + query params.
-                response, result_next_url = self.canvas_client.get(
-                    full_url=next_url
-                )
-            else:
-                # First request for this stage: build from endpoint + params.
-                response, result_next_url = self.canvas_client.get(
-                    endpoint, params=params
-                )
-        except OnyxError as oe:
-            # Re-raise security errors from _parse_next_link (host/scheme
-            # mismatch on pagination URLs) — these must not be silenced.
-            is_api_error = oe._status_code_override is not None
-            if not is_api_error:
-                raise
-            if oe.status_code in (401, 403):
-                _handle_canvas_api_error(oe)
-            logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {oe}"
+        if next_url:
+            # Resuming mid-pagination: the next_url from Canvas's
+            # Link header already contains endpoint + query params.
+            response, result_next_url = self.canvas_client.get(
+                full_url=next_url
             )
-            raise
-        except Exception as e:
-            logger.warning(
-                f"Failed to fetch {stage} for course {course_id}: {e}"
+        else:
+            # First request for this stage: build from endpoint + params.
+            response, result_next_url = self.canvas_client.get(
+                endpoint=endpoint, params=params
             )
-            raise
         return response or [], result_next_url
+
+    def _process_items(
+        self,
+        response: list[Any],
+        stage: CanvasStage,
+        course_id: int,
+        start: float,
+        end: float,
+        include_permissions: bool,
+    ) -> tuple[list[Document | ConnectorFailure], bool]:
+        """Process a page of API results into documents.
+
+        Returns (docs, early_exit). early_exit is True when pages
+        (sorted desc by updated_at) hit an item older than start,
+        signalling that pagination should stop.
+        """
+        results: list[Document | ConnectorFailure] = []
+        early_exit = False
+
+        for item in response:
+            try:
+                if stage == CanvasStage.PAGES:
+                    page = CanvasPage.from_api(item, course_id=course_id)
+                    if not page.updated_at:
+                        continue
+                    # Pages are sorted by updated_at desc — once we see
+                    # an item at or before `start`, all remaining items
+                    # on this and subsequent pages are older too.
+                    if not _in_time_window(page.updated_at, start, end):
+                        if _parse_canvas_dt(page.updated_at).timestamp() <= start:
+                            early_exit = True
+                            break
+                        # ts > end: page is newer than our window, skip it
+                        continue
+                    doc = self._convert_page_to_document(page)
+                    results.append(
+                        self._maybe_attach_permissions(
+                            doc, course_id, include_permissions
+                        )
+                    )
+
+                elif stage == CanvasStage.ASSIGNMENTS:
+                    assignment = CanvasAssignment.from_api(
+                        item, course_id=course_id
+                    )
+                    if not assignment.updated_at or not _in_time_window(
+                        assignment.updated_at, start, end
+                    ):
+                        continue
+                    doc = self._convert_assignment_to_document(assignment)
+                    results.append(
+                        self._maybe_attach_permissions(
+                            doc, course_id, include_permissions
+                        )
+                    )
+
+                elif stage == CanvasStage.ANNOUNCEMENTS:
+                    announcement = CanvasAnnouncement.from_api(
+                        item, course_id=course_id
+                    )
+                    if not announcement.posted_at:
+                        logger.debug(
+                            f"Skipping announcement {announcement.id} in "
+                            f"course {course_id}: no posted_at"
+                        )
+                        continue
+                    if not _in_time_window(
+                        announcement.posted_at, start, end
+                    ):
+                        continue
+                    doc = self._convert_announcement_to_document(announcement)
+                    results.append(
+                        self._maybe_attach_permissions(
+                            doc, course_id, include_permissions
+                        )
+                    )
+
+            except Exception as e:
+                item_id = item.get("id") or item.get("page_id", "unknown")
+                if stage == CanvasStage.PAGES:
+                    doc_link = (
+                        f"{self.canvas_base_url}/courses/{course_id}"
+                        f"/pages/{item.get('url', '')}"
+                    )
+                else:
+                    doc_link = item.get("html_url", "")
+                results.append(
+                    ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=f"canvas-{stage.removesuffix('s')}-{course_id}-{item_id}",
+                            document_link=doc_link,
+                        ),
+                        failure_message=f"Failed to process {stage.removesuffix('s')}: {e}",
+                        exception=e,
+                    )
+                )
+
+        return results, early_exit
 
     def _maybe_attach_permissions(
         self,
@@ -508,6 +590,12 @@ class CanvasConnector(
         if not new_checkpoint.course_ids:
             try:
                 courses = self._list_courses()
+            except OnyxError as e:
+                if e.status_code in (401, 403):
+                    _handle_canvas_api_error(e)
+                logger.warning(f"Failed to list Canvas courses: {e}")
+                new_checkpoint.has_more = True
+                return new_checkpoint
             except Exception as e:
                 logger.warning(f"Failed to list Canvas courses: {e}")
                 new_checkpoint.has_more = True
@@ -519,7 +607,7 @@ class CanvasConnector(
             new_checkpoint.has_more = len(new_checkpoint.course_ids) > 0
             return new_checkpoint
 
-        # All courses done
+        # All courses done.
         if new_checkpoint.current_course_index >= len(
             new_checkpoint.course_ids
         ):
@@ -533,7 +621,8 @@ class CanvasConnector(
 
         if stage not in CanvasStage:
             raise ValueError(
-                f"Invalid checkpoint stage: {stage!r}"
+                f"Invalid checkpoint stage: {stage!r}. "
+                f"Valid stages: {[s.value for s in CanvasStage]}"
             )
 
         # Build endpoint + params from the static template.
@@ -543,104 +632,48 @@ class CanvasConnector(
             k: v.format(course_id=course_id)
             for k, v in config["params"].items()
         }
+        # Only the announcements API supports server-side date filtering
+        # (start_date/end_date). Pages support server-side sorting
+        # (sort=updated_at desc) enabling early exit, but not date
+        # filtering. Assignments support neither. Both are filtered
+        # client-side via _in_time_window after fetching.
         if stage == CanvasStage.ANNOUNCEMENTS:
-            start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
-            end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-            params["start_date"] = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-            params["end_date"] = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["start_date"] = _unix_to_canvas_time(start)
+            params["end_date"] = _unix_to_canvas_time(end)
 
         try:
             response, result_next_url = self._fetch_stage_page(
                 next_url=new_checkpoint.next_url,
                 endpoint=endpoint,
                 params=params,
-                stage=stage,
-                course_id=course_id,
             )
-        except (CredentialExpiredError, InsufficientPermissionsError):
-            raise
-        except OnyxError as e:
-            # Security validation errors from pagination URL parsing must
-            # fail fast; upstream HTTP errors remain retryable.
-            if e._status_code_override is None:
+        except OnyxError as oe:
+            # Security errors from _parse_next_link (host/scheme
+            # mismatch on pagination URLs) have no status code override
+            # and must not be silenced.
+            is_api_error = oe._status_code_override is not None
+            if not is_api_error:
                 raise
+            if oe.status_code in (401, 403):
+                _handle_canvas_api_error(oe)
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {oe}"
+            )
             new_checkpoint.has_more = True
             return new_checkpoint
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                f"Failed to fetch {stage} for course {course_id}: {e}"
+            )
             new_checkpoint.has_more = True
             return new_checkpoint
 
         # Process fetched items
-        early_exit = False
-        for item in response:
-            try:
-                if stage == CanvasStage.PAGES:
-                    page = CanvasPage.from_api(item, course_id=course_id)
-                    if not page.updated_at:
-                        continue
-                    # Pages are sorted by updated_at desc — once we see
-                    # an item at or before `start`, all remaining items
-                    # on this and subsequent pages are older too.
-                    if not _in_time_window(page.updated_at, start, end):
-                        if _parse_canvas_dt(page.updated_at).timestamp() <= start:
-                            early_exit = True
-                            break
-                        # ts > end: page is newer than our window, skip it
-                        continue
-                    doc = self._convert_page_to_document(page)
-                    yield self._maybe_attach_permissions(
-                        doc, course_id, include_permissions
-                    )
-
-                elif stage == CanvasStage.ASSIGNMENTS:
-                    assignment = CanvasAssignment.from_api(
-                        item, course_id=course_id
-                    )
-                    if not assignment.updated_at or not _in_time_window(
-                        assignment.updated_at, start, end
-                    ):
-                        continue
-                    doc = self._convert_assignment_to_document(assignment)
-                    yield self._maybe_attach_permissions(
-                        doc, course_id, include_permissions
-                    )
-
-                elif stage == CanvasStage.ANNOUNCEMENTS:
-                    announcement = CanvasAnnouncement.from_api(
-                        item, course_id=course_id
-                    )
-                    if not announcement.posted_at:
-                        logger.debug(
-                            f"Skipping announcement {announcement.id} in "
-                            f"course {course_id}: no posted_at"
-                        )
-                        continue
-                    if not _in_time_window(
-                        announcement.posted_at, start, end
-                    ):
-                        continue
-                    doc = self._convert_announcement_to_document(announcement)
-                    yield self._maybe_attach_permissions(
-                        doc, course_id, include_permissions
-                    )
-
-            except Exception as e:
-                item_id = item.get("id") or item.get("page_id", "unknown")
-                if stage == CanvasStage.PAGES:
-                    doc_link = (
-                        f"{self.canvas_base_url}/courses/{course_id}"
-                        f"/pages/{item.get('url', '')}"
-                    )
-                else:
-                    doc_link = item.get("html_url", "")
-                yield ConnectorFailure(
-                    failed_document=DocumentFailure(
-                        document_id=f"canvas-{stage.removesuffix('s')}-{course_id}-{item_id}",
-                        document_link=doc_link,
-                    ),
-                    failure_message=f"Failed to process {stage.removesuffix('s')}: {e}",
-                    exception=e,
-                )
+        results, early_exit = self._process_items(
+            response, stage, course_id, start, end, include_permissions
+        )
+        for result in results:
+            yield result
 
         # If we hit an item older than our window (pages sorted desc),
         # skip remaining pagination and advance to the next stage.
@@ -654,9 +687,11 @@ class CanvasConnector(
             # Stage complete — advance to next stage
             new_checkpoint.next_url = None
             stages = list(CanvasStage)
-            idx = stages.index(stage)
-            if idx + 1 < len(stages):
-                new_checkpoint.stage = stages[idx + 1]
+            # Advance to the next stage (e.g. pages → assignments → announcements),
+            # or to the next course if all stages are done.
+            next_idx = stages.index(stage) + 1
+            if next_idx < len(stages):
+                new_checkpoint.stage = stages[next_idx]
             else:
                 new_checkpoint.advance_course()
 

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -454,6 +454,141 @@ class TestPaginate:
 
         assert pages == []
 
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_error_extracts_message_from_error_dict(self, mock_requests: MagicMock) -> None:
+        """Shape 1: {"error": {"message": "Not authorized"}}"""
+        mock_requests.get.return_value = _mock_response(
+            403, {"error": {"message": "Not authorized"}}
+        )
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Not authorized"
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_error_extracts_message_from_error_string(self, mock_requests: MagicMock) -> None:
+        """Shape 2: {"error": "Invalid access token"}"""
+        mock_requests.get.return_value = _mock_response(
+            401, {"error": "Invalid access token"}
+        )
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Invalid access token"
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_error_extracts_message_from_errors_list(self, mock_requests: MagicMock) -> None:
+        """Shape 3: {"errors": [{"message": "Invalid query"}]}"""
+        mock_requests.get.return_value = _mock_response(
+            400, {"errors": [{"message": "Invalid query"}]}
+        )
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Invalid query"
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_error_dict_takes_priority_over_errors_list(self, mock_requests: MagicMock) -> None:
+        """When both error shapes are present, error dict wins."""
+        mock_requests.get.return_value = _mock_response(
+            403, {"error": "Specific error", "errors": [{"message": "Generic"}]}
+        )
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Specific error"
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_error_falls_back_to_reason_when_no_json_message(
+        self, mock_requests: MagicMock
+    ) -> None:
+        """Empty error body falls back to response.reason."""
+        mock_requests.get.return_value = _mock_response(500, {})
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Error"  # from _mock_response's reason for >= 300
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_invalid_json_on_success_raises(self, mock_requests: MagicMock) -> None:
+        """Invalid JSON on a 2xx response raises OnyxError."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.side_effect = ValueError("No JSON")
+        resp.headers = {"Link": ""}
+        mock_requests.get.return_value = resp
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError, match="Invalid JSON"):
+            client.get("courses")
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_invalid_json_on_error_falls_back_to_reason(
+        self, mock_requests: MagicMock
+    ) -> None:
+        """Invalid JSON on a 4xx response falls back to response.reason."""
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.reason = "Internal Server Error"
+        resp.json.side_effect = ValueError("No JSON")
+        resp.headers = {"Link": ""}
+        mock_requests.get.return_value = resp
+        client = CanvasApiClient(
+            bearer_token=FAKE_TOKEN,
+            canvas_base_url=FAKE_BASE_URL,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            client.get("courses")
+
+        result = exc_info.value.detail
+        expected = "Internal Server Error"
+
+        assert result == expected
+
 
 # ---------------------------------------------------------------------------
 # CanvasApiClient._parse_next_link tests
@@ -556,6 +691,47 @@ class TestLoadCredentials:
         self._assert_load_credentials_raises(
             403, InsufficientPermissionsError, mock_requests
         )
+
+
+# ---------------------------------------------------------------------------
+# CanvasConnector — URL normalization
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorUrlNormalization:
+    def test_strips_api_v1_suffix(self) -> None:
+        connector = _build_connector(base_url=f"{FAKE_BASE_URL}/api/v1")
+
+        result = connector.canvas_base_url
+        expected = FAKE_BASE_URL
+
+        assert result == expected
+
+    def test_strips_trailing_slash(self) -> None:
+        connector = _build_connector(base_url=f"{FAKE_BASE_URL}/")
+
+        result = connector.canvas_base_url
+        expected = FAKE_BASE_URL
+
+        assert result == expected
+
+    def test_no_change_for_clean_url(self) -> None:
+        connector = _build_connector(base_url=FAKE_BASE_URL)
+
+        result = connector.canvas_base_url
+        expected = FAKE_BASE_URL
+
+        assert result == expected
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_load_credentials_insufficient_permissions(
+        self, mock_requests: MagicMock
+    ) -> None:
+        mock_requests.get.return_value = _mock_response(403, {})
+        connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL)
+
+        with pytest.raises(InsufficientPermissionsError):
+            connector.load_credentials({"canvas_access_token": FAKE_TOKEN})
 
 
 # ---------------------------------------------------------------------------
@@ -767,6 +943,19 @@ class TestValidateConnectorSettings:
         self._assert_validate_raises(403, InsufficientPermissionsError, mock_requests)
 
     @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_validate_insufficient_permissions(
+        self, mock_requests: MagicMock
+    ) -> None:
+        success_resp = _mock_response(json_data=[_mock_course()])
+        fail_resp = _mock_response(403, {})
+        mock_requests.get.side_effect = [success_resp, fail_resp]
+        connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL)
+        connector.load_credentials({"canvas_access_token": FAKE_TOKEN})
+
+        with pytest.raises(InsufficientPermissionsError):
+            connector.validate_connector_settings()
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
     def test_validate_rate_limited(self, mock_requests: MagicMock) -> None:
         self._assert_validate_raises(429, ConnectorValidationError, mock_requests)
 
@@ -874,3 +1063,263 @@ class TestListAnnouncements:
         result = connector._list_announcements(course_id=1)
 
         assert result == []
+class TestCheckpoint:
+    def test_build_dummy_checkpoint(self) -> None:
+        connector = _build_connector()
+
+        cp = connector.build_dummy_checkpoint()
+
+        assert cp.has_more is True
+        assert cp.course_ids == []
+        assert cp.current_course_index == 0
+        assert cp.stage == "pages"
+
+    def test_validate_checkpoint_json(self) -> None:
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True,
+            course_ids=[1, 2],
+            current_course_index=1,
+            stage="assignments",
+        )
+
+        json_str = cp.model_dump_json()
+        restored = connector.validate_checkpoint_json(json_str)
+
+        assert restored.course_ids == [1, 2]
+        assert restored.current_course_index == 1
+        assert restored.stage == "assignments"
+        assert restored.has_more is True
+
+
+# ---------------------------------------------------------------------------
+# load_from_checkpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFromCheckpoint:
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_first_call_materializes_courses(self, mock_requests: MagicMock) -> None:
+        """First call should populate course_ids and yield no documents."""
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            courses=[_mock_course(1), _mock_course(2, "Data Structures", "CS201")]
+        )
+        connector = _build_connector()
+        cp = connector.build_dummy_checkpoint()
+
+        items, new_cp = _run_checkpoint(connector, cp)
+
+        assert items == []
+        assert new_cp.course_ids == [1, 2]
+        assert new_cp.current_course_index == 0
+        assert new_cp.stage == "pages"
+        assert new_cp.has_more is True
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_processes_pages_stage(self, mock_requests: MagicMock) -> None:
+        """Pages stage yields page documents within the time window."""
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            pages=[_mock_page(10, "Syllabus", "2025-06-15T12:00:00Z")]
+        )
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage="pages",
+        )
+        start = datetime(2025, 6, 1, 0, 0, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, 0, 0, tzinfo=timezone.utc).timestamp()
+
+        items, new_cp = _run_checkpoint(connector, cp, start, end)
+
+        expected_count = 1
+        expected_id = "canvas-page-1-10"
+        expected_next_stage = "assignments"
+
+        assert len(items) == expected_count
+        assert isinstance(items[0], Document)
+        assert items[0].id == expected_id
+        assert new_cp.stage == expected_next_stage
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_advances_through_all_stages(self, mock_requests: MagicMock) -> None:
+        """Calling checkpoint 3 times advances pages -> assignments -> announcements -> next course."""
+        page = _mock_page(10, updated_at="2025-06-15T12:00:00Z")
+        assignment = _mock_assignment(20, updated_at="2025-06-15T12:00:00Z")
+        announcement = _mock_announcement(30, posted_at="2025-06-15T12:00:00Z")
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            pages=[page], assignments=[assignment], announcements=[announcement]
+        )
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+
+        # Stage 1: pages
+        items1, cp = _run_checkpoint(connector, cp, start, end)
+
+        assert cp.stage == "assignments"
+        assert len(items1) == 1
+
+        # Stage 2: assignments
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            assignments=[assignment]
+        )
+
+        items2, cp = _run_checkpoint(connector, cp, start, end)
+
+        assert cp.stage == "announcements"
+        assert len(items2) == 1
+
+        # Stage 3: announcements -> advances course index
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            announcements=[announcement]
+        )
+
+        items3, cp = _run_checkpoint(connector, cp, start, end)
+
+        assert cp.current_course_index == 1
+        assert cp.stage == "pages"
+        assert cp.has_more is False
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_filters_by_time_window(self, mock_requests: MagicMock) -> None:
+        """Only documents within (start, end] are yielded."""
+        old_page = _mock_page(10, updated_at="2025-01-01T00:00:00Z")
+        new_page = _mock_page(11, title="New Page", updated_at="2025-06-15T12:00:00Z")
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            pages=[old_page, new_page]
+        )
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        items, _ = _run_checkpoint(connector, cp, start, end)
+
+        expected_count = 1
+        expected_id = "canvas-page-1-11"
+
+        assert len(items) == expected_count
+        assert items[0].id == expected_id
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_skips_announcement_without_posted_at(self, mock_requests: MagicMock) -> None:
+        announcement = _mock_announcement()
+        announcement["posted_at"] = None
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            announcements=[announcement]
+        )
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="announcements"
+        )
+
+        items, _ = _run_checkpoint(connector, cp)
+
+        assert len(items) == 0
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_stage_failure_does_not_advance(self, mock_requests: MagicMock) -> None:
+        """If listing fails, stage stays the same for retry."""
+        mock_requests.get.side_effect = _make_url_dispatcher(page_error=True)
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+
+        items, new_cp = _run_checkpoint(connector, cp)
+
+        assert items == []
+        assert new_cp.stage == "pages"
+        assert new_cp.current_course_index == 0
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_per_document_conversion_failure_yields_connector_failure(
+        self, mock_requests: MagicMock
+    ) -> None:
+        """Bad data for one page yields ConnectorFailure, doesn't stop processing."""
+        bad_page = {"page_id": 10, "url": "test", "title": "Test", "body": None,
+                     "created_at": "2025-06-15T12:00:00Z", "updated_at": "bad-date"}
+        mock_requests.get.side_effect = _make_url_dispatcher(pages=[bad_page])
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+
+        items, new_cp = _run_checkpoint(connector, cp)
+
+        assert len(items) == 1
+        assert isinstance(items[0], ConnectorFailure)
+        assert new_cp.stage == "assignments"
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_all_courses_done_sets_has_more_false(self, mock_requests: MagicMock) -> None:
+        mock_requests.get.side_effect = _make_url_dispatcher()
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=1
+        )
+
+        items, new_cp = _run_checkpoint(connector, cp)
+
+        assert items == []
+        assert new_cp.has_more is False
+
+    def test_invalid_stage_raises_value_error(self) -> None:
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+        cp.stage = "invalid"  # type: ignore[assignment]
+
+        with pytest.raises(ValueError, match="Invalid checkpoint stage"):
+            _run_checkpoint(connector, cp)
+
+
+# ---------------------------------------------------------------------------
+# load_from_checkpoint_with_perm_sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFromCheckpointWithPermSync:
+    @patch("onyx.connectors.canvas.connector.get_course_permissions")
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_documents_have_external_access(
+        self, mock_requests: MagicMock, mock_perms: MagicMock
+    ) -> None:
+        """load_from_checkpoint_with_perm_sync attaches ExternalAccess to documents."""
+        expected_access = ExternalAccess(
+            external_user_emails={"student@school.edu"},
+            external_user_group_ids=set(),
+            is_public=False,
+        )
+        mock_perms.return_value = expected_access
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            pages=[_mock_page(10, "Syllabus", "2025-06-15T12:00:00Z")]
+        )
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        gen = connector.load_from_checkpoint_with_perm_sync(start, end, cp)
+        items: list[Document | ConnectorFailure] = []
+        try:
+            while True:
+                items.append(next(gen))
+        except StopIteration as e:
+            new_cp = e.value
+
+        assert len(items) == 1
+        assert isinstance(items[0], Document)
+        assert items[0].external_access == expected_access
+        assert new_cp.stage == "assignments"
+        mock_perms.assert_called_once()

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -8,14 +8,18 @@ from unittest.mock import patch
 
 import pytest
 
+from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.canvas.client import CanvasApiClient
 from onyx.connectors.canvas.connector import CanvasConnector
+from onyx.connectors.canvas.connector import CanvasConnectorCheckpoint
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.exceptions import UnexpectedValidationError
+from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
 from onyx.error_handling.exceptions import OnyxError
 
 # ---------------------------------------------------------------------------
@@ -109,6 +113,52 @@ def _mock_response(
     resp.json.return_value = json_data if json_data is not None else []
     resp.headers = {"Link": link_header}
     return resp
+
+
+def _make_url_dispatcher(
+    courses: list[dict[str, Any]] | None = None,
+    pages: list[dict[str, Any]] | None = None,
+    assignments: list[dict[str, Any]] | None = None,
+    announcements: list[dict[str, Any]] | None = None,
+    page_error: bool = False,
+) -> Any:
+    """Return a callable that dispatches mock responses based on the request URL.
+
+    Meant to be assigned to ``mock_requests.get.side_effect``.
+    """
+    api_prefix = f"{FAKE_BASE_URL}/api/v1"
+
+    def _dispatcher(url: str, **kwargs: Any) -> MagicMock:
+        if page_error:
+            return _mock_response(500, {})
+        if url == f"{api_prefix}/courses":
+            return _mock_response(json_data=courses or [])
+        if "/pages" in url:
+            return _mock_response(json_data=pages or [])
+        if "/assignments" in url:
+            return _mock_response(json_data=assignments or [])
+        if "announcements" in url:
+            return _mock_response(json_data=announcements or [])
+        return _mock_response(json_data=[])
+
+    return _dispatcher
+
+
+def _run_checkpoint(
+    connector: CanvasConnector,
+    checkpoint: CanvasConnectorCheckpoint,
+    start: float = 0.0,
+    end: float = datetime(2099, 1, 1, tzinfo=timezone.utc).timestamp(),
+) -> tuple[list[Document | ConnectorFailure], CanvasConnectorCheckpoint]:
+    """Run load_from_checkpoint once and collect yielded items + returned checkpoint."""
+    gen = connector.load_from_checkpoint(start, end, checkpoint)
+    items: list[Document | ConnectorFailure] = []
+    try:
+        while True:
+            items.append(next(gen))
+    except StopIteration as e:
+        new_checkpoint = e.value
+    return items, new_checkpoint
 
 
 # ---------------------------------------------------------------------------
@@ -735,37 +785,6 @@ class TestConnectorUrlNormalization:
 
 
 # ---------------------------------------------------------------------------
-# CanvasConnector — URL normalization
-# ---------------------------------------------------------------------------
-
-
-class TestConnectorUrlNormalization:
-    def test_strips_api_v1_suffix(self) -> None:
-        connector = _build_connector(base_url=f"{FAKE_BASE_URL}/api/v1")
-
-        result = connector.canvas_base_url
-        expected = FAKE_BASE_URL
-
-        assert result == expected
-
-    def test_strips_trailing_slash(self) -> None:
-        connector = _build_connector(base_url=f"{FAKE_BASE_URL}/")
-
-        result = connector.canvas_base_url
-        expected = FAKE_BASE_URL
-
-        assert result == expected
-
-    def test_no_change_for_clean_url(self) -> None:
-        connector = _build_connector(base_url=FAKE_BASE_URL)
-
-        result = connector.canvas_base_url
-        expected = FAKE_BASE_URL
-
-        assert result == expected
-
-
-# ---------------------------------------------------------------------------
 # CanvasConnector — document conversion
 # ---------------------------------------------------------------------------
 
@@ -941,19 +960,6 @@ class TestValidateConnectorSettings:
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_validate_insufficient_permissions(self, mock_requests: MagicMock) -> None:
         self._assert_validate_raises(403, InsufficientPermissionsError, mock_requests)
-
-    @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_validate_insufficient_permissions(
-        self, mock_requests: MagicMock
-    ) -> None:
-        success_resp = _mock_response(json_data=[_mock_course()])
-        fail_resp = _mock_response(403, {})
-        mock_requests.get.side_effect = [success_resp, fail_resp]
-        connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL)
-        connector.load_credentials({"canvas_access_token": FAKE_TOKEN})
-
-        with pytest.raises(InsufficientPermissionsError):
-            connector.validate_connector_settings()
 
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_validate_rate_limited(self, mock_requests: MagicMock) -> None:

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -20,6 +20,7 @@ from onyx.connectors.exceptions import UnexpectedValidationError
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
 # ---------------------------------------------------------------------------
@@ -1197,7 +1198,7 @@ class TestLoadFromCheckpoint:
         old_page = _mock_page(10, updated_at="2025-01-01T00:00:00Z")
         new_page = _mock_page(11, title="New Page", updated_at="2025-06-15T12:00:00Z")
         mock_requests.get.side_effect = _make_url_dispatcher(
-            pages=[old_page, new_page]
+            pages=[new_page, old_page]
         )
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
@@ -1244,6 +1245,34 @@ class TestLoadFromCheckpoint:
         assert items == []
         assert new_cp.stage == "pages"
         assert new_cp.current_course_index == 0
+
+    def test_fatal_auth_failure_during_stage_fetch_propagates(self) -> None:
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+
+        with patch.object(
+            connector,
+            "_fetch_stage_page",
+            side_effect=CredentialExpiredError("expired"),
+        ):
+            with pytest.raises(CredentialExpiredError):
+                _run_checkpoint(connector, cp)
+
+    def test_security_failure_during_stage_fetch_propagates(self) -> None:
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+        )
+
+        with patch.object(
+            connector,
+            "_fetch_stage_page",
+            side_effect=OnyxError(OnyxErrorCode.BAD_GATEWAY, "bad next link"),
+        ):
+            with pytest.raises(OnyxError, match="bad next link"):
+                _run_checkpoint(connector, cp)
 
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_per_document_conversion_failure_yields_connector_failure(

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -11,8 +11,12 @@ import pytest
 from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.canvas.client import CanvasApiClient
+from onyx.connectors.canvas.connector import _in_time_window
+from onyx.connectors.canvas.connector import _parse_canvas_dt
+from onyx.connectors.canvas.connector import _unix_to_canvas_time
 from onyx.connectors.canvas.connector import CanvasConnector
 from onyx.connectors.canvas.connector import CanvasConnectorCheckpoint
+from onyx.connectors.canvas.connector import CanvasStage
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
@@ -1252,11 +1256,8 @@ class TestLoadFromCheckpoint:
             has_more=True, course_ids=[1], current_course_index=0, stage="pages"
         )
 
-        with patch.object(
-            connector,
-            "_fetch_stage_page",
-            side_effect=CredentialExpiredError("expired"),
-        ):
+        with patch("onyx.connectors.canvas.client.rl_requests") as mock_requests:
+            mock_requests.get.return_value = _mock_response(401, {})
             with pytest.raises(CredentialExpiredError):
                 _run_checkpoint(connector, cp)
 
@@ -1358,3 +1359,272 @@ class TestLoadFromCheckpointWithPermSync:
         assert items[0].external_access == expected_access
         assert new_cp.stage == "assignments"
         mock_perms.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCanvasDt:
+    def test_z_suffix_parsed_as_utc(self) -> None:
+        result = _parse_canvas_dt("2025-06-15T12:00:00Z")
+
+        expected = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        assert result == expected
+
+    def test_plus_offset_parsed_as_utc(self) -> None:
+        result = _parse_canvas_dt("2025-06-15T12:00:00+00:00")
+
+        expected = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        assert result == expected
+
+    def test_result_is_timezone_aware(self) -> None:
+        result = _parse_canvas_dt("2025-01-01T00:00:00Z")
+
+        assert result.tzinfo is not None
+
+
+class TestUnixToCanvasTime:
+    def test_known_epoch_produces_expected_string(self) -> None:
+        epoch = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+
+        result = _unix_to_canvas_time(epoch)
+
+        assert result == "2025-06-15T12:00:00Z"
+
+    def test_round_trips_with_parse_canvas_dt(self) -> None:
+        epoch = datetime(2025, 3, 10, 8, 30, 0, tzinfo=timezone.utc).timestamp()
+
+        result = _parse_canvas_dt(_unix_to_canvas_time(epoch))
+        expected = datetime(2025, 3, 10, 8, 30, 0, tzinfo=timezone.utc)
+
+        assert result == expected
+
+
+class TestInTimeWindow:
+    def test_inside_window(self) -> None:
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        result = _in_time_window("2025-06-15T12:00:00Z", start, end)
+
+        assert result is True
+
+    def test_before_window(self) -> None:
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        result = _in_time_window("2025-05-01T12:00:00Z", start, end)
+
+        assert result is False
+
+    def test_after_window(self) -> None:
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        result = _in_time_window("2025-07-15T12:00:00Z", start, end)
+
+        assert result is False
+
+    def test_start_boundary_is_exclusive(self) -> None:
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        result = _in_time_window("2025-06-01T00:00:00Z", start, end)
+
+        assert result is False
+
+    def test_end_boundary_is_inclusive(self) -> None:
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+
+        result = _in_time_window("2025-06-30T00:00:00Z", start, end)
+
+        assert result is True
+
+
+class TestFetchStagePage:
+    def test_uses_full_url_when_next_url_set(self) -> None:
+        connector = _build_connector()
+        connector.canvas_client.get = MagicMock(return_value=([{"id": 1}], None))
+
+        result, next_url = connector._fetch_stage_page(
+            next_url="https://myschool.instructure.com/api/v1/courses?page=2",
+            endpoint="courses/1/pages",
+            params={"per_page": "100"},
+        )
+
+        connector.canvas_client.get.assert_called_once_with(
+            full_url="https://myschool.instructure.com/api/v1/courses?page=2"
+        )
+        assert result == [{"id": 1}]
+
+    def test_uses_endpoint_and_params_when_no_next_url(self) -> None:
+        connector = _build_connector()
+        connector.canvas_client.get = MagicMock(return_value=([{"id": 1}], None))
+
+        result, next_url = connector._fetch_stage_page(
+            next_url=None,
+            endpoint="courses/1/pages",
+            params={"per_page": "100"},
+        )
+
+        connector.canvas_client.get.assert_called_once_with(
+            endpoint="courses/1/pages", params={"per_page": "100"}
+        )
+
+    def test_returns_empty_list_for_none_response(self) -> None:
+        connector = _build_connector()
+        connector.canvas_client.get = MagicMock(return_value=(None, None))
+
+        result, next_url = connector._fetch_stage_page(
+            next_url=None,
+            endpoint="courses/1/pages",
+            params={},
+        )
+
+        assert result == []
+        assert next_url is None
+
+
+class TestProcessItems:
+    def test_pages_in_window_converted(self) -> None:
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        results, early_exit = connector._process_items(
+            response=[_mock_page(10, "Syllabus", "2025-06-15T12:00:00Z")],
+            stage=CanvasStage.PAGES,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert len(results) == 1
+        assert isinstance(results[0], Document)
+        assert early_exit is False
+
+    def test_pages_outside_window_skipped(self) -> None:
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        results, early_exit = connector._process_items(
+            response=[_mock_page(10, "Old", "2025-01-01T12:00:00Z")],
+            stage=CanvasStage.PAGES,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert results == []
+        assert early_exit is True
+
+    def test_assignments_in_window_converted(self) -> None:
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        results, early_exit = connector._process_items(
+            response=[_mock_assignment(20, "HW1", 1, "2025-06-15T12:00:00Z")],
+            stage=CanvasStage.ASSIGNMENTS,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert len(results) == 1
+        assert isinstance(results[0], Document)
+        assert early_exit is False
+
+    def test_announcements_in_window_converted(self) -> None:
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        results, early_exit = connector._process_items(
+            response=[_mock_announcement(30, "News", 1, "2025-06-15T12:00:00Z")],
+            stage=CanvasStage.ANNOUNCEMENTS,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert len(results) == 1
+        assert isinstance(results[0], Document)
+        assert early_exit is False
+
+    def test_bad_item_yields_connector_failure(self) -> None:
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+        bad_page = {
+            "page_id": 10, "url": "test", "title": "Test",
+            "body": None, "created_at": "2025-06-15T12:00:00Z",
+            "updated_at": "bad-date",
+        }
+
+        results, early_exit = connector._process_items(
+            response=[bad_page],
+            stage=CanvasStage.PAGES,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert len(results) == 1
+        assert isinstance(results[0], ConnectorFailure)
+
+    def test_page_early_exit_on_old_item(self) -> None:
+        """Pages sorted desc — item before start triggers early exit."""
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
+
+        results, early_exit = connector._process_items(
+            response=[
+                _mock_page(10, "New", "2025-06-15T12:00:00Z"),
+                _mock_page(11, "Old", "2025-05-01T12:00:00Z"),
+                _mock_page(12, "Older", "2025-04-01T12:00:00Z"),
+            ],
+            stage=CanvasStage.PAGES,
+            course_id=1,
+            start=start,
+            end=end,
+            include_permissions=False,
+        )
+
+        assert len(results) == 1
+        assert early_exit is True
+
+
+class TestMaybeAttachPermissions:
+    def test_attaches_permissions_when_true(self) -> None:
+        connector = _build_connector()
+        doc = MagicMock(spec=Document)
+        doc.external_access = None
+        expected_access = ExternalAccess(
+            external_user_emails={"student@school.edu"},
+            external_user_group_ids=set(),
+            is_public=False,
+        )
+        with patch.object(connector, "_get_course_permissions", return_value=expected_access):
+            result = connector._maybe_attach_permissions(doc, course_id=1, include_permissions=True)
+
+        assert result.external_access == expected_access
+
+    def test_no_op_when_false(self) -> None:
+        connector = _build_connector()
+        doc = MagicMock(spec=Document)
+        doc.external_access = None
+
+        result = connector._maybe_attach_permissions(doc, course_id=1, include_permissions=False)
+
+        assert result.external_access is None

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -23,6 +23,7 @@ from onyx.connectors.exceptions import UnexpectedValidationError
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
@@ -153,10 +154,12 @@ def _run_checkpoint(
     checkpoint: CanvasConnectorCheckpoint,
     start: float = 0.0,
     end: float = datetime(2099, 1, 1, tzinfo=timezone.utc).timestamp(),
-) -> tuple[list[Document | ConnectorFailure], CanvasConnectorCheckpoint]:
+) -> tuple[
+    list[Document | HierarchyNode | ConnectorFailure], CanvasConnectorCheckpoint
+]:
     """Run load_from_checkpoint once and collect yielded items + returned checkpoint."""
     gen = connector.load_from_checkpoint(start, end, checkpoint)
-    items: list[Document | ConnectorFailure] = []
+    items: list[Document | HierarchyNode | ConnectorFailure] = []
     new_checkpoint: CanvasConnectorCheckpoint | None = None
     try:
         while True:
@@ -1426,7 +1429,7 @@ class TestLoadFromCheckpointWithPermSync:
         end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
 
         gen = connector.load_from_checkpoint_with_perm_sync(start, end, cp)
-        items: list[Document | ConnectorFailure] = []
+        items: list[Document | HierarchyNode | ConnectorFailure] = []
         new_cp: CanvasConnectorCheckpoint | None = None
         try:
             while True:

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -17,7 +17,6 @@ from onyx.connectors.canvas.connector import _unix_to_canvas_time
 from onyx.connectors.canvas.connector import CanvasConnector
 from onyx.connectors.canvas.connector import CanvasConnectorCheckpoint
 from onyx.connectors.canvas.connector import CanvasStage
-from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.exceptions import UnexpectedValidationError
@@ -133,7 +132,7 @@ def _make_url_dispatcher(
     """
     api_prefix = f"{FAKE_BASE_URL}/api/v1"
 
-    def _dispatcher(url: str, **kwargs: Any) -> MagicMock:
+    def _dispatcher(url: str, **_kwargs: Any) -> MagicMock:
         if page_error:
             return _mock_response(500, {})
         if url == f"{api_prefix}/courses":
@@ -158,11 +157,13 @@ def _run_checkpoint(
     """Run load_from_checkpoint once and collect yielded items + returned checkpoint."""
     gen = connector.load_from_checkpoint(start, end, checkpoint)
     items: list[Document | ConnectorFailure] = []
+    new_checkpoint: CanvasConnectorCheckpoint | None = None
     try:
         while True:
             items.append(next(gen))
     except StopIteration as e:
         new_checkpoint = e.value
+    assert new_checkpoint is not None
     return items, new_checkpoint
 
 
@@ -501,7 +502,9 @@ class TestPaginate:
         assert pages == []
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_error_extracts_message_from_error_dict(self, mock_requests: MagicMock) -> None:
+    def test_error_extracts_message_from_error_dict(
+        self, mock_requests: MagicMock
+    ) -> None:
         """Shape 1: {"error": {"message": "Not authorized"}}"""
         mock_requests.get.return_value = _mock_response(
             403, {"error": {"message": "Not authorized"}}
@@ -520,7 +523,9 @@ class TestPaginate:
         assert result == expected
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_error_extracts_message_from_error_string(self, mock_requests: MagicMock) -> None:
+    def test_error_extracts_message_from_error_string(
+        self, mock_requests: MagicMock
+    ) -> None:
         """Shape 2: {"error": "Invalid access token"}"""
         mock_requests.get.return_value = _mock_response(
             401, {"error": "Invalid access token"}
@@ -539,7 +544,9 @@ class TestPaginate:
         assert result == expected
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_error_extracts_message_from_errors_list(self, mock_requests: MagicMock) -> None:
+    def test_error_extracts_message_from_errors_list(
+        self, mock_requests: MagicMock
+    ) -> None:
         """Shape 3: {"errors": [{"message": "Invalid query"}]}"""
         mock_requests.get.return_value = _mock_response(
             400, {"errors": [{"message": "Invalid query"}]}
@@ -558,7 +565,9 @@ class TestPaginate:
         assert result == expected
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_error_dict_takes_priority_over_errors_list(self, mock_requests: MagicMock) -> None:
+    def test_error_dict_takes_priority_over_errors_list(
+        self, mock_requests: MagicMock
+    ) -> None:
         """When both error shapes are present, error dict wins."""
         mock_requests.get.return_value = _mock_response(
             403, {"error": "Specific error", "errors": [{"message": "Generic"}]}
@@ -1061,6 +1070,8 @@ class TestListAnnouncements:
         result = connector._list_announcements(course_id=1)
 
         assert result == []
+
+
 class TestCheckpoint:
     def test_build_dummy_checkpoint(self) -> None:
         connector = _build_connector()
@@ -1070,7 +1081,7 @@ class TestCheckpoint:
         assert cp.has_more is True
         assert cp.course_ids == []
         assert cp.current_course_index == 0
-        assert cp.stage == "pages"
+        assert cp.stage == CanvasStage.PAGES
 
     def test_validate_checkpoint_json(self) -> None:
         connector = _build_connector()
@@ -1078,7 +1089,7 @@ class TestCheckpoint:
             has_more=True,
             course_ids=[1, 2],
             current_course_index=1,
-            stage="assignments",
+            stage=CanvasStage.ASSIGNMENTS,
         )
 
         json_str = cp.model_dump_json()
@@ -1086,7 +1097,7 @@ class TestCheckpoint:
 
         assert restored.course_ids == [1, 2]
         assert restored.current_course_index == 1
-        assert restored.stage == "assignments"
+        assert restored.stage == CanvasStage.ASSIGNMENTS
         assert restored.has_more is True
 
 
@@ -1110,7 +1121,7 @@ class TestLoadFromCheckpoint:
         assert items == []
         assert new_cp.course_ids == [1, 2]
         assert new_cp.current_course_index == 0
-        assert new_cp.stage == "pages"
+        assert new_cp.stage == CanvasStage.PAGES
         assert new_cp.has_more is True
 
     @patch("onyx.connectors.canvas.client.rl_requests")
@@ -1124,7 +1135,7 @@ class TestLoadFromCheckpoint:
             has_more=True,
             course_ids=[1],
             current_course_index=0,
-            stage="pages",
+            stage=CanvasStage.PAGES,
         )
         start = datetime(2025, 6, 1, 0, 0, tzinfo=timezone.utc).timestamp()
         end = datetime(2025, 6, 30, 0, 0, tzinfo=timezone.utc).timestamp()
@@ -1133,12 +1144,10 @@ class TestLoadFromCheckpoint:
 
         expected_count = 1
         expected_id = "canvas-page-1-10"
-        expected_next_stage = "assignments"
-
         assert len(items) == expected_count
         assert isinstance(items[0], Document)
         assert items[0].id == expected_id
-        assert new_cp.stage == expected_next_stage
+        assert new_cp.stage == CanvasStage.ASSIGNMENTS
 
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_advances_through_all_stages(self, mock_requests: MagicMock) -> None:
@@ -1153,23 +1162,24 @@ class TestLoadFromCheckpoint:
         start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
         end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         # Stage 1: pages
         items1, cp = _run_checkpoint(connector, cp, start, end)
 
-        assert cp.stage == "assignments"
+        assert cp.stage == CanvasStage.ASSIGNMENTS
         assert len(items1) == 1
 
         # Stage 2: assignments
-        mock_requests.get.side_effect = _make_url_dispatcher(
-            assignments=[assignment]
-        )
+        mock_requests.get.side_effect = _make_url_dispatcher(assignments=[assignment])
 
         items2, cp = _run_checkpoint(connector, cp, start, end)
 
-        assert cp.stage == "announcements"
+        assert cp.stage == CanvasStage.ANNOUNCEMENTS
         assert len(items2) == 1
 
         # Stage 3: announcements -> advances course index
@@ -1180,7 +1190,7 @@ class TestLoadFromCheckpoint:
         items3, cp = _run_checkpoint(connector, cp, start, end)
 
         assert cp.current_course_index == 1
-        assert cp.stage == "pages"
+        assert cp.stage == CanvasStage.PAGES
         assert cp.has_more is False
 
     @patch("onyx.connectors.canvas.client.rl_requests")
@@ -1188,12 +1198,13 @@ class TestLoadFromCheckpoint:
         """Only documents within (start, end] are yielded."""
         old_page = _mock_page(10, updated_at="2025-01-01T00:00:00Z")
         new_page = _mock_page(11, title="New Page", updated_at="2025-06-15T12:00:00Z")
-        mock_requests.get.side_effect = _make_url_dispatcher(
-            pages=[new_page, old_page]
-        )
+        mock_requests.get.side_effect = _make_url_dispatcher(pages=[new_page, old_page])
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
         start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
         end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
@@ -1204,10 +1215,13 @@ class TestLoadFromCheckpoint:
         expected_id = "canvas-page-1-11"
 
         assert len(items) == expected_count
+        assert isinstance(items[0], Document)
         assert items[0].id == expected_id
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_skips_announcement_without_posted_at(self, mock_requests: MagicMock) -> None:
+    def test_skips_announcement_without_posted_at(
+        self, mock_requests: MagicMock
+    ) -> None:
         announcement = _mock_announcement()
         announcement["posted_at"] = None
         mock_requests.get.side_effect = _make_url_dispatcher(
@@ -1215,7 +1229,10 @@ class TestLoadFromCheckpoint:
         )
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="announcements"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.ANNOUNCEMENTS,
         )
 
         items, _ = _run_checkpoint(connector, cp)
@@ -1228,7 +1245,10 @@ class TestLoadFromCheckpoint:
         same failing state forever."""
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1, 2], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1, 2],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         with patch.object(
@@ -1243,13 +1263,11 @@ class TestLoadFromCheckpoint:
             items, new_cp = _run_checkpoint(connector, cp)
 
         expected_entity_id = "canvas-pages-1"
-        expected_next_stage = "assignments"
-
         assert len(items) == 1
         assert isinstance(items[0], ConnectorFailure)
         assert items[0].failed_entity is not None
         assert items[0].failed_entity.entity_id == expected_entity_id
-        assert new_cp.stage == expected_next_stage
+        assert new_cp.stage == CanvasStage.ASSIGNMENTS
         assert new_cp.current_course_index == 0
         assert new_cp.next_url is None
         assert new_cp.has_more is True
@@ -1260,7 +1278,10 @@ class TestLoadFromCheckpoint:
         instead of burning API calls on every stage of a missing course."""
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1, 2], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1, 2],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         with patch.object(
@@ -1276,21 +1297,22 @@ class TestLoadFromCheckpoint:
 
         expected_entity_id = "canvas-course-1"
         expected_next_course_index = 1
-        expected_reset_stage = "pages"
-
         assert len(items) == 1
         assert isinstance(items[0], ConnectorFailure)
         assert items[0].failed_entity is not None
         assert items[0].failed_entity.entity_id == expected_entity_id
         assert new_cp.current_course_index == expected_next_course_index
-        assert new_cp.stage == expected_reset_stage
+        assert new_cp.stage == CanvasStage.PAGES
         assert new_cp.next_url is None
         assert new_cp.has_more is True
 
     def test_fatal_auth_failure_during_stage_fetch_propagates(self) -> None:
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         with patch("onyx.connectors.canvas.client.rl_requests") as mock_requests:
@@ -1301,7 +1323,10 @@ class TestLoadFromCheckpoint:
     def test_security_failure_during_stage_fetch_propagates(self) -> None:
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         with patch.object(
@@ -1317,22 +1342,33 @@ class TestLoadFromCheckpoint:
         self, mock_requests: MagicMock
     ) -> None:
         """Bad data for one page yields ConnectorFailure, doesn't stop processing."""
-        bad_page = {"page_id": 10, "url": "test", "title": "Test", "body": None,
-                     "created_at": "2025-06-15T12:00:00Z", "updated_at": "bad-date"}
+        bad_page = {
+            "page_id": 10,
+            "url": "test",
+            "title": "Test",
+            "body": None,
+            "created_at": "2025-06-15T12:00:00Z",
+            "updated_at": "bad-date",
+        }
         mock_requests.get.side_effect = _make_url_dispatcher(pages=[bad_page])
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
 
         items, new_cp = _run_checkpoint(connector, cp)
 
         assert len(items) == 1
         assert isinstance(items[0], ConnectorFailure)
-        assert new_cp.stage == "assignments"
+        assert new_cp.stage == CanvasStage.ASSIGNMENTS
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_all_courses_done_sets_has_more_false(self, mock_requests: MagicMock) -> None:
+    def test_all_courses_done_sets_has_more_false(
+        self, mock_requests: MagicMock
+    ) -> None:
         mock_requests.get.side_effect = _make_url_dispatcher()
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
@@ -1347,7 +1383,10 @@ class TestLoadFromCheckpoint:
     def test_invalid_stage_raises_value_error(self) -> None:
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
         cp.stage = "invalid"  # type: ignore[assignment]
 
@@ -1378,23 +1417,28 @@ class TestLoadFromCheckpointWithPermSync:
         )
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True,
+            course_ids=[1],
+            current_course_index=0,
+            stage=CanvasStage.PAGES,
         )
         start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
         end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
 
         gen = connector.load_from_checkpoint_with_perm_sync(start, end, cp)
         items: list[Document | ConnectorFailure] = []
+        new_cp: CanvasConnectorCheckpoint | None = None
         try:
             while True:
                 items.append(next(gen))
         except StopIteration as e:
             new_cp = e.value
+        assert new_cp is not None
 
         assert len(items) == 1
         assert isinstance(items[0], Document)
         assert items[0].external_access == expected_access
-        assert new_cp.stage == "assignments"
+        assert new_cp.stage == CanvasStage.ASSIGNMENTS
         mock_perms.assert_called_once()
 
 
@@ -1484,42 +1528,43 @@ class TestInTimeWindow:
 class TestFetchStagePage:
     def test_uses_full_url_when_next_url_set(self) -> None:
         connector = _build_connector()
-        connector.canvas_client.get = MagicMock(return_value=([{"id": 1}], None))
+        with patch.object(
+            connector.canvas_client, "get", return_value=([{"id": 1}], None)
+        ) as mock_get:
+            result, next_url = connector._fetch_stage_page(
+                next_url="https://myschool.instructure.com/api/v1/courses?page=2",
+                endpoint="courses/1/pages",
+                params={"per_page": "100"},
+            )
 
-        result, next_url = connector._fetch_stage_page(
-            next_url="https://myschool.instructure.com/api/v1/courses?page=2",
-            endpoint="courses/1/pages",
-            params={"per_page": "100"},
-        )
-
-        connector.canvas_client.get.assert_called_once_with(
+        mock_get.assert_called_once_with(
             full_url="https://myschool.instructure.com/api/v1/courses?page=2"
         )
         assert result == [{"id": 1}]
 
     def test_uses_endpoint_and_params_when_no_next_url(self) -> None:
         connector = _build_connector()
-        connector.canvas_client.get = MagicMock(return_value=([{"id": 1}], None))
+        with patch.object(
+            connector.canvas_client, "get", return_value=([{"id": 1}], None)
+        ) as mock_get:
+            result, next_url = connector._fetch_stage_page(
+                next_url=None,
+                endpoint="courses/1/pages",
+                params={"per_page": "100"},
+            )
 
-        result, next_url = connector._fetch_stage_page(
-            next_url=None,
-            endpoint="courses/1/pages",
-            params={"per_page": "100"},
-        )
-
-        connector.canvas_client.get.assert_called_once_with(
+        mock_get.assert_called_once_with(
             endpoint="courses/1/pages", params={"per_page": "100"}
         )
 
     def test_returns_empty_list_for_none_response(self) -> None:
         connector = _build_connector()
-        connector.canvas_client.get = MagicMock(return_value=(None, None))
-
-        result, next_url = connector._fetch_stage_page(
-            next_url=None,
-            endpoint="courses/1/pages",
-            params={},
-        )
+        with patch.object(connector.canvas_client, "get", return_value=(None, None)):
+            result, next_url = connector._fetch_stage_page(
+                next_url=None,
+                endpoint="courses/1/pages",
+                params={},
+            )
 
         assert result == []
         assert next_url is None
@@ -1602,8 +1647,11 @@ class TestProcessItems:
         start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
         end = datetime(2025, 6, 30, tzinfo=timezone.utc).timestamp()
         bad_page = {
-            "page_id": 10, "url": "test", "title": "Test",
-            "body": None, "created_at": "2025-06-15T12:00:00Z",
+            "page_id": 10,
+            "url": "test",
+            "title": "Test",
+            "body": None,
+            "created_at": "2025-06-15T12:00:00Z",
             "updated_at": "bad-date",
         }
 
@@ -1652,8 +1700,12 @@ class TestMaybeAttachPermissions:
             external_user_group_ids=set(),
             is_public=False,
         )
-        with patch.object(connector, "_get_course_permissions", return_value=expected_access):
-            result = connector._maybe_attach_permissions(doc, course_id=1, include_permissions=True)
+        with patch.object(
+            connector, "_get_course_permissions", return_value=expected_access
+        ):
+            result = connector._maybe_attach_permissions(
+                doc, course_id=1, include_permissions=True
+            )
 
         assert result.external_access == expected_access
 
@@ -1662,6 +1714,8 @@ class TestMaybeAttachPermissions:
         doc = MagicMock(spec=Document)
         doc.external_access = None
 
-        result = connector._maybe_attach_permissions(doc, course_id=1, include_permissions=False)
+        result = connector._maybe_attach_permissions(
+            doc, course_id=1, include_permissions=False
+        )
 
         assert result.external_access is None

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -325,15 +325,6 @@ class TestGet:
         assert exc_info.value.status_code == 404
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_raises_on_429(self, mock_requests: MagicMock) -> None:
-        mock_requests.get.return_value = _mock_response(429, {})
-
-        with pytest.raises(OnyxError) as exc_info:
-            self.client.get("courses")
-
-        assert exc_info.value.status_code == 429
-
-    @patch("onyx.connectors.canvas.client.rl_requests")
     def test_skips_params_when_using_full_url(self, mock_requests: MagicMock) -> None:
         mock_requests.get.return_value = _mock_response(json_data=[])
         full = f"{FAKE_BASE_URL}/api/v1/courses?page=2"
@@ -967,10 +958,6 @@ class TestValidateConnectorSettings:
         self._assert_validate_raises(403, InsufficientPermissionsError, mock_requests)
 
     @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_validate_rate_limited(self, mock_requests: MagicMock) -> None:
-        self._assert_validate_raises(429, ConnectorValidationError, mock_requests)
-
-    @patch("onyx.connectors.canvas.client.rl_requests")
     def test_validate_unexpected_error(self, mock_requests: MagicMock) -> None:
         self._assert_validate_raises(500, UnexpectedValidationError, mock_requests)
 
@@ -1235,20 +1222,70 @@ class TestLoadFromCheckpoint:
 
         assert len(items) == 0
 
-    @patch("onyx.connectors.canvas.client.rl_requests")
-    def test_stage_failure_does_not_advance(self, mock_requests: MagicMock) -> None:
-        """If listing fails, stage stays the same for retry."""
-        mock_requests.get.side_effect = _make_url_dispatcher(page_error=True)
+    def test_stage_failure_advances_stage_and_yields_failure(self) -> None:
+        """A 500 on a stage fetch yields a stage-level ConnectorFailure and
+        advances to the next stage, so the framework doesn't loop on the
+        same failing state forever."""
         connector = _build_connector()
         cp = CanvasConnectorCheckpoint(
-            has_more=True, course_ids=[1], current_course_index=0, stage="pages"
+            has_more=True, course_ids=[1, 2], current_course_index=0, stage="pages"
         )
 
-        items, new_cp = _run_checkpoint(connector, cp)
+        with patch.object(
+            connector,
+            "_fetch_stage_page",
+            side_effect=OnyxError(
+                OnyxErrorCode.INTERNAL_ERROR,
+                "boom",
+                status_code_override=500,
+            ),
+        ):
+            items, new_cp = _run_checkpoint(connector, cp)
 
-        assert items == []
-        assert new_cp.stage == "pages"
+        expected_entity_id = "canvas-pages-1"
+        expected_next_stage = "assignments"
+
+        assert len(items) == 1
+        assert isinstance(items[0], ConnectorFailure)
+        assert items[0].failed_entity is not None
+        assert items[0].failed_entity.entity_id == expected_entity_id
+        assert new_cp.stage == expected_next_stage
         assert new_cp.current_course_index == 0
+        assert new_cp.next_url is None
+        assert new_cp.has_more is True
+
+    def test_course_404_advances_course_and_yields_failure(self) -> None:
+        """A 404 on a stage fetch means the whole course is inaccessible —
+        yield a course-level ConnectorFailure and skip to the next course
+        instead of burning API calls on every stage of a missing course."""
+        connector = _build_connector()
+        cp = CanvasConnectorCheckpoint(
+            has_more=True, course_ids=[1, 2], current_course_index=0, stage="pages"
+        )
+
+        with patch.object(
+            connector,
+            "_fetch_stage_page",
+            side_effect=OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "course gone",
+                status_code_override=404,
+            ),
+        ):
+            items, new_cp = _run_checkpoint(connector, cp)
+
+        expected_entity_id = "canvas-course-1"
+        expected_next_course_index = 1
+        expected_reset_stage = "pages"
+
+        assert len(items) == 1
+        assert isinstance(items[0], ConnectorFailure)
+        assert items[0].failed_entity is not None
+        assert items[0].failed_entity.entity_id == expected_entity_id
+        assert new_cp.current_course_index == expected_next_course_index
+        assert new_cp.stage == expected_reset_stage
+        assert new_cp.next_url is None
+        assert new_cp.has_more is True
 
     def test_fatal_auth_failure_during_stage_fetch_propagates(self) -> None:
         connector = _build_connector()


### PR DESCRIPTION
This PR runs GitHub Actions CI for #9807.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checkpoint-based incremental indexing to the Canvas connector with staged processing (pages → assignments → announcements) and robust (start, end] time-window filtering. Adds forward-progress error handling and expands unit test coverage.

- **New Features**
  - Implement `_load_from_checkpoint` powering `load_from_checkpoint` and `load_from_checkpoint_with_perm_sync`, with per-course staged flow and resumable pagination via `next_url`.
  - Add `CanvasStage` enum, `_STAGE_CONFIG`, and time helpers (`_parse_canvas_dt`, `_unix_to_canvas_time`, `_in_time_window`); pages sorted by `updated_at` with early exit; announcements use server-side `start_date`/`end_date`; optional permission sync via `_get_course_permissions`.
  - Add `_fetch_stage_page`, `_process_items`, `_maybe_attach_permissions`; implement `build_dummy_checkpoint` and `validate_checkpoint_json`; expand tests for checkpoint lifecycle, error shapes, helpers, and perm sync.

- **Refactors**
  - Forward-progress errors: propagate 401/403; skip whole course on 404 with `ConnectorFailure`; emit stage-level `ConnectorFailure` on other fetch errors; per-item conversion failures yield `ConnectorFailure`; security-critical pagination errors propagate.
  - Remove 429 handling in the client/validation (handled by `rl_requests`); improve validation messages and error detail extraction.

<sup>Written for commit c881a400256780b9a5b22ec40329a16f732dca44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

