### PR TITLE
fix(indexing): add conservative docfetching/docprocessing backpressure

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -36,6 +36,7 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import global_version
+from shared_configs.configs import CONSERVATIVE_INDEXING
 from shared_configs.configs import SENTRY_DSN
 
 logger = setup_logger()
@@ -283,7 +284,8 @@ def process_job_result(
         result.status = IndexingWatchdogTerminalStatus.SUCCEEDED
         task_logger.warning(
             log_builder.build(
-                "Indexing watchdog - spawned task has non-zero exit code but completion signal is OK. Continuing...",
+                "Indexing watchdog - spawned task has non-zero exit code "
+                "but completion signal is OK. Continuing...",
                 exit_code=str(result.exit_code),
             )
         )
@@ -292,9 +294,61 @@ def process_job_result(
             result.status = IndexingWatchdogTerminalStatus.from_code(result.exit_code)
 
         job_level_exception = job.exception()
-        result.exception_str = f"Docfetching returned exit code {result.exit_code} with exception: {job_level_exception}"
+        result.exception_str = (
+            f"Docfetching returned exit code {result.exit_code} "
+            f"with exception: {job_level_exception}"
+        )
 
     return result
+
+
+def _wait_for_index_attempt_completion(
+    index_attempt_id: int,
+    log_builder: ConnectorIndexingLogBuilder,
+    poll_interval: int = 5,
+) -> None:
+    task_logger.info(
+        log_builder.build(
+            "Indexing watchdog - fetch complete, waiting for docprocessing completion"
+        )
+    )
+
+    while True:
+        sleep(poll_interval)
+
+        try:
+            with get_session_with_current_tenant() as db_session:
+                index_attempt = get_index_attempt(
+                    db_session=db_session, index_attempt_id=index_attempt_id
+                )
+
+                if not index_attempt:
+                    continue
+
+                if not index_attempt.is_finished():
+                    continue
+
+                task_logger.info(
+                    log_builder.build(
+                        "Indexing watchdog - index attempt reached terminal state",
+                        final_status=str(index_attempt.status.value),
+                    )
+                )
+                return
+        except Exception:
+            task_logger.exception(
+                log_builder.build(
+                    "Indexing watchdog - transient exception waiting for index attempt completion"
+                )
+            )
+
+
+def _should_wait_for_docprocessing_completion(result: SimpleJobResult) -> bool:
+    return (
+        CONSERVATIVE_INDEXING
+        and result.status == IndexingWatchdogTerminalStatus.SUCCEEDED
+        and result.exception_str is None
+    )
 
 
 @shared_task(
@@ -486,7 +540,11 @@ def docfetching_proxy_task(
                     )
                 finally:
                     job.release()
-                    break
+
+                if _should_wait_for_docprocessing_completion(result):
+                    _wait_for_index_attempt_completion(index_attempt_id, log_builder)
+
+                break
 
             # log the memory usage for tracking down memory leaks / connector-specific memory issues
             pid = job.process.pid

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -323,7 +323,12 @@ def _wait_for_index_attempt_completion(
                 )
 
                 if not index_attempt:
-                    continue
+                    task_logger.warning(
+                        log_builder.build(
+                            "Indexing watchdog - index attempt disappeared while waiting for docprocessing completion"
+                        )
+                    )
+                    return
 
                 if not index_attempt.is_finished():
                     continue

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -65,6 +65,12 @@ MIN_THREADS_ML_MODELS = int(os.environ.get("MIN_THREADS_ML_MODELS") or 1)
 # or intent classification
 INDEXING_ONLY = os.environ.get("INDEXING_ONLY", "").lower() == "true"
 
+# When enabled, docfetching workers hold their slot until the same connector's
+# docprocessing phase finishes, which adds backpressure between the two stages.
+CONSERVATIVE_INDEXING = (
+    os.environ.get("CONSERVATIVE_INDEXING", "true").lower() == "true"
+)
+
 # The process needs to have this for the log file to write to
 # otherwise, it will not create additional log files
 # This should just be the filename base without extension or path.

--- a/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
@@ -32,7 +32,7 @@ def _build_attempt(status: IndexingStatus) -> SimpleNamespace:
 
 
 @pytest.fixture
-def docfetching_tasks_module(monkeypatch: pytest.MonkeyPatch):
+def docfetching_tasks_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     app_base = types.ModuleType("onyx.background.celery.apps.app_base")
     app_base.task_logger = logging.getLogger("docfetching-test")
     monkeypatch.setitem(sys.modules, "onyx.background.celery.apps.app_base", app_base)

--- a/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
@@ -160,6 +160,37 @@ def test_wait_for_index_attempt_completion_retries_until_terminal(
     assert sleep_calls == [7, 7, 7]
 
 
+def test_wait_for_index_attempt_completion_returns_if_attempt_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    docfetching_tasks_module,
+) -> None:
+    sleep_calls: list[int] = []
+
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "get_session_with_current_tenant",
+        lambda: _FakeSessionContext(),
+    )
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "get_index_attempt",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+
+    docfetching_tasks_module._wait_for_index_attempt_completion(
+        index_attempt_id=17,
+        log_builder=_FakeLogBuilder(),
+        poll_interval=7,
+    )
+
+    assert sleep_calls == [7]
+
+
 def test_should_wait_for_docprocessing_completion_enabled_on_success(
     monkeypatch: pytest.MonkeyPatch,
     docfetching_tasks_module,

--- a/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_tasks.py
@@ -1,0 +1,201 @@
+import importlib
+import logging
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from onyx.background.celery.tasks.models import IndexingWatchdogTerminalStatus
+from onyx.background.celery.tasks.models import SimpleJobResult
+from onyx.db.enums import IndexingStatus
+
+
+class _FakeSessionContext:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+class _FakeLogBuilder:
+    def build(self, msg: str, **_: object) -> str:
+        return msg
+
+
+def _build_attempt(status: IndexingStatus) -> SimpleNamespace:
+    return SimpleNamespace(
+        status=status,
+        is_finished=lambda: status.is_terminal(),
+    )
+
+
+@pytest.fixture
+def docfetching_tasks_module(monkeypatch: pytest.MonkeyPatch):
+    app_base = types.ModuleType("onyx.background.celery.apps.app_base")
+    app_base.task_logger = logging.getLogger("docfetching-test")
+    monkeypatch.setitem(sys.modules, "onyx.background.celery.apps.app_base", app_base)
+
+    heartbeat = types.ModuleType("onyx.background.celery.tasks.docprocessing.heartbeat")
+
+    def _start_heartbeat(*_args: object, **_kwargs: object) -> tuple[None, None]:
+        return (None, None)
+
+    def _stop_heartbeat(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    heartbeat.start_heartbeat = _start_heartbeat
+    heartbeat.stop_heartbeat = _stop_heartbeat
+    monkeypatch.setitem(
+        sys.modules,
+        "onyx.background.celery.tasks.docprocessing.heartbeat",
+        heartbeat,
+    )
+
+    docprocessing_tasks = types.ModuleType(
+        "onyx.background.celery.tasks.docprocessing.tasks"
+    )
+
+    class _ConnectorIndexingLogBuilder:
+        def __init__(self, ctx: object) -> None:
+            self.ctx = ctx
+
+        def build(self, msg: str, **_: object) -> str:
+            return msg
+
+    docprocessing_tasks.ConnectorIndexingLogBuilder = _ConnectorIndexingLogBuilder
+    monkeypatch.setitem(
+        sys.modules,
+        "onyx.background.celery.tasks.docprocessing.tasks",
+        docprocessing_tasks,
+    )
+
+    docprocessing_utils = types.ModuleType(
+        "onyx.background.celery.tasks.docprocessing.utils"
+    )
+
+    class _IndexingCallback:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    docprocessing_utils.IndexingCallback = _IndexingCallback
+    monkeypatch.setitem(
+        sys.modules,
+        "onyx.background.celery.tasks.docprocessing.utils",
+        docprocessing_utils,
+    )
+
+    run_docfetching = types.ModuleType("onyx.background.indexing.run_docfetching")
+
+    def _run_docfetching_entrypoint(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    run_docfetching.run_docfetching_entrypoint = _run_docfetching_entrypoint
+    monkeypatch.setitem(
+        sys.modules,
+        "onyx.background.indexing.run_docfetching",
+        run_docfetching,
+    )
+
+    redis_connector = types.ModuleType("onyx.redis.redis_connector")
+
+    class _RedisConnector:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.delete = SimpleNamespace(fenced=False, fence_key="delete-fence")
+            self.stop = SimpleNamespace(fenced=False, fence_key="stop-fence")
+
+    redis_connector.RedisConnector = _RedisConnector
+    monkeypatch.setitem(sys.modules, "onyx.redis.redis_connector", redis_connector)
+
+    monkeypatch.delitem(
+        sys.modules,
+        "onyx.background.celery.tasks.docfetching.tasks",
+        raising=False,
+    )
+
+    return importlib.import_module("onyx.background.celery.tasks.docfetching.tasks")
+
+
+def test_wait_for_index_attempt_completion_retries_until_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    docfetching_tasks_module,
+) -> None:
+    attempts: list[Exception | SimpleNamespace] = [
+        RuntimeError("transient lookup error"),
+        _build_attempt(IndexingStatus.IN_PROGRESS),
+        _build_attempt(IndexingStatus.SUCCESS),
+    ]
+    sleep_calls: list[int] = []
+
+    def fake_get_index_attempt(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        value = attempts.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "get_session_with_current_tenant",
+        lambda: _FakeSessionContext(),
+    )
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "get_index_attempt",
+        fake_get_index_attempt,
+    )
+    monkeypatch.setattr(
+        docfetching_tasks_module,
+        "sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+
+    docfetching_tasks_module._wait_for_index_attempt_completion(
+        index_attempt_id=17,
+        log_builder=_FakeLogBuilder(),
+        poll_interval=7,
+    )
+
+    assert attempts == []
+    assert sleep_calls == [7, 7, 7]
+
+
+def test_should_wait_for_docprocessing_completion_enabled_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    docfetching_tasks_module,
+) -> None:
+    result = SimpleJobResult()
+    result.status = IndexingWatchdogTerminalStatus.SUCCEEDED
+    monkeypatch.setattr(docfetching_tasks_module, "CONSERVATIVE_INDEXING", True)
+    assert (
+        docfetching_tasks_module._should_wait_for_docprocessing_completion(result)
+        is True
+    )
+
+
+def test_should_wait_for_docprocessing_completion_disabled_by_env(
+    monkeypatch: pytest.MonkeyPatch,
+    docfetching_tasks_module,
+) -> None:
+    result = SimpleJobResult()
+    result.status = IndexingWatchdogTerminalStatus.SUCCEEDED
+    monkeypatch.setattr(docfetching_tasks_module, "CONSERVATIVE_INDEXING", False)
+    assert (
+        docfetching_tasks_module._should_wait_for_docprocessing_completion(result)
+        is False
+    )
+
+
+def test_should_wait_for_docprocessing_completion_skips_failed_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+    docfetching_tasks_module,
+) -> None:
+    result = SimpleJobResult()
+    result.status = IndexingWatchdogTerminalStatus.CONNECTOR_EXCEPTIONED
+    result.exit_code = 255
+    result.exception_str = "fetch failed"
+    monkeypatch.setattr(docfetching_tasks_module, "CONSERVATIVE_INDEXING", True)
+    assert (
+        docfetching_tasks_module._should_wait_for_docprocessing_completion(result)
+        is False
+    )


### PR DESCRIPTION
## Description

During prolonged uptime on our environments, we've noticed that most of our connectors transition to a blue `Indexing` status but all stall until we manually delete docfetching/docprocessing. This primarily occurs only when there is 1) an abundance of connectors and 2) their refresh time overlaps, e.g. 3 hours per refresh with >200 connectors.

After some investigation, our tech lead determined that docfetching was "outrunning" docprocessing, which is only exacerbated if you enable contextual rag or have a slow background embedder. Eventually docfetching goes so far ahead that docproc is forever behind until most attempts set to `IN_PROGRESS` by docfetching begin to stall after 6 hours. The main solution we made was for each thread on docfetch to simply "wait" for their current index attempt to finish docprocessing. They do this by polling the DB every 5 seconds once they have finished crawling. If docproc returns any kind of status or the index attempt is removed from the DB, then the loop breaks and the docfetching thread can move onto the next connector.

The main "disadvantage" of this approach is also its benefit; docfetching threads must wait for docprocessing to return a terminal state. The natural consequence of this is no more prefetching connectors for that specific worker. However, this can be largely negated by simply increasing the number of workers on docfetching. After running this patch on production 2.4.2 (backported) and 3.1.2 for over a week, the pipeline poisoning issue no longer occurs and all connectors index at a (relatively) regular interval. (There is one other issue that can unnecessarily trigger a `Stalled indexing` which is its own PR.)

This behavior is controlled by the env var `CONSERVATIVE_INDEXING` which is now set to True by default.

## How Has This Been Tested?

New unit tests that determine that the behavior works as intended, it is disabled when the env flag is set to false, and that it doesn't hold up actual failed connectors (in the event of some kind of actual error from docproc.) Fails on main, succeeds with this branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add conservative backpressure between docfetching and docprocessing to prevent long stalls when many connectors refresh at once. Docfetch workers now wait for the same connector’s docprocessing to finish before moving on; configurable via `CONSERVATIVE_INDEXING` (default true).

- **Bug Fixes**
  - After a successful fetch, poll the DB every 5s until the same index attempt reaches a terminal state; return early if the attempt disappears. Prevents docfetch from outrunning docprocessing.
  - Added `CONSERVATIVE_INDEXING` env flag (default true) to toggle this; increase docfetch worker count if you need more parallelism.
  - Added unit tests for flag on/off, retrying on transient lookup errors, skipping waits when fetch fails, and handling missing index attempts.

<sup>Written for commit 4c4434e9a434c8c4422148789ef3d275e2f7d237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

