### PR TITLE
chore: remove top-level Formik from ChatPreferencesPage

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -965,6 +965,7 @@ function ChatPreferencesForm() {
                     nonInteractive
                   >
                     <Switch
+                      id="disable_default_assistant"
                       checked={s.disable_default_assistant ?? false}
                       onCheckedChange={(checked) => {
                         void saveSettings({

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { markdown } from "@opal/utils";
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Formik, Form } from "formik";
 import useSWR, { mutate } from "swr";
@@ -356,6 +356,27 @@ function ChatPreferencesForm() {
   );
   const savedCompanyName = useRef(companyName);
   const savedCompanyDescription = useRef(companyDescription);
+
+  // Re-sync local state when settings change externally (e.g. another admin),
+  // but only when there's no in-progress edit (local matches last-saved value).
+  useEffect(() => {
+    const incoming = s.company_name ?? "";
+    if (companyName === savedCompanyName.current && incoming !== companyName) {
+      setCompanyName(incoming);
+      savedCompanyName.current = incoming;
+    }
+  }, [s.company_name]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const incoming = s.company_description ?? "";
+    if (
+      companyDescription === savedCompanyDescription.current &&
+      incoming !== companyDescription
+    ) {
+      setCompanyDescription(incoming);
+      savedCompanyDescription.current = incoming;
+    }
+  }, [s.company_description]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Tools availability
   const { tools: availableTools } = useAvailableTools();

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -3,7 +3,7 @@
 import { markdown } from "@opal/utils";
 import React, { useCallback, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Formik, Form, useFormikContext } from "formik";
+import { Formik, Form } from "formik";
 import useSWR, { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -14,10 +14,9 @@ import Card from "@/refresh-components/cards/Card";
 import Separator from "@/refresh-components/Separator";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
-import SwitchField from "@/refresh-components/form/SwitchField";
-import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
-import InputSelectField from "@/refresh-components/form/InputSelectField";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import {
   SvgAddLines,
@@ -57,7 +56,6 @@ import * as ActionsLayouts from "@/layouts/actions-layouts";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { Disabled, Hoverable } from "@opal/core";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import useFilter from "@/hooks/useFilter";
 import { MCPServer } from "@/lib/tools/interfaces";
 import type { IconProps } from "@opal/types";
@@ -68,26 +66,6 @@ interface DefaultAgentConfiguration {
   tool_ids: number[];
   system_prompt: string | null;
   default_system_prompt: string;
-}
-
-interface ChatPreferencesFormValues {
-  // Features
-  search_ui_enabled: boolean;
-  deep_research_enabled: boolean;
-  auto_scroll: boolean;
-
-  // Team context
-  company_name: string;
-  company_description: string;
-
-  // Advanced
-  maximum_chat_retention_days: string;
-  anonymous_user_enabled: boolean;
-  disable_default_assistant: boolean;
-
-  // File limits
-  user_file_max_upload_size_mb: string;
-  file_token_count_threshold_k: string;
 }
 
 interface MCPServerCardTool {
@@ -198,6 +176,7 @@ type FileLimitFieldName =
 
 interface NumericLimitFieldProps {
   name: FileLimitFieldName;
+  initialValue: string;
   defaultValue: string;
   saveSettings: (updates: Partial<Settings>) => Promise<void>;
   maxValue?: number;
@@ -206,16 +185,15 @@ interface NumericLimitFieldProps {
 
 function NumericLimitField({
   name,
+  initialValue: initialValueProp,
   defaultValue,
   saveSettings,
   maxValue,
   allowZero = false,
 }: NumericLimitFieldProps) {
-  const { values, setFieldValue } =
-    useFormikContext<ChatPreferencesFormValues>();
-  const initialValue = useRef(values[name]);
+  const [value, setValue] = useState(initialValueProp);
+  const savedValue = useRef(initialValueProp);
   const restoringRef = useRef(false);
-  const value = values[name];
 
   const parsed = parseInt(value, 10);
   const isOverMax =
@@ -223,8 +201,8 @@ function NumericLimitField({
 
   const handleRestore = () => {
     restoringRef.current = true;
-    initialValue.current = defaultValue;
-    void setFieldValue(name, defaultValue);
+    savedValue.current = defaultValue;
+    setValue(defaultValue);
     void saveSettings({ [name]: parseInt(defaultValue, 10) });
   };
 
@@ -242,11 +220,11 @@ function NumericLimitField({
     if (!isValid) {
       if (allowZero) {
         // Empty/invalid means "no limit" — persist 0 and clear the field.
-        void setFieldValue(name, "");
+        setValue("");
         void saveSettings({ [name]: 0 });
-        initialValue.current = "";
+        savedValue.current = "";
       } else {
-        void setFieldValue(name, initialValue.current);
+        setValue(savedValue.current);
       }
       return;
     }
@@ -259,10 +237,10 @@ function NumericLimitField({
     // For allowZero fields, 0 means "no limit" — clear the display
     // so the "No limit" placeholder is visible, but still persist 0.
     if (allowZero && parsed === 0) {
-      void setFieldValue(name, "");
-      if (initialValue.current !== "") {
+      setValue("");
+      if (savedValue.current !== "") {
         void saveSettings({ [name]: 0 });
-        initialValue.current = "";
+        savedValue.current = "";
       }
       return;
     }
@@ -271,23 +249,24 @@ function NumericLimitField({
 
     // Update the display to the canonical form (e.g. strip leading zeros).
     if (value !== normalizedDisplay) {
-      void setFieldValue(name, normalizedDisplay);
+      setValue(normalizedDisplay);
     }
 
     // Persist only when the value actually changed.
-    if (normalizedDisplay !== initialValue.current) {
+    if (normalizedDisplay !== savedValue.current) {
       void saveSettings({ [name]: parsed });
-      initialValue.current = normalizedDisplay;
+      savedValue.current = normalizedDisplay;
     }
   };
 
   return (
     <Hoverable.Root group="numericLimit" widthVariant="full">
-      <InputTypeInField
-        name={name}
+      <InputTypeIn
         inputMode="numeric"
         showClearButton={false}
         pattern="[0-9]*"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         placeholder={allowZero ? "No limit" : `Default: ${defaultValue}`}
         variant={isOverMax ? "error" : undefined}
         rightSection={
@@ -311,14 +290,18 @@ function NumericLimitField({
 
 interface FileSizeLimitFieldsProps {
   saveSettings: (updates: Partial<Settings>) => Promise<void>;
+  initialUploadSizeMb: string;
   defaultUploadSizeMb: string;
+  initialTokenThresholdK: string;
   defaultTokenThresholdK: string;
   maxAllowedUploadSizeMb?: number;
 }
 
 function FileSizeLimitFields({
   saveSettings,
+  initialUploadSizeMb,
   defaultUploadSizeMb,
+  initialTokenThresholdK,
   defaultTokenThresholdK,
   maxAllowedUploadSizeMb,
 }: FileSizeLimitFieldsProps) {
@@ -336,6 +319,7 @@ function FileSizeLimitFields({
         >
           <NumericLimitField
             name="user_file_max_upload_size_mb"
+            initialValue={initialUploadSizeMb}
             defaultValue={defaultUploadSizeMb}
             saveSettings={saveSettings}
             maxValue={maxAllowedUploadSizeMb}
@@ -349,6 +333,7 @@ function FileSizeLimitFields({
         >
           <NumericLimitField
             name="file_token_count_threshold_k"
+            initialValue={initialTokenThresholdK}
             defaultValue={defaultTokenThresholdK}
             saveSettings={saveSettings}
             allowZero
@@ -359,18 +344,18 @@ function FileSizeLimitFields({
   );
 }
 
-/**
- * Inner form component that uses useFormikContext to access values
- * and create save handlers for settings fields.
- */
 function ChatPreferencesForm() {
   const router = useRouter();
   const settings = useSettingsContext();
-  const { values } = useFormikContext<ChatPreferencesFormValues>();
+  const s = settings.settings;
 
-  // Track initial text values to avoid unnecessary saves on blur
-  const initialCompanyName = useRef(values.company_name);
-  const initialCompanyDescription = useRef(values.company_description);
+  // Local state for text fields (save-on-blur)
+  const [companyName, setCompanyName] = useState(s.company_name ?? "");
+  const [companyDescription, setCompanyDescription] = useState(
+    s.company_description ?? ""
+  );
+  const savedCompanyName = useRef(companyName);
+  const savedCompanyDescription = useRef(companyDescription);
 
   // Tools availability
   const { tools: availableTools } = useAvailableTools();
@@ -526,16 +511,18 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Name"
               subDescription="This is added to all chat sessions as additional context to provide a richer/customized experience."
+              nonInteractive
             >
-              <InputTypeInField
-                name="company_name"
+              <InputTypeIn
                 placeholder="Enter team name"
+                value={companyName}
+                onChange={(e) => setCompanyName(e.target.value)}
                 onBlur={() => {
-                  if (values.company_name !== initialCompanyName.current) {
+                  if (companyName !== savedCompanyName.current) {
                     void saveSettings({
-                      company_name: values.company_name || null,
+                      company_name: companyName || null,
                     });
-                    initialCompanyName.current = values.company_name;
+                    savedCompanyName.current = companyName;
                   }
                 }}
               />
@@ -544,23 +531,21 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Context"
               subDescription="Users can also provide additional individual context in their personal settings."
+              nonInteractive
             >
-              <InputTextAreaField
-                name="company_description"
+              <InputTextArea
                 placeholder="Describe your team and how Onyx should behave."
                 rows={4}
                 maxRows={10}
                 autoResize
+                value={companyDescription}
+                onChange={(e) => setCompanyDescription(e.target.value)}
                 onBlur={() => {
-                  if (
-                    values.company_description !==
-                    initialCompanyDescription.current
-                  ) {
+                  if (companyDescription !== savedCompanyDescription.current) {
                     void saveSettings({
-                      company_description: values.company_description || null,
+                      company_description: companyDescription || null,
                     });
-                    initialCompanyDescription.current =
-                      values.company_description;
+                    savedCompanyDescription.current = companyDescription;
                   }
                 }}
               />
@@ -604,9 +589,10 @@ function ChatPreferencesForm() {
                       title="Search Mode"
                       description="UI mode for quick document search across your organization."
                       disabled={uniqueSources.length === 0}
+                      nonInteractive
                     >
-                      <SwitchField
-                        name="search_ui_enabled"
+                      <Switch
+                        checked={s.search_ui_enabled ?? false}
                         onCheckedChange={(checked) => {
                           void saveSettings({ search_ui_enabled: checked });
                         }}
@@ -619,9 +605,10 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Deep Research"
                 description="Agentic research system that works across the web and connected sources. Uses significantly more tokens per query."
+                nonInteractive
               >
-                <SwitchField
-                  name="deep_research_enabled"
+                <Switch
+                  checked={s.deep_research_enabled ?? true}
                   onCheckedChange={(checked) => {
                     void saveSettings({ deep_research_enabled: checked });
                   }}
@@ -630,9 +617,10 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Chat Auto-Scroll"
                 description="Automatically scroll to new content as chat generates response. Users can override this in their personal settings."
+                nonInteractive
               >
-                <SwitchField
-                  name="auto_scroll"
+                <Switch
+                  checked={s.auto_scroll ?? false}
                   onCheckedChange={(checked) => {
                     void saveSettings({ auto_scroll: checked });
                   }}
@@ -643,7 +631,7 @@ function ChatPreferencesForm() {
 
           <Separator noPadding />
 
-          <Disabled disabled={values.disable_default_assistant}>
+          <Disabled disabled={s.disable_default_assistant ?? false}>
             <div>
               <Section gap={1.5}>
                 {/* Connectors */}
@@ -873,9 +861,12 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Keep Chat History"
                     description="Specify how long Onyx should retain chats in your organization."
+                    nonInteractive
                   >
-                    <InputSelectField
-                      name="maximum_chat_retention_days"
+                    <InputSelect
+                      value={
+                        s.maximum_chat_retention_days?.toString() ?? "forever"
+                      }
                       onValueChange={(value) => {
                         void saveSettings({
                           maximum_chat_retention_days:
@@ -895,7 +886,7 @@ function ChatPreferencesForm() {
                           365 days
                         </InputSelect.Item>
                       </InputSelect.Content>
-                    </InputSelectField>
+                    </InputSelect>
                   </InputLayouts.Horizontal>
                 </Card>
 
@@ -906,17 +897,29 @@ function ChatPreferencesForm() {
                   >
                     <FileSizeLimitFields
                       saveSettings={saveSettings}
+                      initialUploadSizeMb={
+                        (s.user_file_max_upload_size_mb ?? 0) <= 0
+                          ? s.default_user_file_max_upload_size_mb?.toString() ??
+                            "100"
+                          : s.user_file_max_upload_size_mb!.toString()
+                      }
                       defaultUploadSizeMb={
-                        settings?.settings.default_user_file_max_upload_size_mb?.toString() ??
+                        s.default_user_file_max_upload_size_mb?.toString() ??
                         "100"
                       }
+                      initialTokenThresholdK={
+                        s.file_token_count_threshold_k == null
+                          ? s.default_file_token_count_threshold_k?.toString() ??
+                            "200"
+                          : s.file_token_count_threshold_k === 0
+                            ? ""
+                            : s.file_token_count_threshold_k.toString()
+                      }
                       defaultTokenThresholdK={
-                        settings?.settings.default_file_token_count_threshold_k?.toString() ??
+                        s.default_file_token_count_threshold_k?.toString() ??
                         "200"
                       }
-                      maxAllowedUploadSizeMb={
-                        settings?.settings.max_allowed_upload_size_mb
-                      }
+                      maxAllowedUploadSizeMb={s.max_allowed_upload_size_mb}
                     />
                   </InputLayouts.Vertical>
                 </Card>
@@ -925,9 +928,10 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Allow Anonymous Users"
                     description="Allow anyone to start chats without logging in. They do not see any other chats and cannot create agents or update settings."
+                    nonInteractive
                   >
-                    <SwitchField
-                      name="anonymous_user_enabled"
+                    <Switch
+                      checked={s.anonymous_user_enabled ?? false}
                       onCheckedChange={(checked) => {
                         void saveSettings({ anonymous_user_enabled: checked });
                       }}
@@ -937,9 +941,10 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Always Start with an Agent"
                     description="This removes the default chat. Users will always start in an agent, and new chats will be created in their last active agent. Set featured agents to help new users get started."
+                    nonInteractive
                   >
-                    <SwitchField
-                      name="disable_default_assistant"
+                    <Switch
+                      checked={s.disable_default_assistant ?? false}
                       onCheckedChange={(checked) => {
                         void saveSettings({
                           disable_default_assistant: checked,
@@ -1042,50 +1047,5 @@ function ChatPreferencesForm() {
 }
 
 export default function ChatPreferencesPage() {
-  const settings = useSettingsContext();
-
-  const initialValues: ChatPreferencesFormValues = {
-    // Features
-    search_ui_enabled: settings.settings.search_ui_enabled ?? false,
-    deep_research_enabled: settings.settings.deep_research_enabled ?? true,
-    auto_scroll: settings.settings.auto_scroll ?? false,
-
-    // Team context
-    company_name: settings.settings.company_name ?? "",
-    company_description: settings.settings.company_description ?? "",
-
-    // Advanced
-    maximum_chat_retention_days:
-      settings.settings.maximum_chat_retention_days?.toString() ?? "forever",
-    anonymous_user_enabled: settings.settings.anonymous_user_enabled ?? false,
-    disable_default_assistant:
-      settings.settings.disable_default_assistant ?? false,
-
-    // File limits — for upload size: 0/null means "use default";
-    // for token threshold: null means "use default", 0 means "no limit".
-    user_file_max_upload_size_mb:
-      (settings.settings.user_file_max_upload_size_mb ?? 0) <= 0
-        ? settings.settings.default_user_file_max_upload_size_mb?.toString() ??
-          "100"
-        : settings.settings.user_file_max_upload_size_mb!.toString(),
-    file_token_count_threshold_k:
-      settings.settings.file_token_count_threshold_k == null
-        ? settings.settings.default_file_token_count_threshold_k?.toString() ??
-          "200"
-        : settings.settings.file_token_count_threshold_k === 0
-          ? ""
-          : settings.settings.file_token_count_threshold_k.toString(),
-  };
-
-  return (
-    <Formik
-      initialValues={initialValues}
-      onSubmit={() => {}}
-      enableReinitialize
-    >
-      <Form className="h-full w-full">
-        <ChatPreferencesForm />
-      </Form>
-    </Formik>
-  );
+  return <ChatPreferencesForm />;
 }


### PR DESCRIPTION
## Description

Remove the top-level `<Formik>` wrapper from `ChatPreferencesPage`. The page never submits as a form — every field saves independently via `onBlur` or `onCheckedChange` callbacks. Formik was only being used as a state container (`onSubmit: () => {}`), which is not its intended purpose.

## Screenshots + Videos

No UI changes; screenshots / videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the top-level `<Formik>` from `ChatPreferencesPage`; fields now read from `settings` and save on blur/change. Also re-sync team text fields with external updates and restore the `disable_default_assistant` switch id to keep E2E tests stable.

- **Refactors**
  - Replaced `SwitchField`/`InputSelectField` with `Switch`/`InputSelect` reading directly from `settings`; removed page-level `<Formik>/<Form>` (system-prompt modal keeps its own).
  - Moved `company_name`/`company_description` to local `useState` with save-on-blur; swapped `InputTypeInField`/`InputTextAreaField` for `InputTypeIn`/`InputTextArea`.
  - Rewrote `NumericLimitField` with local state and an `initialValue` prop; `FileSizeLimitFields` now pass initial values and call `saveSettings` directly.

- **Bug Fixes**
  - Re-sync `company_name`/`company_description` when the settings context changes, unless the user is mid-edit.
  - Restore `id="disable_default_assistant"` on the `Switch` to keep Playwright E2E selector working.

<sup>Written for commit 433dc0176535955a53f0842db11fd178ce1fa18e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

