### PR TITLE
fix(chat): isolate multi-model streaming errors to their panels

### DIFF
--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -644,6 +644,7 @@ export default function useChatController({
             });
             node.modelDisplayName = model.displayName;
             node.overridden_model = model.modelName;
+            node.is_generating = true;
             return node;
           });
         }
@@ -1052,10 +1053,14 @@ export default function useChatController({
 
               // In multi-model mode, route per-model errors to the specific model's
               // node instead of killing the entire stream. Other models keep streaming.
-              if (isMultiModel && streamingError.details?.model_index != null) {
-                const errorModelIndex = streamingError.details
-                  .model_index as number;
+              if (isMultiModel) {
+                // Multi-model: isolate the error to its panel. Never throw
+                // or set global error state — other models keep streaming.
+                const errorModelIndex = streamingError.details?.model_index as
+                  | number
+                  | undefined;
                 if (
+                  errorModelIndex != null &&
                   errorModelIndex >= 0 &&
                   errorModelIndex < initialAssistantNodes.length
                 ) {
@@ -1088,8 +1093,15 @@ export default function useChatController({
                     completeMessageTreeOverride: currentMessageTreeLocal,
                     chatSessionId: frozenSessionId!,
                   });
+                } else {
+                  // Error without model_index in multi-model — can't route
+                  // to a specific panel. Log and continue; the stream loop
+                  // stays alive for other models.
+                  console.warn(
+                    "Multi-model error without model_index:",
+                    streamingError.error
+                  );
                 }
-                // Skip the normal per-packet upsert — we already upserted the error node
                 continue;
               } else {
                 // Single-model: kill the stream
@@ -1245,6 +1257,7 @@ export default function useChatController({
               errorCode,
               isRetryable,
               errorDetails,
+              is_generating: false,
             })
           : [
               {

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -331,10 +331,13 @@ const ChatUI = React.memo(
             return null;
           })}
 
-          {/* Error banner when last message is user message or error type */}
+          {/* Error banner when last message is user message or error type.
+              Skip for multi-model per-panel errors — those are shown in
+              their own panel, not as a global banner. */}
           {(((error !== null || loadError !== null) &&
             messages[messages.length - 1]?.type === "user") ||
-            messages[messages.length - 1]?.type === "error") && (
+            (messages[messages.length - 1]?.type === "error" &&
+              !messages[messages.length - 1]?.modelDisplayName)) && (
             <div className={`p-4 w-full ${MSG_MAX_W} self-center`}>
               <ErrorBanner
                 resubmit={onResubmit}


### PR DESCRIPTION
## Description

When one model errors during multi-model streaming (e.g. token limit), the error was not properly isolated:
- The error appeared both in the model's panel AND as a global "There was an error" banner at the bottom
- Non-errored models that hadn't finished streaming got stuck — their text dumped all at once
- Users could click the errored panel as preferred during streaming, disrupting the layout

**Root cause:** The error handler checked `isMultiModel && streamingError.details?.model_index != null` — if `model_index` was missing, the error fell through to the single-model path which called `setUncaughtError()` (global banner) and `throw` (killed the stream loop for all models).

**Fix:**
- Gate on `isMultiModel` first — all multi-model errors `continue` without throwing, keeping the stream loop alive for other models. Missing `model_index` logs a warning instead of crashing.
- Global error banner in ChatUI skips messages with `modelDisplayName` (per-panel multi-model errors).
- Set `is_generating: true` on initial multi-model nodes so preferred selection is blocked while any model is still streaming.

## How Has This Been Tested?

fixes this (GPT 5.4 in the middle stopped outputting text due to the azure error):
<img width="600" alt="Screenshot 2026-04-13 at 9 05 41 AM" src="https://github.com/user-attachments/assets/dd054aad-5afe-4bd5-942a-3fa70e138b4d" />

After:


https://github.com/user-attachments/assets/750c4046-563e-4ebb-b68e-e566e5f56dc8


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check