### PR TITLE
fix: CLAUDE.md incorrect task info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,12 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
 
 4. **Light Worker** (`light`)
    - Handles lightweight, fast operations
-   - Tasks: vespa operations, document permissions sync, external group sync
+   - Tasks: vespa metadata sync, connector deletion, doc permissions upsert, checkpoint cleanup, index attempt cleanup
    - Higher concurrency for quick tasks
 
 5. **Heavy Worker** (`heavy`)
    - Handles resource-intensive operations
-   - Primary task: document pruning operations
+   - Tasks: connector pruning, document permissions sync, external group sync, CSV generation
    - Runs with 4 threads concurrency
 
 6. **KG Processing Worker** (`kg_processing`)


### PR DESCRIPTION
## Description

Our CLAUDE.md had incorrect information on which workers run which tasks, leading to faulty inferences when answering questions and debugging

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected worker task assignments in `AGENTS.md` to reflect current `Celery` worker responsibilities. This removes misleading info that affected debugging and support.

- Bug Fixes
  - Updated Light Worker (`light`) tasks: vespa metadata sync, connector deletion, doc permissions upsert, checkpoint cleanup, index attempt cleanup.
  - Updated Heavy Worker (`heavy`) tasks: connector pruning, document permissions sync, external group sync, CSV generation.

<sup>Written for commit 15b83d5324899fdbeec48e3bc4d30c83f34aa5ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

