### PR TITLE
refactor: rename `nonInteractive` to `withLabel` in input layouts

### DIFF
--- a/web/src/app/admin/configuration/voice/VoiceProviderSetupModal.tsx
+++ b/web/src/app/admin/configuration/voice/VoiceProviderSetupModal.tsx
@@ -441,7 +441,6 @@ export default function VoiceProviderSetupModal({
                 subDescription={markdown(
                   "Paste the endpoint shown in [Azure Portal (Keys and Endpoint)](https://portal.azure.com/). Onyx extracts the speech region from this URL. Examples: https://westus.api.cognitive.microsoft.com/ or https://westus.tts.speech.microsoft.com/."
                 )}
-                withLabel={false}
               >
                 <InputTypeIn
                   placeholder={
@@ -456,7 +455,7 @@ export default function VoiceProviderSetupModal({
             )}
 
             {providerType === "openai" && mode === "stt" && (
-              <Horizontal title="STT Model" center withLabel={false}>
+              <Horizontal title="STT Model" center>
                 <InputSelect value={sttModel} onValueChange={setSttModel}>
                   <InputSelect.Trigger />
                   <InputSelect.Content>
@@ -474,7 +473,6 @@ export default function VoiceProviderSetupModal({
               <Vertical
                 title="Default Model"
                 subDescription="This model will be used by Onyx by default for text-to-speech."
-                withLabel={false}
               >
                 <InputSelect value={ttsModel} onValueChange={setTtsModel}>
                   <InputSelect.Trigger />
@@ -500,7 +498,6 @@ export default function VoiceProviderSetupModal({
                     PROVIDER_DOCS_URLS[providerType]
                   }).`
                 )}
-                withLabel={false}
               >
                 <InputComboBox
                   value={defaultVoice}

--- a/web/src/app/admin/configuration/voice/VoiceProviderSetupModal.tsx
+++ b/web/src/app/admin/configuration/voice/VoiceProviderSetupModal.tsx
@@ -441,7 +441,7 @@ export default function VoiceProviderSetupModal({
                 subDescription={markdown(
                   "Paste the endpoint shown in [Azure Portal (Keys and Endpoint)](https://portal.azure.com/). Onyx extracts the speech region from this URL. Examples: https://westus.api.cognitive.microsoft.com/ or https://westus.tts.speech.microsoft.com/."
                 )}
-                nonInteractive
+                withLabel={false}
               >
                 <InputTypeIn
                   placeholder={
@@ -456,7 +456,7 @@ export default function VoiceProviderSetupModal({
             )}
 
             {providerType === "openai" && mode === "stt" && (
-              <Horizontal title="STT Model" center nonInteractive>
+              <Horizontal title="STT Model" center withLabel={false}>
                 <InputSelect value={sttModel} onValueChange={setSttModel}>
                   <InputSelect.Trigger />
                   <InputSelect.Content>
@@ -474,7 +474,7 @@ export default function VoiceProviderSetupModal({
               <Vertical
                 title="Default Model"
                 subDescription="This model will be used by Onyx by default for text-to-speech."
-                nonInteractive
+                withLabel={false}
               >
                 <InputSelect value={ttsModel} onValueChange={setTtsModel}>
                   <InputSelect.Trigger />
@@ -500,7 +500,7 @@ export default function VoiceProviderSetupModal({
                     PROVIDER_DOCS_URLS[providerType]
                   }).`
                 )}
-                nonInteractive
+                withLabel={false}
               >
                 <InputComboBox
                   value={defaultVoice}

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
@@ -315,7 +315,7 @@ export default function HookFormModal({
                   <InputLayouts.Vertical
                     name="fail_strategy"
                     title="Fail Strategy"
-                    nonInteractive
+                    withLabel={false}
                     subDescription={failStrategyDescription}
                   >
                     <InputSelect

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
@@ -315,7 +315,6 @@ export default function HookFormModal({
                   <InputLayouts.Vertical
                     name="fail_strategy"
                     title="Fail Strategy"
-                    withLabel={false}
                     subDescription={failStrategyDescription}
                   >
                     <InputSelect

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -13,7 +13,7 @@ import Label from "@/refresh-components/form/Label";
 interface OrientationLayoutProps {
   name?: string;
   disabled?: boolean;
-  nonInteractive?: boolean;
+  withLabel?: boolean;
   children?: React.ReactNode;
   title: string | RichStr;
   description?: string | RichStr;
@@ -49,7 +49,7 @@ export interface VerticalLayoutProps extends OrientationLayoutProps {
 function VerticalInputLayout({
   name,
   disabled,
-  nonInteractive,
+  withLabel = true,
   children,
   subDescription,
   title,
@@ -76,7 +76,7 @@ function VerticalInputLayout({
     </Section>
   );
 
-  if (nonInteractive) return content;
+  if (!withLabel) return content;
   return (
     <Label name={name} disabled={disabled}>
       {content}
@@ -124,7 +124,7 @@ export interface HorizontalLayoutProps extends OrientationLayoutProps {
 function HorizontalInputLayout({
   name,
   disabled,
-  nonInteractive,
+  withLabel = true,
   children,
   center,
   title,
@@ -155,7 +155,7 @@ function HorizontalInputLayout({
     </Section>
   );
 
-  if (nonInteractive) return content;
+  if (!withLabel) return content;
   return (
     <Label name={name} disabled={disabled}>
       {content}

--- a/web/src/refresh-components/form/Label.stories.tsx
+++ b/web/src/refresh-components/form/Label.stories.tsx
@@ -24,11 +24,3 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
-
-export const NonInteractive: Story = {
-  args: {
-    children: "Non-Interactive Label",
-    name: "readonly-input",
-    nonInteractive: true,
-  },
-};

--- a/web/src/refresh-components/form/Label.tsx
+++ b/web/src/refresh-components/form/Label.tsx
@@ -27,29 +27,17 @@ interface LabelProps
   name?: string;
   /** Whether the associated input is disabled */
   disabled?: boolean;
-  nonInteractive?: boolean;
   ref?: React.Ref<HTMLLabelElement>;
 }
 
-export default function Label({
-  name,
-  disabled,
-  nonInteractive,
-  ref,
-  ...props
-}: LabelProps) {
+export default function Label({ name, disabled, ref, ...props }: LabelProps) {
   return (
     <label
       ref={ref}
-      data-non-interactive={nonInteractive ? "true" : undefined}
       className={cn(
         "flex-1 self-stretch",
-        "peer-disabled:cursor-not-allowed data-[non-interactive=true]:cursor-default",
-        disabled
-          ? "cursor-not-allowed"
-          : nonInteractive
-            ? undefined
-            : "cursor-pointer"
+        "peer-disabled:cursor-not-allowed",
+        disabled ? "cursor-not-allowed" : "cursor-pointer"
       )}
       htmlFor={name}
       {...props}

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -1357,7 +1357,7 @@ function AccountsAccessSettings() {
               title="Email"
               description="Your account email address."
               center
-              nonInteractive
+              withLabel={false}
             >
               <Text>{user?.email ?? "anonymous"}</Text>
             </InputLayouts.Horizontal>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -331,7 +331,7 @@ function FileSizeLimitFields({
               ? `Max: ${maxAllowedUploadSizeMb} MB`
               : undefined
           }
-          nonInteractive
+          withLabel={false}
         >
           <NumericLimitField
             name="user_file_max_upload_size_mb"
@@ -344,7 +344,7 @@ function FileSizeLimitFields({
       <div className="flex-1">
         <InputLayouts.Vertical
           title="File Token Limit (thousand tokens)"
-          nonInteractive
+          withLabel={false}
         >
           <NumericLimitField
             name="file_token_count_threshold_k"

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -527,7 +527,6 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Name"
               subDescription="This is added to all chat sessions as additional context to provide a richer/customized experience."
-              withLabel={false}
             >
               <InputTypeIn
                 placeholder="Enter team name"
@@ -547,7 +546,6 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Context"
               subDescription="Users can also provide additional individual context in their personal settings."
-              withLabel={false}
             >
               <InputTextArea
                 placeholder="Describe your team and how Onyx should behave."
@@ -605,7 +603,6 @@ function ChatPreferencesForm() {
                       title="Search Mode"
                       description="UI mode for quick document search across your organization."
                       disabled={uniqueSources.length === 0}
-                      withLabel={false}
                     >
                       <Switch
                         checked={s.search_ui_enabled ?? false}
@@ -621,7 +618,6 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Deep Research"
                 description="Agentic research system that works across the web and connected sources. Uses significantly more tokens per query."
-                withLabel={false}
               >
                 <Switch
                   checked={s.deep_research_enabled ?? true}
@@ -633,7 +629,6 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Chat Auto-Scroll"
                 description="Automatically scroll to new content as chat generates response. Users can override this in their personal settings."
-                withLabel={false}
               >
                 <Switch
                   checked={s.auto_scroll ?? false}
@@ -880,7 +875,6 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Keep Chat History"
                     description="Specify how long Onyx should retain chats in your organization."
-                    withLabel={false}
                   >
                     <InputSelect
                       value={
@@ -947,7 +941,6 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Allow Anonymous Users"
                     description="Allow anyone to start chats without logging in. They do not see any other chats and cannot create agents or update settings."
-                    withLabel={false}
                   >
                     <Switch
                       checked={s.anonymous_user_enabled ?? false}
@@ -960,7 +953,6 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Always Start with an Agent"
                     description="This removes the default chat. Users will always start in an agent, and new chats will be created in their last active agent. Set featured agents to help new users get started."
-                    withLabel={false}
                   >
                     <Switch
                       id="disable_default_assistant"

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -331,7 +331,6 @@ function FileSizeLimitFields({
               ? `Max: ${maxAllowedUploadSizeMb} MB`
               : undefined
           }
-          withLabel={false}
         >
           <NumericLimitField
             name="user_file_max_upload_size_mb"
@@ -342,10 +341,7 @@ function FileSizeLimitFields({
         </InputLayouts.Vertical>
       </div>
       <div className="flex-1">
-        <InputLayouts.Vertical
-          title="File Token Limit (thousand tokens)"
-          withLabel={false}
-        >
+        <InputLayouts.Vertical title="File Token Limit (thousand tokens)">
           <NumericLimitField
             name="file_token_count_threshold_k"
             defaultValue={defaultTokenThresholdK}

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -527,7 +527,7 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Name"
               subDescription="This is added to all chat sessions as additional context to provide a richer/customized experience."
-              nonInteractive
+              withLabel={false}
             >
               <InputTypeIn
                 placeholder="Enter team name"
@@ -547,7 +547,7 @@ function ChatPreferencesForm() {
             <InputLayouts.Vertical
               title="Team Context"
               subDescription="Users can also provide additional individual context in their personal settings."
-              nonInteractive
+              withLabel={false}
             >
               <InputTextArea
                 placeholder="Describe your team and how Onyx should behave."
@@ -605,7 +605,7 @@ function ChatPreferencesForm() {
                       title="Search Mode"
                       description="UI mode for quick document search across your organization."
                       disabled={uniqueSources.length === 0}
-                      nonInteractive
+                      withLabel={false}
                     >
                       <Switch
                         checked={s.search_ui_enabled ?? false}
@@ -621,7 +621,7 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Deep Research"
                 description="Agentic research system that works across the web and connected sources. Uses significantly more tokens per query."
-                nonInteractive
+                withLabel={false}
               >
                 <Switch
                   checked={s.deep_research_enabled ?? true}
@@ -633,7 +633,7 @@ function ChatPreferencesForm() {
               <InputLayouts.Horizontal
                 title="Chat Auto-Scroll"
                 description="Automatically scroll to new content as chat generates response. Users can override this in their personal settings."
-                nonInteractive
+                withLabel={false}
               >
                 <Switch
                   checked={s.auto_scroll ?? false}
@@ -880,7 +880,7 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Keep Chat History"
                     description="Specify how long Onyx should retain chats in your organization."
-                    nonInteractive
+                    withLabel={false}
                   >
                     <InputSelect
                       value={
@@ -947,7 +947,7 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Allow Anonymous Users"
                     description="Allow anyone to start chats without logging in. They do not see any other chats and cannot create agents or update settings."
-                    nonInteractive
+                    withLabel={false}
                   >
                     <Switch
                       checked={s.anonymous_user_enabled ?? false}
@@ -960,7 +960,7 @@ function ChatPreferencesForm() {
                   <InputLayouts.Horizontal
                     title="Always Start with an Agent"
                     description="This removes the default chat. Users will always start in an agent, and new chats will be created in their last active agent. Set featured agents to help new users get started."
-                    nonInteractive
+                    withLabel={false}
                   >
                     <Switch
                       id="disable_default_assistant"

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -619,7 +619,7 @@ function ChatPreferencesForm() {
                 title="Multi-Model Generation"
                 tag={{ title: "beta", color: "blue" }}
                 description="Allow multiple models to generate responses in parallel in chat."
-                nonInteractive
+                withLabel={false}
               >
                 <Switch
                   checked={s.multi_model_chat_enabled ?? true}

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -450,7 +450,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                   title="Delete This Group"
                   description="Members will lose access to any resources shared with this group."
                   center
-                  nonInteractive
+                  withLabel={false}
                 >
                   <Button
                     variant="danger"

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -450,7 +450,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                   title="Delete This Group"
                   description="Members will lose access to any resources shared with this group."
                   center
-                  withLabel={false}
                 >
                   <Button
                     variant="danger"

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -450,6 +450,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                   title="Delete This Group"
                   description="Members will lose access to any resources shared with this group."
                   center
+                  withLabel={false}
                 >
                   <Button
                     variant="danger"

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -340,7 +340,6 @@ export default function LLMConfigurationPage() {
             <HorizontalInput
               title="Default Model"
               description="This model will be used by Onyx by default in your chats."
-              withLabel={false}
               center
             >
               <InputSelect

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -340,7 +340,7 @@ export default function LLMConfigurationPage() {
             <HorizontalInput
               title="Default Model"
               description="This model will be used by Onyx by default in your chats."
-              nonInteractive
+              withLabel={false}
               center
             >
               <InputSelect

--- a/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -93,12 +93,7 @@ export default function ApiKeyFormModal({
           {({ isSubmitting, values }) => (
             <Form className="w-full overflow-visible">
               <Modal.Body>
-                <VerticalInput
-                  name="name"
-                  title="Name"
-                  withLabel={false}
-                  sizePreset="main-ui"
-                >
+                <VerticalInput name="name" title="Name" sizePreset="main-ui">
                   <FormikField<string>
                     name="name"
                     render={(field, helper) => (
@@ -115,7 +110,6 @@ export default function ApiKeyFormModal({
                 <VerticalInput
                   name="role"
                   title="Account Permissions"
-                  withLabel={false}
                   sizePreset="main-ui"
                 >
                   <FormikField<string>

--- a/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -96,7 +96,7 @@ export default function ApiKeyFormModal({
                 <VerticalInput
                   name="name"
                   title="Name"
-                  nonInteractive
+                  withLabel={false}
                   sizePreset="main-ui"
                 >
                   <FormikField<string>
@@ -115,7 +115,7 @@ export default function ApiKeyFormModal({
                 <VerticalInput
                   name="role"
                   title="Account Permissions"
-                  nonInteractive
+                  withLabel={false}
                   sizePreset="main-ui"
                 >
                   <FormikField<string>

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -374,7 +374,6 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 <Horizontal
                   title="Overwrite System Prompts"
                   description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
-                  withLabel={false}
                   sizePreset="main-ui"
                 >
                   <Switch disabled checked={agent.replace_base_system_prompt} />

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -353,7 +353,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                   <Horizontal
                     title="Default Model"
                     description="This model will be used by Onyx by default in your chats."
-                    nonInteractive
+                    withLabel={false}
                     sizePreset="main-ui"
                   >
                     <Text>{defaultModel}</Text>
@@ -363,7 +363,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                   <Horizontal
                     title="Knowledge Cutoff Date"
                     description="Documents with a last-updated date prior to this will be ignored."
-                    nonInteractive
+                    withLabel={false}
                     sizePreset="main-ui"
                   >
                     <Text mainUiMono>
@@ -374,7 +374,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 <Horizontal
                   title="Overwrite System Prompts"
                   description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
-                  nonInteractive
+                  withLabel={false}
                   sizePreset="main-ui"
                 >
                   <Switch disabled checked={agent.replace_base_system_prompt} />

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -483,7 +483,7 @@ export function ModelSelectionField({
         <InputLayouts.Horizontal
           title="Models"
           description="Select models to make available for this provider."
-          nonInteractive
+          withLabel={false}
           center
         >
           <Section flexDirection="row" gap={0}>


### PR DESCRIPTION
## Description

Rename the `nonInteractive` prop to `withLabel` (default `true`) on `Vertical`/`Horizontal` input layouts. The old name was confusing given the `core/interactive/` primitives. The new name clearly describes what it controls: whether the layout wraps its content in a `<label>`.

- `nonInteractive` (absent) → `withLabel` (absent, defaults to `true`) — renders `<Label>` wrapper (no behavior change)
- `nonInteractive` (present) → `withLabel={false}` — skips `<Label>` wrapper (no behavior change)
- Removes the now-unused `nonInteractive` prop from `Label` component
- Removes the `NonInteractive` story from `Label.stories.tsx`

## How Has This Been Tested?

- `bun run types:check` passes
- Pure rename with inverted default — no runtime behavior change

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `nonInteractive` prop to `withLabel` (default true) on `Vertical` and `Horizontal` input layouts to clearly control the `<label>` wrapper. Restored label behavior to keep click-forwarding, and set `withLabel={false}` on display-only/action rows to avoid labels intercepting clicks.

- **Refactors**
  - Input layouts: `nonInteractive` → `withLabel`; defaults to wrapping in `<Label>` and preserves implicit label click-forwarding even without `name`; use `withLabel={false}` to skip the wrapper.
  - Updated usages across settings/admin pages and modals; added `withLabel={false}` for read-only and action rows (e.g., Settings “Email”, Groups “Delete This Group”, Chat Preferences “Multi‑Model Generation”, Agent viewer summaries, provider model list); removed redundant flags elsewhere.
  - Removed `nonInteractive` from `Label` and simplified cursor classes; deleted the `NonInteractive` story in `Label.stories.tsx`.

<sup>Written for commit 5774199c7ef6a796949bf5cdc9c93a73e17bac65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

