### PR TITLE
fix: Auto-attach uploaded files to persona for RAG + security hardening (0xKushwaha)

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -38,6 +38,8 @@ from onyx.db.models import User__UserGroup
 from onyx.db.models import UserFile
 from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -154,9 +156,9 @@ def fetch_persona_by_id_for_user(
     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
     persona = db_session.scalars(stmt).one_or_none()
     if not persona:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Persona with ID {persona_id} does not exist or user is not authorized to access it",
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            f"Persona with ID {persona_id} does not exist or user is not authorized to access it",
         )
     return persona
 

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -3,7 +3,6 @@ import uuid
 from typing import List
 from uuid import UUID
 
-from fastapi import HTTPException
 from fastapi import UploadFile
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -71,18 +70,12 @@ def create_user_files(
 ) -> CategorizedFilesResult:
     # Validate persona access before creating any file associations
     if persona_id is not None:
-        try:
-            fetch_persona_by_id_for_user(
-                db_session=db_session,
-                persona_id=persona_id,
-                user=user,
-                get_editable=False,
-            )
-        except HTTPException:
-            raise OnyxError(
-                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                "User does not have access to the specified persona",
-            )
+        fetch_persona_by_id_for_user(
+            db_session=db_session,
+            persona_id=persona_id,
+            user=user,
+            get_editable=False,
+        )
 
     # Categorize the files
     categorized_files = categorize_uploaded_files(files, db_session)

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -3,6 +3,7 @@ import uuid
 from typing import List
 from uuid import UUID
 
+from fastapi import HTTPException
 from fastapi import UploadFile
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -23,6 +24,8 @@ from onyx.db.models import Project__UserFile
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.models import UserProject
+from onyx.db.persona import _mark_files_need_persona_sync
+from onyx.db.persona import fetch_persona_by_id_for_user
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents.connector import upload_files
@@ -68,16 +71,12 @@ def create_user_files(
 ) -> CategorizedFilesResult:
     # Validate persona access before creating any file associations
     if persona_id is not None:
-        from fastapi import HTTPException
-
-        from onyx.db.persona import fetch_persona_by_id_for_user
-
         try:
             fetch_persona_by_id_for_user(
                 db_session=db_session,
                 persona_id=persona_id,
                 user=user,
-                get_editable=True,
+                get_editable=False,
             )
         except HTTPException:
             raise OnyxError(
@@ -136,11 +135,7 @@ def create_user_files(
         user_files.append(new_file)
     # Mark files for persona sync before committing, so everything is in one transaction
     if persona_id is not None and user_files:
-        from onyx.db.persona import _mark_files_need_persona_sync
-
-        _mark_files_need_persona_sync(
-            db_session, [uf.id for uf in user_files]
-        )
+        _mark_files_need_persona_sync(db_session, [uf.id for uf in user_files])
     db_session.commit()
     return CategorizedFilesResult(
         user_files=user_files,

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -134,6 +134,13 @@ def create_user_files(
             )
             db_session.add(persona_to_user_file)
         user_files.append(new_file)
+    # Mark files for persona sync before committing, so everything is in one transaction
+    if persona_id is not None and user_files:
+        from onyx.db.persona import _mark_files_need_persona_sync
+
+        _mark_files_need_persona_sync(
+            db_session, [uf.id for uf in user_files]
+        )
     db_session.commit()
     return CategorizedFilesResult(
         user_files=user_files,
@@ -156,24 +163,9 @@ def upload_files_to_user_files_with_indexing(
         if not check_project_ownership(project_id, user.id, db_session):
             raise OnyxError(OnyxErrorCode.NOT_FOUND, "Project not found")
 
-    if persona_id is not None and user is not None:
-        from fastapi import HTTPException
-
-        from onyx.db.persona import fetch_persona_by_id_for_user
-
-        try:
-            fetch_persona_by_id_for_user(
-                db_session=db_session,
-                persona_id=persona_id,
-                user=user,
-                get_editable=False,
-            )
-        except HTTPException:
-            raise OnyxError(
-                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                "User does not have access to the specified persona",
-            )
-
+    # Persona access validation and _mark_files_need_persona_sync are both
+    # handled inside create_user_files to avoid duplicate queries and to
+    # keep everything in a single transaction/commit.
     categorized_files_result = create_user_files(
         files,
         project_id,
@@ -182,13 +174,6 @@ def upload_files_to_user_files_with_indexing(
         temp_id_map=temp_id_map,
         persona_id=persona_id,
     )
-    if persona_id is not None and categorized_files_result.user_files:
-        from onyx.db.persona import _mark_files_need_persona_sync
-
-        _mark_files_need_persona_sync(
-            db_session, [uf.id for uf in categorized_files_result.user_files]
-        )
-        db_session.commit()
     user_files = categorized_files_result.user_files
     rejected_files = categorized_files_result.rejected_files
     id_to_temp_id = categorized_files_result.id_to_temp_id

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -18,6 +18,7 @@ from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.models import Persona__UserFile
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import Project__UserFile
 from onyx.db.models import User
@@ -62,6 +63,7 @@ def create_user_files(
     db_session: Session,
     link_url: str | None = None,
     temp_id_map: dict[str, str] | None = None,
+    persona_id: int | None = None,
 ) -> CategorizedFilesResult:
 
     # Categorize the files
@@ -106,6 +108,12 @@ def create_user_files(
                 user_file_id=new_file.id,
             )
             db_session.add(project_to_user_file)
+        if persona_id:
+            persona_to_user_file = Persona__UserFile(
+                persona_id=persona_id,
+                user_file_id=new_file.id,
+            )
+            db_session.add(persona_to_user_file)
         user_files.append(new_file)
     db_session.commit()
     return CategorizedFilesResult(
@@ -123,6 +131,7 @@ def upload_files_to_user_files_with_indexing(
     temp_id_map: dict[str, str] | None,
     db_session: Session,
     background_tasks: BackgroundTasks | None = None,
+    persona_id: int | None = None,
 ) -> CategorizedFilesResult:
     if project_id is not None and user is not None:
         if not check_project_ownership(project_id, user.id, db_session):
@@ -134,7 +143,15 @@ def upload_files_to_user_files_with_indexing(
         user,
         db_session,
         temp_id_map=temp_id_map,
+        persona_id=persona_id,
     )
+    if persona_id is not None and categorized_files_result.user_files:
+        from onyx.db.persona import _mark_files_need_persona_sync
+
+        _mark_files_need_persona_sync(
+            db_session, [uf.id for uf in categorized_files_result.user_files]
+        )
+        db_session.commit()
     user_files = categorized_files_result.user_files
     rejected_files = categorized_files_result.rejected_files
     id_to_temp_id = categorized_files_result.id_to_temp_id

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -68,6 +68,8 @@ def create_user_files(
 ) -> CategorizedFilesResult:
     # Validate persona access before creating any file associations
     if persona_id is not None:
+        from fastapi import HTTPException
+
         from onyx.db.persona import fetch_persona_by_id_for_user
 
         try:
@@ -77,7 +79,7 @@ def create_user_files(
                 user=user,
                 get_editable=False,
             )
-        except Exception:
+        except HTTPException:
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "User does not have access to the specified persona",
@@ -155,6 +157,8 @@ def upload_files_to_user_files_with_indexing(
             raise OnyxError(OnyxErrorCode.NOT_FOUND, "Project not found")
 
     if persona_id is not None and user is not None:
+        from fastapi import HTTPException
+
         from onyx.db.persona import fetch_persona_by_id_for_user
 
         try:
@@ -164,7 +168,7 @@ def upload_files_to_user_files_with_indexing(
                 user=user,
                 get_editable=False,
             )
-        except Exception:
+        except HTTPException:
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "User does not have access to the specified persona",

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -108,7 +108,7 @@ def create_user_files(
                 user_file_id=new_file.id,
             )
             db_session.add(project_to_user_file)
-        if persona_id:
+        if persona_id is not None:
             persona_to_user_file = Persona__UserFile(
                 persona_id=persona_id,
                 user_file_id=new_file.id,

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -3,7 +3,6 @@ import uuid
 from typing import List
 from uuid import UUID
 
-from fastapi import HTTPException
 from fastapi import UploadFile
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -24,6 +23,8 @@ from onyx.db.models import Project__UserFile
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.models import UserProject
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents.connector import upload_files
 from onyx.server.features.projects.projects_file_utils import categorize_uploaded_files
 from onyx.server.features.projects.projects_file_utils import RejectedFile
@@ -65,6 +66,22 @@ def create_user_files(
     temp_id_map: dict[str, str] | None = None,
     persona_id: int | None = None,
 ) -> CategorizedFilesResult:
+    # Validate persona access before creating any file associations
+    if persona_id is not None:
+        from onyx.db.persona import fetch_persona_by_id_for_user
+
+        try:
+            fetch_persona_by_id_for_user(
+                db_session=db_session,
+                persona_id=persona_id,
+                user=user,
+                get_editable=False,
+            )
+        except Exception:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "User does not have access to the specified persona",
+            )
 
     # Categorize the files
     categorized_files = categorize_uploaded_files(files, db_session)
@@ -135,7 +152,23 @@ def upload_files_to_user_files_with_indexing(
 ) -> CategorizedFilesResult:
     if project_id is not None and user is not None:
         if not check_project_ownership(project_id, user.id, db_session):
-            raise HTTPException(status_code=404, detail="Project not found")
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "Project not found")
+
+    if persona_id is not None and user is not None:
+        from onyx.db.persona import fetch_persona_by_id_for_user
+
+        try:
+            fetch_persona_by_id_for_user(
+                db_session=db_session,
+                persona_id=persona_id,
+                user=user,
+                get_editable=False,
+            )
+        except Exception:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "User does not have access to the specified persona",
+            )
 
     categorized_files_result = create_user_files(
         files,

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -77,7 +77,7 @@ def create_user_files(
                 db_session=db_session,
                 persona_id=persona_id,
                 user=user,
-                get_editable=False,
+                get_editable=True,
             )
         except HTTPException:
             raise OnyxError(

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -28,6 +28,7 @@ from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.models import UserProject
 from onyx.db.persona import get_personas_by_ids
+from onyx.error_handling.exceptions import OnyxError
 from onyx.db.projects import get_project_token_count
 from onyx.db.projects import upload_files_to_user_files_with_indexing
 from onyx.server.features.projects.models import CategorizedFilesSnapshot
@@ -160,6 +161,10 @@ def upload_user_files(
 
         return CategorizedFilesSnapshot.from_result(categorized_files_result)
 
+    except OnyxError:
+        # Re-raise OnyxError (e.g. permission errors) so the global
+        # handler returns the correct status code instead of a generic 500.
+        raise
     except Exception as e:
         logger.exception(f"Error uploading files - {type(e).__name__}: {str(e)}")
         raise HTTPException(

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -129,6 +129,7 @@ def upload_user_files(
     bg_tasks: BackgroundTasks,
     files: list[UploadFile] = File(...),
     project_id: int | None = Form(None),
+    persona_id: int | None = Form(None),
     temp_id_map: str | None = Form(None),  # JSON string mapping hashed key -> temp_id
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
@@ -154,6 +155,7 @@ def upload_user_files(
             temp_id_map=parsed_temp_id_map,
             db_session=db_session,
             background_tasks=bg_tasks if DISABLE_VECTOR_DB else None,
+            persona_id=persona_id,
         )
 
         return CategorizedFilesSnapshot.from_result(categorized_files_result)

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -28,9 +28,9 @@ from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.models import UserProject
 from onyx.db.persona import get_personas_by_ids
-from onyx.error_handling.exceptions import OnyxError
 from onyx.db.projects import get_project_token_count
 from onyx.db.projects import upload_files_to_user_files_with_indexing
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.projects.models import CategorizedFilesSnapshot
 from onyx.server.features.projects.models import ChatSessionRequest
 from onyx.server.features.projects.models import TokenCountResponse

--- a/web/src/app/app/projects/projectsService.ts
+++ b/web/src/app/app/projects/projectsService.ts
@@ -85,12 +85,16 @@ export async function createProject(name: string): Promise<Project> {
 export async function uploadFiles(
   files: File[],
   projectId?: number | null,
-  tempIdMap?: Map<string, string>
+  tempIdMap?: Map<string, string>,
+  personaId?: number | null
 ): Promise<CategorizedFiles> {
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
   if (projectId !== undefined && projectId !== null) {
     formData.append("project_id", String(projectId));
+  }
+  if (personaId !== undefined && personaId !== null) {
+    formData.append("persona_id", String(personaId));
   }
   if (tempIdMap !== undefined && tempIdMap !== null) {
     formData.append(

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1358,7 +1358,10 @@ export default function useChatController({
       updateChatStateAction(getCurrentSessionId(), "uploading");
       const uploadedMessageFiles = await beginUpload(
         Array.from(acceptedFiles),
-        null
+        null,
+        undefined,
+        undefined,
+        liveAgent?.id ?? null
       );
       setCurrentMessageFiles((prev) => [...prev, ...uploadedMessageFiles]);
       updateChatStateAction(getCurrentSessionId(), "input");

--- a/web/src/providers/ProjectsContext.tsx
+++ b/web/src/providers/ProjectsContext.tsx
@@ -97,7 +97,8 @@ interface ProjectsContextType {
     files: File[],
     projectId?: number | null,
     onSuccess?: (uploaded: CategorizedFiles) => void,
-    onFailure?: (failedTempIds: string[]) => void
+    onFailure?: (failedTempIds: string[]) => void,
+    personaId?: number | null
   ) => Promise<ProjectFile[]>;
   allRecentFiles: ProjectFile[];
   allCurrentProjectFiles: ProjectFile[];
@@ -352,7 +353,8 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       files: File[],
       projectId?: number | null,
       onSuccess?: (uploaded: CategorizedFiles) => void,
-      onFailure?: (failedTempIds: string[]) => void
+      onFailure?: (failedTempIds: string[]) => void,
+      personaId?: number | null
     ): Promise<ProjectFile[]> => {
       const rawMax = settingsContext?.settings?.user_file_max_upload_size_mb;
 
@@ -386,7 +388,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
         setAllCurrentProjectFiles((prev) => [...optimisticFiles, ...prev]);
         projectToUploadFilesMapRef.current.set(projectId, optimisticFiles);
       }
-      svcUploadFiles(validFiles, projectId, tempIdMap)
+      svcUploadFiles(validFiles, projectId, tempIdMap, personaId)
         .then((uploaded) => {
           const uploadedFiles = uploaded.user_files || [];
           const tempIdToUploadedFileMap = new Map(


### PR DESCRIPTION
Fixes issue https://github.com/onyx-dot-app/onyx/issues/8088 where uploaded documents were not searchable in chat despite being successfully indexed in Vespa. Includes comprehensive security hardening to prevent unauthorized persona file attachment.

OG PR: #9722 

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add persona-aware file uploads so users can attach files to a specific persona with proper access checks and consistent errors. Files are linked to the persona and marked for persona sync in a single transaction.

- **New Features**
  - API: `upload_user_files` accepts `persona_id`; validates persona access and links files via `Persona__UserFile`.
  - DB: Marks uploaded files for persona sync before commit using `_mark_files_need_persona_sync`.
  - Errors: Replaces ad-hoc `HTTPException` with `OnyxError` (e.g., project not found, insufficient permissions); API re-raises `OnyxError`.
  - Web: `projectsService.uploadFiles`, `ProjectsContext.uploadFiles`, and chat uploads accept optional `personaId`; chat passes `liveAgent?.id` when uploading.

<sup>Written for commit 762a8c249c2da1b8d32711f0dace2efb23dc703c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

