### PR TITLE
refactor: use Opal Disabled + Card in AgentEditorPage

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -193,9 +193,10 @@ hover, active, and disabled states.
 
 ### Disabled (`core/disabled/`)
 
-A pure CSS wrapper that applies disabled visuals (`opacity-50`, `cursor-not-allowed`,
-`pointer-events: none`) to a single child element via Radix `Slot`. Has no React context —
-Interactive primitives and buttons manage their own disabled state via a `disabled` prop.
+A `<div>` wrapper that applies disabled visuals (`opacity-50`, `cursor-not-allowed`,
+`pointer-events: none`) to its children via the `data-opal-disabled` CSS attribute. Supports an
+optional `tooltip` prop (shown on hover when disabled) and `allowClick` to re-enable pointer
+events. Interactive primitives and buttons manage their own disabled state via a `disabled` prop.
 
 ### Hoverable (`core/animations/`)
 

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -1,5 +1,4 @@
 import type { HTMLAttributes } from "react";
-
 import type { RichStr, WithoutStyles } from "@opal/types";
 import { cn } from "@opal/utils";
 import { resolveStr } from "@opal/components/text/InlineMarkdown";

--- a/web/lib/opal/src/components/tooltip.css
+++ b/web/lib/opal/src/components/tooltip.css
@@ -2,6 +2,7 @@
 
 .opal-tooltip {
   z-index: var(--z-tooltip, 1300);
+  max-width: 20rem;
   @apply rounded-08 px-3 py-2 text-sm
     bg-background-neutral-dark-03 text-text-light-05
     animate-in fade-in-0 zoom-in-95

--- a/web/lib/opal/src/core/disabled/Disabled.stories.tsx
+++ b/web/lib/opal/src/core/disabled/Disabled.stories.tsx
@@ -90,12 +90,13 @@ export const WithAllowClick: Story = {
           <p className="text-sm">
             Disabled visuals, but pointer events are still active.
           </p>
-          <button
-            className="mt-2 text-xs underline"
+          <Button
+            prominence="tertiary"
+            size="sm"
             onClick={() => alert("Clicked!")}
           >
             Click me
-          </button>
+          </Button>
         </Card>
       </Disabled>
     </div>

--- a/web/lib/opal/src/core/disabled/Disabled.stories.tsx
+++ b/web/lib/opal/src/core/disabled/Disabled.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import type { Decorator } from "@storybook/react";
+import { Disabled } from "@opal/core";
+import { Card } from "@opal/components";
+import { Button } from "@opal/components/buttons/button/components";
+
+const withTooltipProvider: Decorator = (Story) => (
+  <TooltipPrimitive.Provider>
+    <Story />
+  </TooltipPrimitive.Provider>
+);
+
+const meta: Meta<typeof Disabled> = {
+  title: "opal/core/Disabled",
+  component: Disabled,
+  tags: ["autodocs"],
+  decorators: [withTooltipProvider],
+};
+
+export default meta;
+type Story = StoryObj<typeof Disabled>;
+
+const SampleContent = () => (
+  <Card border="solid" padding="md">
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-medium">Card Title</p>
+      <p className="text-xs text-text-03">Some content that can be disabled.</p>
+      <Button prominence="secondary" size="sm">
+        Action
+      </Button>
+    </div>
+  </Card>
+);
+
+export const Enabled: Story = {
+  render: () => (
+    <div className="w-80">
+      <Disabled disabled={false}>
+        <SampleContent />
+      </Disabled>
+    </div>
+  ),
+};
+
+export const DisabledState: Story = {
+  render: () => (
+    <div className="w-80">
+      <Disabled disabled>
+        <SampleContent />
+      </Disabled>
+    </div>
+  ),
+};
+
+export const WithTooltip: Story = {
+  render: () => (
+    <div className="w-80">
+      <Disabled disabled tooltip="This feature requires a Pro plan">
+        <SampleContent />
+      </Disabled>
+    </div>
+  ),
+};
+
+export const TooltipSides: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8 items-center py-16">
+      {(["top", "right", "bottom", "left"] as const).map((side) => (
+        <Disabled
+          key={side}
+          disabled
+          tooltip={`Tooltip on ${side}`}
+          tooltipSide={side}
+        >
+          <Card border="solid" padding="sm">
+            <p className="text-sm">tooltipSide: {side}</p>
+          </Card>
+        </Disabled>
+      ))}
+    </div>
+  ),
+};
+
+export const WithAllowClick: Story = {
+  render: () => (
+    <div className="w-80">
+      <Disabled disabled allowClick>
+        <Card border="solid" padding="md">
+          <p className="text-sm">
+            Disabled visuals, but pointer events are still active.
+          </p>
+          <button
+            className="mt-2 text-xs underline"
+            onClick={() => alert("Clicked!")}
+          >
+            Click me
+          </button>
+        </Card>
+      </Disabled>
+    </div>
+  ),
+};
+
+export const Comparison: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <div className="flex flex-col gap-2 w-60">
+        <p className="text-xs font-medium">Enabled</p>
+        <Disabled disabled={false}>
+          <SampleContent />
+        </Disabled>
+      </div>
+      <div className="flex flex-col gap-2 w-60">
+        <p className="text-xs font-medium">Disabled</p>
+        <Disabled disabled>
+          <SampleContent />
+        </Disabled>
+      </div>
+      <div className="flex flex-col gap-2 w-60">
+        <p className="text-xs font-medium">Disabled + Tooltip</p>
+        <Disabled disabled tooltip="Not available right now">
+          <SampleContent />
+        </Disabled>
+      </div>
+    </div>
+  ),
+};

--- a/web/lib/opal/src/core/disabled/README.md
+++ b/web/lib/opal/src/core/disabled/README.md
@@ -1,0 +1,42 @@
+# Disabled
+
+**Import:** `import { Disabled } from "@opal/core";`
+
+Wrapper component that applies baseline disabled CSS (opacity, cursor, pointer-events) to its children. Renders a `<div>` with the `data-opal-disabled` attribute so styling cascades into all descendants. Works with any children — DOM elements, React components, or fragments.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `disabled` | `boolean` | `false` | Applies disabled styling when truthy |
+| `allowClick` | `boolean` | `false` | Re-enables pointer events while keeping disabled visuals |
+| `tooltip` | `string` | — | Tooltip shown on hover when disabled (implies `allowClick`) |
+| `tooltipSide` | `"top" \| "bottom" \| "left" \| "right"` | `"right"` | Which side the tooltip appears on |
+
+## CSS behavior
+
+| Selector | Effect |
+|----------|--------|
+| `[data-opal-disabled]` | `cursor-not-allowed`, `select-none`, `pointer-events: none` |
+| `[data-opal-disabled]:not(.interactive)` | `opacity-50` (non-Interactive elements only) |
+| `[data-opal-disabled].interactive` | `pointer-events: auto` (Interactive elements handle their own disabled colors) |
+| `[data-opal-disabled][data-allow-click]` | `pointer-events: auto` |
+
+## Usage
+
+```tsx
+// Basic — disables children visually and blocks pointer events
+<Disabled disabled={!canSubmit}>
+  <Card>Content</Card>
+</Disabled>
+
+// With tooltip — explains why the section is disabled
+<Disabled disabled={!canSubmit} tooltip="Complete the form first">
+  <Card>Content</Card>
+</Disabled>
+
+// With allowClick — keeps pointer events for custom handling
+<Disabled disabled={isProcessing} allowClick>
+  <MyInputBar />
+</Disabled>
+```

--- a/web/lib/opal/src/core/disabled/README.md
+++ b/web/lib/opal/src/core/disabled/README.md
@@ -10,7 +10,7 @@ Wrapper component that applies baseline disabled CSS (opacity, cursor, pointer-e
 |------|------|---------|-------------|
 | `disabled` | `boolean` | `false` | Applies disabled styling when truthy |
 | `allowClick` | `boolean` | `false` | Re-enables pointer events while keeping disabled visuals |
-| `tooltip` | `string` | — | Tooltip shown on hover when disabled (implies `allowClick`) |
+| `tooltip` | `string \| RichStr` | — | Tooltip shown on hover when disabled (implies `allowClick`). Supports `markdown()`. |
 | `tooltipSide` | `"top" \| "bottom" \| "left" \| "right"` | `"right"` | Which side the tooltip appears on |
 
 ## CSS behavior

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -86,6 +86,8 @@ function Disabled({
 
   if (!showTooltip) return wrapper;
 
+  // TODO(@raunakab): Replace this raw Radix tooltip with the opalified
+  // Tooltip component once it lands.
   return (
     <TooltipPrimitive.Root>
       <TooltipPrimitive.Trigger asChild>{wrapper}</TooltipPrimitive.Trigger>

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -37,7 +37,7 @@ interface DisabledProps
   /** Which side the tooltip appears on. @default "right" */
   tooltipSide?: TooltipSide;
 
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { TooltipSide } from "@opal/components";
 import type { RichStr } from "@opal/types";
-import { resolveStr } from "@opal/components/text/InlineMarkdown";
+import { Text } from "@opal/components";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,7 +95,7 @@ function Disabled({
           side={tooltipSide}
           sideOffset={4}
         >
-          {resolveStr(tooltip)}
+          <Text font="secondary-body">{tooltip}</Text>
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -3,6 +3,8 @@ import "@opal/components/tooltip.css";
 import React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { TooltipSide } from "@opal/components";
+import type { RichStr } from "@opal/types";
+import { resolveStr } from "@opal/components/text/InlineMarkdown";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,10 +27,11 @@ interface DisabledProps extends React.HTMLAttributes<HTMLDivElement> {
   allowClick?: boolean;
 
   /**
-   * Tooltip text shown on hover when disabled. Implies `allowClick` so that
-   * the tooltip trigger can receive pointer events.
+   * Tooltip content shown on hover when disabled. Implies `allowClick` so that
+   * the tooltip trigger can receive pointer events. Supports inline markdown
+   * via `markdown()`.
    */
-  tooltip?: string;
+  tooltip?: string | RichStr;
 
   /** Which side the tooltip appears on. @default "right" */
   tooltipSide?: TooltipSide;
@@ -92,7 +95,7 @@ function Disabled({
           side={tooltipSide}
           sideOffset={4}
         >
-          {tooltip}
+          {resolveStr(tooltip)}
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -3,14 +3,15 @@ import "@opal/components/tooltip.css";
 import React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { TooltipSide } from "@opal/components";
-import type { RichStr } from "@opal/types";
+import type { RichStr, WithoutStyles } from "@opal/types";
 import { Text } from "@opal/components";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface DisabledProps extends React.HTMLAttributes<HTMLDivElement> {
+interface DisabledProps
+  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
   ref?: React.Ref<HTMLDivElement>;
 
   /**
@@ -77,6 +78,7 @@ function Disabled({
   const wrapper = (
     <div
       ref={ref}
+      className="opal-disabled"
       {...rest}
       aria-disabled={disabled || undefined}
       data-opal-disabled={disabled || undefined}

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -95,7 +95,7 @@ function Disabled({
       <TooltipPrimitive.Trigger asChild>{wrapper}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>
         <TooltipPrimitive.Content
-          className="opal-tooltip opal-disabled-tooltip"
+          className="opal-tooltip"
           side={tooltipSide}
           sideOffset={4}
         >

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -1,13 +1,15 @@
 import "@opal/core/disabled/styles.css";
+import "@opal/components/tooltip.css";
 import React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import type { TooltipSide } from "@opal/components";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface DisabledProps extends React.HTMLAttributes<HTMLElement> {
-  ref?: React.Ref<HTMLElement>;
+interface DisabledProps extends React.HTMLAttributes<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
 
   /**
    * When truthy, applies disabled styling to child elements.
@@ -16,13 +18,22 @@ interface DisabledProps extends React.HTMLAttributes<HTMLElement> {
 
   /**
    * When `true`, re-enables pointer events while keeping the disabled
-   * visual treatment. Useful for elements that need to show tooltips or
-   * error messages on click.
+   * visual treatment. Useful for elements that need to remain interactive
+   * (e.g. to show tooltips or handle clicks at a higher level).
    * @default false
    */
   allowClick?: boolean;
 
-  children: React.ReactElement;
+  /**
+   * Tooltip text shown on hover when disabled. Implies `allowClick` so that
+   * the tooltip trigger can receive pointer events.
+   */
+  tooltip?: string;
+
+  /** Which side the tooltip appears on. @default "right" */
+  tooltipSide?: TooltipSide;
+
+  children: React.ReactNode;
 }
 
 // ---------------------------------------------------------------------------
@@ -31,35 +42,60 @@ interface DisabledProps extends React.HTMLAttributes<HTMLElement> {
 
 /**
  * Wrapper component that applies baseline disabled CSS (opacity, cursor,
- * pointer-events) to its child element.
+ * pointer-events) to its children.
  *
- * Uses Radix `Slot` — merges props onto the single child element without
- * adding any DOM node. Works correctly inside Radix `asChild` chains.
+ * Renders a `<div>` that carries the `data-opal-disabled` attribute so the
+ * CSS rules in `styles.css` take effect on the wrapper and cascade into its
+ * descendants. Works with any children (DOM elements, React components, or
+ * fragments).
  *
  * @example
  * ```tsx
  * <Disabled disabled={!canSubmit}>
- *   <div>...</div>
+ *   <MyComponent />
+ * </Disabled>
+ *
+ * <Disabled disabled={!canSubmit} tooltip="Feature not available">
+ *   <MyComponent />
  * </Disabled>
  * ```
  */
 function Disabled({
   disabled,
   allowClick,
-  children,
+  tooltip,
+  tooltipSide = "right",
   ref,
   ...rest
 }: DisabledProps) {
-  return (
-    <Slot
+  const showTooltip = disabled && tooltip;
+  const enableClick = allowClick || showTooltip;
+
+  const wrapper = (
+    <div
       ref={ref}
       {...rest}
       aria-disabled={disabled || undefined}
       data-opal-disabled={disabled || undefined}
-      data-allow-click={disabled && allowClick ? "" : undefined}
-    >
-      {children}
-    </Slot>
+      data-allow-click={disabled && enableClick ? "" : undefined}
+    />
+  );
+
+  if (!showTooltip) return wrapper;
+
+  return (
+    <TooltipPrimitive.Root>
+      <TooltipPrimitive.Trigger asChild>{wrapper}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          className="opal-tooltip"
+          side={tooltipSide}
+          sideOffset={4}
+        >
+          {tooltip}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   );
 }
 

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -95,11 +95,13 @@ function Disabled({
       <TooltipPrimitive.Trigger asChild>{wrapper}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>
         <TooltipPrimitive.Content
-          className="opal-tooltip"
+          className="opal-tooltip opal-disabled-tooltip"
           side={tooltipSide}
           sideOffset={4}
         >
-          <Text font="secondary-body">{tooltip}</Text>
+          <Text font="secondary-body" as="p">
+            {tooltip}
+          </Text>
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -13,10 +13,6 @@
   @apply self-stretch;
 }
 
-.opal-disabled-tooltip {
-  max-width: 20rem;
-}
-
 [data-opal-disabled] {
   @apply w-full cursor-not-allowed select-none;
   pointer-events: none;

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -13,6 +13,10 @@
   @apply self-stretch;
 }
 
+.opal-disabled-tooltip {
+  max-width: 20rem;
+}
+
 [data-opal-disabled] {
   @apply w-full cursor-not-allowed select-none;
   pointer-events: none;

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -9,6 +9,10 @@
  * re-enabled so the JS layer can suppress onClick.
  */
 
+.opal-disabled {
+  @apply self-stretch;
+}
+
 [data-opal-disabled] {
   @apply cursor-not-allowed select-none;
   pointer-events: none;

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -1,4 +1,4 @@
-/* Disabled — baseline disabled visuals via Radix Slot (no extra DOM node).
+/* Disabled — baseline disabled visuals applied via a wrapper <div>.
  *
  * [data-opal-disabled]                   → cursor + pointer-events for all
  * [data-opal-disabled]:not(.interactive) → opacity for non-Interactive elements

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -14,7 +14,7 @@
 }
 
 [data-opal-disabled] {
-  @apply cursor-not-allowed select-none;
+  @apply w-full cursor-not-allowed select-none;
   pointer-events: none;
 }
 

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -1376,7 +1376,7 @@ export default function AgentEditorPage({
                               disabled={!isImageGenerationAvailable}
                               tooltip="Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin."
                             >
-                              <Card border="solid">
+                              <Card border="solid" rounding="lg">
                                 <InputLayouts.Horizontal
                                   name="image_generation"
                                   title="Image Generation"
@@ -1392,7 +1392,7 @@ export default function AgentEditorPage({
                             </Disabled>
 
                             <Disabled disabled={!webSearchTool}>
-                              <Card border="solid">
+                              <Card border="solid" rounding="lg">
                                 <InputLayouts.Horizontal
                                   name="web_search"
                                   title="Web Search"
@@ -1408,7 +1408,7 @@ export default function AgentEditorPage({
                             </Disabled>
 
                             <Disabled disabled={!openURLTool}>
-                              <Card border="solid">
+                              <Card border="solid" rounding="lg">
                                 <InputLayouts.Horizontal
                                   name="open_url"
                                   title="Open URL"
@@ -1424,7 +1424,7 @@ export default function AgentEditorPage({
                             </Disabled>
 
                             <Disabled disabled={!codeInterpreterTool}>
-                              <Card border="solid">
+                              <Card border="solid" rounding="lg">
                                 <InputLayouts.Horizontal
                                   name="code_interpreter"
                                   title="Code Interpreter"
@@ -1494,78 +1494,82 @@ export default function AgentEditorPage({
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section>
-                            <Card border="solid">
-                              <InputLayouts.Horizontal
-                                title="Share This Agent"
-                                description="with other users, groups, or everyone in your organization."
-                                center
-                              >
-                                <OpalButton
-                                  prominence="secondary"
-                                  icon={isShared ? SvgUsers : SvgLock}
-                                  onClick={() => shareAgentModal.toggle(true)}
+                            <Card border="solid" rounding="lg">
+                              <GeneralLayouts.Section width="full">
+                                <InputLayouts.Horizontal
+                                  title="Share This Agent"
+                                  description="with other users, groups, or everyone in your organization."
+                                  center
                                 >
-                                  Share
-                                </OpalButton>
-                              </InputLayouts.Horizontal>
-                              {canUpdateFeaturedStatus && (
-                                <>
-                                  <InputLayouts.Horizontal
-                                    name="is_featured"
-                                    title="Feature This Agent"
-                                    description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                  <OpalButton
+                                    prominence="secondary"
+                                    icon={isShared ? SvgUsers : SvgLock}
+                                    onClick={() => shareAgentModal.toggle(true)}
                                   >
-                                    <SwitchField name="is_featured" />
-                                  </InputLayouts.Horizontal>
-                                  {values.is_featured && !isShared && (
-                                    <Message
-                                      static
-                                      close={false}
-                                      className="w-full"
-                                      text="This agent is private to you and will only be featured for yourself."
-                                    />
-                                  )}
-                                </>
-                              )}
+                                    Share
+                                  </OpalButton>
+                                </InputLayouts.Horizontal>
+                                {canUpdateFeaturedStatus && (
+                                  <>
+                                    <InputLayouts.Horizontal
+                                      name="is_featured"
+                                      title="Feature This Agent"
+                                      description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                    >
+                                      <SwitchField name="is_featured" />
+                                    </InputLayouts.Horizontal>
+                                    {values.is_featured && !isShared && (
+                                      <Message
+                                        static
+                                        close={false}
+                                        className="w-full"
+                                        text="This agent is private to you and will only be featured for yourself."
+                                      />
+                                    )}
+                                  </>
+                                )}
+                              </GeneralLayouts.Section>
                             </Card>
 
-                            <Card border="solid">
-                              <InputLayouts.Horizontal
-                                name="llm_model"
-                                title="Default Model"
-                                description="This model will be used by Onyx by default in your chats."
-                              >
-                                <LLMSelector
+                            <Card border="solid" rounding="lg">
+                              <GeneralLayouts.Section width="full">
+                                <InputLayouts.Horizontal
                                   name="llm_model"
-                                  llmProviders={llmProviders ?? []}
-                                  currentLlm={getCurrentLlm(
-                                    values,
-                                    llmProviders
-                                  )}
-                                  onSelect={(selected) =>
-                                    onLlmSelect(selected, setFieldValue)
-                                  }
-                                />
-                              </InputLayouts.Horizontal>
-                              <InputLayouts.Horizontal
-                                name="knowledge_cutoff_date"
-                                title="Knowledge Cutoff Date"
-                                suffix="optional"
-                                description="Documents with a last-updated date prior to this will be ignored."
-                              >
-                                <InputDatePickerField
+                                  title="Default Model"
+                                  description="This model will be used by Onyx by default in your chats."
+                                >
+                                  <LLMSelector
+                                    name="llm_model"
+                                    llmProviders={llmProviders ?? []}
+                                    currentLlm={getCurrentLlm(
+                                      values,
+                                      llmProviders
+                                    )}
+                                    onSelect={(selected) =>
+                                      onLlmSelect(selected, setFieldValue)
+                                    }
+                                  />
+                                </InputLayouts.Horizontal>
+                                <InputLayouts.Horizontal
                                   name="knowledge_cutoff_date"
-                                  maxDate={new Date()}
-                                />
-                              </InputLayouts.Horizontal>
-                              <InputLayouts.Horizontal
-                                name="replace_base_system_prompt"
-                                title="Overwrite System Prompt"
-                                suffix="(Not Recommended)"
-                                description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
-                              >
-                                <SwitchField name="replace_base_system_prompt" />
-                              </InputLayouts.Horizontal>
+                                  title="Knowledge Cutoff Date"
+                                  suffix="optional"
+                                  description="Documents with a last-updated date prior to this will be ignored."
+                                >
+                                  <InputDatePickerField
+                                    name="knowledge_cutoff_date"
+                                    maxDate={new Date()}
+                                  />
+                                </InputLayouts.Horizontal>
+                                <InputLayouts.Horizontal
+                                  name="replace_base_system_prompt"
+                                  title="Overwrite System Prompt"
+                                  suffix="(Not Recommended)"
+                                  description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
+                                >
+                                  <SwitchField name="replace_base_system_prompt" />
+                                </InputLayouts.Horizontal>
+                              </GeneralLayouts.Section>
                             </Card>
 
                             <GeneralLayouts.Section gap={0.25}>
@@ -1598,7 +1602,7 @@ export default function AgentEditorPage({
                             paddingPerpendicular="fit"
                           />
 
-                          <Card border="solid">
+                          <Card border="solid" rounding="lg">
                             <InputLayouts.Horizontal
                               title="Delete This Agent"
                               description="Anyone using this agent will no longer be able to access it."

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -5,11 +5,7 @@ import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
-import {
-  Button as OpalButton,
-  Card as OpalCard,
-  Divider,
-} from "@opal/components";
+import { Button as OpalButton, Card, Divider } from "@opal/components";
 import { Disabled, Hoverable } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
@@ -38,7 +34,6 @@ import {
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
 import Text from "@/refresh-components/texts/Text";
-import { Card } from "@/refresh-components/cards";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
@@ -1381,7 +1376,7 @@ export default function AgentEditorPage({
                               disabled={!isImageGenerationAvailable}
                               tooltip="Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin."
                             >
-                              <OpalCard>
+                              <Card border="solid">
                                 <InputLayouts.Horizontal
                                   name="image_generation"
                                   title="Image Generation"
@@ -1393,11 +1388,11 @@ export default function AgentEditorPage({
                                     disabled={!isImageGenerationAvailable}
                                   />
                                 </InputLayouts.Horizontal>
-                              </OpalCard>
+                              </Card>
                             </Disabled>
 
                             <Disabled disabled={!webSearchTool}>
-                              <OpalCard>
+                              <Card border="solid">
                                 <InputLayouts.Horizontal
                                   name="web_search"
                                   title="Web Search"
@@ -1409,11 +1404,11 @@ export default function AgentEditorPage({
                                     disabled={!webSearchTool}
                                   />
                                 </InputLayouts.Horizontal>
-                              </OpalCard>
+                              </Card>
                             </Disabled>
 
                             <Disabled disabled={!openURLTool}>
-                              <OpalCard>
+                              <Card border="solid">
                                 <InputLayouts.Horizontal
                                   name="open_url"
                                   title="Open URL"
@@ -1425,11 +1420,11 @@ export default function AgentEditorPage({
                                     disabled={!openURLTool}
                                   />
                                 </InputLayouts.Horizontal>
-                              </OpalCard>
+                              </Card>
                             </Disabled>
 
                             <Disabled disabled={!codeInterpreterTool}>
-                              <OpalCard>
+                              <Card border="solid">
                                 <InputLayouts.Horizontal
                                   name="code_interpreter"
                                   title="Code Interpreter"
@@ -1441,7 +1436,7 @@ export default function AgentEditorPage({
                                     disabled={!codeInterpreterTool}
                                   />
                                 </InputLayouts.Horizontal>
-                              </OpalCard>
+                              </Card>
                             </Disabled>
 
                             {/* Tools */}
@@ -1499,7 +1494,7 @@ export default function AgentEditorPage({
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section>
-                            <Card>
+                            <Card border="solid">
                               <InputLayouts.Horizontal
                                 title="Share This Agent"
                                 description="with other users, groups, or everyone in your organization."
@@ -1534,7 +1529,7 @@ export default function AgentEditorPage({
                               )}
                             </Card>
 
-                            <Card>
+                            <Card border="solid">
                               <InputLayouts.Horizontal
                                 name="llm_model"
                                 title="Default Model"
@@ -1603,7 +1598,7 @@ export default function AgentEditorPage({
                             paddingPerpendicular="fit"
                           />
 
-                          <Card>
+                          <Card border="solid">
                             <InputLayouts.Horizontal
                               title="Delete This Agent"
                               description="Anyone using this agent will no longer be able to access it."

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -5,8 +5,12 @@ import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton, Divider } from "@opal/components";
-import { Hoverable } from "@opal/core";
+import {
+  Button as OpalButton,
+  Card as OpalCard,
+  Divider,
+} from "@opal/components";
+import { Disabled, Hoverable } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Formik, Form, FieldArray } from "formik";
@@ -536,9 +540,6 @@ export default function AgentEditorPage({
     (t) => t.in_code_tool_id === PYTHON_TOOL_ID
   );
   const isImageGenerationAvailable = !!imageGenTool;
-  const imageGenerationDisabledTooltip = isImageGenerationAvailable
-    ? undefined
-    : "Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin.";
 
   // Group MCP server tools from availableTools by server ID
   const mcpServersWithTools = mcpServers.map((server) => {
@@ -1376,17 +1377,11 @@ export default function AgentEditorPage({
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section gap={0.5}>
-                            <SimpleTooltip
-                              tooltip={imageGenerationDisabledTooltip}
-                              side="top"
+                            <Disabled
+                              disabled={!isImageGenerationAvailable}
+                              tooltip="Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin."
                             >
-                              <Card
-                                variant={
-                                  isImageGenerationAvailable
-                                    ? undefined
-                                    : "disabled"
-                                }
-                              >
+                              <OpalCard>
                                 <InputLayouts.Horizontal
                                   name="image_generation"
                                   title="Image Generation"
@@ -1398,58 +1393,56 @@ export default function AgentEditorPage({
                                     disabled={!isImageGenerationAvailable}
                                   />
                                 </InputLayouts.Horizontal>
-                              </Card>
-                            </SimpleTooltip>
+                              </OpalCard>
+                            </Disabled>
 
-                            <Card
-                              variant={!!webSearchTool ? undefined : "disabled"}
-                            >
-                              <InputLayouts.Horizontal
-                                name="web_search"
-                                title="Web Search"
-                                description="Search the web for real-time information and up-to-date results."
-                                disabled={!webSearchTool}
-                              >
-                                <SwitchField
+                            <Disabled disabled={!webSearchTool}>
+                              <OpalCard>
+                                <InputLayouts.Horizontal
                                   name="web_search"
+                                  title="Web Search"
+                                  description="Search the web for real-time information and up-to-date results."
                                   disabled={!webSearchTool}
-                                />
-                              </InputLayouts.Horizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="web_search"
+                                    disabled={!webSearchTool}
+                                  />
+                                </InputLayouts.Horizontal>
+                              </OpalCard>
+                            </Disabled>
 
-                            <Card
-                              variant={!!openURLTool ? undefined : "disabled"}
-                            >
-                              <InputLayouts.Horizontal
-                                name="open_url"
-                                title="Open URL"
-                                description="Fetch and read content from web URLs."
-                                disabled={!openURLTool}
-                              >
-                                <SwitchField
+                            <Disabled disabled={!openURLTool}>
+                              <OpalCard>
+                                <InputLayouts.Horizontal
                                   name="open_url"
+                                  title="Open URL"
+                                  description="Fetch and read content from web URLs."
                                   disabled={!openURLTool}
-                                />
-                              </InputLayouts.Horizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="open_url"
+                                    disabled={!openURLTool}
+                                  />
+                                </InputLayouts.Horizontal>
+                              </OpalCard>
+                            </Disabled>
 
-                            <Card
-                              variant={
-                                !!codeInterpreterTool ? undefined : "disabled"
-                              }
-                            >
-                              <InputLayouts.Horizontal
-                                name="code_interpreter"
-                                title="Code Interpreter"
-                                description="Generate and run code."
-                                disabled={!codeInterpreterTool}
-                              >
-                                <SwitchField
+                            <Disabled disabled={!codeInterpreterTool}>
+                              <OpalCard>
+                                <InputLayouts.Horizontal
                                   name="code_interpreter"
+                                  title="Code Interpreter"
+                                  description="Generate and run code."
                                   disabled={!codeInterpreterTool}
-                                />
-                              </InputLayouts.Horizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="code_interpreter"
+                                    disabled={!codeInterpreterTool}
+                                  />
+                                </InputLayouts.Horizontal>
+                              </OpalCard>
+                            </Disabled>
 
                             {/* Tools */}
                             <>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -598,7 +598,6 @@ function ChatPreferencesForm() {
               <Disabled
                 disabled={uniqueSources.length === 0}
                 tooltip="Set up connectors to use Search Mode"
-                tooltipSide="top"
               >
                 <InputLayouts.Horizontal
                   title="Search Mode"

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -595,33 +595,26 @@ function ChatPreferencesForm() {
               variant="section"
             />
             <Card>
-              <SimpleTooltip
-                tooltip={
-                  uniqueSources.length === 0
-                    ? "Set up connectors to use Search Mode"
-                    : undefined
-                }
-                side="top"
+              <Disabled
+                disabled={uniqueSources.length === 0}
+                tooltip="Set up connectors to use Search Mode"
+                tooltipSide="top"
               >
-                <Disabled disabled={uniqueSources.length === 0} allowClick>
-                  <div className="w-full">
-                    <InputLayouts.Horizontal
-                      title="Search Mode"
-                      description="UI mode for quick document search across your organization."
-                      disabled={uniqueSources.length === 0}
-                      nonInteractive
-                    >
-                      <Switch
-                        checked={s.search_ui_enabled ?? false}
-                        onCheckedChange={(checked) => {
-                          void saveSettings({ search_ui_enabled: checked });
-                        }}
-                        disabled={uniqueSources.length === 0}
-                      />
-                    </InputLayouts.Horizontal>
-                  </div>
-                </Disabled>
-              </SimpleTooltip>
+                <InputLayouts.Horizontal
+                  title="Search Mode"
+                  description="UI mode for quick document search across your organization."
+                  disabled={uniqueSources.length === 0}
+                  nonInteractive
+                >
+                  <Switch
+                    checked={s.search_ui_enabled ?? false}
+                    onCheckedChange={(checked) => {
+                      void saveSettings({ search_ui_enabled: checked });
+                    }}
+                    disabled={uniqueSources.length === 0}
+                  />
+                </InputLayouts.Horizontal>
+              </Disabled>
               <InputLayouts.Horizontal
                 title="Deep Research"
                 description="Agentic research system that works across the web and connected sources. Uses significantly more tokens per query."


### PR DESCRIPTION
## Description

Refactors the Actions section of `AgentEditorPage` to use the new Opal `Disabled` component (with `tooltip` support) and Opal `Card`, replacing the legacy `Card variant="disabled"` + `SimpleTooltip` + `allowClick` pattern.

Changes:
- Replace `SimpleTooltip` + legacy `Card variant="disabled"` with `Disabled` wrapping `OpalCard` for Image Generation, Web Search, Open URL, and Code Interpreter actions
- Inline the `imageGenerationDisabledTooltip` string (no longer needs a conditional variable since `Disabled` only shows tooltip when disabled)
- Consolidate `@opal/components` imports

Depends on #10119.

## How Has This Been Tested?

- `bun run types:check` passes
- Visual verification that disabled actions render with opacity and tooltip on hover

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Agent Editor to use `Disabled` from `@opal/core` with `Card` from `@opal/components`, standardizes card styling, and fixes disabled width and tooltip overflow.

- **Refactors**
  - Replace `SimpleTooltip` + legacy `Card variant="disabled"` with `Disabled` wrapping `Card` for Image Generation, Web Search, Open URL, and Code Interpreter; inline the Image Generation tooltip (only shows when disabled).
  - Use `Card border="solid" rounding="lg"` across the page; remove legacy `Card` import; wrap multi-child card contents in `GeneralLayouts.Section` for spacing.
  - Add `w-full` to `Disabled` so disabled cards stay full width; render tooltip text as a paragraph and set global `opal-tooltip` max-width to 20rem to prevent overflow.

<sup>Written for commit c26596d49ebb1cc6e519e9ca0e6fd97efb948974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

