### PR TITLE
fix(deletion): handle null connector in deletion finalization

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -508,7 +508,11 @@ def monitor_connector_deletion_taskset(
                 db_session=db_session,
                 connector_id=connector_id_to_delete,
             )
-            if not connector or not len(connector.credentials):
+            if not connector:
+                task_logger.info(
+                    "Connector deletion - Connector already deleted, skipping connector cleanup"
+                )
+            elif not len(connector.credentials):
                 task_logger.info(
                     "Connector deletion - Found no credentials left for connector, deleting connector"
                 )


### PR DESCRIPTION
## Summary
- Fixes a null safety bug in `monitor_connector_deletion_taskset` where `fetch_connector_by_id` returning `None` would cause `db_session.delete(None)` to raise `UnmappedInstanceError`
- This rolls back the entire Postgres cleanup (index attempts, permission syncs, document sets, user groups, orphan tags, cc_pair) and causes the deletion to loop every 20 seconds indefinitely
- Splits the condition into two branches: log-and-continue when the connector is already gone, only delete when it exists but has no remaining credentials

## Context
Found during a deep audit of the connector deletion workflow. While not currently triggering in production (no "Connector deletion exceptioned" logs on managed_services), a single occurrence (e.g., from a race condition or manual DB intervention) would create a permanent infinite loop.

## Test plan
- [ ] Verify existing integration tests pass (`test_connector_deletion`, `test_connector_deletion_for_overlapping_connectors`)
- [ ] Verify the new log message appears when a connector is already deleted (can be tested by manually deleting a connector from the DB while a deletion is in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix connector deletion finalization to safely handle when a connector is already gone, preventing errors and the 20s retry loop. Logs and skips cleanup if missing; only deletes when the connector exists and has no credentials.

- **Bug Fixes**
  - Guard against `None` from `fetch_connector_by_id`; log “Connector already deleted, skipping connector cleanup” and continue.
  - Only call `db_session.delete()` when the connector exists and has no credentials.
  - Prevents `UnmappedInstanceError` and the resulting infinite retry cycle.

<sup>Written for commit 08873da2986aff649eec846bbf64a73918b8dadd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

