### PR TITLE
fix(deletion): Handle Null Connector Properly

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -508,7 +508,11 @@ def monitor_connector_deletion_taskset(
                 db_session=db_session,
                 connector_id=connector_id_to_delete,
             )
-            if not connector or not len(connector.credentials):
+            if not connector:
+                task_logger.info(
+                    "Connector deletion - Connector already deleted, skipping connector cleanup"
+                )
+            elif not len(connector.credentials):
                 task_logger.info(
                     "Connector deletion - Found no credentials left for connector, deleting connector"
                 )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
- Fixes a null safety bug in `monitor_connector_deletion_taskset` where `fetch_connector_by_id` returning `None` would cause `db_session.delete(None)` to raise `UnmappedInstanceError`
- This rolls back the entire Postgres cleanup (index attempts, permission syncs, document sets, user groups, orphan tags, cc_pair) and causes the deletion to loop every 20 seconds indefinitely
- Splits the condition into two branches: log-and-continue when the connector is already gone, only delete when it exists but has no remaining credentials

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Should be handled by current unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes null connector handling in `monitor_connector_deletion_taskset` to avoid deleting a non-existent connector and breaking the deletion flow. If the connector is missing, we now log and skip; if it exists with no credentials, we delete it.

- **Bug Fixes**
  - Prevents `UnmappedInstanceError` from `db_session.delete(None)`.
  - Stops the 20s retry loop and rollback by safely handling the “already deleted” case.

<sup>Written for commit 92845bf1cdb53e5b7d4678032107e24ec98aad35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

