### PR TITLE
feat(admin): add global multi-model chat toggle

### DIFF
--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -65,6 +65,7 @@ class Settings(BaseModel):
     anonymous_user_enabled: bool | None = None
     invite_only_enabled: bool = False
     deep_research_enabled: bool | None = None
+    multi_model_chat_enabled: bool | None = None
     search_ui_enabled: bool | None = None
 
     # Whether EE features are unlocked for use.
@@ -89,7 +90,8 @@ class Settings(BaseModel):
         default=DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB, ge=0
     )
     file_token_count_threshold_k: int | None = Field(
-        default=None, ge=0  # thousands of tokens; None = context-aware default
+        default=None,
+        ge=0,  # thousands of tokens; None = context-aware default
     )
 
     # Connector settings

--- a/web/src/hooks/useSettings.test.ts
+++ b/web/src/hooks/useSettings.test.ts
@@ -48,6 +48,7 @@ describe("useSettings", () => {
       anonymous_user_enabled: false,
       invite_only_enabled: false,
       deep_research_enabled: true,
+      multi_model_chat_enabled: true,
       temperature_override_enabled: true,
       query_history_type: QueryHistoryType.NORMAL,
     });
@@ -65,6 +66,7 @@ describe("useSettings", () => {
       anonymous_user_enabled: false,
       invite_only_enabled: false,
       deep_research_enabled: true,
+      multi_model_chat_enabled: true,
       temperature_override_enabled: true,
       query_history_type: QueryHistoryType.NORMAL,
     };

--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS = {
   anonymous_user_enabled: false,
   invite_only_enabled: false,
   deep_research_enabled: true,
+  multi_model_chat_enabled: true,
   temperature_override_enabled: true,
   query_history_type: QueryHistoryType.NORMAL,
 } satisfies Settings;

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -27,6 +27,7 @@ export interface Settings {
   query_history_type: QueryHistoryType;
 
   deep_research_enabled?: boolean;
+  multi_model_chat_enabled?: boolean;
   search_ui_enabled?: boolean;
 
   // Image processing settings

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -9,6 +9,7 @@ import { useField, useFormikContext } from "formik";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import Label from "@/refresh-components/form/Label";
+import type { TagProps } from "@opal/components/tag/components";
 
 interface OrientationLayoutProps {
   name?: string;
@@ -16,6 +17,8 @@ interface OrientationLayoutProps {
   nonInteractive?: boolean;
   children?: React.ReactNode;
   title: string | RichStr;
+  /** Tag rendered inline beside the title (passed through to Content). */
+  tag?: TagProps;
   description?: string | RichStr;
   suffix?: "optional" | (string & {});
   sizePreset?: "main-content" | "main-ui";
@@ -128,6 +131,7 @@ function HorizontalInputLayout({
   children,
   center,
   title,
+  tag,
   description,
   suffix,
   sizePreset = "main-content",
@@ -144,6 +148,7 @@ function HorizontalInputLayout({
             title={title}
             description={description}
             suffix={suffix}
+            tag={tag}
             sizePreset={sizePreset}
             variant="section"
             widthVariant="full"

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -6,6 +6,7 @@ import { LlmManager } from "@/lib/hooks";
 import { getModelIcon } from "@/lib/llmConfig";
 import { Button, SelectButton, OpenButton } from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
+import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption } from "@/refresh-components/popovers/interfaces";
 import ModelListContent from "@/refresh-components/popovers/ModelListContent";
 import Separator from "@/refresh-components/Separator";
@@ -44,8 +45,12 @@ export default function ModelSelector({
   // Virtual anchor ref — points to the clicked pill so the popover positions above it
   const anchorRef = useRef<HTMLElement | null>(null);
 
+  const settings = useSettingsContext();
+  const multiModelAllowed =
+    settings?.settings?.multi_model_chat_enabled ?? true;
+
   const isMultiModel = selectedModels.length > 1;
-  const atMax = selectedModels.length >= MAX_MODELS;
+  const atMax = selectedModels.length >= MAX_MODELS || !multiModelAllowed;
 
   const selectedKeys = useMemo(
     () => new Set(selectedModels.map((m) => modelKey(m.provider, m.modelName))),

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -623,6 +623,19 @@ function ChatPreferencesForm() {
                 </Disabled>
               </SimpleTooltip>
               <InputLayouts.Horizontal
+                title="Multi-Model Generation"
+                tag={{ title: "beta", color: "blue" }}
+                description="Allow multiple models to generate responses in parallel in chat."
+                nonInteractive
+              >
+                <Switch
+                  checked={s.multi_model_chat_enabled ?? true}
+                  onCheckedChange={(checked) => {
+                    void saveSettings({ multi_model_chat_enabled: checked });
+                  }}
+                />
+              </InputLayouts.Horizontal>
+              <InputLayouts.Horizontal
                 title="Deep Research"
                 description="Agentic research system that works across the web and connected sources. Uses significantly more tokens per query."
                 nonInteractive


### PR DESCRIPTION
## Description

Adds a "Multi-Model Generation" toggle to the admin chat preferences page (under Features, after Search Mode). When disabled, the "+" button in the model selector is hidden, preventing users from comparing multiple models side-by-side. This setting is saved in the redis KV store alongside other chat preferences

- Backend: `multi_model_chat_enabled` field on `Settings` model (KV store, no migration needed)
- Frontend: reads setting via `useSettingsContext` in `ModelSelector` to gate the add button
- Admin UI: toggle with "beta" tag, default enabled
- Also adds a reusable `titleTag` prop to `InputLayouts.Horizontal` for inline tag rendering


## How Has This Been Tested?

![2026-04-13 12 52 56](https://github.com/user-attachments/assets/92bfe33c-65cf-40e7-acb0-f5f78c8328a0)


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check