### PR TITLE
feat(indexing): add error_type to index_attempt_errors

### DIFF
--- a/backend/alembic/versions/d129f37b3d87_add_error_tracking_fields_to_index_.py
+++ b/backend/alembic/versions/d129f37b3d87_add_error_tracking_fields_to_index_.py
@@ -1,0 +1,28 @@
+"""add_error_tracking_fields_to_index_attempt_errors
+
+Revision ID: d129f37b3d87
+Revises: 503883791c39
+Create Date: 2026-04-06 19:11:18.261800
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d129f37b3d87"
+down_revision = "503883791c39"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column("error_type", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("index_attempt_errors", "error_type")

--- a/backend/onyx/background/indexing/models.py
+++ b/backend/onyx/background/indexing/models.py
@@ -23,6 +23,8 @@ class IndexAttemptErrorPydantic(BaseModel):
 
     index_attempt_id: int
 
+    error_type: str | None = None
+
     @classmethod
     def from_model(cls, model: IndexAttemptError) -> "IndexAttemptErrorPydantic":
         return cls(
@@ -37,4 +39,5 @@ class IndexAttemptErrorPydantic(BaseModel):
             is_resolved=model.is_resolved,
             time_created=model.time_created,
             index_attempt_id=model.index_attempt_id,
+            error_type=model.error_type,
         )

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -134,7 +134,6 @@ class BasicExpertInfo(BaseModel):
 
     @classmethod
     def from_dict(cls, model_dict: dict[str, Any]) -> "BasicExpertInfo":
-
         first_name = cast(str, model_dict.get("FirstName"))
         last_name = cast(str, model_dict.get("LastName"))
         email = cast(str, model_dict.get("Email"))

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -899,6 +899,7 @@ def create_index_attempt_error(
     failure: ConnectorFailure,
     db_session: Session,
 ) -> int:
+    exc = failure.exception
     new_error = IndexAttemptError(
         index_attempt_id=index_attempt_id,
         connector_credential_pair_id=connector_credential_pair_id,
@@ -921,6 +922,7 @@ def create_index_attempt_error(
         ),
         failure_message=failure.failure_message,
         is_resolved=False,
+        error_type=type(exc).__name__ if exc else None,
     )
     db_session.add(new_error)
     db_session.commit()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2422,7 +2422,6 @@ class IndexAttemptError(Base):
     failure_message: Mapped[str] = mapped_column(Text)
     is_resolved: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    # ENG-3979: structured error type for observability
     error_type: Mapped[str | None] = mapped_column(String, nullable=True)
 
     time_created: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2422,6 +2422,9 @@ class IndexAttemptError(Base):
     failure_message: Mapped[str] = mapped_column(Text)
     is_resolved: Mapped[bool] = mapped_column(Boolean, default=False)
 
+    # ENG-3979: structured error type for observability
+    error_type: Mapped[str | None] = mapped_column(String, nullable=True)
+
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -92,6 +92,8 @@ export interface IndexAttemptError {
   time_created: string;
 
   index_attempt_id: number;
+
+  error_type: string | null;
 }
 
 export interface PaginatedIndexAttemptErrors {


### PR DESCRIPTION
## Description

Add `error_type` column to the existing `index_attempt_errors` table. Stores the Python exception class name (e.g. `TimeoutError`, `HttpError`, `RuntimeError`) extracted from `ConnectorFailure.exception` at persistence time.

This enables structured grouping and filtering of indexing failures by error class — answering "what types of errors are happening?" without parsing free-text `failure_message` strings.

**Changes:**
- New nullable `error_type` (String) column on `IndexAttemptError`
- `create_index_attempt_error()` extracts `type(exc).__name__` from the existing exception object
- Alembic migration `d129f37b3d87`
- Zero changes to connector code or the indexing pipeline

**Linear:** [ENG-3979](https://linear.app/onyx-app/issue/ENG-3979/capture-per-document-indexing-errors-in-sentry-structured-error-type)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check