### PR TITLE
fix(widget): surface descriptive error for trial account 429

### DIFF
--- a/backend/onyx/server/usage_limits.py
+++ b/backend/onyx/server/usage_limits.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import ANTHROPIC_DEFAULT_API_KEY
@@ -12,6 +11,8 @@ from onyx.configs.app_configs import OPENROUTER_DEFAULT_API_KEY
 from onyx.db.usage import check_usage_limit
 from onyx.db.usage import UsageLimitExceededError
 from onyx.db.usage import UsageType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.tenant_usage_limits import TenantUsageLimitKeys
 from onyx.server.tenant_usage_limits import TenantUsageLimitOverrides
 from onyx.utils.logger import setup_logger
@@ -270,4 +271,4 @@ def check_usage_and_raise(
                 "Please upgrade your plan or wait for the next billing period."
             )
 
-        raise HTTPException(status_code=429, detail=detail)
+        raise OnyxError(OnyxErrorCode.RATE_LIMITED, detail)

--- a/backend/onyx/server/usage_limits.py
+++ b/backend/onyx/server/usage_limits.py
@@ -255,11 +255,14 @@ def check_usage_and_raise(
                 "Please upgrade your plan or wait for the next billing period."
             )
         elif usage_type == UsageType.API_CALLS:
-            detail = (
-                f"API call limit exceeded for {user_type} account. "
-                f"Calls: {int(e.current)}, Limit: {int(e.limit)} per week. "
-                "Please upgrade your plan or wait for the next billing period."
-            )
+            if is_trial and e.limit == 0:
+                detail = "API access is not available on trial accounts. Please upgrade to a paid plan to use the API and chat widget."
+            else:
+                detail = (
+                    f"API call limit exceeded for {user_type} account. "
+                    f"Calls: {int(e.current)}, Limit: {int(e.limit)} per week. "
+                    "Please upgrade your plan or wait for the next billing period."
+                )
         else:
             detail = (
                 f"Non-streaming API call limit exceeded for {user_type} account. "

--- a/widget/src/services/api-service.ts
+++ b/widget/src/services/api-service.ts
@@ -37,9 +37,16 @@ export class ApiService {
     );
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to create session: ${response.status} ${response.statusText}`,
-      );
+      let detail = response.statusText;
+      try {
+        const body = await response.json();
+        if (body.detail) {
+          detail = body.detail;
+        }
+      } catch {
+        // Fall back to statusText if body isn't JSON
+      }
+      throw new Error(detail);
     }
 
     const data = (await response.json()) as CreateSessionResponse;
@@ -76,9 +83,16 @@ export class ApiService {
     );
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to send message: ${response.status} ${response.statusText}`,
-      );
+      let detail = response.statusText;
+      try {
+        const body = await response.json();
+        if (body.detail) {
+          detail = body.detail;
+        }
+      } catch {
+        // Fall back to statusText if body isn't JSON
+      }
+      throw new Error(detail);
     }
 
     // Parse SSE stream

--- a/widget/src/services/api-service.ts
+++ b/widget/src/services/api-service.ts
@@ -192,9 +192,9 @@ export class ApiService {
     try {
       const response = await fetch(url, options);
 
-      // Retry on 5xx or 429 errors
+      // Retry on 5xx errors only (not 4xx — those are permanent)
       if (!response.ok && retries < this.maxRetries) {
-        if (response.status >= 500 || response.status === 429) {
+        if (response.status >= 500) {
           const delay = this.retryDelay * Math.pow(2, retries);
           await new Promise((resolve) => setTimeout(resolve, delay));
           return this.fetchWithRetry(url, options, retries + 1);


### PR DESCRIPTION
## Description

Trial accounts have an API call limit of 0, so the chat widget would display a cryptic "Failed to send message: 429". Two changes:

1. **Backend**: When a trial account with limit=0 hits the API call check, return a clear message: "API access is not available on trial accounts. Please upgrade to a paid plan to use the API and chat widget."
2. **Widget**: Both `createSession` and `streamMessage` error handlers now read the response body JSON `detail` field instead of showing the generic HTTP status text.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check