### PR TITLE
fix(deletion): External Group Sync Check

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -316,6 +316,11 @@ def try_generate_document_cc_pair_cleanup_tasks(
                 f"Connector deletion - Delayed (permissions in progress): cc_pair={cc_pair_id}"
             )
 
+        if redis_connector.external_group_sync.fenced:
+            raise TaskDependencyError(
+                f"Connector deletion - Delayed (external group sync in progress): cc_pair={cc_pair_id}"
+            )
+
         # add tasks to celery and build up the task set to monitor in redis
         redis_connector.delete.taskset_clear()
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Add missing dependency check for external_group_sync in try_generate_document_cc_pair_cleanup_tasks. The function already checks for indexing, pruning, and permissions fences before starting deletion, but was missing the external group sync check. External group sync modifies access control data in Vespa, so running it concurrently with deletion could leave stale permissions on shared documents that survive the deletion.

The external group sync task was already being revoked in revoke_tasks_blocking_deletion (lines 116-123), but without this blocking check, deletion could proceed before revocation took effect.
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a missing external group sync fence check in `try_generate_document_cc_pair_cleanup_tasks` so connector deletion waits if group sync is in progress. This raises `TaskDependencyError` to delay deletion and prevent stale Vespa permissions on shared documents, closing a race where revocation might not take effect in time.

<sup>Written for commit f880f2901909d3860614d0e74ad91ef03960427e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

