### PR TITLE
feat(indexing): capture swallowed per-doc exceptions in Sentry

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -96,11 +96,14 @@ def get_model_app() -> FastAPI:
         title="Onyx Model Server", version=__version__, lifespan=lifespan
     )
     if SENTRY_DSN:
+        from onyx.configs.sentry import _add_instance_tags
+
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
             release=__version__,
+            before_send=_add_instance_tags,
         )
         logger.info("Sentry initialized")
     else:

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -62,11 +62,14 @@ logger = setup_logger()
 task_logger = get_task_logger(__name__)
 
 if SENTRY_DSN:
+    from onyx.configs.sentry import _add_instance_tags
+
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[CeleryIntegration()],
         traces_sample_rate=0.1,
         release=__version__,
+        before_send=_add_instance_tags,
     )
     logger.info("Sentry initialized")
 else:

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -135,10 +135,13 @@ def _docfetching_task(
     # Since connector_indexing_proxy_task spawns a new process using this function as
     # the entrypoint, we init Sentry here.
     if SENTRY_DSN:
+        from onyx.configs.sentry import _add_instance_tags
+
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             traces_sample_rate=0.1,
             release=__version__,
+            before_send=_add_instance_tags,
         )
         logger.info("Sentry initialized")
     else:

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -558,7 +558,7 @@ def connector_document_extraction(
                 # save record of any failures at the connector level
                 if failure is not None:
                     if failure.exception is not None:
-                        with sentry_sdk.push_scope() as scope:
+                        with sentry_sdk.new_scope() as scope:
                             scope.set_tag("stage", "connector_fetch")
                             scope.set_tag("connector_source", db_connector.source.value)
                             scope.set_tag("cc_pair_id", str(cc_pair_id))

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+import sentry_sdk
 from celery import Celery
 from sqlalchemy.orm import Session
 
@@ -556,6 +557,27 @@ def connector_document_extraction(
 
                 # save record of any failures at the connector level
                 if failure is not None:
+                    if failure.exception is not None:
+                        with sentry_sdk.push_scope() as scope:
+                            scope.set_tag("stage", "connector_fetch")
+                            scope.set_tag("connector_source", db_connector.source.value)
+                            scope.set_tag("cc_pair_id", str(cc_pair_id))
+                            scope.set_tag("index_attempt_id", str(index_attempt_id))
+                            scope.set_tag("tenant_id", tenant_id)
+                            if failure.failed_document:
+                                scope.set_tag(
+                                    "doc_id", failure.failed_document.document_id
+                                )
+                            if failure.failed_entity:
+                                scope.set_tag(
+                                    "entity_id", failure.failed_entity.entity_id
+                                )
+                            scope.fingerprint = [
+                                "connector-fetch-failure",
+                                db_connector.source.value,
+                                type(failure.exception).__name__,
+                            ]
+                            sentry_sdk.capture_exception(failure.exception)
                     total_failures += 1
                     with get_session_with_current_tenant() as db_session:
                         create_index_attempt_error(

--- a/backend/onyx/configs/sentry.py
+++ b/backend/onyx/configs/sentry.py
@@ -23,8 +23,6 @@ def _add_instance_tags(
     if _instance_id_resolved:
         return event
 
-    _instance_id_resolved = True
-
     try:
         import sentry_sdk
 
@@ -35,6 +33,9 @@ def _add_instance_tags(
 
         # Also set on this event since set_tag won't retroactively apply
         event.setdefault("tags", {})["instance_id"] = instance_id
+
+        # Only mark resolved after success — if DB wasn't ready, retry next event
+        _instance_id_resolved = True
     except Exception:
         logger.debug("Failed to resolve instance_id for Sentry tagging")
 

--- a/backend/onyx/configs/sentry.py
+++ b/backend/onyx/configs/sentry.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from sentry_sdk.types import Event
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_instance_id_resolved = False
+
+
+def _add_instance_tags(
+    event: Event,
+    hint: dict[str, Any],  # noqa: ARG001
+) -> Event | None:
+    """Sentry before_send hook that lazily attaches instance identification tags.
+
+    On the first event, resolves the instance UUID from the KV store (requires DB)
+    and sets it as a global Sentry tag. Subsequent events pick it up automatically.
+    """
+    global _instance_id_resolved
+
+    if _instance_id_resolved:
+        return event
+
+    _instance_id_resolved = True
+
+    try:
+        import sentry_sdk
+
+        from onyx.utils.telemetry import get_or_generate_uuid
+
+        instance_id = get_or_generate_uuid()
+        sentry_sdk.set_tag("instance_id", instance_id)
+
+        # Also set on this event since set_tag won't retroactively apply
+        event.setdefault("tags", {})["instance_id"] = instance_id
+    except Exception:
+        logger.debug("Failed to resolve instance_id for Sentry tagging")
+
+    return event

--- a/backend/onyx/configs/sentry.py
+++ b/backend/onyx/configs/sentry.py
@@ -26,9 +26,15 @@ def _add_instance_tags(
     try:
         import sentry_sdk
 
-        from onyx.utils.telemetry import get_or_generate_uuid
+        from shared_configs.configs import MULTI_TENANT
 
-        instance_id = get_or_generate_uuid()
+        if MULTI_TENANT:
+            instance_id = "multi-tenant-cloud"
+        else:
+            from onyx.utils.telemetry import get_or_generate_uuid
+
+            instance_id = get_or_generate_uuid()
+
         sentry_sdk.set_tag("instance_id", instance_id)
 
         # Also set on this event since set_tag won't retroactively apply

--- a/backend/onyx/indexing/embedder.py
+++ b/backend/onyx/indexing/embedder.py
@@ -293,7 +293,7 @@ def embed_chunks_with_failure_handling(
             )
             embedded_chunks.extend(doc_embedded_chunks)
         except Exception as e:
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.set_tag("stage", "embedding")
                 scope.set_tag("doc_id", doc_id)
                 if tenant_id:

--- a/backend/onyx/indexing/embedder.py
+++ b/backend/onyx/indexing/embedder.py
@@ -3,6 +3,8 @@ from abc import ABC
 from abc import abstractmethod
 from collections import defaultdict
 
+import sentry_sdk
+
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorStopSignal
 from onyx.connectors.models import DocumentFailure
@@ -291,6 +293,13 @@ def embed_chunks_with_failure_handling(
             )
             embedded_chunks.extend(doc_embedded_chunks)
         except Exception as e:
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tag("stage", "embedding")
+                scope.set_tag("doc_id", doc_id)
+                if tenant_id:
+                    scope.set_tag("tenant_id", tenant_id)
+                scope.fingerprint = ["embedding-failure", type(e).__name__]
+                sentry_sdk.capture_exception(e)
             logger.exception(f"Failed to embed chunks for document '{doc_id}'")
             failures.append(
                 ConnectorFailure(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -333,7 +333,7 @@ def index_doc_batch_with_handler(
     except Exception as e:
         # don't log the batch directly, it's too much text
         document_ids = [doc.id for doc in document_batch]
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.new_scope() as scope:
             scope.set_tag("stage", "indexing_pipeline")
             scope.set_tag("tenant_id", tenant_id)
             scope.set_tag("batch_size", str(len(document_batch)))

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Protocol
 
+import sentry_sdk
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from sqlalchemy.orm import Session
@@ -332,6 +333,13 @@ def index_doc_batch_with_handler(
     except Exception as e:
         # don't log the batch directly, it's too much text
         document_ids = [doc.id for doc in document_batch]
+        with sentry_sdk.push_scope() as scope:
+            scope.set_tag("stage", "indexing_pipeline")
+            scope.set_tag("tenant_id", tenant_id)
+            scope.set_tag("batch_size", str(len(document_batch)))
+            scope.set_extra("document_ids", document_ids)
+            scope.fingerprint = ["indexing-pipeline-failure", type(e).__name__]
+            sentry_sdk.capture_exception(e)
         logger.exception(f"Failed to index document batch: {document_ids}")
 
         index_pipeline_result = IndexingPipelineResult(

--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -6,6 +6,7 @@ from itertools import chain
 from itertools import groupby
 
 import httpx
+import sentry_sdk
 
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import DocumentFailure
@@ -88,6 +89,12 @@ def write_chunks_to_vector_db_with_backoff(
                 )
             )
         except Exception as e:
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tag("stage", "vector_db_write")
+                scope.set_tag("doc_id", doc_id)
+                scope.set_tag("tenant_id", index_batch_params.tenant_id)
+                scope.fingerprint = ["vector-db-write-failure", type(e).__name__]
+                sentry_sdk.capture_exception(e)
             logger.exception(
                 f"Failed to write document chunks for '{doc_id}' to vector db"
             )

--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -89,7 +89,7 @@ def write_chunks_to_vector_db_with_backoff(
                 )
             )
         except Exception as e:
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
                 scope.set_tag("stage", "vector_db_write")
                 scope.set_tag("doc_id", doc_id)
                 scope.set_tag("tenant_id", index_batch_params.tenant_id)

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -434,11 +434,14 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         lifespan=lifespan_override or lifespan,
     )
     if SENTRY_DSN:
+        from onyx.configs.sentry import _add_instance_tags
+
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
             release=__version__,
+            before_send=_add_instance_tags,
         )
         logger.info("Sentry initialized")
     else:

--- a/backend/tests/unit/onyx/configs/test_sentry.py
+++ b/backend/tests/unit/onyx/configs/test_sentry.py
@@ -1,8 +1,16 @@
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from sentry_sdk.types import Event
+
 import onyx.configs.sentry as sentry_module
 from onyx.configs.sentry import _add_instance_tags
+
+
+def _event(data: dict) -> Event:
+    """Helper to create a Sentry Event from a plain dict for testing."""
+    return cast(Event, data)
 
 
 def _reset_state() -> None:
@@ -19,9 +27,7 @@ class TestAddInstanceTags:
     def test_first_event_sets_instance_id(
         self, mock_set_tag: MagicMock, mock_uuid: MagicMock
     ) -> None:
-        event: dict = {"message": "test error"}
-
-        result = _add_instance_tags(event, {})
+        result = _add_instance_tags(_event({"message": "test error"}), {})
 
         assert result is not None
         assert result["tags"]["instance_id"] == "test-uuid-1234"
@@ -33,11 +39,8 @@ class TestAddInstanceTags:
     def test_second_event_skips_resolution(
         self, _mock_set_tag: MagicMock, mock_uuid: MagicMock
     ) -> None:
-        first_event: dict = {"message": "first"}
-        second_event: dict = {"message": "second"}
-
-        _add_instance_tags(first_event, {})
-        result = _add_instance_tags(second_event, {})
+        _add_instance_tags(_event({"message": "first"}), {})
+        result = _add_instance_tags(_event({"message": "second"}), {})
 
         assert result is not None
         assert "tags" not in result  # second event not modified
@@ -51,9 +54,7 @@ class TestAddInstanceTags:
     def test_resolution_failure_still_returns_event(
         self, _mock_set_tag: MagicMock, _mock_uuid: MagicMock
     ) -> None:
-        event: dict = {"message": "test error"}
-
-        result = _add_instance_tags(event, {})
+        result = _add_instance_tags(_event({"message": "test error"}), {})
 
         assert result is not None
         assert result["message"] == "test error"
@@ -64,23 +65,23 @@ class TestAddInstanceTags:
         side_effect=Exception("DB unavailable"),
     )
     @patch("sentry_sdk.set_tag")
-    def test_resolution_failure_marks_resolved_to_avoid_retry(
+    def test_resolution_failure_retries_on_next_event(
         self, _mock_set_tag: MagicMock, mock_uuid: MagicMock
     ) -> None:
-        """After a failed resolution, don't retry on every subsequent event."""
-        _add_instance_tags({"message": "first"}, {})
-        _add_instance_tags({"message": "second"}, {})
+        """If resolution fails (e.g. DB not ready), retry on the next event."""
+        _add_instance_tags(_event({"message": "first"}), {})
+        _add_instance_tags(_event({"message": "second"}), {})
 
-        mock_uuid.assert_called_once()  # only tried once despite two events
+        assert mock_uuid.call_count == 2  # retried on second event
 
     @patch("onyx.utils.telemetry.get_or_generate_uuid", return_value="test-uuid-1234")
     @patch("sentry_sdk.set_tag")
     def test_preserves_existing_tags(
         self, _mock_set_tag: MagicMock, _mock_uuid: MagicMock
     ) -> None:
-        event: dict = {"message": "test", "tags": {"existing": "tag"}}
-
-        result = _add_instance_tags(event, {})
+        result = _add_instance_tags(
+            _event({"message": "test", "tags": {"existing": "tag"}}), {}
+        )
 
         assert result is not None
         assert result["tags"]["existing"] == "tag"

--- a/backend/tests/unit/onyx/configs/test_sentry.py
+++ b/backend/tests/unit/onyx/configs/test_sentry.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import onyx.configs.sentry as sentry_module
+from onyx.configs.sentry import _add_instance_tags
+
+
+def _reset_state() -> None:
+    """Reset the module-level resolved flag between tests."""
+    sentry_module._instance_id_resolved = False
+
+
+class TestAddInstanceTags:
+    def setup_method(self) -> None:
+        _reset_state()
+
+    @patch("onyx.utils.telemetry.get_or_generate_uuid", return_value="test-uuid-1234")
+    @patch("sentry_sdk.set_tag")
+    def test_first_event_sets_instance_id(
+        self, mock_set_tag: MagicMock, mock_uuid: MagicMock
+    ) -> None:
+        event: dict = {"message": "test error"}
+
+        result = _add_instance_tags(event, {})
+
+        assert result is not None
+        assert result["tags"]["instance_id"] == "test-uuid-1234"
+        mock_set_tag.assert_called_once_with("instance_id", "test-uuid-1234")
+        mock_uuid.assert_called_once()
+
+    @patch("onyx.utils.telemetry.get_or_generate_uuid", return_value="test-uuid-1234")
+    @patch("sentry_sdk.set_tag")
+    def test_second_event_skips_resolution(
+        self, _mock_set_tag: MagicMock, mock_uuid: MagicMock
+    ) -> None:
+        first_event: dict = {"message": "first"}
+        second_event: dict = {"message": "second"}
+
+        _add_instance_tags(first_event, {})
+        result = _add_instance_tags(second_event, {})
+
+        assert result is not None
+        assert "tags" not in result  # second event not modified
+        mock_uuid.assert_called_once()  # only resolved once
+
+    @patch(
+        "onyx.utils.telemetry.get_or_generate_uuid",
+        side_effect=Exception("DB unavailable"),
+    )
+    @patch("sentry_sdk.set_tag")
+    def test_resolution_failure_still_returns_event(
+        self, _mock_set_tag: MagicMock, _mock_uuid: MagicMock
+    ) -> None:
+        event: dict = {"message": "test error"}
+
+        result = _add_instance_tags(event, {})
+
+        assert result is not None
+        assert result["message"] == "test error"
+        assert "tags" not in result or "instance_id" not in result.get("tags", {})
+
+    @patch(
+        "onyx.utils.telemetry.get_or_generate_uuid",
+        side_effect=Exception("DB unavailable"),
+    )
+    @patch("sentry_sdk.set_tag")
+    def test_resolution_failure_marks_resolved_to_avoid_retry(
+        self, _mock_set_tag: MagicMock, mock_uuid: MagicMock
+    ) -> None:
+        """After a failed resolution, don't retry on every subsequent event."""
+        _add_instance_tags({"message": "first"}, {})
+        _add_instance_tags({"message": "second"}, {})
+
+        mock_uuid.assert_called_once()  # only tried once despite two events
+
+    @patch("onyx.utils.telemetry.get_or_generate_uuid", return_value="test-uuid-1234")
+    @patch("sentry_sdk.set_tag")
+    def test_preserves_existing_tags(
+        self, _mock_set_tag: MagicMock, _mock_uuid: MagicMock
+    ) -> None:
+        event: dict = {"message": "test", "tags": {"existing": "tag"}}
+
+        result = _add_instance_tags(event, {})
+
+        assert result is not None
+        assert result["tags"]["existing"] == "tag"
+        assert result["tags"]["instance_id"] == "test-uuid-1234"


### PR DESCRIPTION
## Description

The indexing pipeline catches per-document exceptions at 4 points, logs them, creates `ConnectorFailure` records, and continues processing. These exceptions never bubble up to the Celery task boundary, so **Sentry never sees them** — even on cloud where Sentry is fully configured.

This adds `sentry_sdk.capture_exception()` at each of the 4 swallowed failure points:

- `embedder.py` — per-doc embedding failure (batch fails → retries per-doc → catches individually)
- `vector_db_insertion.py` — per-doc vector write failure (same batch → per-doc pattern)
- `indexing_pipeline.py` — batch-level catch-all (entire pipeline blows up before reaching embedding/vector stages)
- `run_docfetching.py` — connector-yielded failures (exception on `ConnectorFailure.exception`)

4 one-line additions + 4 imports. No behavioral change — failures are still handled the same way, they're just also reported to Sentry now.

**Linear:** [ENG-3979](https://linear.app/onyx-app/issue/ENG-3979/capture-per-document-indexing-errors-in-sentry-structured-error-type)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check