### PR TITLE
fix: show correct knowledge toggle status on agent edit page

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -571,8 +571,13 @@ export default function AgentEditorPage({
       (_, i) => existingAgent?.starter_messages?.[i]?.message ?? ""
     ),
 
-    // Knowledge - enabled if agent has any knowledge sources attached
+    // Knowledge - enabled if the agent has the internal search tool attached
+    // or any knowledge sources attached.
     enable_knowledge:
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
+      ) ??
+        false) ||
       (existingAgent?.document_sets?.length ?? 0) > 0 ||
       (existingAgent?.hierarchy_nodes?.length ?? 0) > 0 ||
       (existingAgent?.attached_documents?.length ?? 0) > 0 ||


### PR DESCRIPTION
## Description
- UI only issue where `Use Knowledge` toggle would show false when user explicitly enabled it previously
- Knowledge toggle bool did not check if the persona had internal search enabled already
- To repro issue: create an agent --> toggle internal search on --> save --> edit the same agent again and see that internal search toggle is off


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Knowledge toggle on the Agent Editor page to show ON when the agent has the internal search tool or any attached knowledge sources. Prevents the toggle from incorrectly showing OFF for agents using internal search.

- **Bug Fixes**
  - Toggle now also checks for `SEARCH_TOOL_ID` in `existingAgent.tools`, alongside existing checks for document sets, hierarchy nodes, and attached documents.

<sup>Written for commit 567ad5d638c3ce56c595b13ada8f3981566cdcec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

