### PR TITLE
fix: llm popover should refresh on admin provider edit

### DIFF
--- a/web/src/hooks/useLLMProviders.ts
+++ b/web/src/hooks/useLLMProviders.ts
@@ -49,11 +49,15 @@ export function useLLMProviders(personaId?: number) {
       ? SWR_KEYS.llmProvidersForPersona(personaId)
       : SWR_KEYS.llmProviders;
 
+  // `revalidateIfStale` is intentionally left at its default (true), unlike
+  // `useAdminLLMProviders` below. Admin edits call `refreshLlmProviderCaches`,
+  // but persona-scoped keys are orphaned when that runs, so `mutate` on them
+  // is a no-op. Mount-time revalidation picks up the edits on next nav.
+  // `dedupingInterval: 60000` keeps this off the hot path.
   const { data, error, mutate } = useSWR<
     LLMProviderResponse<LLMProviderDescriptor>
   >(url, errorHandlingFetcher, {
     revalidateOnFocus: false,
-    revalidateIfStale: false,
     dedupingInterval: 60000,
   });
 


### PR DESCRIPTION
## Description

Issue:
- If admin edits an LLM provider's available models, then navigates to the chat page --> the llm popover list is not refreshed
- Calling mutate is no-op because the popover is not mounted (for the admin)

Fix:
- Allow `revalidateIfStale` to refresh the popover on mount

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LLM provider popover not updating after an admin edits providers. Restores stale revalidation in useLLMProviders for persona-scoped lists so the popover refreshes on next navigation, while keeping focus revalidation off and a 60s dedupe interval.

<sup>Written for commit 7d0a18910e0761bf31d0ba12ef5d53039ec0f8ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

