### PR TITLE
feat(ee): opt-in Sentry DSN for self-hosted error visibility

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -18,6 +18,7 @@ from model_server.encoders import router as encoders_router
 from model_server.management_endpoints import router as management_router
 from model_server.utils import get_gpu_type
 from onyx import __version__
+from onyx.configs.sentry import resolve_sentry_dsn
 from onyx.utils.logger import setup_logger
 from onyx.utils.logger import setup_uvicorn_logger
 from onyx.utils.middleware import add_onyx_request_id_middleware
@@ -26,7 +27,6 @@ from shared_configs.configs import INDEXING_ONLY
 from shared_configs.configs import MIN_THREADS_ML_MODELS
 from shared_configs.configs import MODEL_SERVER_ALLOWED_HOST
 from shared_configs.configs import MODEL_SERVER_PORT
-from shared_configs.configs import SENTRY_DSN
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
@@ -95,9 +95,10 @@ def get_model_app() -> FastAPI:
     application = FastAPI(
         title="Onyx Model Server", version=__version__, lifespan=lifespan
     )
-    if SENTRY_DSN:
+    _sentry_dsn = resolve_sentry_dsn()
+    if _sentry_dsn:
         sentry_sdk.init(
-            dsn=SENTRY_DSN,
+            dsn=_sentry_dsn,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
             release=__version__,

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -31,6 +31,7 @@ from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxRedisLocks
+from onyx.configs.sentry import resolve_sentry_dsn
 from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.document_index.opensearch.client import (
     wait_for_opensearch_with_timeout,
@@ -53,7 +54,6 @@ from onyx.utils.logger import setup_logger
 from shared_configs.configs import DEV_LOGGING_ENABLED
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
-from shared_configs.configs import SENTRY_DSN
 from shared_configs.configs import TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -61,9 +61,10 @@ logger = setup_logger()
 
 task_logger = get_task_logger(__name__)
 
-if SENTRY_DSN:
+_sentry_dsn = resolve_sentry_dsn()
+if _sentry_dsn:
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
+        dsn=_sentry_dsn,
         integrations=[CeleryIntegration()],
         traces_sample_rate=0.1,
         release=__version__,

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -25,6 +25,7 @@ from onyx.background.indexing.job_client import SimpleJobException
 from onyx.background.indexing.run_docfetching import run_docfetching_entrypoint
 from onyx.configs.constants import CELERY_INDEXING_WATCHDOG_CONNECTOR_TIMEOUT
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.configs.sentry import resolve_sentry_dsn
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -36,7 +37,6 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import global_version
-from shared_configs.configs import SENTRY_DSN
 
 logger = setup_logger()
 
@@ -134,9 +134,10 @@ def _docfetching_task(
 ) -> None:
     # Since connector_indexing_proxy_task spawns a new process using this function as
     # the entrypoint, we init Sentry here.
-    if SENTRY_DSN:
+    _sentry_dsn = resolve_sentry_dsn()
+    if _sentry_dsn:
         sentry_sdk.init(
-            dsn=SENTRY_DSN,
+            dsn=_sentry_dsn,
             traces_sample_rate=0.1,
             release=__version__,
         )

--- a/backend/onyx/configs/sentry.py
+++ b/backend/onyx/configs/sentry.py
@@ -1,0 +1,26 @@
+import os
+
+from shared_configs.configs import SENTRY_DSN
+
+
+def resolve_sentry_dsn() -> str | None:
+    """Resolve the Sentry DSN.
+
+    Priority:
+    1. Explicit SENTRY_DSN env var (any deployment — cloud sets this in infra)
+    2. Bundled DSN (ONYX_BUNDLED_SENTRY_DSN + ENABLE_ONYX_SENTRY_REPORTING=true)
+    3. None (disabled)
+
+    The bundled DSN is injected at build time via the ONYX_BUNDLED_SENTRY_DSN
+    env var (never hardcoded in source). For managed customer clusters, Onyx
+    sets both env vars. Self-hosted customers can opt in by setting both.
+    """
+    if SENTRY_DSN:
+        return SENTRY_DSN
+
+    bundled_dsn = os.environ.get("ONYX_BUNDLED_SENTRY_DSN")
+    opt_in = os.environ.get("ENABLE_ONYX_SENTRY_REPORTING", "").lower() == "true"
+    if bundled_dsn and opt_in:
+        return bundled_dsn
+
+    return None

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -56,6 +56,7 @@ from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
+from onyx.configs.sentry import resolve_sentry_dsn
 from onyx.db.engine.async_sql_engine import get_sqlalchemy_async_engine
 from onyx.db.engine.connection_warmup import warm_up_connections
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -165,7 +166,6 @@ from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
 from shared_configs.configs import CORS_ALLOWED_ORIGIN
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
-from shared_configs.configs import SENTRY_DSN
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 warnings.filterwarnings(
@@ -433,9 +433,10 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         ],
         lifespan=lifespan_override or lifespan,
     )
-    if SENTRY_DSN:
+    _sentry_dsn = resolve_sentry_dsn()
+    if _sentry_dsn:
         sentry_sdk.init(
-            dsn=SENTRY_DSN,
+            dsn=_sentry_dsn,
             integrations=[StarletteIntegration(), FastApiIntegration()],
             traces_sample_rate=0.1,
             release=__version__,

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -161,7 +161,8 @@ DEFAULT_REDIS_PREFIX = os.environ.get("DEFAULT_REDIS_PREFIX") or "default"
 
 
 async def async_return_default_schema(
-    *args: Any, **kwargs: Any  # noqa: ARG001
+    *args: Any,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
 ) -> str:  # noqa: ARG001
     return POSTGRES_DEFAULT_SCHEMA
 


### PR DESCRIPTION
## Description

EE self-hosted customers currently have zero error visibility — we're completely blind to their indexing failures. This adds opt-in Sentry support for EE self-hosted deployments.

**How it works:**

| Priority | Condition | Result |
|---|---|---|
| 1 | `SENTRY_DSN` env var set | Uses that DSN (cloud, or customer's own Sentry) |
| 2 | EE + `ENABLE_ONYX_SENTRY_REPORTING=true` + `ONYX_BUNDLED_SENTRY_DSN` set | Uses the bundled Onyx DSN |
| 3 | Otherwise | Sentry disabled |

The actual DSN is injected at build time via `ONYX_BUNDLED_SENTRY_DSN` — never hardcoded in source. CI needs a secret for this env var in the EE Docker build.

No behavioral change for cloud (already sets `SENTRY_DSN` in infra) or CE (no Sentry).

**Linear:** [ENG-3985](https://linear.app/onyx-app/issue/ENG-3985/ee-ship-sentry-dsn-for-self-hosted-error-visibility)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check