### PR TITLE
fix(pruning): Release DB connection before connector enumeration in pruning

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -38,6 +38,7 @@ from onyx.configs.constants import OnyxRedisConstants
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import OnyxRedisSignals
 from onyx.connectors.factory import instantiate_connector
+from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.models import InputType
 from onyx.db.connector import mark_ccpair_as_pruned
 from onyx.db.connector_credential_pair import get_connector_credential_pair
@@ -525,6 +526,14 @@ def connector_pruning_generator_task(
         return None
 
     try:
+        # Session 1: pre-enumeration — load cc_pair and instantiate the connector.
+        # The session is closed before enumeration so the DB connection is not held
+        # open during the 10–30+ minute connector crawl.
+        connector_source: DocumentSource | None = None
+        connector_type: str = ""
+        is_connector_public: bool = False
+        runnable_connector: BaseConnector | None = None
+
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair(
                 db_session=db_session,
@@ -550,44 +559,46 @@ def connector_pruning_generator_task(
             )
             redis_connector.prune.set_fence(new_payload)
 
+            connector_source = cc_pair.connector.source
+            connector_type = connector_source.value
+            is_connector_public = cc_pair.access_type == AccessType.PUBLIC
+
             task_logger.info(
-                f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={cc_pair.connector.source}"
+                f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={connector_source}"
             )
 
             runnable_connector = instantiate_connector(
                 db_session,
-                cc_pair.connector.source,
+                connector_source,
                 InputType.SLIM_RETRIEVAL,
                 cc_pair.connector.connector_specific_config,
                 cc_pair.credential,
             )
+        # Session 1 closed here — connection released before enumeration.
 
-            callback = PruneCallback(
-                0,
-                redis_connector,
-                lock,
-                r,
-                timeout_seconds=JOB_TIMEOUT,
-            )
+        callback = PruneCallback(
+            0,
+            redis_connector,
+            lock,
+            r,
+            timeout_seconds=JOB_TIMEOUT,
+        )
 
-            # Extract docs and hierarchy nodes from the source
-            connector_type = cc_pair.connector.source.value
-            extraction_result = extract_ids_from_runnable_connector(
-                runnable_connector, callback, connector_type=connector_type
-            )
-            all_connector_doc_ids = extraction_result.raw_id_to_parent
+        # Extract docs and hierarchy nodes from the source (no DB session held).
+        extraction_result = extract_ids_from_runnable_connector(
+            runnable_connector, callback, connector_type=connector_type
+        )
+        all_connector_doc_ids = extraction_result.raw_id_to_parent
 
-            # Process hierarchy nodes (same as docfetching):
-            # upsert to Postgres and cache in Redis
-            source = cc_pair.connector.source
+        # Session 2: post-enumeration — hierarchy upserts, diff computation, task dispatch.
+        with get_session_with_current_tenant() as db_session:
+            source = connector_source
             redis_client = get_redis_client(tenant_id=tenant_id)
 
             ensure_source_node_exists(redis_client, db_session, source)
 
             upserted_nodes: list[DBHierarchyNode] = []
             if extraction_result.hierarchy_nodes:
-                is_connector_public = cc_pair.access_type == AccessType.PUBLIC
-
                 upserted_nodes = upsert_hierarchy_nodes_batch(
                     db_session=db_session,
                     nodes=extraction_result.hierarchy_nodes,
@@ -658,7 +669,7 @@ def connector_pruning_generator_task(
                 task_logger.info(
                     "Pruning set collected: "
                     f"cc_pair={cc_pair_id} "
-                    f"connector_source={cc_pair.connector.source} "
+                    f"connector_source={connector_source} "
                     f"docs_to_remove={len(doc_ids_to_remove)}"
                 )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

connector_pruning_generator_task held a single DB session open for the entire task — including connector enumeration, which can take 10–30+ minutes. Under concurrent load (95+ tasks), this exhausted Aurora's connection pool and caused 88 OperationalError failures on April 10.

Split into two sessions: one before enumeration to load the cc_pair and instantiate the connector, and one after to handle DB writes. The connection is released before the long crawl and reacquired only when needed. No behavioral change to pruning logic.

more details: https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.kqt9owz1xyea#heading=h.i2b5dyrqw6iu

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness

## How Has This Been Tested?

  Test plan
  - Run backend/tests/integration/tests/pruning/test_pruning.py and confirm pruning completes successfully end-to-end
  - Monitor pruning OperationalError failure rate in production after rollout — expect the April 10 pattern to not recur

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release the DB connection before long connector enumeration in pruning to prevent Aurora pool exhaustion under load. The task now uses two short-lived DB sessions with no change to pruning behavior. Aligns with Linear ENG-3954 (pruning correctness).

- **Bug Fixes**
  - Use a first session to load the `cc_pair`, capture `connector_source`/`is_connector_public`, and instantiate the runnable connector; close it before enumeration.
  - Run extraction and callback without a DB session; open a second session for hierarchy upserts, diffing, and task dispatch.
  - Refactor: add `BaseConnector` typing, stop referencing `cc_pair` after session close, and log via saved connector source. Avoids 10–30+ minute holds and mitigates the Apr 10 OperationalError spike.

<sup>Written for commit b5e0f494d1c040ea2d0b173c3f7fca685a31b336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



