### PR TITLE
fix(pruning): Adjust Prometheus histogram buckets for pruning metrics

### DIFF
--- a/backend/onyx/server/metrics/pruning_metrics.py
+++ b/backend/onyx/server/metrics/pruning_metrics.py
@@ -28,14 +28,14 @@ PRUNING_ENUMERATION_DURATION = Histogram(
     "onyx_pruning_enumeration_duration_seconds",
     "Duration of document ID enumeration from the source connector during pruning",
     ["connector_type"],
-    buckets=[1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600],
+    buckets=[5, 60, 600, 1800, 3600, 10800, 21600],
 )
 
 PRUNING_DIFF_DURATION = Histogram(
     "onyx_pruning_diff_duration_seconds",
     "Duration of diff computation and subtask dispatch during pruning",
     ["connector_type"],
-    buckets=[1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600],
+    buckets=[0.1, 0.25, 0.5, 1, 2, 5, 15, 30, 60],
 )
 
 PRUNING_RATE_LIMIT_ERRORS = Counter(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Update bucket boundaries for onyx_pruning_enumeration_duration_seconds and onyx_pruning_diff_duration_seconds to better reflect observed distributions.

  - Enumeration: coarser at the low end (0–5s as one bucket), 0–5s, 5s–1min, 1–10min, 10–30min, 30min–1hr, 1–3hr, 3–6hr, >6hr.
  - Diff: granular sub-second buckets (100ms, 250ms, 500ms) since most diff operations complete under 1s
Current
<img width="779" height="289" alt="Screenshot 2026-04-13 at 4 13 35 PM" src="https://github.com/user-attachments/assets/047be595-3764-4704-b8e4-eae4008dc3e7" />
<img width="783" height="286" alt="Screenshot 2026-04-13 at 4 13 30 PM" src="https://github.com/user-attachments/assets/a4d41045-49bc-4483-9af9-addc2c55f6af" />

New buckets take effect on next deployment. Historical data in AMP remains queryable with old boundaries.

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness

## How Has This Been Tested?
n/a
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retuned Prometheus histogram buckets for pruning metrics to match real runtimes and improve visibility. Aligns with Linear ENG-3954 (pruning correctness).

- **Refactors**
  - Enumeration duration: buckets -> [5, 60, 600, 1800, 3600, 10800, 21600] seconds.
  - Diff duration: buckets -> [0.1, 0.25, 0.5, 1, 2, 5, 15, 30, 60] seconds.

- **Migration**
  - No action needed. New buckets apply after deploy; historical data remains queryable.

<sup>Written for commit 935f453dbd9f4cbba2283bf9222137995d425ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



