### PR TITLE
fix(pruning): Commit hierarchy node upserts atomically in pruning

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -592,7 +592,7 @@ def connector_pruning_generator_task(
                     db_session=db_session,
                     nodes=extraction_result.hierarchy_nodes,
                     source=source,
-                    commit=True,
+                    commit=False,
                     is_connector_public=is_connector_public,
                 )
 
@@ -601,8 +601,12 @@ def connector_pruning_generator_task(
                     hierarchy_node_ids=[n.id for n in upserted_nodes],
                     connector_id=connector_id,
                     credential_id=credential_id,
-                    commit=True,
+                    commit=False,
                 )
+
+                # Single commit so the FK reference in the join table can never
+                # outrun the parent hierarchy_node insert.
+                db_session.commit()
 
                 cache_entries = [
                     HierarchyNodeCacheEntry.from_db_model(node)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

upsert_hierarchy_nodes_batch and upsert_hierarchy_node_cc_pair_entries were committed separately. If anything interrupted between the two commits, the join table insert would reference hierarchy_node rows that were never durably written, causing IntegrityError: foreign key constraint violation. Changed both to commit=False with a single db_session.commit() after both writes, making the inserts atomic.

Example we have been seeing:
```
cc_pair=40 (Notion)
IntegrityError: insert or update on table "hierarchynodebyconnectorcredentialpair"  violates foreign key constraint "hierarchynodebyconnectorcredentialpair_hierarchy_node_id_fkey"
 DETAIL: Key (hierarchy_node_id)=(12847) is not present in table "hierarchy_node".
```


More details can be found here: https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.jpsubs3fme0x

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make hierarchy node upserts and their join-table inserts atomic in pruning to prevent foreign key violations if a task is interrupted. Addresses ENG-3954 (pruning correctness).

- **Bug Fixes**
  - Set commit=False in upsert_hierarchy_nodes_batch and upsert_hierarchy_node_cc_pair_entries, then call a single db_session.commit().
  - Ensures the join table never references hierarchy_node rows that aren’t durably written, avoiding IntegrityError.

<sup>Written for commit 865f3223f445814048411dd67696a0b2fbbdd7fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

