### PR TITLE
feat(metrics): Add Deletion-specific Prometheus Metrics

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -63,7 +63,7 @@ from onyx.server.metrics.deletion_metrics import inc_deletion_blocked
 from onyx.server.metrics.deletion_metrics import inc_deletion_completed
 from onyx.server.metrics.deletion_metrics import inc_deletion_fence_reset
 from onyx.server.metrics.deletion_metrics import inc_deletion_started
-from onyx.server.metrics.deletion_metrics import observe_deletion_duration
+from onyx.server.metrics.deletion_metrics import observe_deletion_taskset_duration
 from onyx.utils.variable_functionality import (
     fetch_versioned_implementation_with_fallback,
 )
@@ -539,7 +539,7 @@ def monitor_connector_deletion_taskset(
             duration = (
                 datetime.now(timezone.utc) - fence_data.submitted
             ).total_seconds()
-            observe_deletion_duration(tenant_id, duration)
+            observe_deletion_taskset_duration(tenant_id, "success", duration)
             inc_deletion_completed(tenant_id, "success")
 
         except Exception as e:
@@ -560,6 +560,10 @@ def monitor_connector_deletion_taskset(
                 f"Connector deletion exceptioned: "
                 f"cc_pair={cc_pair_id} connector={connector_id_to_delete} credential={credential_id_to_delete}"
             )
+            duration = (
+                datetime.now(timezone.utc) - fence_data.submitted
+            ).total_seconds()
+            observe_deletion_taskset_duration(tenant_id, "failure", duration)
             inc_deletion_completed(tenant_id, "failure")
             raise e
 

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -59,6 +59,11 @@ from onyx.redis.redis_connector_delete import RedisConnectorDelete
 from onyx.redis.redis_connector_delete import RedisConnectorDeletePayload
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import get_redis_replica_client
+from onyx.server.metrics.deletion_metrics import inc_deletion_blocked
+from onyx.server.metrics.deletion_metrics import inc_deletion_completed
+from onyx.server.metrics.deletion_metrics import inc_deletion_fence_reset
+from onyx.server.metrics.deletion_metrics import inc_deletion_started
+from onyx.server.metrics.deletion_metrics import observe_deletion_duration
 from onyx.utils.variable_functionality import (
     fetch_versioned_implementation_with_fallback,
 )
@@ -300,6 +305,7 @@ def try_generate_document_cc_pair_cleanup_tasks(
                 recent_index_attempts
                 and recent_index_attempts[0].status == IndexingStatus.IN_PROGRESS
             ):
+                inc_deletion_blocked(tenant_id, "indexing")
                 raise TaskDependencyError(
                     "Connector deletion - Delayed (indexing in progress): "
                     f"cc_pair={cc_pair_id} "
@@ -307,11 +313,13 @@ def try_generate_document_cc_pair_cleanup_tasks(
                 )
 
         if redis_connector.prune.fenced:
+            inc_deletion_blocked(tenant_id, "pruning")
             raise TaskDependencyError(
                 f"Connector deletion - Delayed (pruning in progress): cc_pair={cc_pair_id}"
             )
 
         if redis_connector.permissions.fenced:
+            inc_deletion_blocked(tenant_id, "permissions")
             raise TaskDependencyError(
                 f"Connector deletion - Delayed (permissions in progress): cc_pair={cc_pair_id}"
             )
@@ -359,6 +367,7 @@ def try_generate_document_cc_pair_cleanup_tasks(
         # set this only after all tasks have been added
         fence_payload.num_tasks = tasks_generated
         redis_connector.delete.set_fence(fence_payload)
+        inc_deletion_started(tenant_id)
 
     return tasks_generated
 
@@ -527,6 +536,12 @@ def monitor_connector_deletion_taskset(
                 num_docs_synced=fence_data.num_tasks,
             )
 
+            duration = (
+                datetime.now(timezone.utc) - fence_data.submitted
+            ).total_seconds()
+            observe_deletion_duration(tenant_id, duration)
+            inc_deletion_completed(tenant_id, "success")
+
         except Exception as e:
             db_session.rollback()
             stack_trace = traceback.format_exc()
@@ -545,6 +560,7 @@ def monitor_connector_deletion_taskset(
                 f"Connector deletion exceptioned: "
                 f"cc_pair={cc_pair_id} connector={connector_id_to_delete} credential={credential_id_to_delete}"
             )
+            inc_deletion_completed(tenant_id, "failure")
             raise e
 
     task_logger.info(
@@ -721,5 +737,6 @@ def validate_connector_deletion_fence(
         f"fence={fence_key}"
     )
 
+    inc_deletion_fence_reset(tenant_id)
     redis_connector.delete.reset()
     return

--- a/backend/onyx/server/metrics/deletion_metrics.py
+++ b/backend/onyx/server/metrics/deletion_metrics.py
@@ -1,0 +1,94 @@
+"""Connector-deletion-specific Prometheus metrics.
+
+Tracks the deletion lifecycle:
+  1. Deletions started (taskset generated)
+  2. Deletions completed (success or failure)
+  3. Deletion duration (end-to-end, from fence creation to completion)
+  4. Deletion blocked by dependencies (indexing, pruning, permissions, etc.)
+  5. Fence resets (stuck deletion recovery)
+
+All metrics are labeled by tenant_id. cc_pair_id is intentionally excluded
+to avoid unbounded cardinality.
+
+Usage:
+    from onyx.server.metrics.deletion_metrics import (
+        inc_deletion_started,
+        inc_deletion_completed,
+        observe_deletion_duration,
+        inc_deletion_blocked,
+        inc_deletion_fence_reset,
+    )
+"""
+
+from prometheus_client import Counter
+from prometheus_client import Histogram
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+DELETION_STARTED = Counter(
+    "onyx_deletion_started_total",
+    "Connector deletions initiated (taskset generated)",
+    ["tenant_id"],
+)
+
+DELETION_COMPLETED = Counter(
+    "onyx_deletion_completed_total",
+    "Connector deletions completed",
+    ["tenant_id", "outcome"],
+)
+
+DELETION_DURATION = Histogram(
+    "onyx_deletion_duration_seconds",
+    "End-to-end connector deletion duration",
+    ["tenant_id"],
+    buckets=[10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 21600],
+)
+
+DELETION_BLOCKED = Counter(
+    "onyx_deletion_blocked_total",
+    "Times deletion was blocked by a dependency",
+    ["tenant_id", "blocker"],
+)
+
+DELETION_FENCE_RESET = Counter(
+    "onyx_deletion_fence_reset_total",
+    "Deletion fences reset due to missing celery tasks",
+    ["tenant_id"],
+)
+
+
+def inc_deletion_started(tenant_id: str) -> None:
+    try:
+        DELETION_STARTED.labels(tenant_id=tenant_id).inc()
+    except Exception:
+        logger.debug("Failed to record deletion started", exc_info=True)
+
+
+def inc_deletion_completed(tenant_id: str, outcome: str) -> None:
+    try:
+        DELETION_COMPLETED.labels(tenant_id=tenant_id, outcome=outcome).inc()
+    except Exception:
+        logger.debug("Failed to record deletion completed", exc_info=True)
+
+
+def observe_deletion_duration(tenant_id: str, duration_seconds: float) -> None:
+    try:
+        DELETION_DURATION.labels(tenant_id=tenant_id).observe(duration_seconds)
+    except Exception:
+        logger.debug("Failed to record deletion duration", exc_info=True)
+
+
+def inc_deletion_blocked(tenant_id: str, blocker: str) -> None:
+    try:
+        DELETION_BLOCKED.labels(tenant_id=tenant_id, blocker=blocker).inc()
+    except Exception:
+        logger.debug("Failed to record deletion blocked", exc_info=True)
+
+
+def inc_deletion_fence_reset(tenant_id: str) -> None:
+    try:
+        DELETION_FENCE_RESET.labels(tenant_id=tenant_id).inc()
+    except Exception:
+        logger.debug("Failed to record deletion fence reset", exc_info=True)

--- a/backend/onyx/server/metrics/deletion_metrics.py
+++ b/backend/onyx/server/metrics/deletion_metrics.py
@@ -3,7 +3,11 @@
 Tracks the deletion lifecycle:
   1. Deletions started (taskset generated)
   2. Deletions completed (success or failure)
-  3. Deletion duration (end-to-end, from fence creation to completion)
+  3. Taskset duration (from taskset generation to completion or failure).
+     Note: this measures the most recent taskset execution, NOT wall-clock
+     time since the user triggered the deletion. When deletion is blocked by
+     indexing/pruning/permissions, the fence is cleared and a fresh taskset
+     is generated on each retry, resetting this timer.
   4. Deletion blocked by dependencies (indexing, pruning, permissions, etc.)
   5. Fence resets (stuck deletion recovery)
 
@@ -14,7 +18,7 @@ Usage:
     from onyx.server.metrics.deletion_metrics import (
         inc_deletion_started,
         inc_deletion_completed,
-        observe_deletion_duration,
+        observe_deletion_taskset_duration,
         inc_deletion_blocked,
         inc_deletion_fence_reset,
     )
@@ -39,10 +43,12 @@ DELETION_COMPLETED = Counter(
     ["tenant_id", "outcome"],
 )
 
-DELETION_DURATION = Histogram(
-    "onyx_deletion_duration_seconds",
-    "End-to-end connector deletion duration",
-    ["tenant_id"],
+DELETION_TASKSET_DURATION = Histogram(
+    "onyx_deletion_taskset_duration_seconds",
+    "Duration of a connector deletion taskset, from taskset generation "
+    "to completion or failure. Does not include time spent blocked on "
+    "indexing/pruning/permissions before the taskset was generated.",
+    ["tenant_id", "outcome"],
     buckets=[10, 30, 60, 120, 300, 600, 1800, 3600, 7200, 21600],
 )
 
@@ -73,11 +79,15 @@ def inc_deletion_completed(tenant_id: str, outcome: str) -> None:
         logger.debug("Failed to record deletion completed", exc_info=True)
 
 
-def observe_deletion_duration(tenant_id: str, duration_seconds: float) -> None:
+def observe_deletion_taskset_duration(
+    tenant_id: str, outcome: str, duration_seconds: float
+) -> None:
     try:
-        DELETION_DURATION.labels(tenant_id=tenant_id).observe(duration_seconds)
+        DELETION_TASKSET_DURATION.labels(tenant_id=tenant_id, outcome=outcome).observe(
+            duration_seconds
+        )
     except Exception:
-        logger.debug("Failed to record deletion duration", exc_info=True)
+        logger.debug("Failed to record deletion taskset duration", exc_info=True)
 
 
 def inc_deletion_blocked(tenant_id: str, blocker: str) -> None:

--- a/backend/tests/unit/server/metrics/test_deletion_metrics.py
+++ b/backend/tests/unit/server/metrics/test_deletion_metrics.py
@@ -1,0 +1,170 @@
+"""Tests for deletion-specific Prometheus metrics."""
+
+import pytest
+
+from onyx.server.metrics.deletion_metrics import DELETION_BLOCKED
+from onyx.server.metrics.deletion_metrics import DELETION_COMPLETED
+from onyx.server.metrics.deletion_metrics import DELETION_DURATION
+from onyx.server.metrics.deletion_metrics import DELETION_FENCE_RESET
+from onyx.server.metrics.deletion_metrics import DELETION_STARTED
+from onyx.server.metrics.deletion_metrics import inc_deletion_blocked
+from onyx.server.metrics.deletion_metrics import inc_deletion_completed
+from onyx.server.metrics.deletion_metrics import inc_deletion_fence_reset
+from onyx.server.metrics.deletion_metrics import inc_deletion_started
+from onyx.server.metrics.deletion_metrics import observe_deletion_duration
+
+
+class TestIncDeletionStarted:
+    def test_increments_counter(self) -> None:
+        before = DELETION_STARTED.labels(tenant_id="t1")._value.get()
+
+        inc_deletion_started("t1")
+
+        after = DELETION_STARTED.labels(tenant_id="t1")._value.get()
+        assert after == before + 1
+
+    def test_labels_by_tenant(self) -> None:
+        before_t1 = DELETION_STARTED.labels(tenant_id="t1")._value.get()
+        before_t2 = DELETION_STARTED.labels(tenant_id="t2")._value.get()
+
+        inc_deletion_started("t1")
+
+        assert DELETION_STARTED.labels(tenant_id="t1")._value.get() == before_t1 + 1
+        assert DELETION_STARTED.labels(tenant_id="t2")._value.get() == before_t2
+
+    def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            DELETION_STARTED,
+            "labels",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        inc_deletion_started("t1")
+
+
+class TestIncDeletionCompleted:
+    def test_increments_counter(self) -> None:
+        before = DELETION_COMPLETED.labels(
+            tenant_id="t1", outcome="success"
+        )._value.get()
+
+        inc_deletion_completed("t1", "success")
+
+        after = DELETION_COMPLETED.labels(
+            tenant_id="t1", outcome="success"
+        )._value.get()
+        assert after == before + 1
+
+    def test_labels_by_outcome(self) -> None:
+        before_success = DELETION_COMPLETED.labels(
+            tenant_id="t1", outcome="success"
+        )._value.get()
+        before_failure = DELETION_COMPLETED.labels(
+            tenant_id="t1", outcome="failure"
+        )._value.get()
+
+        inc_deletion_completed("t1", "success")
+
+        assert (
+            DELETION_COMPLETED.labels(tenant_id="t1", outcome="success")._value.get()
+            == before_success + 1
+        )
+        assert (
+            DELETION_COMPLETED.labels(tenant_id="t1", outcome="failure")._value.get()
+            == before_failure
+        )
+
+    def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            DELETION_COMPLETED,
+            "labels",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        inc_deletion_completed("t1", "success")
+
+
+class TestObserveDeletionDuration:
+    def test_observes_duration(self) -> None:
+        before = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
+
+        observe_deletion_duration("t1", 120.0)
+
+        after = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
+        assert after == pytest.approx(before + 120.0)
+
+    def test_labels_by_tenant(self) -> None:
+        before_t1 = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
+        before_t2 = DELETION_DURATION.labels(tenant_id="t2")._sum.get()
+
+        observe_deletion_duration("t1", 60.0)
+
+        assert DELETION_DURATION.labels(tenant_id="t1")._sum.get() == pytest.approx(
+            before_t1 + 60.0
+        )
+        assert DELETION_DURATION.labels(tenant_id="t2")._sum.get() == pytest.approx(
+            before_t2
+        )
+
+    def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            DELETION_DURATION,
+            "labels",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        observe_deletion_duration("t1", 10.0)
+
+
+class TestIncDeletionBlocked:
+    def test_increments_counter(self) -> None:
+        before = DELETION_BLOCKED.labels(
+            tenant_id="t1", blocker="indexing"
+        )._value.get()
+
+        inc_deletion_blocked("t1", "indexing")
+
+        after = DELETION_BLOCKED.labels(tenant_id="t1", blocker="indexing")._value.get()
+        assert after == before + 1
+
+    def test_labels_by_blocker(self) -> None:
+        before_idx = DELETION_BLOCKED.labels(
+            tenant_id="t1", blocker="indexing"
+        )._value.get()
+        before_prune = DELETION_BLOCKED.labels(
+            tenant_id="t1", blocker="pruning"
+        )._value.get()
+
+        inc_deletion_blocked("t1", "indexing")
+
+        assert (
+            DELETION_BLOCKED.labels(tenant_id="t1", blocker="indexing")._value.get()
+            == before_idx + 1
+        )
+        assert (
+            DELETION_BLOCKED.labels(tenant_id="t1", blocker="pruning")._value.get()
+            == before_prune
+        )
+
+    def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            DELETION_BLOCKED,
+            "labels",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        inc_deletion_blocked("t1", "indexing")
+
+
+class TestIncDeletionFenceReset:
+    def test_increments_counter(self) -> None:
+        before = DELETION_FENCE_RESET.labels(tenant_id="t1")._value.get()
+
+        inc_deletion_fence_reset("t1")
+
+        after = DELETION_FENCE_RESET.labels(tenant_id="t1")._value.get()
+        assert after == before + 1
+
+    def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            DELETION_FENCE_RESET,
+            "labels",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        inc_deletion_fence_reset("t1")

--- a/backend/tests/unit/server/metrics/test_deletion_metrics.py
+++ b/backend/tests/unit/server/metrics/test_deletion_metrics.py
@@ -4,14 +4,14 @@ import pytest
 
 from onyx.server.metrics.deletion_metrics import DELETION_BLOCKED
 from onyx.server.metrics.deletion_metrics import DELETION_COMPLETED
-from onyx.server.metrics.deletion_metrics import DELETION_DURATION
 from onyx.server.metrics.deletion_metrics import DELETION_FENCE_RESET
 from onyx.server.metrics.deletion_metrics import DELETION_STARTED
+from onyx.server.metrics.deletion_metrics import DELETION_TASKSET_DURATION
 from onyx.server.metrics.deletion_metrics import inc_deletion_blocked
 from onyx.server.metrics.deletion_metrics import inc_deletion_completed
 from onyx.server.metrics.deletion_metrics import inc_deletion_fence_reset
 from onyx.server.metrics.deletion_metrics import inc_deletion_started
-from onyx.server.metrics.deletion_metrics import observe_deletion_duration
+from onyx.server.metrics.deletion_metrics import observe_deletion_taskset_duration
 
 
 class TestIncDeletionStarted:
@@ -82,35 +82,60 @@ class TestIncDeletionCompleted:
         inc_deletion_completed("t1", "success")
 
 
-class TestObserveDeletionDuration:
+class TestObserveDeletionTasksetDuration:
     def test_observes_duration(self) -> None:
-        before = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
+        before = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get()
 
-        observe_deletion_duration("t1", 120.0)
+        observe_deletion_taskset_duration("t1", "success", 120.0)
 
-        after = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
+        after = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get()
         assert after == pytest.approx(before + 120.0)
 
     def test_labels_by_tenant(self) -> None:
-        before_t1 = DELETION_DURATION.labels(tenant_id="t1")._sum.get()
-        before_t2 = DELETION_DURATION.labels(tenant_id="t2")._sum.get()
+        before_t1 = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get()
+        before_t2 = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t2", outcome="success"
+        )._sum.get()
 
-        observe_deletion_duration("t1", 60.0)
+        observe_deletion_taskset_duration("t1", "success", 60.0)
 
-        assert DELETION_DURATION.labels(tenant_id="t1")._sum.get() == pytest.approx(
-            before_t1 + 60.0
-        )
-        assert DELETION_DURATION.labels(tenant_id="t2")._sum.get() == pytest.approx(
-            before_t2
-        )
+        assert DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get() == pytest.approx(before_t1 + 60.0)
+        assert DELETION_TASKSET_DURATION.labels(
+            tenant_id="t2", outcome="success"
+        )._sum.get() == pytest.approx(before_t2)
+
+    def test_labels_by_outcome(self) -> None:
+        before_success = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get()
+        before_failure = DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="failure"
+        )._sum.get()
+
+        observe_deletion_taskset_duration("t1", "failure", 45.0)
+
+        assert DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="success"
+        )._sum.get() == pytest.approx(before_success)
+        assert DELETION_TASKSET_DURATION.labels(
+            tenant_id="t1", outcome="failure"
+        )._sum.get() == pytest.approx(before_failure + 45.0)
 
     def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
-            DELETION_DURATION,
+            DELETION_TASKSET_DURATION,
             "labels",
             lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
         )
-        observe_deletion_duration("t1", 10.0)
+        observe_deletion_taskset_duration("t1", "success", 10.0)
 
 
 class TestIncDeletionBlocked:
@@ -160,6 +185,15 @@ class TestIncDeletionFenceReset:
 
         after = DELETION_FENCE_RESET.labels(tenant_id="t1")._value.get()
         assert after == before + 1
+
+    def test_labels_by_tenant(self) -> None:
+        before_t1 = DELETION_FENCE_RESET.labels(tenant_id="t1")._value.get()
+        before_t2 = DELETION_FENCE_RESET.labels(tenant_id="t2")._value.get()
+
+        inc_deletion_fence_reset("t1")
+
+        assert DELETION_FENCE_RESET.labels(tenant_id="t1")._value.get() == before_t1 + 1
+        assert DELETION_FENCE_RESET.labels(tenant_id="t2")._value.get() == before_t2
 
     def test_does_not_raise_on_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding in proper setup for tracking the deletion pipeline. This is to get more information on if the operations are properly completing or getting reset and understanding what is causing issues with deletions.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Adding tests to properly test

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Prometheus metrics for the connector deletion pipeline to track starts, outcomes, taskset duration, blockers, and fence resets by tenant. This improves visibility into slow or stuck deletions and helps diagnose issues.

- **New Features**
  - Added metrics: `onyx_deletion_started_total`, `onyx_deletion_completed_total{outcome}`, `onyx_deletion_taskset_duration_seconds{outcome}`, `onyx_deletion_blocked_total{blocker}`, `onyx_deletion_fence_reset_total`.
  - Wired into deletion flow: emit on start; on block (indexing/pruning/permissions); on success/failure record duration and completion; on fence reset.
  - Labels: all metrics include `tenant_id`; `completed` and `taskset_duration` add `{outcome}`, and `blocked` adds `{blocker}` to keep cardinality bounded.
  - Added unit tests for counters and the duration histogram.

<sup>Written for commit d698dabb1a9c062d5a0b311cbba84dd030e14184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

