### PR TITLE
fix: properly refresh settings/ee settings on license upload success

### DIFF
--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -205,8 +205,10 @@ export default function BillingPage() {
             await claimLicense(sessionId ?? undefined);
             if (cancelled) return;
             refreshLicense();
-            // Refresh the page to update settings (including ee_features_enabled)
+            // Refresh settings so EE-gated UI (e.g. sidebar) updates immediately.
             router.refresh();
+            mutate(SWR_KEYS.settings);
+            mutate(SWR_KEYS.enterpriseSettings);
             // Navigate to billing details now that the license is active
             changeView("details");
             lastError = null;
@@ -267,7 +269,10 @@ export default function BillingPage() {
         setIsActivating(false);
         refreshLicense();
         refreshBilling();
+        // Refresh settings so EE-gated UI (e.g. sidebar) updates immediately.
         router.refresh();
+        mutate(SWR_KEYS.settings);
+        mutate(SWR_KEYS.enterpriseSettings);
         changeView("details");
       } catch (err) {
         // License not ready yet — keep polling. Log so unexpected failures
@@ -314,7 +319,7 @@ export default function BillingPage() {
   const handleLicenseActivated = () => {
     refreshLicense();
     refreshBilling();
-    // Refresh the page and invalidate SWR cache to update settings (including ee_features_enabled)
+    // Refresh settings so EE-gated UI (e.g. sidebar) updates immediately.
     router.refresh();
     mutate(SWR_KEYS.settings);
     mutate(SWR_KEYS.enterpriseSettings);

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { mutate } from "swr";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
@@ -16,6 +17,7 @@ import {
   claimLicense,
 } from "@/lib/billing";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { useUser } from "@/providers/UserProvider";
 import Message from "@/refresh-components/messages/Message";
 
@@ -312,8 +314,14 @@ export default function BillingPage() {
   const handleLicenseActivated = () => {
     refreshLicense();
     refreshBilling();
-    // Refresh the page to update settings (including ee_features_enabled)
+    // Refresh the page to update settings (including ee_features_enabled).
+    // router.refresh() updates Next.js server-rendered data, but the
+    // SettingsProvider reads /api/settings via SWR on the client, so we also
+    // need to invalidate the SWR cache so the admin sidebar's EE buttons
+    // un-grey immediately without a full page reload.
     router.refresh();
+    mutate(SWR_KEYS.settings);
+    mutate(SWR_KEYS.enterpriseSettings);
     // Navigate to billing details now that the license is active
     changeView("details");
   };

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -314,11 +314,6 @@ export default function BillingPage() {
   const handleLicenseActivated = () => {
     refreshLicense();
     refreshBilling();
-    // Refresh the page to update settings (including ee_features_enabled).
-    // router.refresh() updates Next.js server-rendered data, but the
-    // SettingsProvider reads /api/settings via SWR on the client, so we also
-    // need to invalidate the SWR cache so the admin sidebar's EE buttons
-    // un-grey immediately without a full page reload.
     router.refresh();
     mutate(SWR_KEYS.settings);
     mutate(SWR_KEYS.enterpriseSettings);

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -314,6 +314,7 @@ export default function BillingPage() {
   const handleLicenseActivated = () => {
     refreshLicense();
     refreshBilling();
+    // Refresh the page and invalidate SWR cache to update settings (including ee_features_enabled)
     router.refresh();
     mutate(SWR_KEYS.settings);
     mutate(SWR_KEYS.enterpriseSettings);


### PR DESCRIPTION
## Description


- Previously, after successful license validation, the admin sidebar EE buttons would remain disabled until refresh/nav
- Now, immediately refresh to show users that the settings are available to configure


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale admin settings after license activation by refreshing the route and invalidating `swr` caches. EE settings and the admin sidebar update instantly without a full reload.

- **Bug Fixes**
  - On license activation (upload success, polling completion, and activation handler), call `router.refresh()` and `mutate` `SWR_KEYS.settings` and `SWR_KEYS.enterpriseSettings`.
  - Immediately reflects `ee_features_enabled` and enables EE buttons in the admin sidebar.

<sup>Written for commit 1066807d6f6eb555ae77ba3ea903936f85316f33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



