### PR TITLE
fix(google): handle JSON credential payloads in KV storage (@jack-larch)

### DIFF
--- a/backend/onyx/connectors/google_utils/google_auth.py
+++ b/backend/onyx/connectors/google_utils/google_auth.py
@@ -103,8 +103,12 @@ def get_google_creds(
             GoogleOAuthAuthenticationMethod.UPLOADED.value,
         )
 
-        credentials_dict_str = credentials[DB_CREDENTIALS_DICT_TOKEN_KEY]
-        credentials_dict = json.loads(credentials_dict_str)
+        credentials_payload = credentials[DB_CREDENTIALS_DICT_TOKEN_KEY]
+        credentials_dict = (
+            json.loads(credentials_payload)
+            if isinstance(credentials_payload, str)
+            else credentials_payload
+        )
 
         # only send what get_google_oauth_creds needs
         authorized_user_info = {}
@@ -151,10 +155,14 @@ def get_google_creds(
                 }
     elif DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY in credentials:
         # SERVICE ACCOUNT
-        service_account_key_json_str = credentials[
+        service_account_key_payload = credentials[
             DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY
         ]
-        service_account_key = json.loads(service_account_key_json_str)
+        service_account_key = (
+            json.loads(service_account_key_payload)
+            if isinstance(service_account_key_payload, str)
+            else service_account_key_payload
+        )
 
         service_creds = ServiceAccountCredentials.from_service_account_info(
             service_account_key, scopes=GOOGLE_SCOPES[source]

--- a/backend/onyx/connectors/google_utils/google_auth.py
+++ b/backend/onyx/connectors/google_utils/google_auth.py
@@ -103,12 +103,8 @@ def get_google_creds(
             GoogleOAuthAuthenticationMethod.UPLOADED.value,
         )
 
-        credentials_payload = credentials[DB_CREDENTIALS_DICT_TOKEN_KEY]
-        credentials_dict = (
-            json.loads(credentials_payload)
-            if isinstance(credentials_payload, str)
-            else credentials_payload
-        )
+        credentials_dict_str = credentials[DB_CREDENTIALS_DICT_TOKEN_KEY]
+        credentials_dict = json.loads(credentials_dict_str)
 
         # only send what get_google_oauth_creds needs
         authorized_user_info = {}
@@ -155,14 +151,10 @@ def get_google_creds(
                 }
     elif DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY in credentials:
         # SERVICE ACCOUNT
-        service_account_key_payload = credentials[
+        service_account_key_json_str = credentials[
             DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY
         ]
-        service_account_key = (
-            json.loads(service_account_key_payload)
-            if isinstance(service_account_key_payload, str)
-            else service_account_key_payload
-        )
+        service_account_key = json.loads(service_account_key_json_str)
 
         service_creds = ServiceAccountCredentials.from_service_account_info(
             service_account_key, scopes=GOOGLE_SCOPES[source]

--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -55,6 +55,13 @@ logger = setup_logger()
 
 
 def _load_google_json(raw: object) -> dict[str, Any]:
+    """Accept both the current (dict) and legacy (JSON string) KV payload shapes.
+
+    Payloads written before the fix for serializing Google credentials into
+    ``EncryptedJson`` columns are stored as JSON strings; new writes store dicts.
+    Once every install has re-uploaded their Google credentials the legacy
+    ``str`` branch can be removed.
+    """
     if isinstance(raw, dict):
         return raw
     if isinstance(raw, str):
@@ -152,9 +159,7 @@ def build_service_account_creds(
     service_account_key = get_service_account_key(source=source)
 
     credential_dict = {
-        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.model_dump(
-            mode="json"
-        ),
+        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.json(),
     }
     if primary_admin_email:
         credential_dict[DB_CREDENTIALS_PRIMARY_ADMIN_KEY] = primary_admin_email

--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import ParseResult
@@ -51,6 +52,14 @@ from onyx.server.documents.models import GoogleServiceAccountKey
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def _load_google_json(raw: object) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        return json.loads(raw)
+    raise ValueError(f"Unexpected Google credential payload type: {type(raw)!r}")
 
 
 def _build_frontend_google_drive_redirect(source: DocumentSource) -> str:
@@ -143,7 +152,9 @@ def build_service_account_creds(
     service_account_key = get_service_account_key(source=source)
 
     credential_dict = {
-        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.json(),
+        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.model_dump(
+            mode="json"
+        ),
     }
     if primary_admin_email:
         credential_dict[DB_CREDENTIALS_PRIMARY_ADMIN_KEY] = primary_admin_email
@@ -162,12 +173,13 @@ def build_service_account_creds(
 
 def get_auth_url(credential_id: int, source: DocumentSource) -> str:
     if source == DocumentSource.GOOGLE_DRIVE:
-        creds_str = str(get_kv_store().load(KV_GOOGLE_DRIVE_CRED_KEY))
+        credential_json = _load_google_json(
+            get_kv_store().load(KV_GOOGLE_DRIVE_CRED_KEY)
+        )
     elif source == DocumentSource.GMAIL:
-        creds_str = str(get_kv_store().load(KV_GMAIL_CRED_KEY))
+        credential_json = _load_google_json(get_kv_store().load(KV_GMAIL_CRED_KEY))
     else:
         raise ValueError(f"Unsupported source: {source}")
-    credential_json = json.loads(creds_str)
     flow = InstalledAppFlow.from_client_config(
         credential_json,
         scopes=GOOGLE_SCOPES[source],
@@ -188,12 +200,12 @@ def get_auth_url(credential_id: int, source: DocumentSource) -> str:
 
 def get_google_app_cred(source: DocumentSource) -> GoogleAppCredentials:
     if source == DocumentSource.GOOGLE_DRIVE:
-        creds_str = str(get_kv_store().load(KV_GOOGLE_DRIVE_CRED_KEY))
+        creds = _load_google_json(get_kv_store().load(KV_GOOGLE_DRIVE_CRED_KEY))
     elif source == DocumentSource.GMAIL:
-        creds_str = str(get_kv_store().load(KV_GMAIL_CRED_KEY))
+        creds = _load_google_json(get_kv_store().load(KV_GMAIL_CRED_KEY))
     else:
         raise ValueError(f"Unsupported source: {source}")
-    return GoogleAppCredentials(**json.loads(creds_str))
+    return GoogleAppCredentials(**creds)
 
 
 def upsert_google_app_cred(
@@ -201,10 +213,14 @@ def upsert_google_app_cred(
 ) -> None:
     if source == DocumentSource.GOOGLE_DRIVE:
         get_kv_store().store(
-            KV_GOOGLE_DRIVE_CRED_KEY, app_credentials.json(), encrypt=True
+            KV_GOOGLE_DRIVE_CRED_KEY,
+            app_credentials.model_dump(mode="json"),
+            encrypt=True,
         )
     elif source == DocumentSource.GMAIL:
-        get_kv_store().store(KV_GMAIL_CRED_KEY, app_credentials.json(), encrypt=True)
+        get_kv_store().store(
+            KV_GMAIL_CRED_KEY, app_credentials.model_dump(mode="json"), encrypt=True
+        )
     else:
         raise ValueError(f"Unsupported source: {source}")
 
@@ -220,12 +236,14 @@ def delete_google_app_cred(source: DocumentSource) -> None:
 
 def get_service_account_key(source: DocumentSource) -> GoogleServiceAccountKey:
     if source == DocumentSource.GOOGLE_DRIVE:
-        creds_str = str(get_kv_store().load(KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY))
+        creds = _load_google_json(
+            get_kv_store().load(KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY)
+        )
     elif source == DocumentSource.GMAIL:
-        creds_str = str(get_kv_store().load(KV_GMAIL_SERVICE_ACCOUNT_KEY))
+        creds = _load_google_json(get_kv_store().load(KV_GMAIL_SERVICE_ACCOUNT_KEY))
     else:
         raise ValueError(f"Unsupported source: {source}")
-    return GoogleServiceAccountKey(**json.loads(creds_str))
+    return GoogleServiceAccountKey(**creds)
 
 
 def upsert_service_account_key(
@@ -234,12 +252,14 @@ def upsert_service_account_key(
     if source == DocumentSource.GOOGLE_DRIVE:
         get_kv_store().store(
             KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY,
-            service_account_key.json(),
+            service_account_key.model_dump(mode="json"),
             encrypt=True,
         )
     elif source == DocumentSource.GMAIL:
         get_kv_store().store(
-            KV_GMAIL_SERVICE_ACCOUNT_KEY, service_account_key.json(), encrypt=True
+            KV_GMAIL_SERVICE_ACCOUNT_KEY,
+            service_account_key.model_dump(mode="json"),
+            encrypt=True,
         )
     else:
         raise ValueError(f"Unsupported source: {source}")

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
@@ -1,0 +1,196 @@
+from typing import Any
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import KV_GOOGLE_DRIVE_CRED_KEY
+from onyx.connectors.google_utils.google_auth import get_google_creds
+from onyx.connectors.google_utils.google_kv import build_service_account_creds
+from onyx.connectors.google_utils.google_kv import get_auth_url
+from onyx.connectors.google_utils.google_kv import get_google_app_cred
+from onyx.connectors.google_utils.google_kv import upsert_google_app_cred
+from onyx.connectors.google_utils.shared_constants import (
+    DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY,
+)
+from onyx.server.documents.models import GoogleAppCredentials
+from onyx.server.documents.models import GoogleServiceAccountKey
+
+
+def _make_app_creds() -> GoogleAppCredentials:
+    return GoogleAppCredentials(
+        web={
+            "client_id": "client-id.apps.googleusercontent.com",
+            "project_id": "test-project",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_secret": "secret",
+            "redirect_uris": ["https://example.com/callback"],
+            "javascript_origins": ["https://example.com"],
+        }
+    )
+
+
+def _make_service_account_key() -> GoogleServiceAccountKey:
+    return GoogleServiceAccountKey(
+        type="service_account",
+        project_id="test-project",
+        private_key_id="private-key-id",
+        private_key="-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n",
+        client_email="test@test-project.iam.gserviceaccount.com",
+        client_id="123",
+        auth_uri="https://accounts.google.com/o/oauth2/auth",
+        token_uri="https://oauth2.googleapis.com/token",
+        auth_provider_x509_cert_url="https://www.googleapis.com/oauth2/v1/certs",
+        client_x509_cert_url="https://www.googleapis.com/robot/v1/metadata/x509/test",
+        universe_domain="googleapis.com",
+    )
+
+
+def test_upsert_google_app_cred_stores_dict(monkeypatch: Any) -> None:
+    stored: dict[str, Any] = {}
+
+    class _StubKvStore:
+        def store(self, key: str, value: object, encrypt: bool) -> None:
+            stored["key"] = key
+            stored["value"] = value
+            stored["encrypt"] = encrypt
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_kv_store", lambda: _StubKvStore()
+    )
+
+    upsert_google_app_cred(_make_app_creds(), DocumentSource.GOOGLE_DRIVE)
+
+    assert stored["key"] == KV_GOOGLE_DRIVE_CRED_KEY
+    assert stored["encrypt"] is True
+    assert isinstance(stored["value"], dict)
+    assert stored["value"]["web"]["client_id"] == "client-id.apps.googleusercontent.com"
+
+
+@pytest.mark.parametrize("legacy_string", [False, True])
+def test_get_google_app_cred_accepts_dict_and_legacy_string(
+    monkeypatch: Any, legacy_string: bool
+) -> None:
+    payload: dict[str, Any] = _make_app_creds().model_dump(mode="json")
+    stored_value: object = (
+        payload if not legacy_string else _make_app_creds().model_dump_json()
+    )
+
+    class _StubKvStore:
+        def load(self, key: str) -> object:
+            assert key == KV_GOOGLE_DRIVE_CRED_KEY
+            return stored_value
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_kv_store", lambda: _StubKvStore()
+    )
+
+    creds = get_google_app_cred(DocumentSource.GOOGLE_DRIVE)
+
+    assert creds.web.client_id == "client-id.apps.googleusercontent.com"
+
+
+@pytest.mark.parametrize("legacy_string", [False, True])
+def test_get_auth_url_accepts_dict_and_legacy_string(
+    monkeypatch: Any, legacy_string: bool
+) -> None:
+    payload = _make_app_creds().model_dump(mode="json")
+    stored_value: object = (
+        payload if not legacy_string else _make_app_creds().model_dump_json()
+    )
+    stored_state: dict[str, object] = {}
+
+    class _StubKvStore:
+        def load(self, key: str) -> object:
+            assert key == KV_GOOGLE_DRIVE_CRED_KEY
+            return stored_value
+
+        def store(self, key: str, value: object, encrypt: bool) -> None:
+            stored_state["key"] = key
+            stored_state["value"] = value
+            stored_state["encrypt"] = encrypt
+
+    class _StubFlow:
+        def authorization_url(self, prompt: str) -> tuple[str, None]:
+            assert prompt == "consent"
+            return "https://accounts.google.com/o/oauth2/auth?state=test-state", None
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_kv_store", lambda: _StubKvStore()
+    )
+
+    def _from_client_config(
+        _app_config: object, *, scopes: object, redirect_uri: object
+    ) -> _StubFlow:
+        del scopes, redirect_uri
+        return _StubFlow()
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.InstalledAppFlow.from_client_config",
+        _from_client_config,
+    )
+
+    auth_url = get_auth_url(42, DocumentSource.GOOGLE_DRIVE)
+
+    assert auth_url.startswith("https://accounts.google.com")
+    assert stored_state["value"] == {"value": "test-state"}
+    assert stored_state["encrypt"] is True
+
+
+def test_build_service_account_creds_uses_dict_payload(monkeypatch: Any) -> None:
+    def _get_service_account_key(*, source: object) -> GoogleServiceAccountKey:
+        del source
+        return _make_service_account_key()
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_service_account_key",
+        _get_service_account_key,
+    )
+
+    creds = build_service_account_creds(DocumentSource.GOOGLE_DRIVE)
+
+    assert isinstance(
+        creds.credential_json[DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY], dict
+    )
+
+
+def test_get_google_creds_accepts_service_account_dict_payload(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubServiceCreds:
+        valid = False
+        expired = True
+
+        def refresh(self, _request: object) -> None:
+            self.valid = True
+
+    def _from_service_account_info(
+        service_account_info: dict[str, Any], scopes: list[str]
+    ) -> _StubServiceCreds:
+        captured["service_account_info"] = service_account_info
+        captured["scopes"] = scopes
+        return _StubServiceCreds()
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_auth.ServiceAccountCredentials.from_service_account_info",
+        _from_service_account_info,
+    )
+
+    creds, updated = get_google_creds(
+        {
+            DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: _make_service_account_key().model_dump(
+                mode="json"
+            )
+        },
+        DocumentSource.GOOGLE_DRIVE,
+    )
+
+    assert creds is not None
+    assert updated is None
+    assert (
+        captured["service_account_info"]["client_email"]
+        == "test@test-project.iam.gserviceaccount.com"
+    )

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
@@ -11,21 +11,22 @@ from onyx.connectors.google_utils.google_kv import get_service_account_key
 from onyx.connectors.google_utils.google_kv import upsert_google_app_cred
 from onyx.connectors.google_utils.google_kv import upsert_service_account_key
 from onyx.server.documents.models import GoogleAppCredentials
+from onyx.server.documents.models import GoogleAppWebCredentials
 from onyx.server.documents.models import GoogleServiceAccountKey
 
 
 def _make_app_creds() -> GoogleAppCredentials:
     return GoogleAppCredentials(
-        web={
-            "client_id": "client-id.apps.googleusercontent.com",
-            "project_id": "test-project",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-            "client_secret": "secret",
-            "redirect_uris": ["https://example.com/callback"],
-            "javascript_origins": ["https://example.com"],
-        }
+        web=GoogleAppWebCredentials(
+            client_id="client-id.apps.googleusercontent.com",
+            project_id="test-project",
+            auth_uri="https://accounts.google.com/o/oauth2/auth",
+            token_uri="https://oauth2.googleapis.com/token",
+            auth_provider_x509_cert_url="https://www.googleapis.com/oauth2/v1/certs",
+            client_secret="secret",
+            redirect_uris=["https://example.com/callback"],
+            javascript_origins=["https://example.com"],
+        )
     )
 
 

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
@@ -4,14 +4,12 @@ import pytest
 
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import KV_GOOGLE_DRIVE_CRED_KEY
-from onyx.connectors.google_utils.google_auth import get_google_creds
-from onyx.connectors.google_utils.google_kv import build_service_account_creds
+from onyx.configs.constants import KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY
 from onyx.connectors.google_utils.google_kv import get_auth_url
 from onyx.connectors.google_utils.google_kv import get_google_app_cred
+from onyx.connectors.google_utils.google_kv import get_service_account_key
 from onyx.connectors.google_utils.google_kv import upsert_google_app_cred
-from onyx.connectors.google_utils.shared_constants import (
-    DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY,
-)
+from onyx.connectors.google_utils.google_kv import upsert_service_account_key
 from onyx.server.documents.models import GoogleAppCredentials
 from onyx.server.documents.models import GoogleServiceAccountKey
 
@@ -68,6 +66,27 @@ def test_upsert_google_app_cred_stores_dict(monkeypatch: Any) -> None:
     assert stored["value"]["web"]["client_id"] == "client-id.apps.googleusercontent.com"
 
 
+def test_upsert_service_account_key_stores_dict(monkeypatch: Any) -> None:
+    stored: dict[str, Any] = {}
+
+    class _StubKvStore:
+        def store(self, key: str, value: object, encrypt: bool) -> None:
+            stored["key"] = key
+            stored["value"] = value
+            stored["encrypt"] = encrypt
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_kv_store", lambda: _StubKvStore()
+    )
+
+    upsert_service_account_key(_make_service_account_key(), DocumentSource.GOOGLE_DRIVE)
+
+    assert stored["key"] == KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY
+    assert stored["encrypt"] is True
+    assert isinstance(stored["value"], dict)
+    assert stored["value"]["project_id"] == "test-project"
+
+
 @pytest.mark.parametrize("legacy_string", [False, True])
 def test_get_google_app_cred_accepts_dict_and_legacy_string(
     monkeypatch: Any, legacy_string: bool
@@ -89,6 +108,30 @@ def test_get_google_app_cred_accepts_dict_and_legacy_string(
     creds = get_google_app_cred(DocumentSource.GOOGLE_DRIVE)
 
     assert creds.web.client_id == "client-id.apps.googleusercontent.com"
+
+
+@pytest.mark.parametrize("legacy_string", [False, True])
+def test_get_service_account_key_accepts_dict_and_legacy_string(
+    monkeypatch: Any, legacy_string: bool
+) -> None:
+    stored_value: object = (
+        _make_service_account_key().model_dump(mode="json")
+        if not legacy_string
+        else _make_service_account_key().model_dump_json()
+    )
+
+    class _StubKvStore:
+        def load(self, key: str) -> object:
+            assert key == KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY
+            return stored_value
+
+    monkeypatch.setattr(
+        "onyx.connectors.google_utils.google_kv.get_kv_store", lambda: _StubKvStore()
+    )
+
+    key = get_service_account_key(DocumentSource.GOOGLE_DRIVE)
+
+    assert key.client_email == "test@test-project.iam.gserviceaccount.com"
 
 
 @pytest.mark.parametrize("legacy_string", [False, True])
@@ -136,61 +179,3 @@ def test_get_auth_url_accepts_dict_and_legacy_string(
     assert auth_url.startswith("https://accounts.google.com")
     assert stored_state["value"] == {"value": "test-state"}
     assert stored_state["encrypt"] is True
-
-
-def test_build_service_account_creds_uses_dict_payload(monkeypatch: Any) -> None:
-    def _get_service_account_key(*, source: object) -> GoogleServiceAccountKey:
-        del source
-        return _make_service_account_key()
-
-    monkeypatch.setattr(
-        "onyx.connectors.google_utils.google_kv.get_service_account_key",
-        _get_service_account_key,
-    )
-
-    creds = build_service_account_creds(DocumentSource.GOOGLE_DRIVE)
-
-    assert isinstance(
-        creds.credential_json[DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY], dict
-    )
-
-
-def test_get_google_creds_accepts_service_account_dict_payload(
-    monkeypatch: Any,
-) -> None:
-    captured: dict[str, Any] = {}
-
-    class _StubServiceCreds:
-        valid = False
-        expired = True
-
-        def refresh(self, _request: object) -> None:
-            self.valid = True
-
-    def _from_service_account_info(
-        service_account_info: dict[str, Any], scopes: list[str]
-    ) -> _StubServiceCreds:
-        captured["service_account_info"] = service_account_info
-        captured["scopes"] = scopes
-        return _StubServiceCreds()
-
-    monkeypatch.setattr(
-        "onyx.connectors.google_utils.google_auth.ServiceAccountCredentials.from_service_account_info",
-        _from_service_account_info,
-    )
-
-    creds, updated = get_google_creds(
-        {
-            DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: _make_service_account_key().model_dump(
-                mode="json"
-            )
-        },
-        DocumentSource.GOOGLE_DRIVE,
-    )
-
-    assert creds is not None
-    assert updated is None
-    assert (
-        captured["service_account_info"]["client_email"]
-        == "test@test-project.iam.gserviceaccount.com"
-    )


### PR DESCRIPTION
Google app credentials and service-account keys failed to upload with TypeError: EncryptedJson column expected dict, got str. The KV store writers passed model.json() (a JSON string) into KVStore.encrypted_value, which is an EncryptedJson column that requires a dict at the top level.

Credit to @jack-larch for the original fix (#10115) and root-cause analysis. This PR is a narrowed version of that work.

Changes:
- Writers (upsert_google_app_cred, upsert_service_account_key): store model_dump(mode="json") instead of .json().
- Readers (get_google_app_cred, get_service_account_key, get_auth_url): route through a new _load_google_json helper that accepts both the new dict shape and legacy JSON-string payloads from existing installs.
- Tests: round-trip coverage for both app creds and service-account keys under both the new and legacy storage shapes.

Testing:
- Uploaded google creds to fresh Onyx and it is accepted without error
- Existing dev stack with google creds continues to work without error

- [x] Override Linear Check
- [x] [Optional] Please cherry-pick this PR to the latest release version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store Google OAuth app and service-account credentials in KV as JSON objects (dicts) instead of strings, with a backward-compatible read path and clearer errors. Standardizes on Pydantic v2 `model_dump` and includes typing cleanups for mypy.

- **Bug Fixes**
  - Normalize KV values via `_load_google_json`; accept dicts and legacy JSON strings in `get_auth_url`, `get_google_app_cred`, and `get_service_account_key` for Drive and Gmail; raise a clear `ValueError` otherwise.
  - Write credentials as dicts using `model_dump(mode="json")` in `upsert_google_app_cred` and `upsert_service_account_key`.
  - Add unit tests for both payload shapes and auth URL state handling; tighten types to satisfy mypy.

<sup>Written for commit 46f944588fab4d06e21ae3c19c5f2cee0b7799d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



