### PR TITLE
chore(pruning): Add Celery task queue wait time metric

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -10,6 +10,7 @@ from celery import bootsteps  # type: ignore
 from celery import Task
 from celery.app import trace
 from celery.exceptions import WorkerShutdown
+from celery.signals import before_task_publish
 from celery.signals import task_postrun
 from celery.signals import task_prerun
 from celery.states import READY_STATES
@@ -92,6 +93,17 @@ class TenantAwareTask(Task):
             # Clear or reset after the task runs
             # so it does not leak into any subsequent tasks on the same worker process
             CURRENT_TENANT_ID_CONTEXTVAR.set(None)
+
+
+@before_task_publish.connect
+def on_before_task_publish(
+    headers: dict[str, Any] | None = None,
+    **kwargs: Any,  # noqa: ARG001
+) -> None:
+    """Stamp the current wall-clock time into the task message headers so that
+    workers can compute queue wait time (time between publish and execution)."""
+    if headers is not None:
+        headers["enqueued_at"] = time.time()
 
 
 @task_prerun.connect

--- a/backend/onyx/server/metrics/celery_task_metrics.py
+++ b/backend/onyx/server/metrics/celery_task_metrics.py
@@ -1,7 +1,8 @@
 """Generic Celery task lifecycle Prometheus metrics.
 
 Provides signal handlers that track task started/completed/failed counts,
-active task gauge, task duration histograms, and retry/reject/revoke counts.
+active task gauge, task duration histograms, queue wait time histograms,
+and retry/reject/revoke counts.
 These fire for ALL tasks on the worker — no per-connector enrichment
 (see indexing_task_metrics.py for that).
 
@@ -71,6 +72,32 @@ TASK_REJECTED = Counter(
     ["task_name"],
 )
 
+TASK_QUEUE_WAIT = Histogram(
+    "onyx_celery_task_queue_wait_seconds",
+    "Time a Celery task spent waiting in the queue before execution started",
+    ["task_name", "queue"],
+    buckets=[
+        0.1,
+        0.5,
+        1,
+        5,
+        30,
+        60,
+        300,
+        600,
+        1800,
+        3600,
+        7200,
+        14400,
+        28800,
+        43200,
+        86400,
+        172800,
+        432000,
+        864000,
+    ],
+)
+
 # task_id → (monotonic start time, metric labels)
 _task_start_times: dict[str, tuple[float, dict[str, str]]] = {}
 
@@ -133,6 +160,13 @@ def on_celery_task_prerun(
         with _task_start_times_lock:
             _evict_stale_start_times()
             _task_start_times[task_id] = (time.monotonic(), labels)
+
+        headers = getattr(task.request, "headers", None) or {}
+        enqueued_at = headers.get("enqueued_at")
+        if isinstance(enqueued_at, (int, float)):
+            TASK_QUEUE_WAIT.labels(**labels).observe(
+                max(0.0, time.time() - enqueued_at)
+            )
     except Exception:
         logger.debug("Failed to record celery task prerun metrics", exc_info=True)
 

--- a/backend/tests/unit/server/metrics/test_celery_task_metrics.py
+++ b/backend/tests/unit/server/metrics/test_celery_task_metrics.py
@@ -1,15 +1,18 @@
 """Tests for generic Celery task lifecycle Prometheus metrics."""
 
+import time
 from collections.abc import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
+from onyx.background.celery.apps.app_base import on_before_task_publish
 from onyx.server.metrics.celery_task_metrics import _task_start_times
 from onyx.server.metrics.celery_task_metrics import on_celery_task_postrun
 from onyx.server.metrics.celery_task_metrics import on_celery_task_prerun
 from onyx.server.metrics.celery_task_metrics import TASK_COMPLETED
 from onyx.server.metrics.celery_task_metrics import TASK_DURATION
+from onyx.server.metrics.celery_task_metrics import TASK_QUEUE_WAIT
 from onyx.server.metrics.celery_task_metrics import TASK_STARTED
 from onyx.server.metrics.celery_task_metrics import TASKS_ACTIVE
 
@@ -22,11 +25,18 @@ def reset_metrics() -> Iterator[None]:
     _task_start_times.clear()
 
 
-def _make_task(name: str = "test_task", queue: str = "test_queue") -> MagicMock:
+def _make_task(
+    name: str = "test_task",
+    queue: str = "test_queue",
+    enqueued_at: float | None = None,
+) -> MagicMock:
     task = MagicMock()
     task.name = name
     task.request = MagicMock()
     task.request.delivery_info = {"routing_key": queue}
+    task.request.headers = (
+        {"enqueued_at": enqueued_at} if enqueued_at is not None else {}
+    )
     return task
 
 
@@ -71,6 +81,35 @@ class TestCeleryTaskPrerun:
         task.request.delivery_info = None
         on_celery_task_prerun("task-1", task)
         assert "task-1" in _task_start_times
+
+    def test_observes_queue_wait_when_enqueued_at_present(self) -> None:
+        enqueued_at = time.time() - 30  # simulates 30s wait
+        task = _make_task(enqueued_at=enqueued_at)
+
+        before = TASK_QUEUE_WAIT.labels(
+            task_name="test_task", queue="test_queue"
+        )._sum.get()
+
+        on_celery_task_prerun("task-1", task)
+
+        after = TASK_QUEUE_WAIT.labels(
+            task_name="test_task", queue="test_queue"
+        )._sum.get()
+        assert after >= before + 30
+
+    def test_skips_queue_wait_when_enqueued_at_missing(self) -> None:
+        task = _make_task()  # no enqueued_at in headers
+
+        before = TASK_QUEUE_WAIT.labels(
+            task_name="test_task", queue="test_queue"
+        )._sum.get()
+
+        on_celery_task_prerun("task-2", task)
+
+        after = TASK_QUEUE_WAIT.labels(
+            task_name="test_task", queue="test_queue"
+        )._sum.get()
+        assert after == before
 
 
 class TestCeleryTaskPostrun:
@@ -151,3 +190,15 @@ class TestCeleryTaskPostrun:
         task = _make_task()
         on_celery_task_postrun("task-1", task, "SUCCESS")
         # Should not raise
+
+
+class TestBeforeTaskPublish:
+    def test_stamps_enqueued_at_into_headers(self) -> None:
+        before = time.time()
+        headers: dict = {}
+        on_before_task_publish(headers=headers)
+        assert "enqueued_at" in headers
+        assert headers["enqueued_at"] >= before
+
+    def test_noop_when_headers_is_none(self) -> None:
+        on_before_task_publish(headers=None)  # should not raise


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Summary:
Adds onyx_celery_task_queue_wait_seconds histogram to track how long tasks sit in the queue before execution. A before_task_publish signal in  app_base.py stamps enqueued_at into task message headers; on_celery_task_prerun reads it and observes the wait time. No per-task changes needed — works automatically across all workers and queues.

Buckets cover from 100ms to 10 days to capture both fast queues (light, monitoring) and long starvation events like the April 10 incident where a pruning task waited 3 days unprocessed.

doc: https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.m3lnnrqsb83d
https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness

## How Has This Been Tested?
Updated unit tests

  - Run backend/tests/unit/server/metrics/test_celery_task_metrics.py
  - Monitor onyx_celery_task_queue_wait_seconds in Grafana after rollout — filter by task_name=~"connector_pruning.*" to watch pruning queue wait times
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Prometheus histogram to measure Celery task queue wait time so we can spot starving tasks (e.g., pruning delays) across all workers and queues. Addresses Linear ENG-3954 by tracking time from publish to execution with no per-task changes.

- New Features
  - Exposes `onyx_celery_task_queue_wait_seconds` labeled by `task_name` and `queue`.
  - Stamps `enqueued_at` in headers via Celery `before_task_publish`; observed in `on_celery_task_prerun`.
  - Buckets range from 0.1s to 10 days to capture both fast and long waits.
  - Adds unit tests for header stamping and wait-time observation.

<sup>Written for commit 4c29c64acdbb37d8ab85740c1fabe679b2a6dc41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

