### PR TITLE
fix: document set name patch

### DIFF
--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -335,6 +335,7 @@ def update_document_set(
                 "Cannot update document set while it is syncing. Please wait for it to finish syncing, and then try again."
             )
 
+        document_set_row.name = document_set_update_request.name
         document_set_row.description = document_set_update_request.description
         if not DISABLE_VECTOR_DB:
             document_set_row.is_up_to_date = False

--- a/backend/onyx/server/features/document_set/models.py
+++ b/backend/onyx/server/features/document_set/models.py
@@ -63,6 +63,7 @@ class DocumentSetCreationRequest(BaseModel):
 
 class DocumentSetUpdateRequest(BaseModel):
     id: int
+    name: str
     description: str
     cc_pair_ids: list[int]
     is_public: bool

--- a/backend/tests/integration/common_utils/managers/document_set.py
+++ b/backend/tests/integration/common_utils/managers/document_set.py
@@ -62,6 +62,7 @@ class DocumentSetManager:
     ) -> bool:
         doc_set_update_request = {
             "id": document_set.id,
+            "name": document_set.name,
             "description": document_set.description,
             "cc_pair_ids": document_set.cc_pair_ids,
             "is_public": document_set.is_public,

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
@@ -157,5 +159,60 @@ def test_removing_connector(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[],
+        doc_creating_user=admin_user,
+    )
+
+
+def test_renaming_document_set(
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,
+) -> None:
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    api_key: DATestAPIKey = APIKeyManager.create(
+        user_performing_action=admin_user,
+    )
+
+    cc_pair = CCPairManager.create_from_scratch(
+        source=DocumentSource.INGESTION_API,
+        user_performing_action=admin_user,
+    )
+
+    cc_pair.documents = DocumentManager.seed_dummy_docs(
+        cc_pair=cc_pair,
+        num_docs=NUM_DOCS,
+        api_key=api_key,
+    )
+
+    original_name = f"original_doc_set_{uuid4()}"
+    doc_set = DocumentSetManager.create(
+        name=original_name,
+        cc_pair_ids=[cc_pair.id],
+        user_performing_action=admin_user,
+    )
+
+    DocumentSetManager.wait_for_sync(user_performing_action=admin_user)
+    DocumentSetManager.verify(
+        document_set=doc_set,
+        user_performing_action=admin_user,
+    )
+
+    new_name = f"renamed_doc_set_{uuid4()}"
+    doc_set.name = new_name
+    DocumentSetManager.edit(
+        doc_set,
+        user_performing_action=admin_user,
+    )
+
+    DocumentSetManager.wait_for_sync(user_performing_action=admin_user)
+    DocumentSetManager.verify(
+        document_set=doc_set,
+        user_performing_action=admin_user,
+    )
+
+    DocumentManager.verify(
+        vespa_client=vespa_client,
+        cc_pair=cc_pair,
+        doc_set_names=[new_name],
         doc_creating_user=admin_user,
     )

--- a/web/src/app/admin/documents/sets/lib.ts
+++ b/web/src/app/admin/documents/sets/lib.ts
@@ -38,6 +38,7 @@ export const createDocumentSet = async ({
 
 interface DocumentSetUpdateRequest {
   id: number;
+  name: string;
   description: string;
   cc_pair_ids: number[];
   is_public: boolean;
@@ -48,6 +49,7 @@ interface DocumentSetUpdateRequest {
 
 export const updateDocumentSet = async ({
   id,
+  name,
   description,
   cc_pair_ids,
   is_public,
@@ -62,6 +64,7 @@ export const updateDocumentSet = async ({
     },
     body: JSON.stringify({
       id,
+      name,
       description,
       cc_pair_ids,
       is_public,


### PR DESCRIPTION
## Description

We were not updating document set names when patching them, now we are

## How Has This Been Tested?

new test

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes document set renaming. Updating a document set from the admin UI now saves the new name and syncs it through to the search index.

- **Bug Fixes**
  - Adds `name` to the backend `DocumentSetUpdateRequest` and persists it in `update_document_set`.
  - Sends `name` in the web admin update request and adds an integration test to verify rename propagation after sync.

<sup>Written for commit bcf382093573796d0611c9082539cf01706f198b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



