### PR TITLE
fix: agent knowledge toggle persist

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -571,8 +571,12 @@ export default function AgentEditorPage({
       (_, i) => existingAgent?.starter_messages?.[i]?.message ?? ""
     ),
 
-    // Knowledge - enabled if agent has any knowledge sources attached
+    // Knowledge - enabled if agent has search tool or any knowledge sources attached
     enable_knowledge:
+      (existingAgent?.tools?.some(
+        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
+      ) ??
+        false) ||
       (existingAgent?.document_sets?.length ?? 0) > 0 ||
       (existingAgent?.hierarchy_nodes?.length ?? 0) > 0 ||
       (existingAgent?.attached_documents?.length ?? 0) > 0 ||


### PR DESCRIPTION
## Description

When returning toe dit and agent with just knowledge enabled, the toggle shows as off. Now we correctly detect that it had been turned on (this was just a FE issue)

## How Has This Been Tested?

test in FE

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a frontend bug where the Knowledge toggle showed as off when editing an agent with only search enabled. The toggle now initializes from the search tool (`SEARCH_TOOL_ID`) or any attached knowledge sources, so it persists correctly.

<sup>Written for commit f4b9942e767099ce62c1e5ad868ccac7e571f0bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

