### PR TITLE
fix(files): Lower log level on file store cache miss

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -364,7 +364,7 @@ def _get_or_extract_plaintext(
         plaintext_io = file_store.read_file(plaintext_key, mode="b")
         return plaintext_io.read().decode("utf-8")
     except Exception:
-        logger.exception(f"Error when reading file, id={file_id}")
+        logger.info(f"Cache miss for file with id={file_id}")
 
     # Cache miss — extract and store.
     content_text = extract_fn()


### PR DESCRIPTION
## Description
Currently when we attempt to get a file that is not in the file store we raise an error. For the file cache, we use this to say we don't have that file. Currently we log that error as an exception though.

This lowers the exception to info level since it is expected.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered log level for file-store cache misses in `_get_or_extract_plaintext` from exception to info to reduce noisy error logs and avoid false alerts. Cache misses are expected; we now log them at info and proceed with extraction as before.

<sup>Written for commit c4cdfa070bd1523f9ea25ba04ba5b7530640a9f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

