### PR TITLE
fix: use static provider list instead of querying be

### DIFF
--- a/web/src/hooks/useLLMProviders.ts
+++ b/web/src/hooks/useLLMProviders.ts
@@ -114,26 +114,6 @@ export function useAdminLLMProviders() {
 }
 
 /**
- * Fetches the catalog of well-known (built-in) LLM providers.
- *
- * Hits `GET /api/admin/llm/built-in/options` which returns the static
- * list of provider descriptors that Onyx ships with out of the box
- * (OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Ollama, OpenRouter,
- * etc.). Each descriptor includes the provider's known models and the
- * recommended default model.
- *
- * Used primarily on the LLM Configuration page and onboarding flows
- * to show which providers are available to set up, and to pre-populate
- * model lists before the user has entered credentials.
- *
- * @returns
- * - `wellKnownLLMProviders` — The array of built-in provider descriptors,
- *    or `null` while loading.
- * - `isLoading` — `true` until the first successful response or error.
- * - `error` — The SWR error object, if any.
- * - `mutate` — SWR `mutate` function to trigger a revalidation.
- */
-/**
  * Fetches the descriptor for a single well-known (built-in) LLM provider.
  *
  * Hits `GET /api/admin/llm/built-in/options/{providerEndpoint}` which returns
@@ -192,29 +172,5 @@ export function useCustomProviderNames() {
     customProviderNames: data ?? null,
     isLoading,
     error,
-  };
-}
-
-export function useWellKnownLLMProviders() {
-  const {
-    data: wellKnownLLMProviders,
-    error,
-    isLoading,
-    mutate,
-  } = useSWR<WellKnownLLMProviderDescriptor[]>(
-    SWR_KEYS.wellKnownLlmProviders,
-    errorHandlingFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      dedupingInterval: 60000,
-    }
-  );
-
-  return {
-    wellKnownLLMProviders: wellKnownLLMProviders ?? null,
-    isLoading,
-    error,
-    mutate,
   };
 }

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -3,10 +3,7 @@
 import { useState } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
-import {
-  useAdminLLMProviders,
-  useWellKnownLLMProviders,
-} from "@/hooks/useLLMProviders";
+import { useAdminLLMProviders } from "@/hooks/useLLMProviders";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { Content, Card as CardLayout, InputHorizontal } from "@opal/layouts";
 import { Button, Divider, SelectCard, Text, Card } from "@opal/components";
@@ -22,11 +19,7 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Message from "@/refresh-components/messages/Message";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
-import {
-  LLMProviderName,
-  LLMProviderView,
-  WellKnownLLMProviderDescriptor,
-} from "@/interfaces/llm";
+import { LLMProviderName, LLMProviderView } from "@/interfaces/llm";
 import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
 
@@ -187,13 +180,16 @@ function ExistingProviderCard({
 // ============================================================================
 
 interface NewProviderCardProps {
-  provider: WellKnownLLMProviderDescriptor;
+  providerName: string;
   isFirstProvider: boolean;
 }
 
-function NewProviderCard({ provider, isFirstProvider }: NewProviderCardProps) {
+function NewProviderCard({
+  providerName,
+  isFirstProvider,
+}: NewProviderCardProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { icon, productName, companyName, Modal } = getProvider(provider.name);
+  const { icon, productName, companyName, Modal } = getProvider(providerName);
 
   return (
     <SelectCard
@@ -283,7 +279,6 @@ export default function LLMConfigurationPage() {
   const { mutate } = useSWRConfig();
   const { llmProviders: existingLlmProviders, defaultText } =
     useAdminLLMProviders();
-  const { wellKnownLLMProviders } = useWellKnownLLMProviders();
 
   if (!existingLlmProviders) {
     return <ThreeDotsLoader />;
@@ -424,22 +419,13 @@ export default function LLMConfigurationPage() {
           />
 
           <div className="grid grid-cols-2 gap-2">
-            {[...(wellKnownLLMProviders ?? [])]
-              .sort((a, b) => {
-                const aIndex = PROVIDER_DISPLAY_ORDER.indexOf(a.name);
-                const bIndex = PROVIDER_DISPLAY_ORDER.indexOf(b.name);
-                return (
-                  (aIndex === -1 ? Infinity : aIndex) -
-                  (bIndex === -1 ? Infinity : bIndex)
-                );
-              })
-              .map((provider) => (
-                <NewProviderCard
-                  key={provider.name}
-                  provider={provider}
-                  isFirstProvider={isFirstProvider}
-                />
-              ))}
+            {PROVIDER_DISPLAY_ORDER.map((name) => (
+              <NewProviderCard
+                key={name}
+                providerName={name}
+                isFirstProvider={isFirstProvider}
+              />
+            ))}
             <NewCustomProviderCard isFirstProvider={isFirstProvider} />
           </div>
         </GeneralLayouts.Section>

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -29,15 +29,15 @@ const route = ADMIN_ROUTES.LLM_MODELS;
 // Provider form mapping (keyed by provider name from the API)
 // ============================================================================
 
-// Client-side ordering for the "Add Provider" cards. The backend may return
-// wellKnownLLMProviders in an arbitrary order, so we sort explicitly here.
+// Static list of well-known providers rendered in the "Add Provider" grid.
+// Must match the backend's WELL_KNOWN_PROVIDER_NAMES (minus any that lack a
+// dedicated modal). Order here controls display order.
 const PROVIDER_DISPLAY_ORDER: string[] = [
   LLMProviderName.OPENAI,
   LLMProviderName.ANTHROPIC,
   LLMProviderName.VERTEX_AI,
   LLMProviderName.BEDROCK,
   LLMProviderName.AZURE,
-  LLMProviderName.LITELLM,
   LLMProviderName.LITELLM_PROXY,
   LLMProviderName.OLLAMA_CHAT,
   LLMProviderName.OPENROUTER,


### PR DESCRIPTION
## Description


- Provider cards would not render until `/api/admin/llm/built-in/options` returned wellknownproviders --> this endpoint is a bit troll and takes ~1s to respond on our cloud
  - This would cause the Custom LLM Provider card to render and then shift after ~1s once all other providers were found
- We have a hardcoded list of providers on the FE that determine the sorting order. We can just use this to render
- What isn't great is that new provider implementations have an extra place they need to define their provider, but maybe that's good as it forces devs to think about the final order on the page?
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render LLM provider cards from a static list instead of querying the backend, removing the load-time layout shift on the configuration page. Provider order is now fixed by `PROVIDER_DISPLAY_ORDER`.

- **Bug Fixes**
  - Replaced backend fetch with static `PROVIDER_DISPLAY_ORDER`; removed the `useWellKnownLLMProviders` hook and related descriptor types.
  - Updated `NewProviderCard` to take `providerName` and resolve details via `getProvider`.

<sup>Written for commit 8525c1e18c166de35b1dfa579dcefe0a7d2d01ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



