### PR TITLE
fix: uploaded files as knowledge source

### DIFF
--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -185,6 +185,10 @@ class MinimalPersonaSnapshot(BaseModel):
         for doc_set in persona.document_sets:
             for cc_pair in doc_set.connector_credential_pairs:
                 sources.add(cc_pair.connector.source)
+            for fed_ds in doc_set.federated_connectors:
+                non_fed = fed_ds.federated_connector.source.to_non_federated_source()
+                if non_fed is not None:
+                    sources.add(non_fed)
 
         # Sources from hierarchy nodes
         for node in persona.hierarchy_nodes:
@@ -194,6 +198,9 @@ class MinimalPersonaSnapshot(BaseModel):
         for doc in persona.attached_documents:
             if doc.parent_hierarchy_node:
                 sources.add(doc.parent_hierarchy_node.source)
+
+        if persona.user_files:
+            sources.add(DocumentSource.USER_FILE)
 
         return MinimalPersonaSnapshot(
             # Core fields actually used by ChatPage

--- a/backend/tests/integration/tests/personas/test_persona_knowledge_sources.py
+++ b/backend/tests/integration/tests/personas/test_persona_knowledge_sources.py
@@ -49,7 +49,7 @@ def test_persona_with_user_files_includes_user_file_source(
     )
     assert not error, f"File upload failed: {error}"
 
-    user_file_id = file_descriptors[0]["user_file_id"]
+    user_file_id = file_descriptors[0]["user_file_id"] or ""
 
     persona = PersonaManager.create(
         user_performing_action=admin_user,

--- a/backend/tests/integration/tests/personas/test_persona_knowledge_sources.py
+++ b/backend/tests/integration/tests/personas/test_persona_knowledge_sources.py
@@ -1,0 +1,83 @@
+"""
+Integration tests verifying the knowledge_sources field on MinimalPersonaSnapshot.
+
+The GET /persona endpoint returns MinimalPersonaSnapshot, which includes a
+knowledge_sources list derived from the persona's document sets, hierarchy
+nodes, attached documents, and user files.  These tests verify that the
+field is populated correctly.
+"""
+
+import requests
+
+from onyx.configs.constants import DocumentSource
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.file import FileManager
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_file_utils import create_test_text_file
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _get_minimal_persona(
+    persona_id: int,
+    user: DATestUser,
+) -> dict:
+    """Fetch personas from the list endpoint and find the one with the given id."""
+    response = requests.get(
+        f"{API_SERVER_URL}/persona",
+        params={"persona_ids": persona_id},
+        headers=user.headers,
+    )
+    response.raise_for_status()
+    personas = response.json()
+    matches = [p for p in personas if p["id"] == persona_id]
+    assert (
+        len(matches) == 1
+    ), f"Expected 1 persona with id={persona_id}, got {len(matches)}"
+    return matches[0]
+
+
+def test_persona_with_user_files_includes_user_file_source(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """When a persona has user files attached, knowledge_sources includes 'user_file'."""
+    text_file = create_test_text_file("test content for knowledge source verification")
+    file_descriptors, error = FileManager.upload_files(
+        files=[("test_ks.txt", text_file)],
+        user_performing_action=admin_user,
+    )
+    assert not error, f"File upload failed: {error}"
+
+    user_file_id = file_descriptors[0]["user_file_id"]
+
+    persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="KS User File Agent",
+        description="Agent with user files for knowledge_sources test",
+        system_prompt="You are a helpful assistant.",
+        user_file_ids=[user_file_id],
+    )
+
+    minimal = _get_minimal_persona(persona.id, admin_user)
+    assert (
+        DocumentSource.USER_FILE.value in minimal["knowledge_sources"]
+    ), f"Expected 'user_file' in knowledge_sources, got: {minimal['knowledge_sources']}"
+
+
+def test_persona_without_user_files_excludes_user_file_source(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """When a persona has no user files, knowledge_sources should not contain 'user_file'."""
+    persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="KS No Files Agent",
+        description="Agent without files for knowledge_sources test",
+        system_prompt="You are a helpful assistant.",
+    )
+
+    minimal = _get_minimal_persona(persona.id, admin_user)
+    assert (
+        DocumentSource.USER_FILE.value not in minimal["knowledge_sources"]
+    ), f"Unexpected 'user_file' in knowledge_sources: {minimal['knowledge_sources']}"

--- a/backend/tests/unit/onyx/server/features/persona/test_knowledge_sources.py
+++ b/backend/tests/unit/onyx/server/features/persona/test_knowledge_sources.py
@@ -1,0 +1,188 @@
+"""Unit tests for MinimalPersonaSnapshot.from_model knowledge_sources aggregation."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FederatedConnectorSource
+from onyx.server.features.document_set.models import DocumentSetSummary
+from onyx.server.features.persona.models import MinimalPersonaSnapshot
+
+
+_STUB_DS_SUMMARY = DocumentSetSummary(
+    id=1,
+    name="stub",
+    description=None,
+    cc_pair_summaries=[],
+    is_up_to_date=True,
+    is_public=True,
+    users=[],
+    groups=[],
+)
+
+
+def _make_persona(**overrides: object) -> MagicMock:
+    """Build a mock Persona with sensible defaults.
+
+    Every relationship defaults to empty so tests only need to set the
+    fields they care about.
+    """
+    p = MagicMock()
+    p.id = 1
+    p.name = "test"
+    p.description = ""
+    p.tools = []
+    p.starter_messages = None
+    p.document_sets = []
+    p.hierarchy_nodes = []
+    p.attached_documents = []
+    p.user_files = []
+    p.llm_model_version_override = None
+    p.llm_model_provider_override = None
+    p.uploaded_image_id = None
+    p.icon_name = None
+    p.is_public = True
+    p.is_listed = True
+    p.display_priority = None
+    p.is_featured = False
+    p.builtin_persona = False
+    p.labels = []
+    p.user = None
+
+    for k, v in overrides.items():
+        setattr(p, k, v)
+    return p
+
+
+def _make_cc_pair(source: DocumentSource) -> MagicMock:
+    cc = MagicMock()
+    cc.connector.source = source
+    cc.name = source.value
+    cc.id = 1
+    cc.access_type = "PUBLIC"
+    return cc
+
+
+def _make_doc_set(
+    cc_pairs: list[MagicMock] | None = None,
+    fed_connectors: list[MagicMock] | None = None,
+) -> MagicMock:
+    ds = MagicMock()
+    ds.id = 1
+    ds.name = "ds"
+    ds.description = None
+    ds.is_up_to_date = True
+    ds.is_public = True
+    ds.users = []
+    ds.groups = []
+    ds.connector_credential_pairs = cc_pairs or []
+    ds.federated_connectors = fed_connectors or []
+    return ds
+
+
+def _make_federated_ds_mapping(
+    source: FederatedConnectorSource,
+) -> MagicMock:
+    mapping = MagicMock()
+    mapping.federated_connector.source = source
+    mapping.federated_connector_id = 1
+    mapping.entities = {}
+    return mapping
+
+
+def _make_hierarchy_node(source: DocumentSource) -> MagicMock:
+    node = MagicMock()
+    node.source = source
+    return node
+
+
+def _make_attached_document(source: DocumentSource) -> MagicMock:
+    doc = MagicMock()
+    doc.parent_hierarchy_node = MagicMock()
+    doc.parent_hierarchy_node.source = source
+    return doc
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_empty_persona_has_no_knowledge_sources(_mock_ds: MagicMock) -> None:
+    persona = _make_persona()
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    assert snapshot.knowledge_sources == []
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_user_files_adds_user_file_source(_mock_ds: MagicMock) -> None:
+    persona = _make_persona(user_files=[MagicMock()])
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    assert DocumentSource.USER_FILE in snapshot.knowledge_sources
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_no_user_files_excludes_user_file_source(_mock_ds: MagicMock) -> None:
+    cc = _make_cc_pair(DocumentSource.CONFLUENCE)
+    ds = _make_doc_set(cc_pairs=[cc])
+    persona = _make_persona(document_sets=[ds])
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    assert DocumentSource.USER_FILE not in snapshot.knowledge_sources
+    assert DocumentSource.CONFLUENCE in snapshot.knowledge_sources
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_federated_connector_in_doc_set(_mock_ds: MagicMock) -> None:
+    fed = _make_federated_ds_mapping(FederatedConnectorSource.FEDERATED_SLACK)
+    ds = _make_doc_set(fed_connectors=[fed])
+    persona = _make_persona(document_sets=[ds])
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    assert DocumentSource.SLACK in snapshot.knowledge_sources
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_hierarchy_nodes_and_attached_documents(_mock_ds: MagicMock) -> None:
+    node = _make_hierarchy_node(DocumentSource.GOOGLE_DRIVE)
+    doc = _make_attached_document(DocumentSource.SHAREPOINT)
+    persona = _make_persona(hierarchy_nodes=[node], attached_documents=[doc])
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    assert DocumentSource.GOOGLE_DRIVE in snapshot.knowledge_sources
+    assert DocumentSource.SHAREPOINT in snapshot.knowledge_sources
+
+
+@patch(
+    "onyx.server.features.persona.models.DocumentSetSummary.from_model",
+    return_value=_STUB_DS_SUMMARY,
+)
+def test_all_source_types_combined(_mock_ds: MagicMock) -> None:
+    cc = _make_cc_pair(DocumentSource.CONFLUENCE)
+    fed = _make_federated_ds_mapping(FederatedConnectorSource.FEDERATED_SLACK)
+    ds = _make_doc_set(cc_pairs=[cc], fed_connectors=[fed])
+    node = _make_hierarchy_node(DocumentSource.GOOGLE_DRIVE)
+    doc = _make_attached_document(DocumentSource.SHAREPOINT)
+    persona = _make_persona(
+        document_sets=[ds],
+        hierarchy_nodes=[node],
+        attached_documents=[doc],
+        user_files=[MagicMock()],
+    )
+    snapshot = MinimalPersonaSnapshot.from_model(persona)
+    sources = set(snapshot.knowledge_sources)
+    assert sources == {
+        DocumentSource.CONFLUENCE,
+        DocumentSource.SLACK,
+        DocumentSource.GOOGLE_DRIVE,
+        DocumentSource.SHAREPOINT,
+        DocumentSource.USER_FILE,
+    }

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -1154,6 +1154,16 @@ export function useSourcePreferences({
     setSelectedSources,
   ]);
 
+  // Re-initialize when the available source set changes (e.g. switching agents).
+  const prevSourcesKey = useRef(availableSources.join(","));
+  useEffect(() => {
+    const key = availableSources.join(",");
+    if (key !== prevSourcesKey.current) {
+      prevSourcesKey.current = key;
+      setSourcesInitialized(false);
+    }
+  }, [availableSources]);
+
   const enableSources = (sources: SourceMetadata[]) => {
     setSelectedSources([...sources]);
     persistSourcePreferencesState(sources, configuredSources);

--- a/web/src/lib/sourcePreferences.test.tsx
+++ b/web/src/lib/sourcePreferences.test.tsx
@@ -1,0 +1,156 @@
+import { renderHook, act } from "@testing-library/react";
+import { ValidSources } from "@/lib/types";
+import { SourceMetadata } from "@/lib/search/interfaces";
+import { useSourcePreferences } from "@/lib/hooks";
+import { buildFilters } from "@/lib/search/utils";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function setup(availableSources: ValidSources[]) {
+  const state: { selected: SourceMetadata[] } = { selected: [] };
+
+  const hook = renderHook(
+    ({ avail }) =>
+      useSourcePreferences({
+        availableSources: avail,
+        selectedSources: state.selected,
+        setSelectedSources: (sources: SourceMetadata[]) => {
+          state.selected = sources;
+        },
+      }),
+    { initialProps: { avail: availableSources } }
+  );
+
+  return { hook, state };
+}
+
+function sourceNames(sources: SourceMetadata[]): string[] {
+  return sources.map((s) => s.internalName).sort();
+}
+
+describe("useSourcePreferences — initialization", () => {
+  test("all sources default to enabled on first load", () => {
+    const { state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+    expect(sourceNames(state.selected)).toEqual(["notion", "user_file"]);
+  });
+
+  test("single source defaults to enabled", () => {
+    const { state } = setup([ValidSources.Confluence]);
+    expect(sourceNames(state.selected)).toEqual(["confluence"]);
+  });
+});
+
+describe("useSourcePreferences — toggling", () => {
+  test("toggling a source off removes it from selected", () => {
+    const { hook, state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+
+    act(() => {
+      hook.result.current.toggleSource("notion");
+    });
+
+    expect(sourceNames(state.selected)).toEqual(["user_file"]);
+  });
+
+  test("toggling persists preference to localStorage", () => {
+    const { hook } = setup([ValidSources.Notion, ValidSources.UserFile]);
+
+    act(() => {
+      hook.result.current.toggleSource("notion");
+    });
+
+    const saved = JSON.parse(
+      localStorage.getItem("selectedInternalSearchSources")!
+    );
+    expect(saved.sourcePreferences.notion).toBe(false);
+    expect(saved.sourcePreferences.user_file).toBe(true);
+  });
+});
+
+describe("useSourcePreferences — agent switching", () => {
+  test("switching agents re-initializes with new sources enabled", () => {
+    const { hook, state } = setup([ValidSources.Notion, ValidSources.Web]);
+    expect(sourceNames(state.selected)).toEqual(["notion", "web"]);
+
+    hook.rerender({
+      avail: [ValidSources.Notion, ValidSources.UserFile],
+    });
+
+    expect(sourceNames(state.selected)).toEqual(["notion", "user_file"]);
+    expect(
+      state.selected.find((s) => s.internalName === "web")
+    ).toBeUndefined();
+  });
+
+  test("switching to default agent (all sources) shows everything", () => {
+    const { hook, state } = setup([ValidSources.Notion]);
+    expect(sourceNames(state.selected)).toEqual(["notion"]);
+
+    hook.rerender({
+      avail: [ValidSources.Notion, ValidSources.Web, ValidSources.Confluence],
+    });
+
+    expect(sourceNames(state.selected)).toEqual([
+      "confluence",
+      "notion",
+      "web",
+    ]);
+  });
+});
+
+describe("useSourcePreferences — localStorage persistence across agents", () => {
+  test("saved preference honored when switching agents", () => {
+    // Pre-seed localStorage: notion off, confluence on
+    localStorage.setItem(
+      "selectedInternalSearchSources",
+      JSON.stringify({
+        sourcePreferences: { notion: false, confluence: true },
+      })
+    );
+
+    const { state } = setup([ValidSources.Notion, ValidSources.Confluence]);
+
+    // Notion should be off (from saved prefs), confluence on
+    expect(sourceNames(state.selected)).toEqual(["confluence"]);
+  });
+
+  test("new sources not in saved prefs default to enabled", () => {
+    localStorage.setItem(
+      "selectedInternalSearchSources",
+      JSON.stringify({
+        sourcePreferences: { notion: true },
+      })
+    );
+
+    const { state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+
+    // user_file has no saved pref → defaults to enabled
+    expect(sourceNames(state.selected)).toEqual(["notion", "user_file"]);
+  });
+});
+
+describe("buildFilters — source_type payload", () => {
+  test("enabled sources produce a source_type array", () => {
+    const { state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+
+    const filters = buildFilters(state.selected, [], null, []);
+    expect(filters.source_type?.sort()).toEqual(["notion", "user_file"]);
+  });
+
+  test("no sources produces null source_type", () => {
+    const filters = buildFilters([], [], null, []);
+    expect(filters.source_type).toBeNull();
+  });
+
+  test("toggled-off source excluded from payload", () => {
+    const { hook, state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+
+    act(() => {
+      hook.result.current.toggleSource("notion");
+    });
+
+    const filters = buildFilters(state.selected, [], null, []);
+    expect(filters.source_type).toEqual(["user_file"]);
+  });
+});

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -52,8 +52,8 @@ import { ValidSources } from "./types";
 import { SourceCategory, SourceMetadata } from "./search/interfaces";
 import { Persona } from "@/app/admin/agents/interfaces";
 import React from "react";
-import { DOCS_ADMINS_PATH } from "./constants";
-import { SvgFileText, SvgGlobe } from "@opal/icons";
+import { DOCS_ADMINS_PATH, DOCS_BASE_URL } from "./constants";
+import { SvgFileText, SvgGlobe, SvgUploadCloud } from "@opal/icons";
 
 interface PartialSourceMetadata {
   icon: React.FC<{ size?: number; className?: string }>;
@@ -412,11 +412,10 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     isPopular: true,
   },
   user_file: {
-    // TODO: write docs for projects and link them here
-    icon: SvgFileText,
-    displayName: "File",
+    icon: SvgUploadCloud,
+    displayName: "Uploaded Files",
     category: SourceCategory.Other,
-    docs: `${DOCS_ADMINS_PATH}/connectors/official/file`,
+    docs: `${DOCS_BASE_URL}/overview/core_features/chat#projects`,
     isPopular: false, // Needs to be false to hide from the Add Connector page
   },
 

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -22,7 +22,7 @@ import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAgentPreferences from "@/hooks/useAgentPreferences";
 import { useUser } from "@/providers/UserProvider";
 import { FilterManager, useSourcePreferences } from "@/lib/hooks";
-import { listSourceMetadata } from "@/lib/sources";
+import { getSourceMetadata } from "@/lib/sources";
 import MCPApiKeyModal from "@/components/chat/MCPApiKeyModal";
 import { ValidSources } from "@/lib/types";
 import { SourceMetadata } from "@/lib/search/interfaces";
@@ -121,31 +121,26 @@ const getAdminConfigureInfo = (
 function getConfiguredSources(
   availableSources: ValidSources[]
 ): Array<SourceMetadata & { originalName: string; uniqueKey: string }> {
-  const allSources = listSourceMetadata();
-
-  const seenSources = new Set<string>();
-  const configuredSources: Array<
+  const seen = new Set<string>();
+  const result: Array<
     SourceMetadata & { originalName: string; uniqueKey: string }
   > = [];
 
-  availableSources.forEach((sourceName) => {
-    // Handle federated connectors by removing the federated_ prefix
-    const cleanName = sourceName.replace("federated_", "");
-    // Skip if we've already seen this source type
-    if (seenSources.has(cleanName)) return;
-    seenSources.add(cleanName);
-    const source = allSources.find(
-      (source) => source.internalName === cleanName
-    );
-    if (source) {
-      configuredSources.push({
-        ...source,
-        originalName: sourceName,
-        uniqueKey: cleanName,
-      });
-    }
-  });
-  return configuredSources;
+  for (const sourceName of availableSources) {
+    const cleanName = sourceName.replace("federated_", "") as ValidSources;
+    if (seen.has(cleanName)) continue;
+    seen.add(cleanName);
+
+    const metadata = getSourceMetadata(cleanName);
+    if (metadata.internalName === ValidSources.NotApplicable) continue;
+
+    result.push({
+      ...metadata,
+      originalName: sourceName,
+      uniqueKey: cleanName,
+    });
+  }
+  return result;
 }
 
 type SecondaryViewState =
@@ -184,6 +179,37 @@ export default function ActionsPopover({
     selectedAgent.id
   );
 
+  const isDefaultAgent = selectedAgent.id === 0;
+
+  const hasSearchTool = selectedAgent.tools.some(
+    (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
+  );
+
+  // knowledge_sources from the backend is the complete set of source types this agent
+  // can search over (doc sets, federated, hierarchy nodes, attached docs, user files).
+  // Default agent is special-cased to show everything available.
+  const agentAccessibleSources = useMemo(() => {
+    if (isDefaultAgent) {
+      return null; // null means "all accessible"
+    }
+
+    const sources = selectedAgent.knowledge_sources ?? [];
+    if (sources.length === 0 && hasSearchTool) {
+      return null;
+    }
+
+    return new Set<string>(sources);
+  }, [isDefaultAgent, selectedAgent.knowledge_sources, hasSearchTool]);
+
+  // Scope availableSources to only what this agent can access. This ensures
+  // that (a) agent-only sources like user_file appear in the toggle list and
+  // (b) stale sources from localStorage (e.g. Web on an agent with only Notion)
+  // don't leak into selectedSources / the YQL query.
+  const effectiveAvailableSources = useMemo(() => {
+    if (agentAccessibleSources === null) return availableSources;
+    return Array.from(agentAccessibleSources) as ValidSources[];
+  }, [agentAccessibleSources, availableSources]);
+
   const {
     sourcesInitialized,
     enableSources,
@@ -192,76 +218,13 @@ export default function ActionsPopover({
     toggleSource: baseToggleSource,
     isSourceEnabled,
   } = useSourcePreferences({
-    availableSources,
+    availableSources: effectiveAvailableSources,
     selectedSources,
     setSelectedSources,
   });
 
   // Store previously enabled sources when search tool is disabled
   const previouslyEnabledSourcesRef = useRef<SourceMetadata[]>([]);
-
-  const isDefaultAgent = selectedAgent.id === 0;
-
-  // Check if the search tool is explicitly enabled on this persona (admin enabled "Use Knowledge")
-  const hasSearchTool = selectedAgent.tools.some(
-    (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
-  );
-
-  // Get sources the agent has access to via document sets, hierarchy nodes, and attached documents
-  // Default agent has access to all sources
-  const agentAccessibleSources = useMemo(() => {
-    if (isDefaultAgent) {
-      return null; // null means "all accessible"
-    }
-
-    const sourceSet = new Set<string>();
-
-    // Add sources from document sets
-    selectedAgent.document_sets.forEach((docSet) => {
-      // Check cc_pair_summaries (regular connectors)
-      docSet.cc_pair_summaries?.forEach((ccPair) => {
-        // Normalize by removing federated_ prefix
-        const normalized = ccPair.source.replace("federated_", "");
-        sourceSet.add(normalized);
-      });
-
-      // Check federated_connector_summaries (federated connectors)
-      docSet.federated_connector_summaries?.forEach((fedConnector) => {
-        // Normalize by removing federated_ prefix
-        const normalized = fedConnector.source.replace("federated_", "");
-        sourceSet.add(normalized);
-      });
-    });
-
-    // Add sources from hierarchy nodes and attached documents (via knowledge_sources)
-    selectedAgent.knowledge_sources?.forEach((source) => {
-      // Normalize by removing federated_ prefix
-      const normalized = source.replace("federated_", "");
-      sourceSet.add(normalized);
-    });
-
-    // If agent has search tool but no specific sources, it can search everything
-    if (sourceSet.size === 0 && hasSearchTool) {
-      return null;
-    }
-
-    return sourceSet;
-  }, [
-    isDefaultAgent,
-    selectedAgent.document_sets,
-    selectedAgent.knowledge_sources,
-    hasSearchTool,
-  ]);
-
-  // Check if non-default agent has no knowledge sources (Internal Search should be disabled)
-  // Knowledge sources include document sets, hierarchy nodes, and attached documents
-  // If the search tool is present, the admin intentionally enabled knowledge search
-  const hasNoKnowledgeSources =
-    !isDefaultAgent &&
-    !hasSearchTool &&
-    selectedAgent.document_sets.length === 0 &&
-    (selectedAgent.hierarchy_node_count ?? 0) === 0 &&
-    (selectedAgent.attached_document_count ?? 0) === 0;
 
   // Store MCP server auth/loading state (tools are part of selectedAgent.tools)
   const [mcpServerData, setMcpServerData] = useState<{
@@ -347,48 +310,31 @@ export default function ActionsPopover({
   // Handle explicit force toggle from ActionLineItem
   const handleForceToggleWithTracking = useCallback(
     (toolId: number, wasForced: boolean) => {
-      // If pinning internal search, enable all accessible sources
       if (
         !wasForced &&
         internalSearchTool &&
         toolId === internalSearchTool.id
       ) {
-        const sources = getConfiguredSources(availableSources);
-        const accessibleSources = sources.filter(
-          (s) =>
-            agentAccessibleSources === null ||
-            agentAccessibleSources.has(s.uniqueKey)
-        );
-        setSelectedSources(accessibleSources);
+        setSelectedSources(getConfiguredSources(effectiveAvailableSources));
       }
       toggleForcedTool(toolId);
     },
     [
       toggleForcedTool,
       internalSearchTool,
-      availableSources,
-      agentAccessibleSources,
+      effectiveAvailableSources,
       setSelectedSources,
     ]
   );
 
-  // Wrapped source functions that auto-pin internal search when sources change
   const enableAllSources = useCallback(() => {
-    // Only enable sources the agent has access to
-    const allConfiguredSources = getConfiguredSources(availableSources);
-    const accessibleSources = allConfiguredSources.filter(
-      (s) =>
-        agentAccessibleSources === null ||
-        agentAccessibleSources.has(s.uniqueKey)
-    );
-    setSelectedSources(accessibleSources);
+    setSelectedSources(getConfiguredSources(effectiveAvailableSources));
 
     if (internalSearchTool) {
       setForcedToolIds([internalSearchTool.id]);
     }
   }, [
-    agentAccessibleSources,
-    availableSources,
+    effectiveAvailableSources,
     setSelectedSources,
     internalSearchTool,
     setForcedToolIds,
@@ -413,15 +359,12 @@ export default function ActionsPopover({
       const wasEnabled = isSourceEnabled(sourceUniqueKey);
       baseToggleSource(sourceUniqueKey);
 
-      const configuredSources = getConfiguredSources(availableSources);
-
       if (internalSearchTool) {
         if (!wasEnabled) {
-          // Enabling a source - auto-pin internal search
           setForcedToolIds([internalSearchTool.id]);
         } else {
-          // Disabling a source - check if all sources will be disabled
-          const remainingEnabled = configuredSources.filter(
+          const allSources = getConfiguredSources(effectiveAvailableSources);
+          const remainingEnabled = allSources.filter(
             (s) =>
               s.uniqueKey !== sourceUniqueKey && isSourceEnabled(s.uniqueKey)
           );
@@ -429,7 +372,6 @@ export default function ActionsPopover({
             remainingEnabled.length === 0 &&
             forcedToolIds.includes(internalSearchTool.id)
           ) {
-            // All sources disabled - unpin
             setForcedToolIds([]);
           }
         }
@@ -439,7 +381,7 @@ export default function ActionsPopover({
       baseToggleSource,
       internalSearchTool,
       isSourceEnabled,
-      availableSources,
+      effectiveAvailableSources,
       forcedToolIds,
       setForcedToolIds,
     ]
@@ -780,7 +722,7 @@ export default function ActionsPopover({
     </LineItem>
   ) : undefined;
 
-  const configuredSources = getConfiguredSources(availableSources);
+  const configuredSources = getConfiguredSources(effectiveAvailableSources);
 
   const numSourcesEnabled = configuredSources.filter((source) =>
     isSourceEnabled(source.uniqueKey)
@@ -859,14 +801,7 @@ export default function ActionsPopover({
     }
   };
 
-  // Only show sources the agent has access to
-  const accessibleConfiguredSources = configuredSources.filter(
-    (source) =>
-      agentAccessibleSources === null ||
-      agentAccessibleSources.has(source.uniqueKey)
-  );
-
-  const sourceToggleItems: SwitchListItem[] = accessibleConfiguredSources.map(
+  const sourceToggleItems: SwitchListItem[] = configuredSources.map(
     (source) => ({
       id: source.uniqueKey,
       label: source.displayName,
@@ -880,11 +815,10 @@ export default function ActionsPopover({
     (source) => !isSourceEnabled(source.uniqueKey)
   );
 
-  // Count enabled sources for display (only accessible sources)
-  const enabledSourceCount = accessibleConfiguredSources.filter((source) =>
+  const enabledSourceCount = configuredSources.filter((source) =>
     isSourceEnabled(source.uniqueKey)
   ).length;
-  const totalSourceCount = accessibleConfiguredSources.length;
+  const totalSourceCount = configuredSources.length;
 
   const primaryView = (
     <PopoverMenu>


### PR DESCRIPTION
## Description

When uploading and attaching large files to an assistant and also selecting some subset of uploaded knowledge to attach to an agent, we were previously unable to actually retrieve info from the attached user files (we were not passing user_file as a source filter through to the vector db). Now we do so, and make explicit the uploaded files as a searchable source type in the actions popover.

One note: this toggle will now exist whether the uploaded files in question fit in the context or not. It's still meaningful (decides whether the search tool can see the files), but there's a potential weird UX thing where a user might expect that toggling it off means the agent can't see the uploaded files at all. That isn't the case, based on our assumptions about what people want when they attach uploaded files to assistants (we directly inject small uploaded files into the context).

<img width="285" height="256" alt="Screenshot 2026-04-14 at 2 50 25 PM" src="https://github.com/user-attachments/assets/0e15c277-e1e2-4595-8033-b92b3d8d1036" />


## How Has This Been Tested?

tested in UI and added frontend unit and backend integration tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes knowledge search so attached uploaded files are actually queried and shown as an “Uploaded Files” source. Also scopes and resets source toggles per agent to avoid stale selections when switching agents.

- **Bug Fixes**
  - Add `user_file` to persona `knowledge_sources` when user files are attached; map federated connectors to their non‑federated sources.
  - Scope toggles and filter building to the agent’s `knowledge_sources` (default agent shows all); propagate selected sources to the `source_type` filter.
  - Re-initialize source preferences when the available source set changes. Added tests: backend unit + integration for `knowledge_sources`; frontend tests for preferences and filter payloads.

- **New Features**
  - Show “Uploaded Files” with a new icon and updated docs link in the Actions popover. UX: the toggle controls search visibility; small files may still be injected into context even if toggled off.

<sup>Written for commit 1a9386e34364a040797cf01c5a862191c00f9839. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

