### PR TITLE
feat(notifications): announce upcoming group-based permissions migration

### DIFF
--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -11,6 +11,9 @@ from onyx.db.notification import dismiss_notification
 from onyx.db.notification import get_notification_by_id
 from onyx.db.notification import get_notifications
 from onyx.server.features.build.utils import ensure_build_mode_intro_notification
+from onyx.server.features.notifications.utils import (
+    ensure_permissions_migration_notification,
+)
 from onyx.server.features.release_notes.utils import (
     ensure_release_notes_fresh_and_notify,
 )
@@ -48,6 +51,13 @@ def get_notifications_api(
         ensure_release_notes_fresh_and_notify(db_session)
     except Exception:
         logger.exception("Failed to check for release notes in notifications endpoint")
+
+    try:
+        ensure_permissions_migration_notification(user, db_session)
+    except Exception:
+        logger.exception(
+            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+        )
 
     notifications = [
         NotificationModel.from_model(notif)

--- a/backend/onyx/server/features/notifications/utils.py
+++ b/backend/onyx/server/features/notifications/utils.py
@@ -1,0 +1,21 @@
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import NotificationType
+from onyx.db.models import User
+from onyx.db.notification import create_notification
+
+
+def ensure_permissions_migration_notification(user: User, db_session: Session) -> None:
+    # Feature id "permissions_migration_v1" must not change after shipping —
+    # it is the dedup key on (user_id, notif_type, additional_data).
+    create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        db_session=db_session,
+        title="Permissions are changing in Onyx",
+        description="Roles are moving to group-based permissions. Click for details.",
+        additional_data={
+            "feature": "permissions_migration_v1",
+            "link": "https://docs.onyx.app/admins/permissions/whats_changing",
+        },
+    )


### PR DESCRIPTION
## Description
Adds an in-app feature-announcement notification informing users that Onyx is moving from role-based to group-based permissions.

## How Has This Been Tested?
Verified the notification from UI.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-app announcement about the upcoming move from role-based to group-based permissions, shown via the notifications API to keep users informed with a link to docs.

- **New Features**
  - Added `ensure_permissions_migration_notification` to create a `FEATURE_ANNOUNCEMENT` with feature id `permissions_migration_v1` and a docs link.
  - Hooked into `get_notifications_api` so the announcement is ensured per user and deduped by the feature id.

<sup>Written for commit 17b5b3c4652815820ba66e472f95dca7341f4c30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

