### PR TITLE
fix(llm): Fix the Auto Fetch workflow

### DIFF
--- a/web/src/sections/modals/llmConfig/BedrockModal.tsx
+++ b/web/src/sections/modals/llmConfig/BedrockModal.tsx
@@ -17,6 +17,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -123,7 +124,13 @@ function BedrockModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/BifrostModal.tsx
+++ b/web/src/sections/modals/llmConfig/BifrostModal.tsx
@@ -14,6 +14,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -55,7 +56,13 @@ function BifrostModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/LMStudioModal.tsx
+++ b/web/src/sections/modals/llmConfig/LMStudioModal.tsx
@@ -12,6 +12,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues as BaseLLMModalValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -61,7 +62,13 @@ function LMStudioModalInternals({
     if (data.error) {
       throw new Error(data.error);
     }
-    formikProps.setFieldValue("model_configurations", data.models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        data.models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/LiteLLMProxyModal.tsx
+++ b/web/src/sections/modals/llmConfig/LiteLLMProxyModal.tsx
@@ -13,6 +13,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -57,7 +58,13 @@ function LiteLLMProxyModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/OllamaModal.tsx
+++ b/web/src/sections/modals/llmConfig/OllamaModal.tsx
@@ -15,6 +15,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -83,7 +84,13 @@ function OllamaModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/OpenAICompatibleModal.tsx
+++ b/web/src/sections/modals/llmConfig/OpenAICompatibleModal.tsx
@@ -14,6 +14,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -55,7 +56,13 @@ function OpenAICompatibleModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
+++ b/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
@@ -13,6 +13,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/llmConfig/utils";
 import { submitProvider } from "@/sections/modals/llmConfig/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics";
@@ -49,7 +50,7 @@ function OpenRouterModalInternals({
     !formikProps.values.api_base || !formikProps.values.api_key;
 
   const handleFetchModels = async () => {
-    const { models, error } = await fetchOpenRouterModels({
+    const { models: fetched, error } = await fetchOpenRouterModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key,
       provider_name: existingLlmProvider?.name,
@@ -57,7 +58,13 @@ function OpenRouterModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue("model_configurations", models);
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        fetched,
+        formikProps.values.model_configurations
+      )
+    );
   };
 
   return (

--- a/web/src/sections/modals/llmConfig/utils.ts
+++ b/web/src/sections/modals/llmConfig/utils.ts
@@ -123,6 +123,30 @@ export interface BaseLLMFormValues {
   custom_config?: Record<string, string>;
 }
 
+// ─── mergeFetchedModelConfigurations ──────────────────────────────────────
+
+/**
+ * Merges a freshly-fetched model list with the current form state so that
+ * refreshing the model list does not clobber the user's selections.
+ *
+ * - If the form has no models yet (first fetch / onboarding), the fetched
+ *   list is returned as-is so each provider's own default `is_visible` applies.
+ * - Otherwise, models that already exist in the form keep their prior
+ *   `is_visible` value, and newly-discovered models are added unselected so
+ *   the user can opt-in explicitly.
+ */
+export function mergeFetchedModelConfigurations(
+  fetched: ModelConfiguration[],
+  existing: ModelConfiguration[]
+): ModelConfiguration[] {
+  if (existing.length === 0) return fetched;
+  const priorByName = new Map(existing.map((m) => [m.name, m]));
+  return fetched.map((model) => {
+    const prior = priorByName.get(model.name);
+    return { ...model, is_visible: prior ? prior.is_visible : false };
+  });
+}
+
 // ─── Misc ─────────────────────────────────────────────────────────────────
 
 export type TestApiKeyResult =


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently the LLM models that auto fetch models are fetching and then setting all of the models as selected which is not intended. The fetch should just fetch without updating the selected model.

Centralizing the implementation to the `utils.ts` so that we can reuse the function across all of the providers that fetch models.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally against all of the providers to ensure that they are not overwriting selections

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LLM Auto Fetch so fetching models no longer selects all models or overwrites user choices. Centralizes merge logic to keep existing visibility selections across providers.

- **Bug Fixes**
  - Added `mergeFetchedModelConfigurations` in `utils.ts` to merge fetched models with the form: keep prior `is_visible`, add new models unselected; on first fetch use provider defaults.
  - Updated all LLM provider modals to use this merge when setting `model_configurations`.

<sup>Written for commit 6320f344bb01ffed4dfc898b338e7418726bd677. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

