### PR TITLE
chore(fe): Toast logs to the console by default in dev

### DIFF
--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -28,6 +28,16 @@ export interface Toast extends ToastOptions {
 
 export const MAX_VISIBLE_TOASTS = 3;
 const DEFAULT_DURATION = 4000;
+const TOAST_CONSOLE_METHOD: Record<
+  ToastLevel,
+  "log" | "warn" | "error" | "info"
+> = {
+  error: "error",
+  warning: "warn",
+  info: "info",
+  success: "log",
+  default: "log",
+};
 
 // ---------------------------------------------------------------------------
 // Module‑level store (external to React)
@@ -47,13 +57,22 @@ function addToast(options: ToastOptions): string {
   const id = `toast-${++nextId}-${Date.now()}`;
   const duration = options.duration ?? DEFAULT_DURATION;
 
+  const level = options.level ?? "info";
+
   const entry: Toast = {
     ...options,
     id,
-    level: options.level ?? "info",
+    level,
     dismissible: options.dismissible ?? true,
     createdAt: Date.now(),
   };
+
+  const method = TOAST_CONSOLE_METHOD[level];
+  if (entry.description) {
+    console[method](`[Toast] ${entry.message}`, entry.description);
+  } else {
+    console[method](`[Toast] ${entry.message}`);
+  }
 
   toasts = [...toasts, entry];
   notify();

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -67,11 +67,13 @@ function addToast(options: ToastOptions): string {
     createdAt: Date.now(),
   };
 
-  const method = TOAST_CONSOLE_METHOD[level];
-  if (entry.description) {
-    console[method](`[Toast] ${entry.message}`, entry.description);
-  } else {
-    console[method](`[Toast] ${entry.message}`);
+  if (process.env.NODE_ENV === "development") {
+    const method = TOAST_CONSOLE_METHOD[level];
+    if (entry.description) {
+      console[method](`[Toast] ${entry.message}`, entry.description);
+    } else {
+      console[method](`[Toast] ${entry.message}`);
+    }
   }
 
   toasts = [...toasts, entry];


### PR DESCRIPTION
## Description

Logs to the console by default when we toast.

The toast message is usually quite significant and is also at a timer, so if it disappears or the message overflows, this context is lost. Instead, always log the message at the corresponding level to the dev console.

I made this dev-only for now to avoid log spam/noise.

## How Has This Been Tested?

not really

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log all toasts to the console in development at the matching severity. Keeps important messages available after the toast disappears without affecting production.

- **New Features**
  - Dev-only logging (`process.env.NODE_ENV === "development"`); level maps to console method: error→error, warning→warn, info→info, success/default→log.
  - Logs both the toast message and description (when provided).

<sup>Written for commit a77f286bbcfa3903a04cdd30585189c53cbd4535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



