### PR TITLE
Add Datadog admission opt-out label to sandbox pods (#10040) to release v3.2

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -618,6 +618,7 @@ done
                     "app.kubernetes.io/managed-by": "onyx",
                     "onyx.app/sandbox-id": sandbox_id,
                     "onyx.app/tenant-id": tenant_id,
+                    "admission.datadoghq.com/enabled": "false",
                 },
             ),
             spec=pod_spec,


### PR DESCRIPTION
Cherry-pick of commit c3ed2135f1b8bb9edc4d737c06aed401a299c31c to release/v3.2 branch.

Original PR: #10040

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Datadog admission on sandbox pods by adding the label admission.datadoghq.com/enabled: "false". This prevents sidecar injection and other mutations, keeping ephemeral sandboxes lightweight and avoiding startup delays.

<sup>Written for commit 283f750ee931c1a530d6b8aae42a7292bcfefcf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

