### PR TITLE
chore(opensearch): Add debug log for when the migration task releases its lock

### DIFF
--- a/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
+++ b/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
@@ -325,6 +325,7 @@ def migrate_chunks_from_vespa_to_opensearch_task(
     finally:
         if lock.owned():
             lock.release()
+            task_logger.debug("Released the OpenSearch migration lock.")
         else:
             task_logger.warning(
                 "The OpenSearch migration lock was not owned on completion of the migration task."

--- a/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
+++ b/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
@@ -172,6 +172,10 @@ def migrate_chunks_from_vespa_to_opensearch_task(
             search_settings = get_current_search_settings(db_session)
             indexing_setting = IndexingSetting.from_db_model(search_settings)
 
+            task_logger.debug(
+                "Verified tenant info, migration record, and search settings."
+            )
+
             # 2.e. Build sanitized to original doc ID mapping to check for
             # conflicts in the event we sanitize a doc ID to an
             # already-existing doc ID.


### PR DESCRIPTION
## Description
This should be a little helpful in seeing why migrations on cloud are not doing anything interesting.

## How Has This Been Tested?
'twasn't.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add debug logs to the OpenSearch migration task: after verifying tenant/setup and when the lock is released. Helps trace migration flow and explain idle-looking cloud runs.

<sup>Written for commit 6162770a14eb56d632a72f971b87b51adce35516. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

