### PR TITLE
fix(deletion): Commit Session in per-doc cleanup

### DIFF
--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -248,6 +248,7 @@ def document_by_cc_pair_cleanup_task(
                         ),
                     )
                     mark_document_as_modified(document_id, db_session)
+                    db_session.commit()
                 completion_status = (
                     OnyxCeleryTaskCompletionStatus.NON_RETRYABLE_EXCEPTION
                 )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
When `document_by_cc_pair_cleanup_task` exhausts its 3 retries, it enters a "mark dirty for reconciliation" branch that opens a new DB session, deletes the `DocumentByConnectorCredentialPair` row, and marks the document as modified — but never commits. `get_session_with_tenant` does not auto-commit on context exit, so both writes silently roll back. The consequence is that `monitor_connector_deletion_taskset` later finds the doc still associated with the cc_pair (tasks.py:433), resets the fence, and restarts the deletion which hits the same failing doc again, looping indefinitely until reconciliation or manual intervention clears it.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commit DB changes in the "mark dirty for reconciliation" path of `document_by_cc_pair_cleanup_task`. This ensures the `DocumentByConnectorCredentialPair` delete and the modified flag persist, preventing the deletion loop and fence resets in `monitor_connector_deletion_taskset`.

<sup>Written for commit 2b17f76baf8b939eacf31ede01fe72680e32ce23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

