### PR TITLE
fix(chat): render inline citation chips in multi-model panels

### DIFF
--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -136,13 +136,17 @@ const AgentMessage = React.memo(function AgentMessage({
       finalAnswerComing
     );
 
-  // Memoize merged citations separately to avoid creating new object when neither source changed
+  // Merge streaming citation/document data with chatState props.
+  // NOTE: citationMap and documentMap from usePacketProcessor are mutated in
+  // place (same object reference), so we use citations.length / documentMap.size
+  // as change-detection proxies to bust the memo cache when new data arrives.
   const mergedCitations = useMemo(
     () => ({
       ...chatState.citations,
       ...citationMap,
     }),
-    [chatState.citations, citationMap]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chatState.citations, citationMap, citations.length]
   );
 
   // Merge streaming documentMap into chatState.docs so inline citation chips
@@ -155,10 +159,10 @@ const AgentMessage = React.memo(function AgentMessage({
       (d) => !seen.has(d.document_id)
     );
     return extras.length > 0 ? [...propDocs, ...extras] : propDocs;
-  }, [chatState.docs, documentMap]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatState.docs, documentMap, documentMap.size]);
 
   // Create a chatState that uses streaming citations and documents for immediate rendering.
-  // This merges the prop citations/docs with streaming data, preferring streaming ones.
   // Memoized with granular dependencies to prevent cascading re-renders.
   // Note: chatState object is recreated upstream on every render, so we depend on
   // individual fields instead of the whole object for proper memoization.

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -145,23 +145,36 @@ const AgentMessage = React.memo(function AgentMessage({
     [chatState.citations, citationMap]
   );
 
-  // Create a chatState that uses streaming citations for immediate rendering
-  // This merges the prop citations with streaming citations, preferring streaming ones
-  // Memoized with granular dependencies to prevent cascading re-renders
+  // Merge streaming documentMap into chatState.docs so inline citation chips
+  // can resolve [1] → document even when chatState.docs is empty (multi-model).
+  const mergedDocs = useMemo(() => {
+    const propDocs = chatState.docs ?? [];
+    if (documentMap.size === 0) return propDocs;
+    const seen = new Set(propDocs.map((d) => d.document_id));
+    const extras = Array.from(documentMap.values()).filter(
+      (d) => !seen.has(d.document_id)
+    );
+    return extras.length > 0 ? [...propDocs, ...extras] : propDocs;
+  }, [chatState.docs, documentMap]);
+
+  // Create a chatState that uses streaming citations and documents for immediate rendering.
+  // This merges the prop citations/docs with streaming data, preferring streaming ones.
+  // Memoized with granular dependencies to prevent cascading re-renders.
   // Note: chatState object is recreated upstream on every render, so we depend on
-  // individual fields instead of the whole object for proper memoization
+  // individual fields instead of the whole object for proper memoization.
   const effectiveChatState = useMemo<FullChatState>(
     () => ({
       ...chatState,
       citations: mergedCitations,
+      docs: mergedDocs,
     }),
     [
       chatState.agent,
-      chatState.docs,
       chatState.setPresentingDocument,
       chatState.overriddenModel,
       chatState.researchType,
       mergedCitations,
+      mergedDocs,
     ]
   );
 


### PR DESCRIPTION
## Description

Inline citation chips (`Slack`, `Google Drive`, etc.) were not rendering in multi-model response panels — `[1]` appeared as raw text instead.

**Two issues:**

1. **Empty docs:** `MemoizedAnchor` resolves `[1]` → document via `chatState.docs`, but multi-model passed `emptyDocs` (documents live in `usePacketProcessor`'s `documentMap`, not on the message). Fixed by merging `documentMap` values into `effectiveChatState.docs`.

2. **Stale memos:** `mergedCitations` and `mergedDocs` `useMemo` deps used `citationMap` and `documentMap` — which are mutated in place by `usePacketProcessor` (same object reference). The memos never recomputed. In single-model this was masked because `chatState.citations` changed on each Zustand flush, forcing recomputation. In multi-model, `chatState.citations = undefined` (constant), so the memo was stale forever. Fixed by adding `citations.length` and `documentMap.size` as change-detection proxy deps.

**Linear:** [ENG-4024](https://linear.app/onyx-app/issue/ENG-4024/multi-model-source-chips-not-rendered-in-response-panels)

## How Has This Been Tested?

<img width="1114" height="591" alt="Screenshot 2026-04-14 at 3 43 14 PM" src="https://github.com/user-attachments/assets/c1ddceae-0121-4503-827b-b45d72edd11e" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check