### PR TITLE
chore(devtools): install java runtime into devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:26.04@sha256:cc925e589b7543b910fea57a240468940003fbfc0515245a495dd0a
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
+  default-jre \
   fd-find \
   fzf \
   git \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:12184169c5bcc9cca0388286d5ffe504b569bc9c37bfa631b76ee8eee2064055",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:0f02d9299928849c7b15f3b348dcfdcdcb64411ff7a4580cbc026a6ee7aa1554",
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/dev/.claude,type=bind",


### PR DESCRIPTION
## Description

A java runtime is needed as part of the openapi client generation script, so install one into the devcontainer. Also, AFAICT, this workflow is broken at HEAD(?),

```
Exception in thread "main" java.lang.RuntimeException: Error! Codegen Property not yet supported in getPydanticType: CodegenProperty{openApiType='null', baseName='data', complexType='null', getter='getData', setter='setData', description='null', dataType='none_type', datatypeWithEnum='none_type', dataFormat='null', name='data', min='null', max='null', defaultValue='null', defaultValueWithParam=' = data.data;', baseType='none_type', containerType='null', containerTypeMapped='null', title='Data', unescapedDescription='null', maxLength=null, minLength=null, pattern='null', example='null', jsonSchema='{
  "title" : "Data"
}', minimum='null', maximum='null', exclusiveMinimum=false, exclusiveMaximum=false, required=false, deprecated=false, isPrimitiveType=true, isModel=false, isContainer=false, isString=false, isNumeric=false, isInteger=false, isShort=false, isLong=false, isUnboundedInteger=false, isNumber=false, isFloat=false, isDouble=false, isDecimal=false, isByteArray=false, isBinary=false, isFile=false, isBoolean=false, isDate=false, isDateTime=false, isUuid=false, isUri=false, isEmail=false, isPassword=false, isFreeFormObject=false, isArray=false, isMap=false, isOptional=false, isEnum=false, isInnerEnum=false, isEnumRef=false, isAnyType=false, isReadOnly=false, isWriteOnly=false, isNullable=false, isSelfReference=false, isCircularReference=false, isDiscriminator=false, isNew=false, isOverridden=null, _enum=null, allowableValues=null, items=null, additionalProperties=null, vars=[], requiredVars=[], mostInnerItems=null, vendorExtensions={}, hasValidation=false, isInherited=false, discriminatorValue='null', nameInCamelCase='data', nameInPascalCase='Data', nameInSnakeCase='DATA', enumName='null', maxItems=null, minItems=null, maxProperties=null, minProperties=null, uniqueItems=false, uniqueItemsBoolean=null, multipleOf=null, isXmlAttribute=false, xmlPrefix='null', xmlName='null', xmlNamespace='null', isXmlWrapped=false, isNull=true, isVoid=false, getAdditionalPropertiesIsAnyType=false, getHasVars=false, getHasRequired=false, getHasDiscriminatorWithNonEmptyMapping=false, composedSchemas=null, hasMultipleTypes=false, hasSanitizedName=false, requiredVarsMap=null, ref=null, schemaIsFromAdditionalProperties=false, isBooleanSchemaTrue=false, isBooleanSchemaFalse=false, format=null, dependentRequired=null, contains=null}
	at org.openapitools.codegen.languages.AbstractPythonCodegen$PydanticType.getType(AbstractPythonCodegen.java:2132)
	at org.openapitools.codegen.languages.AbstractPythonCodegen$PydanticType.generatePythonType(AbstractPythonCodegen.java:2081)
	at org.openapitools.codegen.languages.AbstractPythonCodegen.postProcessModelsMap(AbstractPythonCodegen.java:940)
	at org.openapitools.codegen.languages.AbstractPythonCodegen.postProcessAllModels(AbstractPythonCodegen.java:834)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:527)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:444)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:1292)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:535)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
Generated Python client at /home/jamison/code/onyx/backend/generated/onyx_openapi_client
```

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install a Java runtime in the devcontainer to enable local OpenAPI client generation. Also updates the devcontainer image digest.

- **Dependencies**
  - Add `default-jre` to `.devcontainer/Dockerfile`.
  - Update `onyxdotapp/onyx-devcontainer` image digest in `.devcontainer/devcontainer.json`.

<sup>Written for commit e43efa134bbb449ef59d109020d0a9fe7535fd62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

