### PR TITLE
fix(chat): only header click selects preferred in multi-model panels

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -89,8 +89,10 @@ export default function MultiModelPanel({
     <div
       className={cn(
         "rounded-12",
-        isPreferred ? "bg-background-tint-02" : "bg-background-tint-00"
+        isPreferred ? "bg-background-tint-02" : "bg-background-tint-00",
+        canSelect && "cursor-pointer hover:bg-background-tint-02"
       )}
+      onClick={handlePanelClick}
     >
       <ContentAction
         sizePreset="main-ui"
@@ -145,13 +147,7 @@ export default function MultiModelPanel({
   }
 
   return (
-    <div
-      className={cn(
-        "flex flex-col gap-3 min-w-0 rounded-16 transition-colors",
-        canSelect && "cursor-pointer hover:bg-background-tint-02"
-      )}
-      onClick={canSelect ? handlePanelClick : undefined}
-    >
+    <div className="flex flex-col gap-3 min-w-0 rounded-16">
       {header}
       {errorMessage ? (
         <div className="p-4">

--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -88,7 +88,7 @@ export default function MultiModelPanel({
   const header = (
     <div
       className={cn(
-        "rounded-12",
+        "rounded-12 transition-colors",
         isPreferred ? "bg-background-tint-02" : "bg-background-tint-00",
         canSelect && "cursor-pointer hover:bg-background-tint-02"
       )}


### PR DESCRIPTION
## Description

Clicking anywhere on a multi-model response panel selected it as preferred, making text selection impossible and causing layout shifts. Moved the `onClick` handler and `cursor-pointer`/`hover` styles from the outer panel wrapper to the header div only. The response body now allows normal text interaction.

**Linear:** [ENG-4021](https://linear.app/onyx-app/issue/ENG-4021/multi-model-clicking-panel-body-should-not-select-preferred-response)

## How Has This Been Tested?


https://github.com/user-attachments/assets/ac6172f8-da9c-4d97-84ed-8eddee7401ad



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check