### PR TITLE
fix(chat): disable hover/pointer states on multi-model panels during streaming

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -44,6 +44,8 @@ export interface MultiModelPanelProps {
   errorStackTrace?: string | null;
   /** Additional error details */
   errorDetails?: Record<string, any> | null;
+  /** Whether any model is still streaming — disables preferred selection */
+  isGenerating?: boolean;
 }
 
 /**
@@ -73,12 +75,15 @@ export default function MultiModelPanel({
   isRetryable,
   errorStackTrace,
   errorDetails,
+  isGenerating,
 }: MultiModelPanelProps) {
   const ModelIcon = getModelIcon(provider, modelName);
 
+  const canSelect = !isHidden && !isPreferred && !isGenerating;
+
   const handlePanelClick = useCallback(() => {
-    if (!isHidden && !isPreferred) onSelect();
-  }, [isHidden, isPreferred, onSelect]);
+    if (canSelect) onSelect();
+  }, [canSelect, onSelect]);
 
   const header = (
     <div
@@ -143,9 +148,9 @@ export default function MultiModelPanel({
     <div
       className={cn(
         "flex flex-col gap-3 min-w-0 rounded-16 transition-colors",
-        !isPreferred && "cursor-pointer hover:bg-background-tint-02"
+        canSelect && "cursor-pointer hover:bg-background-tint-02"
       )}
-      onClick={handlePanelClick}
+      onClick={canSelect ? handlePanelClick : undefined}
     >
       {header}
       {errorMessage ? (

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -416,6 +416,7 @@ export default function MultiModelResponseView({
       isRetryable: response.isRetryable,
       errorStackTrace: response.errorStackTrace,
       errorDetails: response.errorDetails,
+      isGenerating,
     }),
     [
       preferredIndex,
@@ -429,6 +430,7 @@ export default function MultiModelResponseView({
       onMessageSelection,
       onRegenerate,
       parentMessage,
+      isGenerating,
     ]
   );
 


### PR DESCRIPTION
## Description

Multi-model panels showed `cursor-pointer` and hover highlight during streaming, even though clicking to select a preferred response was not functional until streaming completed. Added `isGenerating` prop to `MultiModelPanel` — hover styles and click handler are now gated behind `canSelect` (`!isHidden && !isPreferred && !isGenerating`).

**Linear:** [ENG-4020](https://linear.app/onyx-app/issue/ENG-4020/multi-model-panels-disable-hoverpointer-states-during-streaming), [ENG-4021](https://linear.app/onyx-app/issue/ENG-4021/multi-model-clicking-panel-body-should-not-select-preferred-response)

## How Has This Been Tested?

![2026-04-14 16 29 36](https://github.com/user-attachments/assets/e9a26a6a-5066-438e-a5a7-f04992c8fd54)


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check