### PR TITLE
fix(chat): keep model selector popover open until max models reached

### DIFF
--- a/web/lib/opal/src/core/interactive/stateful/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateful/components.tsx
@@ -15,6 +15,7 @@ type InteractiveStatefulVariant =
   | "select-heavy"
   | "select-card"
   | "select-tinted"
+  | "select-input"
   | "select-filter"
   | "sidebar-heavy"
   | "sidebar-light";
@@ -35,6 +36,7 @@ interface InteractiveStatefulProps
    * - `"select-heavy"` — tinted selected background (for list rows, model pickers)
    * - `"select-card"` — like select-heavy but filled state has a visible background (for cards/larger surfaces)
    * - `"select-tinted"` — like select-heavy but with a tinted rest background
+   * - `"select-input"` — rests at neutral-00 (matches input bar), hover/open shows neutral-03 + border-01
    * - `"select-filter"` — like select-tinted for empty/filled; selected state uses inverted tint backgrounds and inverted text (for filter buttons)
    * - `"sidebar-heavy"` — sidebar navigation items: muted when unselected (text-03/text-02), bold when selected (text-04/text-03)
    * - `"sidebar-light"` — sidebar navigation items: uniformly muted across all states (text-02/text-02)

--- a/web/lib/opal/src/core/interactive/stateful/styles.css
+++ b/web/lib/opal/src/core/interactive/stateful/styles.css
@@ -365,7 +365,7 @@
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="hover"]:not(
     [data-disabled]
   ) {
-  @apply bg-background-neutral-03 border border-border-01;
+  @apply bg-background-neutral-03;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-03);
 }
@@ -375,7 +375,7 @@
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="active"]:not(
     [data-disabled]
   ) {
-  @apply bg-background-neutral-03 border border-border-01;
+  @apply bg-background-neutral-03;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
 }

--- a/web/lib/opal/src/core/interactive/stateful/styles.css
+++ b/web/lib/opal/src/core/interactive/stateful/styles.css
@@ -351,6 +351,41 @@
 }
 
 /* ---------------------------------------------------------------------------
+   Select-Input — Empty
+   Matches input bar background at rest, tints on hover/open.
+   --------------------------------------------------------------------------- */
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"] {
+  @apply bg-background-neutral-00;
+  --interactive-foreground: var(--text-04);
+  --interactive-foreground-icon: var(--text-03);
+}
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"]:hover:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="hover"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-neutral-03 border border-border-01;
+  --interactive-foreground: var(--text-04);
+  --interactive-foreground-icon: var(--text-03);
+}
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"]:active:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="active"]:not(
+    [data-disabled]
+  ) {
+  @apply bg-background-neutral-03 border border-border-01;
+  --interactive-foreground: var(--text-05);
+  --interactive-foreground-icon: var(--text-05);
+}
+.interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-disabled] {
+  @apply bg-transparent;
+  --interactive-foreground: var(--text-01);
+  --interactive-foreground-icon: var(--text-01);
+}
+
+/* ---------------------------------------------------------------------------
    Select-Tinted — Filled
    --------------------------------------------------------------------------- */
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"] {

--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -108,22 +108,20 @@ export default function useMultiModelChat(
 
   const removeModel = useCallback(
     (index: number) => {
-      setSelectedModels((prev) => {
-        const next = prev.filter((_, i) => i !== index);
-        // When dropping to single-model, switch llmManager to the surviving
-        // model so it becomes the active model instead of reverting to the
-        // user's default.
-        if (next.length === 1 && next[0]) {
-          llmManager.updateCurrentLlm({
-            name: next[0].name,
-            provider: next[0].provider,
-            modelName: next[0].modelName,
-          });
-        }
-        return next;
-      });
+      const next = selectedModels.filter((_, i) => i !== index);
+      // When dropping to single-model, switch llmManager to the surviving
+      // model so it becomes the active model instead of reverting to the
+      // user's default.
+      if (next.length === 1 && next[0]) {
+        llmManager.updateCurrentLlm({
+          name: next[0].name,
+          provider: next[0].provider,
+          modelName: next[0].modelName,
+        });
+      }
+      setSelectedModels(next);
     },
-    [llmManager]
+    [selectedModels, llmManager]
   );
 
   const replaceModel = useCallback(

--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -106,9 +106,25 @@ export default function useMultiModelChat(
     [currentLlmModel]
   );
 
-  const removeModel = useCallback((index: number) => {
-    setSelectedModels((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const removeModel = useCallback(
+    (index: number) => {
+      setSelectedModels((prev) => {
+        const next = prev.filter((_, i) => i !== index);
+        // When dropping to single-model, switch llmManager to the surviving
+        // model so it becomes the active model instead of reverting to the
+        // user's default.
+        if (next.length === 1 && next[0]) {
+          llmManager.updateCurrentLlm({
+            name: next[0].name,
+            provider: next[0].provider,
+            modelName: next[0].modelName,
+          });
+        }
+        return next;
+      });
+    },
+    [llmManager]
+  );
 
   const replaceModel = useCallback(
     (index: number, model: SelectedModel) => {

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -187,7 +187,6 @@ export default function ModelSelector({
                       rightIcon={isMultiModel ? SvgX : undefined}
                       state="empty"
                       variant="select-heavy"
-                      interaction="hover"
                       size="lg"
                       onClick={(e: React.MouseEvent) => {
                         if (isMultiModel) {

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -109,7 +109,10 @@ export default function ModelSelector({
       onRemove(existingIndex);
     } else if (!atMax) {
       onAdd(model);
-      setOpen(false);
+      // Close the popover only when we've reached the max model count
+      if (selectedModels.length + 1 >= MAX_MODELS) {
+        setOpen(false);
+      }
     }
   };
 

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -186,7 +186,7 @@ export default function ModelSelector({
                       icon={ProviderIcon}
                       rightIcon={isMultiModel ? SvgX : undefined}
                       state="empty"
-                      variant="select-heavy"
+                      variant="select-input"
                       size="lg"
                       onClick={(e: React.MouseEvent) => {
                         if (isMultiModel) {

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useRef } from "react";
 import Popover from "@/refresh-components/Popover";
 import { LlmManager } from "@/lib/hooks";
 import { getModelIcon } from "@/lib/llmConfig";
-import { Button, SelectButton, OpenButton } from "@opal/components";
+import { Button, OpenButton } from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption } from "@/refresh-components/popovers/interfaces";
@@ -166,13 +166,23 @@ export default function ModelSelector({
                   model.modelName
                 );
 
-                if (!isMultiModel) {
-                  // Stable key — keying on model would unmount the pill
-                  // on change and leave Radix's anchorRef detached,
-                  // flashing the closing popover at (0,0).
-                  return (
+                return (
+                  <div
+                    key={
+                      isMultiModel
+                        ? modelKey(model.provider, model.modelName)
+                        : "single-model-pill"
+                    }
+                    className="flex items-center"
+                  >
+                    {isMultiModel && index > 0 && (
+                      <Separator
+                        orientation="vertical"
+                        paddingXRem={0.5}
+                        className="h-5"
+                      />
+                    )}
                     <OpenButton
-                      key="single-model-pill"
                       icon={ProviderIcon}
                       onClick={(e: React.MouseEvent) =>
                         handlePillClick(index, e.currentTarget as HTMLElement)
@@ -180,44 +190,14 @@ export default function ModelSelector({
                     >
                       {model.displayName}
                     </OpenButton>
-                  );
-                }
-
-                return (
-                  <div
-                    key={modelKey(model.provider, model.modelName)}
-                    className="flex items-center"
-                  >
-                    {index > 0 && (
-                      <Separator
-                        orientation="vertical"
-                        paddingXRem={0.5}
-                        className="h-5"
+                    {isMultiModel && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgX}
+                        size="sm"
+                        onClick={() => onRemove(index)}
                       />
                     )}
-                    <SelectButton
-                      icon={ProviderIcon}
-                      rightIcon={SvgX}
-                      state="empty"
-                      variant="select-tinted"
-                      interaction="hover"
-                      size="lg"
-                      onClick={(e: React.MouseEvent) => {
-                        const target = e.target as HTMLElement;
-                        const btn = e.currentTarget as HTMLElement;
-                        const icons = btn.querySelectorAll(
-                          ".interactive-foreground-icon"
-                        );
-                        const lastIcon = icons[icons.length - 1];
-                        if (lastIcon && lastIcon.contains(target)) {
-                          onRemove(index);
-                        } else {
-                          handlePillClick(index, btn);
-                        }
-                      }}
-                    >
-                      {model.displayName}
-                    </SelectButton>
                   </div>
                 );
               })}

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useRef } from "react";
 import Popover from "@/refresh-components/Popover";
 import { LlmManager } from "@/lib/hooks";
 import { getModelIcon } from "@/lib/llmConfig";
-import { Button, OpenButton } from "@opal/components";
+import { Button, SelectButton } from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption } from "@/refresh-components/popovers/interfaces";
@@ -175,29 +175,38 @@ export default function ModelSelector({
                     }
                     className="flex items-center"
                   >
-                    {isMultiModel && index > 0 && (
+                    {index > 0 && (
                       <Separator
                         orientation="vertical"
                         paddingXRem={0.5}
                         className="h-5"
                       />
                     )}
-                    <OpenButton
+                    <SelectButton
                       icon={ProviderIcon}
-                      onClick={(e: React.MouseEvent) =>
-                        handlePillClick(index, e.currentTarget as HTMLElement)
-                      }
+                      rightIcon={isMultiModel ? SvgX : undefined}
+                      state="empty"
+                      variant="select-tinted"
+                      interaction="hover"
+                      size="lg"
+                      onClick={(e: React.MouseEvent) => {
+                        if (isMultiModel) {
+                          const target = e.target as HTMLElement;
+                          const btn = e.currentTarget as HTMLElement;
+                          const icons = btn.querySelectorAll(
+                            ".interactive-foreground-icon"
+                          );
+                          const lastIcon = icons[icons.length - 1];
+                          if (lastIcon && lastIcon.contains(target)) {
+                            onRemove(index);
+                            return;
+                          }
+                        }
+                        handlePillClick(index, e.currentTarget as HTMLElement);
+                      }}
                     >
                       {model.displayName}
-                    </OpenButton>
-                    {isMultiModel && (
-                      <Button
-                        prominence="tertiary"
-                        icon={SvgX}
-                        size="sm"
-                        onClick={() => onRemove(index)}
-                      />
-                    )}
+                    </SelectButton>
                   </div>
                 );
               })}

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -186,7 +186,7 @@ export default function ModelSelector({
                       icon={ProviderIcon}
                       rightIcon={isMultiModel ? SvgX : undefined}
                       state="empty"
-                      variant="select-tinted"
+                      variant="select-heavy"
                       interaction="hover"
                       size="lg"
                       onClick={(e: React.MouseEvent) => {

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -227,7 +227,7 @@ export default function ModelSelector({
       </div>
 
       {!(atMax && replacingIndex === null) && (
-        <Popover.Content side="top" align="end" width="lg">
+        <Popover.Content side="top" align="end" width="xl">
           <ModelListContent
             llmProviders={llmManager.llmProviders}
             isLoading={llmManager.isLoadingProviders}


### PR DESCRIPTION
## Description

Improvements to the multi-model selector UX:

1. **Popover stays open:** Previously closed after each model addition. Now stays open until `MAX_MODELS` (3) is reached.

2. **Surviving model preserved:** When removing models from A/B/C down to just C, the active model reverted to the user's default. Now `removeModel` updates `llmManager.currentLlm` to the surviving model.

3. **Wider popover:** Changed width from `"lg"` to `"xl"` to match the `LLMPopover` in the message footer.

4. **Consistent pill style:** Both single and multi-model pills now use `SelectButton`. Single-model just omits the X icon.

5. **New `select-input` variant:** Created a new interactive variant that rests at `bg-background-neutral-00` (matches input bar) and shows `bg-background-neutral-03` on hover/open. Pills now blend seamlessly with the input bar at rest. This is to be mock compliant.

**Linear:** [ENG-4019](https://linear.app/onyx-app/issue/ENG-4019/model-selector-keep-popover-open-and-preserve-order-when-adding-models)

## How Has This Been Tested?

![2026-04-14 20 15 32](https://github.com/user-attachments/assets/7fa3eb8e-4316-47f1-965f-cd443cca48aa)

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check