### PR TITLE
feat(indexing): add admin API for failed documents

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -981,6 +981,53 @@ def get_index_attempt_errors_for_cc_pair(
     return list(db_session.scalars(stmt).all())
 
 
+def get_index_attempt_errors_across_connectors(
+    db_session: Session,
+    cc_pair_id: int | None = None,
+    error_type: str | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    unresolved_only: bool = True,
+    page: int = 0,
+    page_size: int = 25,
+) -> tuple[list[IndexAttemptError], int]:
+    """Query index attempt errors across all connectors with optional filters.
+
+    Returns (errors, total_count) for pagination.
+    """
+    stmt = select(IndexAttemptError)
+    count_stmt = select(func.count()).select_from(IndexAttemptError)
+
+    if cc_pair_id is not None:
+        stmt = stmt.where(IndexAttemptError.connector_credential_pair_id == cc_pair_id)
+        count_stmt = count_stmt.where(
+            IndexAttemptError.connector_credential_pair_id == cc_pair_id
+        )
+
+    if error_type is not None:
+        stmt = stmt.where(IndexAttemptError.error_type == error_type)
+        count_stmt = count_stmt.where(IndexAttemptError.error_type == error_type)
+
+    if unresolved_only:
+        stmt = stmt.where(IndexAttemptError.is_resolved.is_(False))
+        count_stmt = count_stmt.where(IndexAttemptError.is_resolved.is_(False))
+
+    if start_time is not None:
+        stmt = stmt.where(IndexAttemptError.time_created >= start_time)
+        count_stmt = count_stmt.where(IndexAttemptError.time_created >= start_time)
+
+    if end_time is not None:
+        stmt = stmt.where(IndexAttemptError.time_created <= end_time)
+        count_stmt = count_stmt.where(IndexAttemptError.time_created <= end_time)
+
+    stmt = stmt.order_by(desc(IndexAttemptError.time_created))
+    stmt = stmt.offset(page * page_size).limit(page_size)
+
+    total = db_session.scalar(count_stmt) or 0
+    errors = list(db_session.scalars(stmt).all())
+    return errors, total
+
+
 # ── Metrics query helpers ──────────────────────────────────────────────
 
 

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -226,7 +226,12 @@ def get_failed_documents(
     """Get indexing errors across all connectors with optional filters.
 
     Provides a cross-connector view of document indexing failures.
+    Defaults to last 30 days if no start_time is provided to avoid
+    unbounded count queries.
     """
+    if start_time is None:
+        start_time = datetime.now(tz=timezone.utc) - timedelta(days=30)
+
     errors, total = get_index_attempt_errors_across_connectors(
         db_session=db_session,
         cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -29,6 +29,7 @@ from onyx.db.feedback import fetch_docs_ranked_by_boost_for_user
 from onyx.db.feedback import update_document_boost_for_user
 from onyx.db.feedback import update_document_hidden_for_user
 from onyx.db.index_attempt import cancel_indexing_attempts_for_ccpair
+from onyx.db.index_attempt import get_index_attempt_errors_across_connectors
 from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
 from onyx.key_value_store.factory import get_kv_store
@@ -226,8 +227,6 @@ def get_failed_documents(
 
     Provides a cross-connector view of document indexing failures.
     """
-    from onyx.db.index_attempt import get_index_attempt_errors_across_connectors
-
     errors, total = get_index_attempt_errors_across_connectors(
         db_session=db_session,
         cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.background.celery.versioned_apps.client import app as client_app
+from onyx.background.indexing.models import IndexAttemptErrorPydantic
 from onyx.configs.app_configs import GENERATIVE_MODEL_ACCESS_CHECK_FREQ
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import KV_GEN_AI_KEY_CHECK_TIME
@@ -35,6 +36,7 @@ from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.llm.factory import get_default_llm
 from onyx.llm.utils import test_llm
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
+from onyx.server.documents.models import PaginatedReturn
 from onyx.server.manage.models import BoostDoc
 from onyx.server.manage.models import BoostUpdateRequest
 from onyx.server.manage.models import HiddenUpdateRequest
@@ -206,3 +208,37 @@ def create_deletion_attempt_for_connector_id(
         file_store = get_default_file_store()
         for file_id in connector.connector_specific_config.get("file_locations", []):
             file_store.delete_file(file_id)
+
+
+@router.get("/admin/indexing/failed-documents")
+def get_failed_documents(
+    cc_pair_id: int | None = None,
+    error_type: str | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    include_resolved: bool = False,
+    page_num: int = 0,
+    page_size: int = 25,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> PaginatedReturn[IndexAttemptErrorPydantic]:
+    """Get indexing errors across all connectors with optional filters.
+
+    Provides a cross-connector view of document indexing failures.
+    """
+    from onyx.db.index_attempt import get_index_attempt_errors_across_connectors
+
+    errors, total = get_index_attempt_errors_across_connectors(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+        error_type=error_type,
+        start_time=start_time,
+        end_time=end_time,
+        unresolved_only=not include_resolved,
+        page=page_num,
+        page_size=page_size,
+    )
+    return PaginatedReturn(
+        items=[IndexAttemptErrorPydantic.from_model(e) for e in errors],
+        total_items=total,
+    )

--- a/backend/tests/unit/onyx/db/test_index_attempt_errors.py
+++ b/backend/tests/unit/onyx/db/test_index_attempt_errors.py
@@ -1,0 +1,86 @@
+"""Tests for get_index_attempt_errors_across_connectors."""
+
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import MagicMock
+
+from onyx.db.index_attempt import get_index_attempt_errors_across_connectors
+from onyx.db.models import IndexAttemptError
+
+
+def _make_error(
+    id: int = 1,
+    cc_pair_id: int = 1,
+    error_type: str | None = "TimeoutError",
+    is_resolved: bool = False,
+) -> IndexAttemptError:
+    """Create a mock IndexAttemptError."""
+    error = MagicMock(spec=IndexAttemptError)
+    error.id = id
+    error.connector_credential_pair_id = cc_pair_id
+    error.error_type = error_type
+    error.is_resolved = is_resolved
+    return error
+
+
+class TestGetIndexAttemptErrorsAcrossConnectors:
+    def test_returns_errors_and_count(self) -> None:
+        mock_session = MagicMock()
+        mock_errors = [_make_error(id=1), _make_error(id=2)]
+        mock_session.scalar.return_value = 2
+        mock_session.scalars.return_value.all.return_value = mock_errors
+
+        errors, total = get_index_attempt_errors_across_connectors(
+            db_session=mock_session,
+        )
+
+        assert total == 2
+        assert len(errors) == 2
+
+    def test_returns_empty_when_no_errors(self) -> None:
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = 0
+        mock_session.scalars.return_value.all.return_value = []
+
+        errors, total = get_index_attempt_errors_across_connectors(
+            db_session=mock_session,
+        )
+
+        assert total == 0
+        assert errors == []
+
+    def test_null_count_returns_zero(self) -> None:
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = None
+        mock_session.scalars.return_value.all.return_value = []
+
+        errors, total = get_index_attempt_errors_across_connectors(
+            db_session=mock_session,
+        )
+
+        assert total == 0
+
+    def test_passes_filters_to_query(self) -> None:
+        """Verify that filter parameters result in .where() calls on the statement."""
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = 0
+        mock_session.scalars.return_value.all.return_value = []
+
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 12, 31, tzinfo=timezone.utc)
+
+        # Should not raise — just verifying the function accepts all filter params
+        get_index_attempt_errors_across_connectors(
+            db_session=mock_session,
+            cc_pair_id=42,
+            error_type="TimeoutError",
+            start_time=start,
+            end_time=end,
+            unresolved_only=True,
+            page=2,
+            page_size=10,
+        )
+
+        # The function should have called scalar (for count) and scalars (for results)
+        assert mock_session.scalar.called
+        assert mock_session.scalars.called


### PR DESCRIPTION
## Description

Today, when documents fail to index, the only way to investigate is to SSH into the server and grep through logs. The `index_attempt_errors` table has been recording per-document failures for a while (document ID, failure message, connector, timestamp), but there's no API to query it.

This adds `GET /api/admin/indexing/failed-documents` — a cross-connector view of all indexing failures, with filters:

| Parameter | Type | Description |
|---|---|---|
| `cc_pair_id` | int (optional) | Scope to a specific connector |
| `error_type` | string (optional) | Filter by exception class (e.g. `TimeoutError`, `HttpError`) — requires [#10134](https://github.com/onyx-dot-app/onyx/pull/10134) |
| `start_time` / `end_time` | datetime (optional) | Time range filter |
| `include_resolved` | bool (default false) | Include errors that have been marked resolved |
| `page_num` / `page_size` | int | Pagination (default page 0, 25 per page) |

**Use cases:**
- Admin dashboard: "Show me all failed documents in the last 24 hours" — answers "is indexing healthy?" at a glance
- Connector debugging: "Show me all TimeoutErrors for this Google Drive connector" — narrows down whether it's the source system, network, or embedder
- Triage: "What are the most common error types across all connectors?" — `error_type` filter lets you group and count
- Future: data source for an admin UI failed-documents page, and for call-home telemetry

**Existing endpoint vs this one:**
There's already `GET /api/manage/admin/cc-pair/{id}/index-attempt-errors` scoped to a single CC pair. This new endpoint is the cross-connector equivalent — "show me everything that's broken, across all connectors."

Returns `PaginatedReturn[IndexAttemptErrorPydantic]` — same response shape as the existing per-CC-pair endpoint.

**Linear:** [ENG-3980](https://linear.app/onyx-app/issue/ENG-3980/admin-api-for-failed-documents)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check