### PR TITLE
fix(pruning): GitHub connector pruning timeout via SlimConnector

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -35,10 +35,16 @@ from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import ConnectorCheckpoint
 from onyx.connectors.interfaces import ConnectorFailure
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import IndexingHeartbeatInterface
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
 
@@ -427,7 +433,11 @@ def make_cursor_url_callback(
     return cursor_url_callback
 
 
-class GithubConnector(CheckpointedConnectorWithPermSync[GithubConnectorCheckpoint]):
+class GithubConnector(
+    CheckpointedConnectorWithPermSync[GithubConnectorCheckpoint],
+    SlimConnector,
+    SlimConnectorWithPermSync,
+):
     def __init__(
         self,
         repo_owner: str,
@@ -559,6 +569,7 @@ class GithubConnector(CheckpointedConnectorWithPermSync[GithubConnectorCheckpoin
         start: datetime | None = None,
         end: datetime | None = None,
         include_permissions: bool = False,
+        is_slim: bool = False,
     ) -> Generator[Document | ConnectorFailure, None, GithubConnectorCheckpoint]:
         if self.github_client is None:
             raise ConnectorMissingCredentialError("GitHub")
@@ -614,36 +625,46 @@ class GithubConnector(CheckpointedConnectorWithPermSync[GithubConnectorCheckpoin
             for pr in pr_batch:
                 num_prs += 1
 
-                # we iterate backwards in time, so at this point we stop processing prs
-                if (
-                    start is not None
-                    and pr.updated_at
-                    and pr.updated_at.replace(tzinfo=timezone.utc) < start
-                ):
-                    done_with_prs = True
-                    break
-                # Skip PRs updated after the end date
-                if (
-                    end is not None
-                    and pr.updated_at
-                    and pr.updated_at.replace(tzinfo=timezone.utc) > end
-                ):
-                    continue
-                try:
-                    yield _convert_pr_to_document(
-                        cast(PullRequest, pr), repo_external_access
+                if is_slim:
+                    yield Document(
+                        id=pr.html_url,
+                        sections=[],
+                        external_access=repo_external_access,
+                        source=DocumentSource.GITHUB,
+                        semantic_identifier="",
+                        metadata={},
                     )
-                except Exception as e:
-                    error_msg = f"Error converting PR to document: {e}"
-                    logger.exception(error_msg)
-                    yield ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=str(pr.id), document_link=pr.html_url
-                        ),
-                        failure_message=error_msg,
-                        exception=e,
-                    )
-                    continue
+                else:
+                    # we iterate backwards in time, so at this point we stop processing prs
+                    if (
+                        start is not None
+                        and pr.updated_at
+                        and pr.updated_at.replace(tzinfo=timezone.utc) < start
+                    ):
+                        done_with_prs = True
+                        break
+                    # Skip PRs updated after the end date
+                    if (
+                        end is not None
+                        and pr.updated_at
+                        and pr.updated_at.replace(tzinfo=timezone.utc) > end
+                    ):
+                        continue
+                    try:
+                        yield _convert_pr_to_document(
+                            cast(PullRequest, pr), repo_external_access
+                        )
+                    except Exception as e:
+                        error_msg = f"Error converting PR to document: {e}"
+                        logger.exception(error_msg)
+                        yield ConnectorFailure(
+                            failed_document=DocumentFailure(
+                                document_id=str(pr.id), document_link=pr.html_url
+                            ),
+                            failure_message=error_msg,
+                            exception=e,
+                        )
+                        continue
 
             # If we reach this point with a cursor url in the checkpoint, we were using
             # the fallback cursor-based pagination strategy. That strategy tries to get all
@@ -689,38 +710,47 @@ class GithubConnector(CheckpointedConnectorWithPermSync[GithubConnectorCheckpoin
             for issue in issue_batch:
                 num_issues += 1
                 issue = cast(Issue, issue)
-                # we iterate backwards in time, so at this point we stop processing prs
-                if (
-                    start is not None
-                    and issue.updated_at.replace(tzinfo=timezone.utc) < start
-                ):
-                    done_with_issues = True
-                    break
-                # Skip PRs updated after the end date
-                if (
-                    end is not None
-                    and issue.updated_at.replace(tzinfo=timezone.utc) > end
-                ):
-                    continue
-
                 if issue.pull_request is not None:
                     # PRs are handled separately
                     continue
 
-                try:
-                    yield _convert_issue_to_document(issue, repo_external_access)
-                except Exception as e:
-                    error_msg = f"Error converting issue to document: {e}"
-                    logger.exception(error_msg)
-                    yield ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=str(issue.id),
-                            document_link=issue.html_url,
-                        ),
-                        failure_message=error_msg,
-                        exception=e,
+                if is_slim:
+                    yield Document(
+                        id=issue.html_url,
+                        sections=[],
+                        external_access=repo_external_access,
+                        source=DocumentSource.GITHUB,
+                        semantic_identifier="",
+                        metadata={},
                     )
-                    continue
+                else:
+                    # we iterate backwards in time, so at this point we stop processing issues
+                    if (
+                        start is not None
+                        and issue.updated_at.replace(tzinfo=timezone.utc) < start
+                    ):
+                        done_with_issues = True
+                        break
+                    # Skip issues updated after the end date
+                    if (
+                        end is not None
+                        and issue.updated_at.replace(tzinfo=timezone.utc) > end
+                    ):
+                        continue
+                    try:
+                        yield _convert_issue_to_document(issue, repo_external_access)
+                    except Exception as e:
+                        error_msg = f"Error converting issue to document: {e}"
+                        logger.exception(error_msg)
+                        yield ConnectorFailure(
+                            failed_document=DocumentFailure(
+                                document_id=str(issue.id),
+                                document_link=issue.html_url,
+                            ),
+                            failure_message=error_msg,
+                            exception=e,
+                        )
+                        continue
 
             logger.info(f"Fetched {num_issues} issues for repo: {repo.name}")
             # if we found any issues on the page, and we're not done, return the checkpoint.
@@ -802,6 +832,60 @@ class GithubConnector(CheckpointedConnectorWithPermSync[GithubConnectorCheckpoin
         return self._load_from_checkpoint(
             start, end, checkpoint, include_permissions=True
         )
+
+    def _retrieve_slim_docs(
+        self,
+        include_permissions: bool,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        """Iterate all PRs and issues across all configured repos as SlimDocuments.
+
+        Drives _fetch_from_github in a checkpoint loop — each call processes one
+        page and returns an updated checkpoint. The inner while True drains all
+        yielded Documents from a single page, terminating when _fetch_from_github
+        returns (which raises StopIteration and carries the next checkpoint as
+        e.value). Rate limiting and pagination are handled centrally by
+        _fetch_from_github via _get_batch_rate_limited.
+        """
+        checkpoint = self.build_dummy_checkpoint()
+        while checkpoint.has_more:
+            batch: list[SlimDocument | HierarchyNode] = []
+            gen = self._fetch_from_github(
+                checkpoint, include_permissions=include_permissions, is_slim=True
+            )
+            try:
+                while True:
+                    result = next(gen)
+                    if isinstance(result, Document):
+                        batch.append(
+                            SlimDocument(
+                                id=result.id, external_access=result.external_access
+                            )
+                        )
+            except StopIteration as e:
+                checkpoint = e.value
+            if batch:
+                yield batch
+            if callback and callback.should_stop():
+                raise RuntimeError("github_slim_docs: Stop signal detected")
+
+    @override
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        return self._retrieve_slim_docs(include_permissions=False, callback=callback)
+
+    @override
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        return self._retrieve_slim_docs(include_permissions=True, callback=callback)
 
     def validate_connector_settings(self) -> None:
         if self.github_client is None:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -22,6 +22,7 @@ from typing_extensions import override
 from onyx.access.models import ExternalAccess
 from onyx.configs.app_configs import GITHUB_CONNECTOR_BASE_URL
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.connector_runner import CheckpointOutputWrapper
 from onyx.connectors.connector_runner import ConnectorRunner
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
@@ -841,11 +842,10 @@ class GithubConnector(
         """Iterate all PRs and issues across all configured repos as SlimDocuments.
 
         Drives _fetch_from_github in a checkpoint loop — each call processes one
-        page and returns an updated checkpoint. The inner while True drains all
-        yielded Documents from a single page, terminating when _fetch_from_github
-        returns (which raises StopIteration and carries the next checkpoint as
-        e.value). Rate limiting and pagination are handled centrally by
-        _fetch_from_github via _get_batch_rate_limited.
+        page and returns an updated checkpoint. CheckpointOutputWrapper handles
+        draining the generator and extracting the returned checkpoint. Rate
+        limiting and pagination are handled centrally by _fetch_from_github via
+        _get_batch_rate_limited.
         """
         checkpoint = self.build_dummy_checkpoint()
         while checkpoint.has_more:
@@ -853,17 +853,18 @@ class GithubConnector(
             gen = self._fetch_from_github(
                 checkpoint, include_permissions=include_permissions, is_slim=True
             )
-            try:
-                while True:
-                    result = next(gen)
-                    if isinstance(result, Document):
-                        batch.append(
-                            SlimDocument(
-                                id=result.id, external_access=result.external_access
-                            )
+            wrapper: CheckpointOutputWrapper[GithubConnectorCheckpoint] = (
+                CheckpointOutputWrapper()
+            )
+            for document, _, _, next_checkpoint in wrapper(gen):
+                if document is not None:
+                    batch.append(
+                        SlimDocument(
+                            id=document.id, external_access=document.external_access
                         )
-            except StopIteration as e:
-                checkpoint = e.value
+                    )
+                if next_checkpoint is not None:
+                    checkpoint = next_checkpoint
             if batch:
                 yield batch
             if callback and callback.should_stop():

--- a/backend/tests/unit/onyx/connectors/github/test_github_slim_connector.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_slim_connector.py
@@ -1,0 +1,172 @@
+"""
+Tests verifying that GithubConnector implements SlimConnector and SlimConnectorWithPermSync
+correctly, and that pruning uses the cheap slim path (no lazy loading).
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import PropertyMock
+
+import pytest
+
+from onyx.access.models import ExternalAccess
+from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
+from onyx.connectors.github.connector import GithubConnector
+from onyx.connectors.interfaces import SlimConnector
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.models import SlimDocument
+
+
+def _make_pr(html_url: str) -> MagicMock:
+    pr = MagicMock()
+    pr.html_url = html_url
+    pr.pull_request = None
+    # commits and changed_files should never be accessed during slim retrieval
+    type(pr).commits = PropertyMock(side_effect=AssertionError("lazy load triggered"))
+    type(pr).changed_files = PropertyMock(
+        side_effect=AssertionError("lazy load triggered")
+    )
+    return pr
+
+
+def _make_issue(html_url: str) -> MagicMock:
+    issue = MagicMock()
+    issue.html_url = html_url
+    issue.pull_request = None
+    return issue
+
+
+def _make_connector(include_issues: bool = False) -> GithubConnector:
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=True,
+        include_issues=include_issues,
+    )
+    connector.github_client = MagicMock()
+    return connector
+
+
+@pytest.fixture(autouse=True)
+def patch_deserialize_repository(mock_repo: MagicMock) -> Generator[None, None, None]:
+    with patch(
+        "onyx.connectors.github.connector.deserialize_repository",
+        return_value=mock_repo,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_repo() -> MagicMock:
+    repo = MagicMock()
+    repo.name = "test-repo"
+    repo.id = 123
+    repo.raw_headers = {"x-github-request-id": "test"}
+    repo.raw_data = {"id": 123, "name": "test-repo", "full_name": "test-org/test-repo"}
+    prs = [
+        _make_pr(f"https://github.com/test-org/test-repo/pull/{i}") for i in range(1, 4)
+    ]
+    mock_paginated = MagicMock()
+    mock_paginated.get_page.side_effect = lambda page: prs if page == 0 else []
+    repo.get_pulls.return_value = mock_paginated
+    return repo
+
+
+def test_github_connector_implements_slim_connector() -> None:
+    connector = _make_connector()
+    assert isinstance(connector, SlimConnector)
+
+
+def test_github_connector_implements_slim_connector_with_perm_sync() -> None:
+    connector = _make_connector()
+    assert isinstance(connector, SlimConnectorWithPermSync)
+
+
+def test_retrieve_all_slim_docs_returns_pr_urls(mock_repo: MagicMock) -> None:
+    connector = _make_connector()
+    with patch.object(connector, "fetch_configured_repos", return_value=[mock_repo]):
+        batches = list(connector.retrieve_all_slim_docs())
+
+    all_docs = [doc for batch in batches for doc in batch]
+    assert len(all_docs) == 3
+    assert all(isinstance(doc, SlimDocument) for doc in all_docs)
+    assert {doc.id for doc in all_docs if isinstance(doc, SlimDocument)} == {
+        "https://github.com/test-org/test-repo/pull/1",
+        "https://github.com/test-org/test-repo/pull/2",
+        "https://github.com/test-org/test-repo/pull/3",
+    }
+
+
+def test_retrieve_all_slim_docs_has_no_external_access(mock_repo: MagicMock) -> None:
+    """Pruning does not need permissions — external_access should be None."""
+    connector = _make_connector()
+    with patch.object(connector, "fetch_configured_repos", return_value=[mock_repo]):
+        batches = list(connector.retrieve_all_slim_docs())
+
+    all_docs = [doc for batch in batches for doc in batch]
+    assert all(doc.external_access is None for doc in all_docs)
+
+
+def test_retrieve_all_slim_docs_perm_sync_populates_external_access(
+    mock_repo: MagicMock,
+) -> None:
+    connector = _make_connector()
+    mock_access = MagicMock(spec=ExternalAccess)
+
+    with patch.object(connector, "fetch_configured_repos", return_value=[mock_repo]):
+        with patch(
+            "onyx.connectors.github.connector.get_external_access_permission",
+            return_value=mock_access,
+        ) as mock_perm:
+            batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    # permission fetched at least once per repo (once per page in checkpoint-based flow)
+    mock_perm.assert_called_with(mock_repo, connector.github_client)
+
+    all_docs = [doc for batch in batches for doc in batch]
+    assert all(doc.external_access is mock_access for doc in all_docs)
+
+
+def test_retrieve_all_slim_docs_skips_pr_issues(mock_repo: MagicMock) -> None:
+    """Issues that are actually PRs should be skipped when include_issues=True."""
+    connector = _make_connector(include_issues=True)
+
+    pr_issue = MagicMock()
+    pr_issue.html_url = "https://github.com/test-org/test-repo/pull/99"
+    pr_issue.pull_request = MagicMock()  # non-None means it's a PR
+
+    real_issue = _make_issue("https://github.com/test-org/test-repo/issues/1")
+    issues = [pr_issue, real_issue]
+    mock_issues_paginated = MagicMock()
+    mock_issues_paginated.get_page.side_effect = lambda page: (
+        issues if page == 0 else []
+    )
+    mock_repo.get_issues.return_value = mock_issues_paginated
+
+    with patch.object(connector, "fetch_configured_repos", return_value=[mock_repo]):
+        batches = list(connector.retrieve_all_slim_docs())
+
+    issue_ids = {
+        doc.id
+        for batch in batches
+        for doc in batch
+        if isinstance(doc, SlimDocument) and "issues" in doc.id
+    }
+    assert issue_ids == {"https://github.com/test-org/test-repo/issues/1"}
+
+
+def test_pruning_routes_to_slim_connector_path(mock_repo: MagicMock) -> None:
+    """extract_ids_from_runnable_connector must use SlimConnector, not CheckpointedConnector."""
+    connector = _make_connector()
+
+    with patch.object(connector, "fetch_configured_repos", return_value=[mock_repo]):
+        # If the CheckpointedConnector fallback were used instead, it would call
+        # load_from_checkpoint which hits _convert_pr_to_document and lazy loads.
+        # We verify the slim path is taken by checking load_from_checkpoint is NOT called.
+        with patch.object(connector, "load_from_checkpoint") as mock_load:
+            result = extract_ids_from_runnable_connector(connector)
+            mock_load.assert_not_called()
+
+    assert len(result.raw_id_to_parent) == 3
+    assert "https://github.com/test-org/test-repo/pull/1" in result.raw_id_to_parent


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
[Problem](https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.nxv83jg60gwy)
connector_pruning_generator_task times out after 6 hours for GitHub connectors with large repos. GithubConnector only implemented CheckpointedConnectorWithPermSync, so pruning fell back to _checkpointed_batched_items — a full crawl from epoch 0 to now. Each PR in _convert_pr_to_document accesses pull_request.commits and pull_request.changed_files, which are not included in GitHub's list-PRs API response. PyGitHub lazy-loads them via one GET /pulls/{number} per PR, causing the timeout on repos with 10k+ PRs.

Fix
Add SlimConnector and SlimConnectorWithPermSync to GithubConnector. The slim path iterates repos and reads only pr.html_url (available in the list response, no lazy loading), returning SlimDocument batches. Pruning now hits the SlimConnector branch in extract_ids_from_runnable_connector instead of the CheckpointedConnector fallback, eliminating per-PR HTTP calls entirely. SlimConnectorWithPermSync is also implemented to set GitHub up for the generic_doc_sync EE perm sync path in a follow-up.

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
<!--- Describe the tests you ran to verify your changes --->

7 unit tests added verifying correct interface implementation, no external_access on slim docs for pruning, one permission call per repo for perm sync, PR-typed issues filtered out, and that load_from_checkpoint is never called during pruning

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub pruning timeouts on large repos by routing pruning through a slim path that emits only PR/issue URLs and avoids per-PR API calls. Also adds a slim perm-sync path that attaches repo-level permissions. Addresses ENG-3954.

- **Bug Fixes**
  - Route pruning through `SlimConnector` in `GithubConnector`, bypassing the checkpointed full crawl.
  - Use checkpoint-driven slim iteration; read only `pr.html_url`/`issue.html_url`, skip PR-typed issues, and honor include flags.
  - Respect stop signals via `IndexingHeartbeatInterface` during slim iteration.

- **New Features**
  - Implement `SlimConnector` and `SlimConnectorWithPermSync` with batched `SlimDocument` generation.
  - Add slim perm-sync that attaches repo-level `external_access`; pruning leaves it unset.
  - Add tests for slim routing via `extract_ids_from_runnable_connector`, permission attachment, no lazy loads, and issue filtering.

<sup>Written for commit 5b562d2fd28e38bf76d889737e550708ded3e339. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



