### PR TITLE
feat: add ref forwarding to input layout components

### DIFF
--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -54,6 +54,8 @@ interface InputLayoutProps {
   withLabel?: boolean | string;
 
   disabled?: boolean;
+  /** Ref forwarded to the inner content `Section`. */
+  ref?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
   title: string | RichStr;
   /** Tag rendered inline beside the title (passed through to Content). */
@@ -73,6 +75,7 @@ export interface VerticalProps extends InputLayoutProps {
 function Vertical({
   withLabel: withLabelProp = false,
   disabled,
+  ref,
   children,
   subDescription,
   title,
@@ -84,7 +87,7 @@ function Vertical({
     typeof withLabelProp === "string" ? withLabelProp : undefined;
 
   const content = (
-    <Section gap={0.25} alignItems="start">
+    <Section ref={ref} gap={0.25} alignItems="start">
       <Content
         title={title}
         description={description}
@@ -123,6 +126,7 @@ export interface HorizontalProps extends InputLayoutProps {
 function Horizontal({
   withLabel: withLabelProp = false,
   disabled,
+  ref,
   children,
   center,
   title,
@@ -134,7 +138,7 @@ function Horizontal({
     typeof withLabelProp === "string" ? withLabelProp : undefined;
 
   const content = (
-    <Section gap={0.25} alignItems="start">
+    <Section ref={ref} gap={0.25} alignItems="start">
       <Section
         flexDirection="row"
         justifyContent="between"
@@ -210,9 +214,14 @@ export type InputErrorType = "error" | "warning";
 interface InputErrorTextProps {
   children?: React.ReactNode;
   type?: InputErrorType;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-function InputErrorText({ children, type = "error" }: InputErrorTextProps) {
+function InputErrorText({
+  children,
+  type = "error",
+  ref,
+}: InputErrorTextProps) {
   const Icon = type === "error" ? SvgXOctagon : SvgAlertCircle;
   const colorClass =
     type === "error" ? "text-status-error-05" : "text-status-warning-05";
@@ -220,7 +229,7 @@ function InputErrorText({ children, type = "error" }: InputErrorTextProps) {
     type === "error" ? "stroke-status-error-05" : "stroke-status-warning-05";
 
   return (
-    <div className="px-1">
+    <div ref={ref} className="px-1">
       {/* TODO(@raunakab): update this with `Content` when it supports custom colours */}
       <Section flexDirection="row" justifyContent="start" gap={0.25}>
         <Icon size={12} className={strokeClass} />
@@ -250,10 +259,12 @@ function InputDivider() {
 // InputPadder
 // ---------------------------------------------------------------------------
 
-type InputPadderProps = WithoutStyles<React.HTMLAttributes<HTMLDivElement>>;
+type InputPadderProps = WithoutStyles<React.HTMLAttributes<HTMLDivElement>> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
 
-function InputPadder(props: InputPadderProps) {
-  return <div {...props} className="p-2 w-full" />;
+function InputPadder({ ref, ...props }: InputPadderProps) {
+  return <div ref={ref} {...props} className="p-2 w-full" />;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Add `ref` props to input layout components in `@opal/layouts/inputs/`:

- **`Vertical` / `Horizontal`**: `ref` forwarded to the inner content `Section` (always points to the content div, regardless of label wrapping)
- **`InputErrorText`**: `ref` forwarded to the root `<div>`
- **`InputPadder`**: `ref` forwarded to the root `<div>`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ref forwarding to input layout components in `@opal/layouts/inputs` so parents can reliably focus, measure, or scroll to input content.

- **New Features**
  - `Vertical`, `Horizontal`: forward `ref` to the inner content `Section` (always the content div, independent of label wrapping).
  - `InputErrorText`: forward `ref` to the root div.
  - `InputPadder`: forward `ref` to the root div.

<sup>Written for commit e7d6a128d83ef49eff8f3326ae6cc0f096e01383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->