### PR TITLE
feat(indexing): notify admins when connector enters repeated error state

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -50,6 +50,7 @@ from onyx.configs.constants import AuthType
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_INDEXING_LOCK_TIMEOUT
 from onyx.configs.constants import MilestoneRecordType
+from onyx.configs.constants import NotificationType
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -85,6 +86,7 @@ from onyx.db.indexing_coordination import INDEXING_PROGRESS_TIMEOUT_HOURS
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import SearchSettings
+from onyx.db.notification import create_notification
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
@@ -400,7 +402,6 @@ def check_indexing_completion(
     tenant_id: str,
     task: Task,
 ) -> None:
-
     logger.info(
         f"Checking for indexing completion: attempt={index_attempt_id} tenant={tenant_id}"
     )
@@ -848,6 +849,33 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         cc_pair_id=cc_pair_id,
                         in_repeated_error_state=True,
                     )
+
+                    connector_name = (
+                        cc_pair.name
+                        or cc_pair.connector.name
+                        or f"CC pair {cc_pair.id}"
+                    )
+                    source = cc_pair.connector.source.value
+                    create_notification(
+                        user_id=None,
+                        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+                        db_session=db_session,
+                        title=f"Connector '{connector_name}' has entered repeated error state",
+                        description=(
+                            f"The {source} connector has failed repeatedly and "
+                            f"has been flagged. Check the connector's indexing "
+                            f"history for details."
+                        ),
+                        additional_data={"cc_pair_id": cc_pair.id},
+                    )
+
+                    task_logger.error(
+                        f"Connector entered repeated error state: "
+                        f"cc_pair={cc_pair.id} "
+                        f"connector={cc_pair.connector.name} "
+                        f"source={source}"
+                    )
+
                     # When entering repeated error state, also pause the connector
                     # to prevent continued indexing retry attempts burning through embedding credits.
                     # NOTE: only for Cloud, since most self-hosted users use self-hosted embedding

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -87,6 +87,7 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import SearchSettings
 from onyx.db.notification import create_notification
+from onyx.db.notification import get_notifications
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
@@ -552,6 +553,21 @@ def check_indexing_completion(
             # Clear repeated error state on success
             if cc_pair.in_repeated_error_state:
                 cc_pair.in_repeated_error_state = False
+
+                # Delete any existing error notification for this CC pair so a
+                # fresh one is created if the connector fails again later.
+                for notif in get_notifications(
+                    user=None,
+                    db_session=db_session,
+                    notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+                    include_dismissed=True,
+                ):
+                    if (
+                        notif.additional_data
+                        and notif.additional_data.get("cc_pair_id") == cc_pair.id
+                    ):
+                        db_session.delete(notif)
+
                 db_session.commit()
 
             if attempt.status == IndexingStatus.SUCCESS:
@@ -856,6 +872,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         or f"CC pair {cc_pair.id}"
                     )
                     source = cc_pair.connector.source.value
+                    connector_url = f"/admin/connector/{cc_pair.id}"
                     create_notification(
                         user_id=None,
                         notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
@@ -863,8 +880,8 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         title=f"Connector '{connector_name}' has entered repeated error state",
                         description=(
                             f"The {source} connector has failed repeatedly and "
-                            f"has been flagged. Check the connector's indexing "
-                            f"history for details."
+                            f"has been flagged. View indexing history in the "
+                            f"Advanced section: {connector_url}"
                         ),
                         additional_data={"cc_pair_id": cc_pair.id},
                     )

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -283,6 +283,7 @@ class NotificationType(str, Enum):
     RELEASE_NOTES = "release_notes"
     ASSISTANT_FILES_READY = "assistant_files_ready"
     FEATURE_ANNOUNCEMENT = "feature_announcement"
+    CONNECTOR_REPEATED_ERRORS = "connector_repeated_errors"
 
 
 class BlobType(str, Enum):


### PR DESCRIPTION
## Description

Connectors currently die silently. When a connector fails repeatedly and enters the "repeated error" state, admins only discover it when they happen to check the connector list in the UI, or when a user complains about stale search results. There's no proactive notification.

This adds an in-app admin notification at the exact point where a connector transitions to repeated error state. The notification includes:
- Connector name and source type (e.g. "Google Drive", "Confluence")
- CC pair ID for linking to the connector's detail page

**How it works:**

The transition point is in `check_for_indexing` (runs every 15s). When `is_in_repeated_error_state()` detects consecutive failures and the connector wasn't already in that state, three things now happen:
1. `set_cc_pair_repeated_error_state(True)` — existing behavior
2. `create_notification()` — **new**: creates an admin notification with `user_id=None` (visible to all admins)
3. `task_logger.error()` — **new**: structured ERROR log for cloud monitoring

The notification uses `additional_data={"cc_pair_id": cc_pair.id}` for deduplication — if the same connector re-enters error state after recovery, a new notification is created. If it's already in error state and hasn't been dismissed, the timestamp is updated (existing `create_notification` behavior).

Uses the new `NotificationType.CONNECTOR_REPEATED_ERRORS` enum value.

**Linear:** [ENG-3983](https://linear.app/onyx-app/issue/ENG-3983/connector-invalid-admin-notification)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check