### PR TITLE
fix(fe): handle file attachment overflow

### DIFF
--- a/web/src/layouts/general-layouts.tsx
+++ b/web/src/layouts/general-layouts.tsx
@@ -173,8 +173,13 @@ function AttachmentItemLayout({
   rightChildren,
 }: AttachmentItemLayoutProps) {
   return (
-    <Section flexDirection="row" gap={0.25} padding={0.25}>
-      <div className={cn("h-[2.25rem] aspect-square rounded-08")}>
+    <Section
+      flexDirection="row"
+      justifyContent="start"
+      gap={0.25}
+      padding={0.25}
+    >
+      <div className={cn("h-[2.25rem] aspect-square rounded-08 flex-shrink-0")}>
         <Section>
           <div
             className="attachment-button__icon-wrapper"
@@ -189,6 +194,7 @@ function AttachmentItemLayout({
         justifyContent="between"
         alignItems="center"
         gap={1.5}
+        className="min-w-0"
       >
         <div data-testid="attachment-item-title" className="flex-1 min-w-0">
           <Content

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -184,8 +184,8 @@ export function FileCard({
       }
     >
       <div className="min-w-0 max-w-[12rem]">
-        <Interactive.Container border heightVariant="fit">
-          <div className="[&_.opal-content-md-title-row]:min-w-0 [&_.opal-content-md-title]:break-all">
+        <Interactive.Container border heightVariant="fit" widthVariant="full">
+          <div className="min-w-0">
             <AttachmentItemLayout
               icon={isProcessing ? SimpleLoader : SvgFileText}
               title={file.name}

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -185,19 +185,17 @@ export function FileCard({
     >
       <div className="min-w-0 max-w-[12rem]">
         <Interactive.Container border heightVariant="fit" widthVariant="full">
-          <div className="min-w-0">
-            <AttachmentItemLayout
-              icon={isProcessing ? SimpleLoader : SvgFileText}
-              title={file.name}
-              description={
-                isProcessing
-                  ? file.status === UserFileStatus.UPLOADING
-                    ? "Uploading..."
-                    : "Processing..."
-                  : typeLabel
-              }
-            />
-          </div>
+          <AttachmentItemLayout
+            icon={isProcessing ? SimpleLoader : SvgFileText}
+            title={file.name}
+            description={
+              isProcessing
+                ? file.status === UserFileStatus.UPLOADING
+                  ? "Uploading..."
+                  : "Processing..."
+                : typeLabel
+            }
+          />
           <Spacer horizontal rem={0.5} />
         </Interactive.Container>
       </div>


### PR DESCRIPTION
## Description



## How Has This Been Tested?

**before**
<img width="1416" height="1820" alt="20260414_18h09m04s_grim" src="https://github.com/user-attachments/assets/56ed9891-899f-49ca-a4a0-0b4c4d4f0935" />

**after**
<img width="1416" height="1820" alt="20260414_18h08m56s_grim" src="https://github.com/user-attachments/assets/8e0d0ba6-3c5f-4f22-bef9-2ec5da8e54d0" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow in file attachment cards. Long filenames no longer break the layout on narrow screens.

- **Bug Fixes**
  - Prevented icon shrink (`flex-shrink-0`) and left-aligned the row (`justifyContent="start"`).
  - Added `min-w-0` to content sections for proper truncation.
  - Set `Interactive.Container` to `widthVariant="full"` to avoid clipping.

<sup>Written for commit 2bad0b8496f026d7c2741fe1e3b9eba0ab6be6be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

