### PR TITLE
fix(voice): send TTS text in POST body instead of query params

### DIFF
--- a/backend/onyx/server/manage/voice/user_api.py
+++ b/backend/onyx/server/manage/voice/user_api.py
@@ -8,6 +8,7 @@ from fastapi import File
 from fastapi import UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from pydantic import Field
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -139,9 +140,9 @@ def _extract_provider_error(exc: Exception) -> str:
 
 
 class SynthesizeRequest(BaseModel):
-    text: str
+    text: str = Field(..., min_length=1)
     voice: str | None = None
-    speed: float | None = None
+    speed: float | None = Field(default=None, ge=0.5, le=2.0)
 
 
 @router.post("/synthesize")

--- a/backend/onyx/server/manage/voice/user_api.py
+++ b/backend/onyx/server/manage/voice/user_api.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterator
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import File
-from fastapi import Query
 from fastapi import UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -113,28 +112,22 @@ async def transcribe_audio(
         ) from exc
 
 
+class SynthesizeRequest(BaseModel):
+    text: str
+    voice: str | None = None
+    speed: float | None = None
+
+
 @router.post("/synthesize")
 async def synthesize_speech(
-    text: str | None = Query(
-        default=None, description="Text to synthesize", max_length=4096
-    ),
-    voice: str | None = Query(default=None, description="Voice ID to use"),
-    speed: float | None = Query(
-        default=None, description="Playback speed (0.5-2.0)", ge=0.5, le=2.0
-    ),
+    body: SynthesizeRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> StreamingResponse:
-    """
-    Synthesize text to speech using the default TTS provider.
-
-    Accepts parameters via query string for streaming compatibility.
-    """
-    logger.info(
-        f"TTS request: text length={len(text) if text else 0}, voice={voice}, speed={speed}"
-    )
-
-    if not text:
-        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, "Text is required")
+    """Synthesize text to speech using the default TTS provider."""
+    text = body.text
+    voice = body.voice
+    speed = body.speed
+    logger.info(f"TTS request: text length={len(text)}, voice={voice}, speed={speed}")
 
     # Use short-lived session to fetch provider config, then release connection
     # before starting the long-running streaming response
@@ -177,31 +170,34 @@ async def synthesize_speech(
             logger.error(f"Failed to get voice provider: {exc}")
             raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, str(exc)) from exc
 
-    # Session is now closed - streaming response won't hold DB connection
+    # Pull the first chunk before returning the StreamingResponse. If the
+    # provider rejects the request (e.g. text too long), the error surfaces
+    # as a proper HTTP error instead of a broken audio stream.
+    stream_iter = provider.synthesize_stream(
+        text=text, voice=final_voice, speed=final_speed
+    )
+    try:
+        first_chunk = await stream_iter.__anext__()
+    except StopAsyncIteration:
+        raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "TTS provider returned no audio")
+    except Exception as exc:
+        raise OnyxError(OnyxErrorCode.BAD_GATEWAY, str(exc)) from exc
+
     async def audio_stream() -> AsyncIterator[bytes]:
-        try:
-            chunk_count = 0
-            async for chunk in provider.synthesize_stream(
-                text=text, voice=final_voice, speed=final_speed
-            ):
-                chunk_count += 1
-                yield chunk
-            logger.info(f"TTS streaming complete: {chunk_count} chunks sent")
-        except NotImplementedError as exc:
-            logger.error(f"TTS not implemented: {exc}")
-            raise
-        except Exception as exc:
-            logger.error(f"Synthesis failed: {exc}")
-            raise
+        yield first_chunk
+        chunk_count = 1
+        async for chunk in stream_iter:
+            chunk_count += 1
+            yield chunk
+        logger.info(f"TTS streaming complete: {chunk_count} chunks sent")
 
     return StreamingResponse(
         audio_stream(),
         media_type="audio/mpeg",
         headers={
             "Content-Disposition": "inline; filename=speech.mp3",
-            # Allow streaming by not setting content-length
             "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
+            "X-Accel-Buffering": "no",
         },
     )
 

--- a/backend/onyx/server/manage/voice/user_api.py
+++ b/backend/onyx/server/manage/voice/user_api.py
@@ -1,3 +1,4 @@
+import json
 import secrets
 from collections.abc import AsyncIterator
 
@@ -112,6 +113,31 @@ async def transcribe_audio(
         ) from exc
 
 
+def _extract_provider_error(exc: Exception) -> str:
+    """Extract a human-readable message from a provider exception.
+
+    Provider errors often embed JSON from upstream APIs (e.g. ElevenLabs).
+    This tries to parse a readable ``message`` field out of common JSON
+    error shapes; falls back to ``str(exc)`` if nothing better is found.
+    """
+    raw = str(exc)
+    try:
+        # Many providers embed JSON after a prefix like "ElevenLabs TTS failed: {...}"
+        json_start = raw.find("{")
+        if json_start == -1:
+            return raw
+        parsed = json.loads(raw[json_start:])
+        # Shape: {"detail": {"message": "..."}} (ElevenLabs)
+        detail = parsed.get("detail", parsed)
+        if isinstance(detail, dict):
+            return detail.get("message") or detail.get("error") or raw
+        if isinstance(detail, str):
+            return detail
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        pass
+    return raw
+
+
 class SynthesizeRequest(BaseModel):
     text: str
     voice: str | None = None
@@ -181,7 +207,9 @@ async def synthesize_speech(
     except StopAsyncIteration:
         raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "TTS provider returned no audio")
     except Exception as exc:
-        raise OnyxError(OnyxErrorCode.BAD_GATEWAY, str(exc)) from exc
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY, _extract_provider_error(exc)
+        ) from exc
 
     async def audio_stream() -> AsyncIterator[bytes]:
         yield first_chunk

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -757,18 +757,7 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"ElevenLabs TTS failed: {error_text}")
-                    # Extract human-readable message from ElevenLabs JSON error
-                    message = error_text
-                    try:
-                        import json
-
-                        parsed = json.loads(error_text)
-                        detail = parsed.get("detail", {})
-                        if isinstance(detail, dict) and detail.get("message"):
-                            message = detail["message"]
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
-                    raise RuntimeError(message)
+                    raise RuntimeError(f"ElevenLabs TTS failed: {error_text}")
 
                 # Use 8192 byte chunks for smoother streaming
                 chunk_count = 0

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -757,7 +757,18 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
                 if response.status != 200:
                     error_text = await response.text()
                     logger.error(f"ElevenLabs TTS failed: {error_text}")
-                    raise RuntimeError(f"ElevenLabs TTS failed: {error_text}")
+                    # Extract human-readable message from ElevenLabs JSON error
+                    message = error_text
+                    try:
+                        import json
+
+                        parsed = json.loads(error_text)
+                        detail = parsed.get("detail", {})
+                        if isinstance(detail, dict) and detail.get("message"):
+                            message = detail["message"]
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+                    raise RuntimeError(message)
 
                 # Use 8192 byte chunks for smoother streaming
                 chunk_count = 0

--- a/web/src/app/app/message/messageComponents/TTSButton.tsx
+++ b/web/src/app/app/message/messageComponents/TTSButton.tsx
@@ -59,7 +59,6 @@ function TTSButton({ text, voice, speed }: TTSButtonProps) {
   // Surface streaming voice playback errors to the user via toast
   useEffect(() => {
     if (error) {
-      console.error("Voice playback error:", error);
       toast.error(error);
     }
   }, [error]);

--- a/web/src/lib/streamingTTS.ts
+++ b/web/src/lib/streamingTTS.ts
@@ -53,18 +53,17 @@ export class HTTPStreamingTTSPlayer {
     // Create abort controller for this request
     this.abortController = new AbortController();
 
-    // Build URL with query params
-    const params = new URLSearchParams();
-    params.set("text", text);
-    if (voice) params.set("voice", voice);
-    params.set("speed", speed.toString());
-
-    const url = `${this.getAPIUrl()}?${params}`;
+    const url = this.getAPIUrl();
+    const body = JSON.stringify({
+      text,
+      ...(voice && { voice }),
+      speed,
+    });
 
     // Check if MediaSource is supported
     if (!window.MediaSource || !MediaSource.isTypeSupported("audio/mpeg")) {
       // Fallback to simple buffered playback
-      return this.fallbackSpeak(url);
+      return this.fallbackSpeak(url, body);
     }
 
     // Create MediaSource and audio element
@@ -129,15 +128,21 @@ export class HTTPStreamingTTSPlayer {
     try {
       const response = await fetch(url, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
         signal: this.abortController.signal,
-        credentials: "include", // Include cookies for authentication
+        credentials: "include",
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(
-          `TTS request failed: ${response.status} - ${errorText}`
-        );
+        let message = `TTS request failed (${response.status})`;
+        try {
+          const errorJson = await response.json();
+          if (errorJson.detail) message = errorJson.detail;
+        } catch {
+          // response wasn't JSON — use status text
+        }
+        throw new Error(message);
       }
 
       const reader = response.body?.getReader();
@@ -242,16 +247,24 @@ export class HTTPStreamingTTSPlayer {
    * Fallback for browsers that don't support MediaSource Extensions.
    * Buffers all audio before playing.
    */
-  private async fallbackSpeak(url: string): Promise<void> {
+  private async fallbackSpeak(url: string, body: string): Promise<void> {
     const response = await fetch(url, {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
       signal: this.abortController?.signal,
-      credentials: "include", // Include cookies for authentication
+      credentials: "include",
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`TTS request failed: ${response.status} - ${errorText}`);
+      let message = `TTS request failed (${response.status})`;
+      try {
+        const errorJson = await response.json();
+        if (errorJson.detail) message = errorJson.detail;
+      } catch {
+        // response wasn't JSON — use status text
+      }
+      throw new Error(message);
     }
 
     const audioData = await response.arrayBuffer();


### PR DESCRIPTION
## Description

Three fixes for TTS playback:

1. **403 from nginx:** Text was sent as a URL query parameter. Long responses exceeded nginx's URL length limit → 403 Forbidden. Moved text to a JSON POST body via `SynthesizeRequest` Pydantic model.

2. **Provider errors not surfacing:** Provider errors (e.g. ElevenLabs `text_too_long`) were thrown inside the streaming response generator — after 200 headers were already sent — so the frontend got a broken audio stream with no error message. Now the first audio chunk is pulled *before* returning the `StreamingResponse`. If the provider rejects immediately, the error surfaces as a proper HTTP error with a JSON body. A generic `_extract_provider_error()` helper parses the human-readable message from any provider's JSON error response. Frontend parses `detail` from the response and displays it in the toast.

3. **Duplicate console logging:** The error was logged twice — once in `useVoicePlayback` (`onError` callback) and again in `TTSButton` (`useEffect`). Removed the duplicate `console.error` from `TTSButton`; it now only fires the toast.

**Linear:** [ENG-4023](https://linear.app/onyx-app/issue/ENG-4023/multi-model-tts-playback-intermittently-fails-with-403)

## How Has This Been Tested?

<img width="346" height="217" alt="Screenshot 2026-04-14 at 9 08 11 PM" src="https://github.com/user-attachments/assets/0a5ca04e-43eb-4ccf-91de-4606ef1a1991" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check