### PR TITLE
chore(tests): avoid openapi client import in tests

### DIFF
--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -12,7 +12,7 @@ from onyx.db.models import DocumentByConnectorCredentialPair
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import DATestAPIKey
-from tests.integration.common_utils.managers.cc_pair import DATestCCPair
+from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.test_models import SimpleTestDocument
 from tests.integration.common_utils.vespa import vespa_fixture

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -14,7 +14,6 @@ from onyx.db.search_settings import get_current_search_settings
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
 from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
-from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.image_generation import (
     ImageGenerationConfigManager,
@@ -196,6 +195,9 @@ def image_generation_config(
 
 @pytest.fixture
 def document_builder(admin_user: DATestUser) -> DocumentBuilderType:
+    # HACK: Avoid importing generated OpenAPI client modules unless this fixture is used.
+    from tests.integration.common_utils.managers.cc_pair import CCPairManager
+
     api_key: DATestAPIKey = APIKeyManager.create(
         user_performing_action=admin_user,
     )


### PR DESCRIPTION
## Description

I am still hitting issues with generating the openapi client as documented in [chore(devtools): install java runtime into devcontainer](https://github.com/onyx-dot-app/onyx/pull/10197). Workaround by deferring loading this module for tests that need it.

## How Has This Been Tested?

`uv run pytest backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py`

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid importing the generated OpenAPI client during integration test collection by lazy-loading `CCPairManager` in the `document_builder` fixture. Prevents failures on environments without the Java-based codegen.

- **Bug Fixes**
  - Defer OpenAPI client load by moving `CCPairManager` import into `document_builder`.
  - Import `DATestCCPair` from `tests.integration.common_utils.test_models` instead of `managers.cc_pair`.

<sup>Written for commit 3f0a846fe317700197963eea7337e99a0aebc5ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

