### PR TITLE
chore(devtools): connect databases and github remote to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Onyx Dev Sandbox",
   "image": "onyxdotapp/onyx-devcontainer@sha256:0f02d9299928849c7b15f3b348dcfdcdcb64411ff7a4580cbc026a6ee7aa1554",
-  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW", "--network=onyx_default"],
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/dev/.claude,type=bind",
     "source=${localEnv:HOME}/.claude.json,target=/home/dev/.claude.json,type=bind",
@@ -12,10 +12,13 @@
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
   ],
   "containerEnv": {
-    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock"
+    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
+    "POSTGRES_HOST": "relational_db",
+    "REDIS_HOST": "cache"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",
   "updateRemoteUserUID": false,
+  "initializeCommand": "docker network create onyx_default 2>/dev/null || true",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postStartCommand": "sudo bash /workspace/.devcontainer/init-dev-user.sh && sudo bash /workspace/.devcontainer/init-firewall.sh",

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -4,21 +4,11 @@ set -euo pipefail
 
 echo "Setting up firewall..."
 
-# Preserve docker dns resolution
-DOCKER_DNS_RULES=$(iptables-save | grep -E "^-A.*-d 127.0.0.11/32" || true)
-
-# Flush all rules
-iptables -t nat -F
-iptables -t nat -X
-iptables -t mangle -F
-iptables -t mangle -X
+# Only flush the filter table.  The nat and mangle tables are managed by Docker
+# (DNS DNAT to 127.0.0.11, container networking, etc.) and must not be touched —
+# flushing them breaks Docker's embedded DNS resolver.
 iptables -F
 iptables -X
-
-# Restore docker dns rules
-if [ -n "$DOCKER_DNS_RULES" ]; then
-    echo "$DOCKER_DNS_RULES" | iptables-restore -n
-fi
 
 # Create ipset for allowed destinations
 ipset create allowed-domains hash:net || true
@@ -34,6 +24,7 @@ done
 
 # Resolve allowed domains
 ALLOWED_DOMAINS=(
+    "github.com"
     "registry.npmjs.org"
     "api.anthropic.com"
     "api-staging.anthropic.com"
@@ -64,6 +55,14 @@ if [ -n "$DOCKER_GATEWAY" ]; then
         echo "warning: failed to add Docker gateway $DOCKER_GATEWAY to allowlist" >&2
     fi
 fi
+
+# Allow traffic to all attached Docker network subnets so the container can
+# reach sibling services (e.g. relational_db, cache) on shared compose networks.
+for subnet in $(ip -4 -o addr show scope global | awk '{print $4}'); do
+    if ! ipset add allowed-domains "$subnet" -exist 2>&1; then
+        echo "warning: failed to add Docker subnet $subnet to allowlist" >&2
+    fi
+done
 
 # Set default policies to DROP
 iptables -P FORWARD DROP

--- a/backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py
+++ b/backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py
@@ -108,12 +108,12 @@ def current_head_rev() -> str:
         ["alembic", "heads", "--resolve-dependencies"],
         cwd=_BACKEND_DIR,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         text=True,
     )
     assert (
         result.returncode == 0
-    ), f"alembic heads failed (exit {result.returncode}):\n{result.stdout}"
+    ), f"alembic heads failed (exit {result.returncode}):\n{result.stdout}\n{result.stderr}"
     # Output looks like "d5c86e2c6dc6 (head)\n"
     rev = result.stdout.strip().split()[0]
     assert len(rev) > 0

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -154,11 +154,11 @@ func worktreeGitMount(root string) (string, bool) {
 func sshAgentMount() (string, bool) {
 	sock := os.Getenv("SSH_AUTH_SOCK")
 	if sock == "" {
-		log.Debug("SSH_AUTH_SOCK not set — skipping SSH agent forwarding")
+		log.Warn("SSH_AUTH_SOCK not set — SSH agent forwarding disabled (git over SSH won't work inside the container)")
 		return "", false
 	}
 	if _, err := os.Stat(sock); err != nil {
-		log.Debugf("SSH_AUTH_SOCK=%s not accessible: %v", sock, err)
+		log.Warnf("SSH_AUTH_SOCK=%s not accessible — SSH agent forwarding disabled: %v", sock, err)
 		return "", false
 	}
 	mount := fmt.Sprintf("type=bind,source=%s,target=/tmp/ssh-agent.sock", sock)


### PR DESCRIPTION
## Description

Attaches the devcontainer to the `onyx_default` network so it can talk to the databases (needed for integration tests).

Also improves the UX around configuring the SSH socket.

Also fixes `test_run_multitenant_migrations.py`. Per Claude,

>   Root cause: The alembic heads subprocess was merging stderr into stdout. ANSI-colored WARNING log messages (e.g., USER_AUTH_SECRET is not set) were appearing before   
  the revision hash in the combined output. When the fixture parsed the first word with .split()[0], it got \x1b[93mWARNING\x1b[0m: instead of the actual revision hash. 
  This caused tenant_schema_at_head to be seeded with a bogus version_num, so get_schemas_needing_migration never recognized it as "at head", breaking all three tests   
  that depended on the at-head schema being skipped.

## How Has This Been Tested?

`uv run pytest backend/tests/integration/multitenant_tests/migrations/test_run_multitenant_migrations.py`

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the devcontainer to the `onyx_default` network and configures the firewall so it can reach Postgres/Redis and `github.com`. Also improves SSH agent forwarding messages and fixes the multitenant migrations test.

- **New Features**
  - Join `onyx_default` (create if missing); set `POSTGRES_HOST=relational_db` and `REDIS_HOST=cache` for integration tests.
  - Firewall: only flush filter table; allow `github.com`, Docker gateway, and attached Docker subnets; defaults stay DROP.
  - SSH agent: clearer warnings when `SSH_AUTH_SOCK` is missing or inaccessible; forwarding disabled so Git over SSH won’t work.
  - Fix multitenant migrations test: capture stderr separately and include it on failure to avoid parsing warnings as revision IDs.

<sup>Written for commit 9fb7b1e3eca0e525246bca1f19fc1f1368288d48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



