### PR TITLE
fix(chat): hide incomplete citation links during streaming

### DIFF
--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -73,7 +73,10 @@ export const MemoizedAnchor = memo(
             : undefined;
 
           if (!associatedDoc && !associatedSubQuestion) {
-            return <>{children}</>;
+            // Citation not resolved yet (data still streaming) — hide the
+            // raw [[N]](url) link entirely. It will render as a chip once
+            // the citation/document data arrives.
+            return <></>;
           }
 
           let icon: React.ReactNode = null;

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -81,6 +81,15 @@ export function ScrollableTable({
  * Processes content for markdown rendering by handling code blocks and LaTeX
  */
 export const processContent = (content: string): string => {
+  // Strip incomplete citation links at the end of streaming content.
+  // During typewriter animation, [[N]](url) is revealed character by character.
+  // ReactMarkdown can't parse an incomplete link and renders it as raw text.
+  // This regex removes any trailing partial citation pattern so only complete
+  // links are passed to the markdown parser.
+  content = content.replace(/\[\[\d+\]\]\([^)]*$/g, "");
+  // Also strip a lone [[ or [[N] or [[N]] at the very end (before the URL part arrives)
+  content = content.replace(/\[\[(?:\d+\]?\]?)?$/g, "");
+
   const codeBlockRegex = /```(\w*)\n[\s\S]*?```|```[\s\S]*?$/g;
   const matches = content.match(codeBlockRegex);
 

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -86,9 +86,9 @@ export const processContent = (content: string): string => {
   // ReactMarkdown can't parse an incomplete link and renders it as raw text.
   // This regex removes any trailing partial citation pattern so only complete
   // links are passed to the markdown parser.
-  content = content.replace(/\[\[\d+\]\]\([^)]*$/g, "");
+  content = content.replace(/\[\[\d+\]\]\([^)]*$/, "");
   // Also strip a lone [[ or [[N] or [[N]] at the very end (before the URL part arrives)
-  content = content.replace(/\[\[(?:\d+\]?\]?)?$/g, "");
+  content = content.replace(/\[\[(?:\d+\]?\]?)?$/, "");
 
   const codeBlockRegex = /```(\w*)\n[\s\S]*?```|```[\s\S]*?$/g;
   const matches = content.match(codeBlockRegex);


### PR DESCRIPTION
## Description

During streaming, the typewriter animation reveals `[[N]](url)` citation links character by character. ReactMarkdown can't parse incomplete links and renders them as raw text — showing ugly URLs like `[[10]](https://app.fireflies.ai/view/01KM0R` mid-stream.

Two fixes:

1. **Strip incomplete citation patterns** in `processContent` before markdown parsing. Regex removes any trailing partial `[[N]](url...` at the end of the streaming content so only complete links reach ReactMarkdown.

2. **Hide unresolved citations** in `MemoizedAnchor`. When the text matches `[N]` but the document/citation data hasn't arrived yet, render nothing instead of the raw text. The chip appears once the data arrives.

## How Has This Been Tested?

<img width="1626" height="1860" alt="2026-04-15 13 16 06" src="https://github.com/user-attachments/assets/046c8d5e-6fec-48fd-9003-d90b992c118e" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check