### PR TITLE
fix(chat): snap typewriter to full content on tab re-focus

### DIFF
--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -110,6 +110,23 @@ export function useTypewriter(target: string, enabled: boolean): string {
     }
   }, [target.length, displayedLength]);
 
+  // When the user navigates away and back (tab switch, window focus),
+  // snap to all collected content so they see the full response immediately.
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        const targetLen = targetRef.current.length;
+        if (displayedLengthRef.current < targetLen) {
+          displayedLengthRef.current = targetLen;
+          setDisplayedLength(targetLen);
+        }
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility);
+  }, []);
+
   return useMemo(
     () => target.slice(0, Math.min(displayedLength, target.length)),
     [target, displayedLength]


### PR DESCRIPTION
## Description

When a user sends a message, switches to another tab, and comes back, the streaming response was stuck at the point where they left — slowly animating the backlog of buffered content. Now the typewriter listens for `visibilitychange` and snaps `displayedLength` to the full `target.length` when the tab becomes visible again. If streaming is still ongoing, the typewriter continues normally from there.

## How Has This Been Tested?

kind hard to see but tested by naving away and back. If I wait long enough for the stream to complete, it completely appears on re-nav


https://github.com/user-attachments/assets/5e8032d0-cc4d-4de7-aee3-2a770d585eae



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check