### PR TITLE
fix(xlsx): Openpyxl Formatting Issues

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -379,12 +379,24 @@ def _worksheet_to_matrix(
     worksheet: Worksheet,
 ) -> list[list[str]]:
     """
-    Converts a singular worksheet to a matrix of values
+    Converts a singular worksheet to a matrix of values.
+
+    Rows are padded to a uniform width. In openpyxl's read_only mode,
+    iter_rows can yield rows of differing lengths (trailing empty cells
+    are sometimes omitted), and downstream column cleanup assumes a
+    rectangular matrix.
     """
     rows: list[list[str]] = []
+    max_len = 0
     for worksheet_row in worksheet.iter_rows(min_row=1, values_only=True):
         row = ["" if cell is None else str(cell) for cell in worksheet_row]
+        if len(row) > max_len:
+            max_len = len(row)
         rows.append(row)
+
+    for row in rows:
+        if len(row) < max_len:
+            row.extend([""] * (max_len - len(row)))
 
     return rows
 

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -1,9 +1,12 @@
 import io
 from typing import cast
+from unittest.mock import MagicMock
 
 import openpyxl
 from openpyxl.worksheet.worksheet import Worksheet
 
+from onyx.file_processing.extract_file_text import _clean_worksheet_matrix
+from onyx.file_processing.extract_file_text import _worksheet_to_matrix
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.extract_file_text import xlsx_to_text
 
@@ -197,6 +200,52 @@ class TestXlsxToText:
         assert "r1c1" in lines[0] and "r1c2" in lines[0]
         assert "r2c1" in lines[1] and "r2c2" in lines[1]
         assert "r3c1" in lines[2] and "r3c2" in lines[2]
+
+
+class TestWorksheetToMatrixJaggedRows:
+    """openpyxl read_only mode can yield rows of differing widths when
+    trailing cells are empty. The matrix must be padded to a rectangle
+    so downstream column cleanup can index safely."""
+
+    def test_pads_shorter_trailing_rows(self) -> None:
+        ws = MagicMock()
+        ws.iter_rows.return_value = iter(
+            [
+                ("A", "B", "C"),
+                ("X", "Y"),
+                ("P",),
+            ]
+        )
+        matrix = _worksheet_to_matrix(ws)
+        assert matrix == [["A", "B", "C"], ["X", "Y", ""], ["P", "", ""]]
+
+    def test_pads_when_first_row_is_shorter(self) -> None:
+        ws = MagicMock()
+        ws.iter_rows.return_value = iter(
+            [
+                ("A",),
+                ("X", "Y", "Z"),
+            ]
+        )
+        matrix = _worksheet_to_matrix(ws)
+        assert matrix == [["A", "", ""], ["X", "Y", "Z"]]
+
+    def test_clean_worksheet_matrix_no_index_error_on_jagged_rows(self) -> None:
+        """Regression: previously raised IndexError when a later row was
+        shorter than the first row and the out-of-range column on the
+        first row was empty (so the short-circuit in `all()` did not
+        save us)."""
+        ws = MagicMock()
+        ws.iter_rows.return_value = iter(
+            [
+                ("A", "", "", "B"),
+                ("X", "Y"),
+            ]
+        )
+        matrix = _worksheet_to_matrix(ws)
+        # Must not raise.
+        cleaned = _clean_worksheet_matrix(matrix)
+        assert cleaned == [["A", "", "", "B"], ["X", "Y", "", ""]]
 
 
 class TestXlsxSheetExtraction:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Trying to fix a particular issue we have seen that results in the following error:
```
Traceback (most recent call last):
  File "/app/onyx/background/indexing/run_docfetching.py", line 567, in connector_document_extraction
    _check_failure_threshold(
  File "/app/onyx/background/indexing/run_docfetching.py", line 232, in _check_failure_threshold
    raise last_failure.exception from last_failure.exception
  File "/app/onyx/connectors/google_drive/doc_conversion.py", line 658, in _convert_drive_item_to_document
    sections = _download_and_extract_sections_basic(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/google_drive/doc_conversion.py", line 360, in _download_and_extract_sections_basic
    text = xlsx_to_text(io.BytesIO(response_call()), file_name=file_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/file_processing/extract_file_text.py", line 508, in xlsx_to_text
    sheet_matrix = _clean_worksheet_matrix(_worksheet_to_matrix(sheet))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/file_processing/extract_file_text.py", line 408, in _clean_worksheet_matrix
    keep_cols = _columns_to_keep(matrix, num_cols, max_empty=MAX_EMPTY_COLS)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/file_processing/extract_file_text.py", line 427, in _columns_to_keep
    col_is_empty = all(not row[col_idx] for row in matrix)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/file_processing/extract_file_text.py", line 427, in <genexpr>
    col_is_empty = all(not row[col_idx] for row in matrix)
                           \~\~\~^^^^^^^^^
IndexError: list index out of range
```

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added unit tests and reproduced locally with mocks to emulate the issue we had seen.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IndexError when parsing some XLSX files in `openpyxl` read_only mode by padding worksheet rows to a uniform width. This stabilizes Google Drive XLSX extraction and keeps column cleanup consistent.

- **Bug Fixes**
  - Update `_worksheet_to_matrix` to compute max row length and pad shorter rows with empty strings, creating a rectangular matrix.
  - Add unit tests for jagged rows and a regression test to ensure `_clean_worksheet_matrix` no longer raises.

<sup>Written for commit 9f071911ef44dfd385bad032b9d8367515a2f206. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

