### PR TITLE
fix(pruning): Resolve hierarchy node FK error for Confluence and Notion

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -51,7 +51,6 @@ from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType
 from onyx.db.hierarchy import delete_orphaned_hierarchy_nodes
-from onyx.db.hierarchy import link_hierarchy_nodes_to_documents
 from onyx.db.hierarchy import remove_stale_hierarchy_node_cc_pair_entries
 from onyx.db.hierarchy import reparent_orphaned_hierarchy_nodes
 from onyx.db.hierarchy import update_document_parent_hierarchy_nodes
@@ -641,16 +640,6 @@ def connector_pruning_generator_task(
                 redis_client=redis_client,
                 source=source,
                 raw_id_to_parent=all_connector_doc_ids,
-            )
-
-            # Link hierarchy nodes to documents for sources where pages can be
-            # both hierarchy nodes AND documents (e.g. Notion, Confluence)
-            all_doc_id_list = list(all_connector_doc_ids.keys())
-            link_hierarchy_nodes_to_documents(
-                db_session=db_session,
-                document_ids=all_doc_id_list,
-                source=source,
-                commit=True,
             )
 
             diff_start = time.monotonic()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Summary ([more details](https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.h77c0jz003b3))
The pruning task was calling link_hierarchy_nodes_to_documents with all document IDs from slim retrieval (the full connector scope), which includes pages that were never indexed. Since hierarchy_node.document_id has a FK to document.id, attempting to set it for unindexed pages caused a ForeignKeyViolation that aborted the entire pruning task deterministically.

The fix removes the call from pruning. The document_id linking is already handled correctly by the indexing pipeline, which calls link_hierarchy_nodes_to_documents only after documents are written to the document table. The pruning call was redundant at best and crash-inducing at worst.

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness

## How Has This Been Tested?
It is more of a clean up. 
Existing unit tests run successfully.
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a ForeignKeyViolation in the pruning task for Confluence and Notion by removing the redundant call to link hierarchy nodes to documents. The indexing pipeline already links nodes after documents exist, preventing crashes (Linear ENG-3954).

<sup>Written for commit f94d373273bf9777a4ed0c4d5762af4be9d8a379. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

