### PR TITLE
fix(model-server): add missing onyx/configs to Dockerfile for sentry support

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -50,6 +50,10 @@ COPY ./onyx/utils/logger.py /app/onyx/utils/logger.py
 COPY ./onyx/utils/middleware.py /app/onyx/utils/middleware.py
 COPY ./onyx/utils/tenant.py /app/onyx/utils/tenant.py
 
+# Sentry configuration (used when SENTRY_DSN is set)
+COPY ./onyx/configs/__init__.py /app/onyx/configs/__init__.py
+COPY ./onyx/configs/sentry.py /app/onyx/configs/sentry.py
+
 # Place to fetch version information
 COPY ./onyx/__init__.py /app/onyx/__init__.py
 


### PR DESCRIPTION
## Description

The model server Dockerfile only copies select `onyx/` files into the image but was missing `onyx/configs/`. When `SENTRY_DSN` is set, the model server imports `onyx.configs.sentry` at startup, causing a `ModuleNotFoundError` crash. This adds the two missing COPY lines (`onyx/configs/__init__.py` and `onyx/configs/sentry.py`).

## How Has This Been Tested?

building + running image locally

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check