### PR TITLE
feat(metrics): add connector_name label to push-based connector metrics

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -537,10 +537,12 @@ def check_indexing_completion(
             )
 
         source = cc_pair.connector.source.value
+        connector_name = cc_pair.connector.name or f"cc_pair_{cc_pair.id}"
         on_index_attempt_status_change(
             tenant_id=tenant_id,
             source=source,
             cc_pair_id=cc_pair.id,
+            connector_name=connector_name,
             status=attempt.status.value,
         )
 
@@ -568,6 +570,7 @@ def check_indexing_completion(
                 tenant_id=tenant_id,
                 source=source,
                 cc_pair_id=cc_pair.id,
+                connector_name=connector_name,
                 docs_indexed=attempt.new_docs_indexed or 0,
                 success_timestamp=attempt.time_updated.timestamp(),
             )
@@ -595,6 +598,7 @@ def check_indexing_completion(
                     tenant_id=tenant_id,
                     source=source,
                     cc_pair_id=cc_pair.id,
+                    connector_name=connector_name,
                     in_error=False,
                 )
 
@@ -920,10 +924,14 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         cc_pair_id=cc_pair_id,
                         in_repeated_error_state=True,
                     )
+                    error_connector_name = (
+                        cc_pair.connector.name or f"cc_pair_{cc_pair.id}"
+                    )
                     on_connector_error_state_change(
                         tenant_id=tenant_id,
                         source=cc_pair.connector.source.value,
                         cc_pair_id=cc_pair_id,
+                        connector_name=error_connector_name,
                         in_error=True,
                     )
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -273,7 +273,7 @@ def run_docfetching_entrypoint(
             tenant_id=tenant_id,
             source=attempt.connector_credential_pair.connector.source.value,
             cc_pair_id=connector_credential_pair_id,
-            connector_name=connector_name,
+            connector_name=connector_name or f"cc_pair_{connector_credential_pair_id}",
             status="in_progress",
         )
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -273,6 +273,7 @@ def run_docfetching_entrypoint(
             tenant_id=tenant_id,
             source=attempt.connector_credential_pair.connector.source.value,
             cc_pair_id=connector_credential_pair_id,
+            connector_name=connector_name,
             status="in_progress",
         )
 

--- a/backend/onyx/server/metrics/connector_health_metrics.py
+++ b/backend/onyx/server/metrics/connector_health_metrics.py
@@ -7,7 +7,7 @@ to avoid disrupting the caller's business logic.
 Gauge metrics (error state, last success timestamp) are per-process.
 With multiple worker pods, use max() aggregation in PromQL to get the
 correct value across instances, e.g.:
-    max by (cc_pair_id) (onyx_connector_in_error_state)
+    max by (cc_pair_id, connector_name) (onyx_connector_in_error_state)
 
 Unlike the per-task counters in indexing_task_metrics.py, these metrics
 include connector_name because their cardinality is bounded by the number

--- a/backend/onyx/server/metrics/connector_health_metrics.py
+++ b/backend/onyx/server/metrics/connector_health_metrics.py
@@ -8,6 +8,11 @@ Gauge metrics (error state, last success timestamp) are per-process.
 With multiple worker pods, use max() aggregation in PromQL to get the
 correct value across instances, e.g.:
     max by (cc_pair_id) (onyx_connector_in_error_state)
+
+Unlike the per-task counters in indexing_task_metrics.py, these metrics
+include connector_name because their cardinality is bounded by the number
+of connectors (one series per connector), not by the number of task
+executions.
 """
 
 from prometheus_client import Counter
@@ -17,12 +22,14 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+_CONNECTOR_LABELS = ["tenant_id", "source", "cc_pair_id", "connector_name"]
+
 # --- Index attempt lifecycle ---
 
 INDEX_ATTEMPT_STATUS = Counter(
     "onyx_index_attempt_transitions_total",
     "Index attempt status transitions",
-    ["tenant_id", "source", "cc_pair_id", "status"],
+    [*_CONNECTOR_LABELS, "status"],
 )
 
 # --- Connector health ---
@@ -30,25 +37,25 @@ INDEX_ATTEMPT_STATUS = Counter(
 CONNECTOR_IN_ERROR_STATE = Gauge(
     "onyx_connector_in_error_state",
     "Whether the connector is in a repeated error state (1=yes, 0=no)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_LAST_SUCCESS_TIMESTAMP = Gauge(
     "onyx_connector_last_success_timestamp_seconds",
     "Unix timestamp of last successful indexing for this connector",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_DOCS_INDEXED = Counter(
     "onyx_connector_docs_indexed_total",
     "Total documents indexed per connector (monotonic)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_INDEXING_ERRORS = Counter(
     "onyx_connector_indexing_errors_total",
     "Total failed index attempts per connector (monotonic)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 
@@ -56,6 +63,7 @@ def on_index_attempt_status_change(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     status: str,
 ) -> None:
     """Called on any index attempt status transition."""
@@ -64,6 +72,7 @@ def on_index_attempt_status_change(
             "tenant_id": tenant_id,
             "source": source,
             "cc_pair_id": str(cc_pair_id),
+            "connector_name": connector_name,
         }
         INDEX_ATTEMPT_STATUS.labels(**labels, status=status).inc()
         if status == "failed":
@@ -76,6 +85,7 @@ def on_connector_error_state_change(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     in_error: bool,
 ) -> None:
     """Called when a connector's in_repeated_error_state changes."""
@@ -84,6 +94,7 @@ def on_connector_error_state_change(
             tenant_id=tenant_id,
             source=source,
             cc_pair_id=str(cc_pair_id),
+            connector_name=connector_name,
         ).set(1.0 if in_error else 0.0)
     except Exception:
         logger.debug("Failed to record connector error state metric", exc_info=True)
@@ -93,6 +104,7 @@ def on_connector_indexing_success(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     docs_indexed: int,
     success_timestamp: float,
 ) -> None:
@@ -102,6 +114,7 @@ def on_connector_indexing_success(
             "tenant_id": tenant_id,
             "source": source,
             "cc_pair_id": str(cc_pair_id),
+            "connector_name": connector_name,
         }
         CONNECTOR_LAST_SUCCESS_TIMESTAMP.labels(**labels).set(success_timestamp)
         if docs_indexed > 0:

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -217,19 +217,19 @@ Enriches docfetching and docprocessing tasks with connector-level labels. Silent
 | `onyx_indexing_task_completed_total`  | Counter   | `task_name`, `source`, `tenant_id`, `cc_pair_id`, `outcome` | Indexing tasks completed per connector   |
 | `onyx_indexing_task_duration_seconds` | Histogram | `task_name`, `source`, `tenant_id`                          | Indexing task duration by connector type |
 
-`connector_name` is intentionally excluded from these push-based counters to avoid unbounded cardinality (it's a free-form user string).
+`connector_name` is intentionally excluded from these per-task counters to avoid unbounded cardinality (it's a free-form user string).
 
 ### Connector Health Metrics (`onyx.server.metrics.connector_health_metrics`)
 
-Push-based metrics emitted by docfetching and docprocessing workers at the point where connector state changes occur. Scales to any number of tenants (no schema iteration).
+Push-based metrics emitted by docfetching and docprocessing workers at the point where connector state changes occur. Scales to any number of tenants (no schema iteration). Unlike the per-task counters above, these include `connector_name` because their cardinality is bounded by the number of connectors (one series per connector), not by the number of task executions.
 
-| Metric                                          | Type    | Labels                                        | Description                                                   |
-| ----------------------------------------------- | ------- | --------------------------------------------- | ------------------------------------------------------------- |
-| `onyx_index_attempt_transitions_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `status` | Index attempt status transitions (in_progress, success, etc.) |
-| `onyx_connector_in_error_state`                 | Gauge   | `tenant_id`, `source`, `cc_pair_id`           | Whether connector is in repeated error state (1=yes, 0=no)    |
-| `onyx_connector_last_success_timestamp_seconds` | Gauge   | `tenant_id`, `source`, `cc_pair_id`           | Unix timestamp of last successful indexing                    |
-| `onyx_connector_docs_indexed_total`             | Counter | `tenant_id`, `source`, `cc_pair_id`           | Total documents indexed per connector (monotonic)             |
-| `onyx_connector_indexing_errors_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`           | Total failed index attempts per connector (monotonic)         |
+| Metric                                          | Type    | Labels                                                          | Description                                                   |
+| ----------------------------------------------- | ------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
+| `onyx_index_attempt_transitions_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`, `status` | Index attempt status transitions (in_progress, success, etc.) |
+| `onyx_connector_in_error_state`                 | Gauge   | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Whether connector is in repeated error state (1=yes, 0=no)    |
+| `onyx_connector_last_success_timestamp_seconds` | Gauge   | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Unix timestamp of last successful indexing                    |
+| `onyx_connector_docs_indexed_total`             | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Total documents indexed per connector (monotonic)             |
+| `onyx_connector_indexing_errors_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Total failed index attempts per connector (monotonic)         |
 
 ### Pull-Based Collectors (`onyx.server.metrics.indexing_pipeline`)
 


### PR DESCRIPTION
## Description

Follow-up to #10189. The push-based connector health metrics dropped `connector_name`, leaving only `cc_pair_id` which isn't human-readable in Grafana dashboards.

Unlike the per-task counters in `indexing_task_metrics.py` (where `connector_name` creates unbounded cardinality), the connector health metrics have bounded cardinality — one series per connector — so `connector_name` is safe to include.

Adds `connector_name` to all 5 push-based metrics and passes it through from all caller sites in `run_docfetching.py` and `docprocessing/tasks.py`.

## How Has This Been Tested?

- `black`, `mypy`, `ruff` pass on all changed files
- Metric label addition is additive — existing queries using `cc_pair_id` continue to work

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check