### PR TITLE
chore(helm): update Grafana dashboard for new push-based metric names

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -537,10 +537,12 @@ def check_indexing_completion(
             )
 
         source = cc_pair.connector.source.value
+        connector_name = cc_pair.connector.name or f"cc_pair_{cc_pair.id}"
         on_index_attempt_status_change(
             tenant_id=tenant_id,
             source=source,
             cc_pair_id=cc_pair.id,
+            connector_name=connector_name,
             status=attempt.status.value,
         )
 
@@ -568,6 +570,7 @@ def check_indexing_completion(
                 tenant_id=tenant_id,
                 source=source,
                 cc_pair_id=cc_pair.id,
+                connector_name=connector_name,
                 docs_indexed=attempt.new_docs_indexed or 0,
                 success_timestamp=attempt.time_updated.timestamp(),
             )
@@ -595,6 +598,7 @@ def check_indexing_completion(
                     tenant_id=tenant_id,
                     source=source,
                     cc_pair_id=cc_pair.id,
+                    connector_name=connector_name,
                     in_error=False,
                 )
 
@@ -920,10 +924,14 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         cc_pair_id=cc_pair_id,
                         in_repeated_error_state=True,
                     )
+                    error_connector_name = (
+                        cc_pair.connector.name or f"cc_pair_{cc_pair.id}"
+                    )
                     on_connector_error_state_change(
                         tenant_id=tenant_id,
                         source=cc_pair.connector.source.value,
                         cc_pair_id=cc_pair_id,
+                        connector_name=error_connector_name,
                         in_error=True,
                     )
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -273,7 +273,7 @@ def run_docfetching_entrypoint(
             tenant_id=tenant_id,
             source=attempt.connector_credential_pair.connector.source.value,
             cc_pair_id=connector_credential_pair_id,
-            connector_name=connector_name,
+            connector_name=connector_name or f"cc_pair_{connector_credential_pair_id}",
             status="in_progress",
         )
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -273,6 +273,7 @@ def run_docfetching_entrypoint(
             tenant_id=tenant_id,
             source=attempt.connector_credential_pair.connector.source.value,
             cc_pair_id=connector_credential_pair_id,
+            connector_name=connector_name,
             status="in_progress",
         )
 

--- a/backend/onyx/server/metrics/connector_health_metrics.py
+++ b/backend/onyx/server/metrics/connector_health_metrics.py
@@ -7,7 +7,7 @@ to avoid disrupting the caller's business logic.
 Gauge metrics (error state, last success timestamp) are per-process.
 With multiple worker pods, use max() aggregation in PromQL to get the
 correct value across instances, e.g.:
-    max by (cc_pair_id) (onyx_connector_in_error_state)
+    max by (cc_pair_id, connector_name) (onyx_connector_in_error_state)
 
 Unlike the per-task counters in indexing_task_metrics.py, these metrics
 include connector_name because their cardinality is bounded by the number

--- a/backend/onyx/server/metrics/connector_health_metrics.py
+++ b/backend/onyx/server/metrics/connector_health_metrics.py
@@ -8,6 +8,11 @@ Gauge metrics (error state, last success timestamp) are per-process.
 With multiple worker pods, use max() aggregation in PromQL to get the
 correct value across instances, e.g.:
     max by (cc_pair_id) (onyx_connector_in_error_state)
+
+Unlike the per-task counters in indexing_task_metrics.py, these metrics
+include connector_name because their cardinality is bounded by the number
+of connectors (one series per connector), not by the number of task
+executions.
 """
 
 from prometheus_client import Counter
@@ -17,12 +22,14 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+_CONNECTOR_LABELS = ["tenant_id", "source", "cc_pair_id", "connector_name"]
+
 # --- Index attempt lifecycle ---
 
 INDEX_ATTEMPT_STATUS = Counter(
     "onyx_index_attempt_transitions_total",
     "Index attempt status transitions",
-    ["tenant_id", "source", "cc_pair_id", "status"],
+    [*_CONNECTOR_LABELS, "status"],
 )
 
 # --- Connector health ---
@@ -30,25 +37,25 @@ INDEX_ATTEMPT_STATUS = Counter(
 CONNECTOR_IN_ERROR_STATE = Gauge(
     "onyx_connector_in_error_state",
     "Whether the connector is in a repeated error state (1=yes, 0=no)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_LAST_SUCCESS_TIMESTAMP = Gauge(
     "onyx_connector_last_success_timestamp_seconds",
     "Unix timestamp of last successful indexing for this connector",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_DOCS_INDEXED = Counter(
     "onyx_connector_docs_indexed_total",
     "Total documents indexed per connector (monotonic)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 CONNECTOR_INDEXING_ERRORS = Counter(
     "onyx_connector_indexing_errors_total",
     "Total failed index attempts per connector (monotonic)",
-    ["tenant_id", "source", "cc_pair_id"],
+    _CONNECTOR_LABELS,
 )
 
 
@@ -56,6 +63,7 @@ def on_index_attempt_status_change(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     status: str,
 ) -> None:
     """Called on any index attempt status transition."""
@@ -64,6 +72,7 @@ def on_index_attempt_status_change(
             "tenant_id": tenant_id,
             "source": source,
             "cc_pair_id": str(cc_pair_id),
+            "connector_name": connector_name,
         }
         INDEX_ATTEMPT_STATUS.labels(**labels, status=status).inc()
         if status == "failed":
@@ -76,6 +85,7 @@ def on_connector_error_state_change(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     in_error: bool,
 ) -> None:
     """Called when a connector's in_repeated_error_state changes."""
@@ -84,6 +94,7 @@ def on_connector_error_state_change(
             tenant_id=tenant_id,
             source=source,
             cc_pair_id=str(cc_pair_id),
+            connector_name=connector_name,
         ).set(1.0 if in_error else 0.0)
     except Exception:
         logger.debug("Failed to record connector error state metric", exc_info=True)
@@ -93,6 +104,7 @@ def on_connector_indexing_success(
     tenant_id: str,
     source: str,
     cc_pair_id: int,
+    connector_name: str,
     docs_indexed: int,
     success_timestamp: float,
 ) -> None:
@@ -102,6 +114,7 @@ def on_connector_indexing_success(
             "tenant_id": tenant_id,
             "source": source,
             "cc_pair_id": str(cc_pair_id),
+            "connector_name": connector_name,
         }
         CONNECTOR_LAST_SUCCESS_TIMESTAMP.labels(**labels).set(success_timestamp)
         if docs_indexed > 0:

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.44
+version: 0.4.45
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
+++ b/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
@@ -158,7 +158,7 @@
       "pluginVersion": "10.4.1",
       "targets": [
         {
-          "expr": "sum(onyx_connectors_in_error_total{tenant_id=~\"$tenant_id\"})",
+          "expr": "sum(onyx_connector_in_error_state{tenant_id=~\"$tenant_id\"} == 1)",
           "legendFormat": "Connectors in error",
           "refId": "A"
         }
@@ -462,7 +462,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Current indexing attempts by status and connector.",
+      "description": "Rate of index attempt status transitions per minute, grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -516,12 +516,12 @@
       },
       "targets": [
         {
-          "expr": "onyx_index_attempts_active{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
-          "legendFormat": "{{status}} / {{source}} / {{connector_name}}",
+          "expr": "sum by (status) (rate(onyx_index_attempt_transitions_total{tenant_id=~\"$tenant_id\", source=~\"$source\"}[5m])) * 60",
+          "legendFormat": "{{status}}",
           "refId": "A"
         }
       ],
-      "title": "Active Index Attempts",
+      "title": "Index attempt transitions / min",
       "type": "timeseries"
     },
     {
@@ -529,7 +529,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Distribution of all connectors by their current status.",
+      "description": "Distribution of index attempt transitions by status over the last hour.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -567,12 +567,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (status) (onyx_connectors_by_status{tenant_id=~\"$tenant_id\"})",
+          "expr": "sum by (status) (increase(onyx_index_attempt_transitions_total{tenant_id=~\"$tenant_id\"}[1h]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
       ],
-      "title": "Connectors by Status",
+      "title": "Attempt transitions by status (1h)",
       "type": "piechart"
     },
     {
@@ -699,19 +699,19 @@
       },
       "targets": [
         {
-          "expr": "topk(20, onyx_connector_last_success_age_seconds{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"})",
+          "expr": "topk(20, time() - onyx_connector_last_success_timestamp_seconds{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
         },
         {
-          "expr": "onyx_connector_error_count{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
+          "expr": "onyx_connector_indexing_errors_total{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
           "format": "table",
           "instant": true,
           "refId": "B"
         },
         {
-          "expr": "onyx_connector_docs_indexed{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
+          "expr": "onyx_connector_docs_indexed_total{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -921,13 +921,13 @@
       },
       "targets": [
         {
-          "expr": "onyx_connector_docs_indexed{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
+          "expr": "onyx_connector_docs_indexed_total{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
         },
         {
-          "expr": "onyx_connector_error_count{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
+          "expr": "onyx_connector_indexing_errors_total{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}",
           "format": "table",
           "instant": true,
           "refId": "B"
@@ -1203,8 +1203,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (source, connector_name, outcome) (rate(onyx_indexing_task_completed_total{source=~\"$source\", tenant_id=~\"$tenant_id\", connector_name=~\"$connector_name\"}[5m])) * 60",
-          "legendFormat": "{{source}} / {{connector_name}} ({{outcome}})",
+          "expr": "sum by (source, cc_pair_id, outcome) (rate(onyx_indexing_task_completed_total{source=~\"$source\", tenant_id=~\"$tenant_id\", cc_pair_id=~\"$cc_pair_id\"}[5m])) * 60",
+          "legendFormat": "{{source}} / {{cc_pair_id}} ({{outcome}})",
           "refId": "A"
         }
       ],
@@ -1267,8 +1267,8 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (source, connector_name, le) (rate(onyx_indexing_task_duration_seconds_bucket{source=~\"$source\", tenant_id=~\"$tenant_id\", connector_name=~\"$connector_name\"}[5m])))",
-          "legendFormat": "p95 {{source}} / {{connector_name}}",
+          "expr": "histogram_quantile(0.95, sum by (source, cc_pair_id, le) (rate(onyx_indexing_task_duration_seconds_bucket{source=~\"$source\", tenant_id=~\"$tenant_id\", cc_pair_id=~\"$cc_pair_id\"}[5m])))",
+          "legendFormat": "p95 {{source}} / {{cc_pair_id}}",
           "refId": "A"
         }
       ],
@@ -1980,13 +1980,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_age_seconds, source)",
+        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, source)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "source",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_age_seconds, source)",
+        "query": "label_values(onyx_connector_last_success_timestamp_seconds, source)",
         "refresh": 1,
         "type": "query"
       },
@@ -1996,13 +1996,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_age_seconds, connector_name)",
+        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, connector_name)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "connector_name",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_age_seconds, connector_name)",
+        "query": "label_values(onyx_connector_last_success_timestamp_seconds, connector_name)",
         "refresh": 1,
         "type": "query"
       },
@@ -2012,13 +2012,29 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_age_seconds, tenant_id)",
+        "definition": "label_values(onyx_indexing_task_completed_total, cc_pair_id)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "cc_pair_id",
+        "options": [],
+        "query": "label_values(onyx_indexing_task_completed_total, cc_pair_id)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, tenant_id)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "tenant_id",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_age_seconds, tenant_id)",
+        "query": "label_values(onyx_connector_last_success_timestamp_seconds, tenant_id)",
         "refresh": 1,
         "type": "query"
       }

--- a/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
+++ b/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
@@ -1216,7 +1216,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "95th percentile indexing task duration per individual connector.",
+      "description": "95th percentile indexing task duration per source type.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1267,12 +1267,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (source, cc_pair_id, le) (rate(onyx_indexing_task_duration_seconds_bucket{source=~\"$source\", tenant_id=~\"$tenant_id\", cc_pair_id=~\"$cc_pair_id\"}[5m])))",
-          "legendFormat": "p95 {{source}} / {{cc_pair_id}}",
+          "expr": "histogram_quantile(0.95, sum by (source, le) (rate(onyx_indexing_task_duration_seconds_bucket{source=~\"$source\", tenant_id=~\"$tenant_id\"}[5m])))",
+          "legendFormat": "p95 {{source}}",
           "refId": "A"
         }
       ],
-      "title": "p95 duration by connector",
+      "title": "p95 duration by source",
       "type": "timeseries"
     },
     {

--- a/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
+++ b/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
@@ -567,7 +567,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (status) (increase(onyx_index_attempt_transitions_total{tenant_id=~\"$tenant_id\"}[1h]))",
+          "expr": "sum by (status) (increase(onyx_index_attempt_transitions_total{tenant_id=~\"$tenant_id\", source=~\"$source\"}[1h]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -1980,13 +1980,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, source)",
+        "definition": "label_values(onyx_index_attempt_transitions_total, source)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "source",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_timestamp_seconds, source)",
+        "query": "label_values(onyx_index_attempt_transitions_total, source)",
         "refresh": 1,
         "type": "query"
       },
@@ -1996,13 +1996,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, connector_name)",
+        "definition": "label_values(onyx_index_attempt_transitions_total, connector_name)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "connector_name",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_timestamp_seconds, connector_name)",
+        "query": "label_values(onyx_index_attempt_transitions_total, connector_name)",
         "refresh": 1,
         "type": "query"
       },
@@ -2028,13 +2028,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(onyx_connector_last_success_timestamp_seconds, tenant_id)",
+        "definition": "label_values(onyx_index_attempt_transitions_total, tenant_id)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "tenant_id",
         "options": [],
-        "query": "label_values(onyx_connector_last_success_timestamp_seconds, tenant_id)",
+        "query": "label_values(onyx_index_attempt_transitions_total, tenant_id)",
         "refresh": 1,
         "type": "query"
       }

--- a/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
+++ b/deployment/helm/charts/onyx/dashboards/indexing-pipeline.json
@@ -158,7 +158,7 @@
       "pluginVersion": "10.4.1",
       "targets": [
         {
-          "expr": "sum(onyx_connector_in_error_state{tenant_id=~\"$tenant_id\"} == 1)",
+          "expr": "count(max by (cc_pair_id, connector_name, source, tenant_id) (onyx_connector_in_error_state{tenant_id=~\"$tenant_id\"}) == 1)",
           "legendFormat": "Connectors in error",
           "refId": "A"
         }
@@ -699,7 +699,7 @@
       },
       "targets": [
         {
-          "expr": "topk(20, time() - onyx_connector_last_success_timestamp_seconds{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"})",
+          "expr": "topk(20, time() - max by (cc_pair_id, connector_name, source, tenant_id) (onyx_connector_last_success_timestamp_seconds{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}))",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -809,7 +809,7 @@
       },
       "targets": [
         {
-          "expr": "onyx_connector_in_error_state{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"} == 1",
+          "expr": "max by (cc_pair_id, connector_name, source, tenant_id) (onyx_connector_in_error_state{tenant_id=~\"$tenant_id\", source=~\"$source\", connector_name=~\"$connector_name\"}) == 1",
           "format": "table",
           "instant": true,
           "refId": "A"

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -217,19 +217,19 @@ Enriches docfetching and docprocessing tasks with connector-level labels. Silent
 | `onyx_indexing_task_completed_total`  | Counter   | `task_name`, `source`, `tenant_id`, `cc_pair_id`, `outcome` | Indexing tasks completed per connector   |
 | `onyx_indexing_task_duration_seconds` | Histogram | `task_name`, `source`, `tenant_id`                          | Indexing task duration by connector type |
 
-`connector_name` is intentionally excluded from these push-based counters to avoid unbounded cardinality (it's a free-form user string).
+`connector_name` is intentionally excluded from these per-task counters to avoid unbounded cardinality (it's a free-form user string).
 
 ### Connector Health Metrics (`onyx.server.metrics.connector_health_metrics`)
 
-Push-based metrics emitted by docfetching and docprocessing workers at the point where connector state changes occur. Scales to any number of tenants (no schema iteration).
+Push-based metrics emitted by docfetching and docprocessing workers at the point where connector state changes occur. Scales to any number of tenants (no schema iteration). Unlike the per-task counters above, these include `connector_name` because their cardinality is bounded by the number of connectors (one series per connector), not by the number of task executions.
 
-| Metric                                          | Type    | Labels                                        | Description                                                   |
-| ----------------------------------------------- | ------- | --------------------------------------------- | ------------------------------------------------------------- |
-| `onyx_index_attempt_transitions_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `status` | Index attempt status transitions (in_progress, success, etc.) |
-| `onyx_connector_in_error_state`                 | Gauge   | `tenant_id`, `source`, `cc_pair_id`           | Whether connector is in repeated error state (1=yes, 0=no)    |
-| `onyx_connector_last_success_timestamp_seconds` | Gauge   | `tenant_id`, `source`, `cc_pair_id`           | Unix timestamp of last successful indexing                    |
-| `onyx_connector_docs_indexed_total`             | Counter | `tenant_id`, `source`, `cc_pair_id`           | Total documents indexed per connector (monotonic)             |
-| `onyx_connector_indexing_errors_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`           | Total failed index attempts per connector (monotonic)         |
+| Metric                                          | Type    | Labels                                                          | Description                                                   |
+| ----------------------------------------------- | ------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
+| `onyx_index_attempt_transitions_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`, `status` | Index attempt status transitions (in_progress, success, etc.) |
+| `onyx_connector_in_error_state`                 | Gauge   | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Whether connector is in repeated error state (1=yes, 0=no)    |
+| `onyx_connector_last_success_timestamp_seconds` | Gauge   | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Unix timestamp of last successful indexing                    |
+| `onyx_connector_docs_indexed_total`             | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Total documents indexed per connector (monotonic)             |
+| `onyx_connector_indexing_errors_total`          | Counter | `tenant_id`, `source`, `cc_pair_id`, `connector_name`           | Total failed index attempts per connector (monotonic)         |
 
 ### Pull-Based Collectors (`onyx.server.metrics.indexing_pipeline`)
 


### PR DESCRIPTION
## Description

Follow-up to #10189 and #10237. Updates the `indexing-pipeline.json` Grafana dashboard to use the new push-based metric names and the `connector_name` label.

**Metric replacements:**
- `onyx_connectors_in_error_total` → `onyx_connector_in_error_state == 1`
- `onyx_connector_last_success_age_seconds` → `time() - onyx_connector_last_success_timestamp_seconds`
- `onyx_connectors_by_status` → `onyx_index_attempt_transitions_total` (by status)
- `onyx_connector_error_count` → `onyx_connector_indexing_errors_total`
- `onyx_connector_docs_indexed` → `onyx_connector_docs_indexed_total`
- `onyx_index_attempts_active` → `onyx_index_attempt_transitions_total` (rate)

**Label changes:**
- Connector health panels filter/display by `connector_name` (human-readable)
- Task lifecycle panels filter by `cc_pair_id` (only label available on those metrics)
- Template variables updated to reference metrics that exist

**Depends on:** #10237 (must merge first)

## How Has This Been Tested?

- JSON validates with `python3 -c "import json; json.load(...)"`
- Grep confirms zero references to removed metric names
- All new metric names verified present in correct panels

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check