### PR TITLE
chore: [Running GitHub actions for #9999]

### DIFF
--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -172,7 +172,7 @@ def upsert_ingestion_doc(
 
     return IngestionResult(
         document_id=document.id,
-        already_existed=indexing_pipeline_result.new_docs > 0,
+        already_existed=indexing_pipeline_result.new_docs == 0,
     )
 
 


### PR DESCRIPTION
This PR runs GitHub Actions CI for #9999.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the ingestion API so `already_existed` is true only when no new documents were indexed (`new_docs == 0`), instead of when new documents were found. This ensures clients receive the correct existence flag.

<sup>Written for commit 7c40b84c407cc71e4b540c6843808c28c0109d5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

