### PR TITLE
chore(gha): run mypy in the devcontainer

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -29,6 +29,8 @@ jobs:
         "extras=s3-cache",
       ]
     timeout-minutes: 15
+    container:
+      image: onyxdotapp/onyx-devcontainer@sha256:0f02d9299928849c7b15f3b348dcfdcdcb64411ff7a4580cbc026a6ee7aa1554
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2


### PR DESCRIPTION
## Description



## How Has This Been Tested?



## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run mypy inside the devcontainer in GitHub Actions to match local development and keep type-check results consistent. Sets the PR Python checks job container to `onyxdotapp/onyx-devcontainer@sha256:0f02d9299928849c7b15f3b348dcfdcdcb64411ff7a4580cbc026a6ee7aa1554`.

<sup>Written for commit 040c0881c59e67c73dfc38da77a1494c3977760b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

