### PR TITLE
chore(tests): remove defunct `test_litellm_embedding`

### DIFF
--- a/.github/workflows/pr-python-model-tests.yml
+++ b/.github/workflows/pr-python-model-tests.yml
@@ -17,8 +17,6 @@ env:
 
   # API keys for testing
   COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-  LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
-  LITELLM_API_URL: ${{ secrets.LITELLM_API_URL }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
   AZURE_API_URL: ${{ vars.AZURE_API_URL }}

--- a/backend/tests/daily/embedding/test_embeddings.py
+++ b/backend/tests/daily/embedding/test_embeddings.py
@@ -67,27 +67,6 @@ def test_cohere_embedding(cohere_embedding_model: EmbeddingModel) -> None:
 
 
 @pytest.fixture
-def litellm_embedding_model() -> EmbeddingModel:
-    return EmbeddingModel(
-        server_host="localhost",
-        server_port=9000,
-        model_name="text-embedding-3-small",
-        normalize=True,
-        query_prefix=None,
-        passage_prefix=None,
-        api_key=os.environ["LITELLM_API_KEY"],
-        provider_type=EmbeddingProvider.LITELLM,
-        api_url=os.environ["LITELLM_API_URL"],
-    )
-
-
-@pytest.mark.skip(reason="re-enable when we can get the correct litellm key and url")
-def test_litellm_embedding(litellm_embedding_model: EmbeddingModel) -> None:
-    _run_embeddings(VALID_SAMPLE, litellm_embedding_model, 1536)
-    _run_embeddings(TOO_LONG_SAMPLE, litellm_embedding_model, 1536)
-
-
-@pytest.fixture
 def local_nomic_embedding_model() -> EmbeddingModel:
     return EmbeddingModel(
         server_host="localhost",


### PR DESCRIPTION
## Description

This test has never worked, so delete.

## How Has This Been Tested?

n/a removing dead code

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the defunct `test_litellm_embedding` and cleaned up CI by deleting the unused `LITELLM_API_KEY` and `LITELLM_API_URL` entries from `.github/workflows/pr-python-model-tests.yml`.

<sup>Written for commit 20ae7ba1264c2a414a57428ccbcb9af37919e062. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

