### PR TITLE
fix(helm): increase proxy timeouts to prevent HTTP/2 stream resets

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.45
+version: 0.4.46
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.nginx.timeouts.read }}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.nginx.timeouts.send }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "5G"
     cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
 spec:
   {{- if .Values.ingress.className }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -284,10 +284,13 @@ serviceAccount:
 nginx:
   enabled: true
   # Nginx proxy timeout settings (in seconds)
+  # These apply to both the internal nginx proxy AND the ingress-nginx annotations.
+  # Must be high enough to cover deep research (30+ min sessions) and LLM TTFT
+  # for large prompts (70K+ tokens). 900s matches the craft/build timeout in production.
   timeouts:
     connect: 300  # Time to establish connection with upstream server
-    send: 300     # Time to send request to upstream server
-    read: 300     # Time to read response from upstream server
+    send: 900     # Time to send request to upstream server
+    read: 900     # Time to read response from upstream server
   controller:
     containerPort:
       http: 1024


### PR DESCRIPTION
## Description

The ingress-nginx controller defaults to `proxy_read_timeout: 60s`. Long-running SSE streams (chat with large prompts, deep research) can have idle gaps exceeding 60s during LLM TTFT (time-to-first-token) or tool execution phases. When this happens, the ingress-nginx resets the HTTP/2 stream, causing `ERR_HTTP2_PROTOCOL_ERROR` on the client — while the server completes the request successfully on the inner nginx hop (which has a 300s timeout).

Changes:
- Add `proxy-read-timeout`, `proxy-send-timeout`, and `proxy-body-size` annotations to the API ingress template so the ingress-nginx layer respects appropriate timeouts
- Increase `nginx.timeouts.read` and `nginx.timeouts.send` from 300s to 900s to cover deep research sessions (30+ min with 5-min LLM timeout for final report generation) and large-prompt TTFT
- 900s matches the craft/build timeout already configured in production

Root cause traced from session `Kw6q4ISG` which hit this exact failure: 70K token prompt → long TTFT → ingress-nginx killed the stream at 60s → `ERR_HTTP2_PROTOCOL_ERROR`.

## How Has This Been Tested?

Verified the ingress-nginx controller config (`/etc/nginx/nginx.conf`) confirms 60s default for all cloud.onyx.app locations. Traced the full request path: browser → NLB → ingress-nginx (60s) → danswer nginx (300s) → api-server. Server logs confirmed the stream completed successfully on the backend while the client received the protocol error.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check