### PR TITLE
fix(metrics): move in_progress emission from subprocess to watchdog thread

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -34,6 +34,7 @@ from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.db.index_attempt import mark_attempt_failed
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
+from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import SENTRY_DSN
@@ -468,6 +469,15 @@ def docfetching_proxy_task(
 
             result.connector_source = (
                 index_attempt.connector_credential_pair.connector.source.value
+            )
+
+            cc_pair = index_attempt.connector_credential_pair
+            on_index_attempt_status_change(
+                tenant_id=tenant_id,
+                source=result.connector_source,
+                cc_pair_id=cc_pair_id,
+                connector_name=cc_pair.connector.name or f"cc_pair_{cc_pair_id}",
+                status="in_progress",
             )
 
         while True:

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -69,7 +69,6 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.indexing.persistent_document_writer import (
     get_persistent_document_writer,
 )
-from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
 from onyx.utils.middleware import make_randomized_onyx_request_id
 from onyx.utils.postgres_sanitization import sanitize_document_for_postgres
@@ -268,14 +267,6 @@ def run_docfetching_entrypoint(
             attempt.connector_credential_pair.connector.connector_specific_config
         )
         credential_id = attempt.connector_credential_pair.credential_id
-
-        on_index_attempt_status_change(
-            tenant_id=tenant_id,
-            source=attempt.connector_credential_pair.connector.source.value,
-            cc_pair_id=connector_credential_pair_id,
-            connector_name=connector_name or f"cc_pair_{connector_credential_pair_id}",
-            status="in_progress",
-        )
 
     logger.info(
         f"Docfetching starting{tenant_str}: "


### PR DESCRIPTION
## Description

Depends on #10257 (primary worker metrics server).

The `in_progress` metric emission in `run_docfetching.py` ran inside a subprocess spawned by `SimpleJobClient` via `multiprocessing.Process`. That subprocess has its own isolated `prometheus_client` registry — counter increments there are invisible to the parent's HTTP metrics server on `:9092`.

**Fix:** Move the `in_progress` emission from the spawned subprocess to the watchdog thread (`docfetching_proxy_task`), which runs in the main docfetching process and shares memory with the HTTP server.

**Changes:**
- Remove broken `on_index_attempt_status_change("in_progress")` call from `run_docfetching.py` (spawned subprocess)
- Add the same emission to `docfetching_proxy_task` in `docfetching/tasks.py` after spawn succeeds and the index attempt is loaded (watchdog thread, shared memory)

After this PR + #10257:
| Metric | Worker | Process | Port |
|--------|--------|---------|------|
| `in_progress` transition | docfetching | watchdog thread (main) | 9092 |
| terminal status transitions | primary | thread (main) | 9097 |
| connector success/error | primary | thread (main) | 9097 |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check