### PR TITLE
chore(python): replace `mypy` with `ty`

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -19,16 +19,15 @@ permissions:
 jobs:
   mypy-check:
     # See https://runs-on.com/runners/linux/
-    # Note: Mypy seems quite optimized for x64 compared to arm64.
-    # Similarly, mypy is single-threaded and incremental, so 2cpu is sufficient.
+    # NOTE: This job is named mypy-check for branch protection compatibility,
+    # but it actually runs ty (astral-sh's Rust type checker).
     runs-on:
       [
         runs-on,
-        runner=2cpu-linux-x64,
+        runner=2cpu-linux-arm64,
         "run-id=${{ github.run_id }}-mypy-check",
-        "extras=s3-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 15
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
@@ -46,26 +45,7 @@ jobs:
             backend/requirements/model_server.txt
             backend/requirements/ee.txt
 
-      - name: Generate OpenAPI schema and Python client
-        shell: bash
-        # TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
+      - name: Run ty
         env:
-          LICENSE_ENFORCEMENT_ENABLED: "false"
-        run: |
-          ods openapi all
-
-      - name: Cache mypy cache
-        if: ${{ vars.DISABLE_MYPY_CACHE != 'true' }}
-        uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # ratchet:runs-on/cache@v4
-        with:
-          path: .mypy_cache
-          key: mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-${{ hashFiles('**/*.py', '**/*.pyi', 'pyproject.toml') }}
-          restore-keys: |
-            mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-
-            mypy-${{ runner.os }}-
-
-      - name: Run MyPy
-        env:
-          MYPY_FORCE_COLOR: 1
           TERM: xterm-256color
-        run: mypy .
+        run: ty check --output-format github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,11 +67,12 @@ repos:
         args: ["--active", "--with=onyx-devtools", "ods", "check-lazy-imports"]
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$
-      # NOTE: This takes ~6s on a single, large module which is prohibitively slow.
+      # NOTE: ty is fast enough to run in pre-commit but is pre-release (v0.0.31).
+      # Uncomment to enable.
       # - id: uv-run
-      #   name: mypy
-      #   args: ["--all-extras", "mypy"]
-      #   pass_filenames: true
+      #   name: ty
+      #   args: ["--active", "ty", "check"]
+      #   pass_filenames: false
       #   files: ^backend/.*\.py$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -26,7 +26,9 @@ from shared_configs.configs import (
     TENANT_ID_PREFIX,
 )
 from onyx.db.models import Base
-from celery.backends.database.session import ResultModelBase  # type: ignore
+from celery.backends.database.session import (  # ty: ignore[unresolved-import]
+    ResultModelBase,
+)
 from onyx.db.engine.sql_engine import SqlEngine
 
 # Make sure in alembic.ini [logger_root] level=INFO is set or most logging will be

--- a/backend/alembic/versions/47433d30de82_create_indexattempt_table.py
+++ b/backend/alembic/versions/47433d30de82_create_indexattempt_table.py
@@ -49,7 +49,7 @@ def upgrade() -> None:
             "time_updated",
             sa.DateTime(timezone=True),
             server_default=sa.text("now()"),
-            server_onupdate=sa.text("now()"),  # type: ignore
+            server_onupdate=sa.text("now()"),
             nullable=True,
         ),
         sa.Column(

--- a/backend/alembic/versions/4f8a2b3c1d9e_add_open_url_tool.py
+++ b/backend/alembic/versions/4f8a2b3c1d9e_add_open_url_tool.py
@@ -68,7 +68,7 @@ def upgrade() -> None:
             sa.text("SELECT id FROM tool WHERE in_code_tool_id = :in_code_tool_id"),
             {"in_code_tool_id": OPEN_URL_TOOL["in_code_tool_id"]},
         ).fetchone()
-        tool_id = result[0]  # type: ignore
+        tool_id = result[0]
 
     # Associate the tool with all existing personas
     # Get all persona IDs

--- a/backend/ee/onyx/access/access.py
+++ b/backend/ee/onyx/access/access.py
@@ -112,7 +112,7 @@ def _get_access_for_documents(
         access_map[document_id] = DocumentAccess.build(
             user_emails=list(non_ee_access.user_emails),
             user_groups=user_group_info.get(document_id, []),
-            is_public=is_public_anywhere,
+            is_public=is_public_anywhere,  # ty: ignore[invalid-argument-type]
             external_user_emails=list(ext_u_emails),
             external_user_group_ids=list(ext_u_groups),
         )

--- a/backend/ee/onyx/db/analytics.py
+++ b/backend/ee/onyx/db/analytics.py
@@ -53,7 +53,7 @@ def fetch_query_analytics(
         .order_by(cast(ChatMessage.time_sent, Date))
     )
 
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def fetch_per_user_query_analytics(
@@ -92,7 +92,7 @@ def fetch_per_user_query_analytics(
         .order_by(cast(ChatMessage.time_sent, Date), ChatSession.user_id)
     )
 
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def fetch_onyxbot_analytics(

--- a/backend/ee/onyx/db/connector.py
+++ b/backend/ee/onyx/db/connector.py
@@ -9,7 +9,7 @@ logger = setup_logger()
 
 
 def fetch_sources_with_connectors(db_session: Session) -> list[DocumentSource]:
-    sources = db_session.query(distinct(Connector.source)).all()  # type: ignore
+    sources = db_session.query(distinct(Connector.source)).all()
 
     document_sources = [source[0] for source in sources]
 

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -128,9 +128,9 @@ def get_used_seats(tenant_id: str | None = None) -> int:
                 select(func.count())
                 .select_from(User)
                 .where(
-                    User.is_active == True,  # type: ignore  # noqa: E712
+                    User.is_active == True,  # noqa: E712
                     User.role != UserRole.EXT_PERM_USER,
-                    User.email != ANONYMOUS_USER_EMAIL,  # type: ignore
+                    User.email != ANONYMOUS_USER_EMAIL,
                     User.account_type != AccountType.SERVICE_ACCOUNT,
                 )
             )

--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -121,7 +121,7 @@ class ScimDAL(DAL):
         """Update the last_used_at timestamp for a token."""
         token = self._session.get(ScimToken, token_id)
         if token:
-            token.last_used_at = func.now()  # type: ignore[assignment]
+            token.last_used_at = func.now()
 
     # ------------------------------------------------------------------
     # User mapping operations
@@ -229,7 +229,7 @@ class ScimDAL(DAL):
     def get_user(self, user_id: UUID) -> User | None:
         """Fetch a user by ID."""
         return self._session.scalar(
-            select(User).where(User.id == user_id)  # type: ignore[arg-type]
+            select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         )
 
     def get_user_by_email(self, email: str) -> User | None:
@@ -293,16 +293,22 @@ class ScimDAL(DAL):
             if attr == "username":
                 # arg-type: fastapi-users types User.email as str, not a column expression
                 # assignment: union return type widens but query is still Select[tuple[User]]
-                query = _apply_scim_string_op(query, User.email, scim_filter)  # type: ignore[arg-type, assignment]
+                query = _apply_scim_string_op(
+                    query, User.email, scim_filter  # ty: ignore[invalid-argument-type]
+                )
             elif attr == "active":
                 query = query.where(
-                    User.is_active.is_(scim_filter.value.lower() == "true")  # type: ignore[attr-defined]
+                    User.is_active.is_(  # ty: ignore[unresolved-attribute]
+                        scim_filter.value.lower() == "true"
+                    )
                 )
             elif attr == "externalid":
                 mapping = self.get_user_mapping_by_external_id(scim_filter.value)
                 if not mapping:
                     return [], 0
-                query = query.where(User.id == mapping.user_id)  # type: ignore[arg-type]
+                query = query.where(
+                    User.id == mapping.user_id  # ty: ignore[invalid-argument-type]
+                )
             else:
                 raise ValueError(
                     f"Unsupported filter attribute: {scim_filter.attribute}"
@@ -318,7 +324,9 @@ class ScimDAL(DAL):
         offset = max(start_index - 1, 0)
         users = list(
             self._session.scalars(
-                query.order_by(User.id).offset(offset).limit(count)  # type: ignore[arg-type]
+                query.order_by(User.id)  # ty: ignore[invalid-argument-type]
+                .offset(offset)
+                .limit(count)
             )
             .unique()
             .all()
@@ -577,7 +585,7 @@ class ScimDAL(DAL):
             attr = scim_filter.attribute.lower()
             if attr == "displayname":
                 # assignment: union return type widens but query is still Select[tuple[UserGroup]]
-                query = _apply_scim_string_op(query, UserGroup.name, scim_filter)  # type: ignore[assignment]
+                query = _apply_scim_string_op(query, UserGroup.name, scim_filter)
             elif attr == "externalid":
                 mapping = self.get_group_mapping_by_external_id(scim_filter.value)
                 if not mapping:
@@ -615,7 +623,9 @@ class ScimDAL(DAL):
 
         users = (
             self._session.scalars(
-                select(User).where(User.id.in_(user_ids))  # type: ignore[attr-defined]
+                select(User).where(
+                    User.id.in_(user_ids)  # ty: ignore[unresolved-attribute]
+                )
             )
             .unique()
             .all()
@@ -640,7 +650,9 @@ class ScimDAL(DAL):
             return []
         existing_users = (
             self._session.scalars(
-                select(User).where(User.id.in_(uuids))  # type: ignore[attr-defined]
+                select(User).where(
+                    User.id.in_(uuids)  # ty: ignore[unresolved-attribute]
+                )
             )
             .unique()
             .all()

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -300,8 +300,11 @@ def fetch_user_groups_for_user(
     stmt = (
         select(UserGroup)
         .join(User__UserGroup, User__UserGroup.user_group_id == UserGroup.id)
-        .join(User, User.id == User__UserGroup.user_id)  # type: ignore
-        .where(User.id == user_id)  # type: ignore
+        .join(
+            User,
+            User.id == User__UserGroup.user_id,  # ty: ignore[invalid-argument-type]
+        )
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
     )
     if only_curator_groups:
         stmt = stmt.where(User__UserGroup.is_curator == True)  # noqa: E712
@@ -430,7 +433,7 @@ def fetch_user_groups_for_documents(
         .group_by(Document.id)
     )
 
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def _check_user_group_is_modifiable(user_group: UserGroup) -> None:
@@ -804,7 +807,9 @@ def update_user_group(
         db_user_group.is_up_to_date = False
 
     removed_users = db_session.scalars(
-        select(User).where(User.id.in_(removed_user_ids))  # type: ignore
+        select(User).where(
+            User.id.in_(removed_user_ids)  # ty: ignore[unresolved-attribute]
+        )
     ).unique()
 
     # Filter out admin and global curator users before validating curator status

--- a/backend/ee/onyx/external_permissions/google_drive/folder_retrieval.py
+++ b/backend/ee/onyx/external_permissions/google_drive/folder_retrieval.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 
-from googleapiclient.discovery import Resource  # type: ignore
+from googleapiclient.discovery import Resource
 
 from ee.onyx.external_permissions.google_drive.models import GoogleDrivePermission
 from ee.onyx.external_permissions.google_drive.permission_retrieval import (
@@ -38,7 +38,7 @@ def get_folder_permissions_by_ids(
         A list of permissions matching the provided permission IDs
     """
     return get_permissions_by_ids(
-        drive_service=service,
+        drive_service=service,  # ty: ignore[invalid-argument-type]
         doc_id=folder_id,
         permission_ids=permission_ids,
     )
@@ -68,7 +68,7 @@ def get_modified_folders(
 
     # Retrieve and yield folders
     for folder in execute_paginated_retrieval(
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         list_key="files",
         continue_on_404_or_403=True,
         corpora="allDrives",

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from googleapiclient.errors import HttpError  # type: ignore
+from googleapiclient.errors import HttpError
 from pydantic import BaseModel
 
 from ee.onyx.db.external_perm import ExternalUserGroup
@@ -183,7 +183,7 @@ def _get_drive_members(
     )
 
     admin_user_info = (
-        admin_service.users()
+        admin_service.users()  # ty: ignore[unresolved-attribute]
         .get(userKey=google_drive_connector.primary_admin_email)
         .execute()
     )
@@ -197,7 +197,7 @@ def _get_drive_members(
 
         try:
             for permission in execute_paginated_retrieval(
-                drive_service.permissions().list,
+                drive_service.permissions().list,  # ty: ignore[unresolved-attribute]
                 list_key="permissions",
                 fileId=drive_id,
                 fields="permissions(emailAddress, type),nextPageToken",
@@ -256,7 +256,7 @@ def _get_all_google_groups(
     """
     group_emails: set[str] = set()
     for group in execute_paginated_retrieval(
-        admin_service.groups().list,
+        admin_service.groups().list,  # ty: ignore[unresolved-attribute]
         list_key="groups",
         domain=google_domain,
         fields="groups(email),nextPageToken",
@@ -274,7 +274,7 @@ def _google_group_to_onyx_group(
     """
     group_member_emails: set[str] = set()
     for member in execute_paginated_retrieval(
-        admin_service.members().list,
+        admin_service.members().list,  # ty: ignore[unresolved-attribute]
         list_key="members",
         groupKey=group_email,
         fields="members(email),nextPageToken",
@@ -298,7 +298,7 @@ def _map_group_email_to_member_emails(
     for group_email in group_emails:
         group_member_emails: set[str] = set()
         for member in execute_paginated_retrieval(
-            admin_service.members().list,
+            admin_service.members().list,  # ty: ignore[unresolved-attribute]
             list_key="members",
             groupKey=group_email,
             fields="members(email),nextPageToken",

--- a/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
+++ b/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
@@ -33,7 +33,7 @@ def get_permissions_by_ids(
 
     # Fetch all permissions for the document
     fetched_permissions = execute_paginated_retrieval(
-        retrieval_function=drive_service.permissions().list,
+        retrieval_function=drive_service.permissions().list,  # ty: ignore[unresolved-attribute]
         list_key="permissions",
         fileId=doc_id,
         fields="permissions(id, emailAddress, type, domain, allowFileDiscovery, permissionDetails),nextPageToken",

--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -68,7 +68,7 @@ def _build_holder_map(permissions: list[dict]) -> dict[str, list[Holder]]:
             logger.warning(f"Expected a 'raw' field, but none was found: {raw_perm=}")
             continue
 
-        permission = Permission(**raw_perm.raw)
+        permission = Permission(**raw_perm.raw)  # ty: ignore[invalid-argument-type]
 
         # We only care about ability to browse through projects + issues (not other permissions such as read/write).
         if permission.permission != "BROWSE_PROJECTS":

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from office365.sharepoint.client_context import ClientContext  # type: ignore[import-untyped]
+from office365.sharepoint.client_context import ClientContext
 
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.sharepoint.permission_utils import (

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -7,11 +7,11 @@ from typing import Any
 from urllib.parse import urlparse
 
 import requests as _requests
-from office365.graph_client import GraphClient  # type: ignore[import-untyped]
-from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore[import-untyped]
-from office365.runtime.client_request import ClientRequestException  # type: ignore
-from office365.sharepoint.client_context import ClientContext  # type: ignore[import-untyped]
-from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection  # type: ignore[import-untyped]
+from office365.graph_client import GraphClient
+from office365.onedrive.driveitems.driveItem import DriveItem
+from office365.runtime.client_request import ClientRequestException
+from office365.sharepoint.client_context import ClientContext
+from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection
 from pydantic import BaseModel
 
 from ee.onyx.db.external_perm import ExternalUserGroup

--- a/backend/ee/onyx/server/features/hooks/api.py
+++ b/backend/ee/onyx/server/features/hooks/api.py
@@ -287,8 +287,10 @@ def update_hook(
     validated_is_reachable: bool | None = None
     if endpoint_url_changing or api_key_changing or timeout_changing:
         existing = _get_hook_or_404(db_session, hook_id)
-        effective_url: str = (
-            req.endpoint_url if endpoint_url_changing else existing.endpoint_url  # type: ignore[assignment]  # endpoint_url is required on create and cannot be cleared on update
+        effective_url: str = (  # ty: ignore[invalid-assignment]
+            req.endpoint_url
+            if endpoint_url_changing
+            else existing.endpoint_url  # endpoint_url is required on create and cannot be cleared on update
         )
         effective_api_key: str | None = (
             (api_key if not isinstance(api_key, UnsetType) else None)
@@ -299,8 +301,10 @@ def update_hook(
                 else None
             )
         )
-        effective_timeout: float = (
-            req.timeout_seconds if timeout_changing else existing.timeout_seconds  # type: ignore[assignment]  # req.timeout_seconds is non-None when timeout_changing (validated by HookUpdateRequest)
+        effective_timeout: float = (  # ty: ignore[invalid-assignment]
+            req.timeout_seconds
+            if timeout_changing
+            else existing.timeout_seconds  # req.timeout_seconds is non-None when timeout_changing (validated by HookUpdateRequest)
         )
         validation = _validate_endpoint(
             endpoint_url=effective_url,

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -97,7 +97,7 @@ def fetch_and_process_chat_session_history(
             break
 
         paged_snapshots = parallel_yield(
-            [
+            [  # ty: ignore[invalid-argument-type]
                 yield_snapshot_from_chat_session(
                     db_session=db_session,
                     chat_session=chat_session,

--- a/backend/ee/onyx/server/tenants/schema_management.py
+++ b/backend/ee/onyx/server/tenants/schema_management.py
@@ -55,8 +55,10 @@ def run_alembic_migrations(schema_name: str) -> None:
         alembic_cfg.attributes["configure_logger"] = False
 
         # Mimic command-line options by adding 'cmd_opts' to the config
-        alembic_cfg.cmd_opts = SimpleNamespace()  # type: ignore
-        alembic_cfg.cmd_opts.x = [f"schemas={schema_name}"]  # type: ignore
+        alembic_cfg.cmd_opts = SimpleNamespace()  # ty: ignore[invalid-assignment]
+        alembic_cfg.cmd_opts.x = [  # ty: ignore[invalid-assignment]
+            f"schemas={schema_name}"
+        ]
 
         # Run migrations programmatically
         command.upgrade(alembic_cfg, "head")

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -349,8 +349,9 @@ def get_tenant_count(tenant_id: str) -> int:
         user_count = (
             db_session.query(User)
             .filter(
-                User.email.in_(emails),  # type: ignore
-                User.is_active == True,  # type: ignore  # noqa: E712
+                User.email.in_(emails),  # ty: ignore[unresolved-attribute]
+                User.is_active  # noqa: E712  # ty: ignore[invalid-argument-type]
+                == True,
             )
             .count()
         )

--- a/backend/ee/onyx/utils/posthog_client.py
+++ b/backend/ee/onyx/utils/posthog_client.py
@@ -73,7 +73,7 @@ def capture_and_sync_with_alternate_posthog(
             cloud_props.pop("onyx_cloud_user_id", None)
 
             posthog.identify(
-                distinct_id=cloud_user_id,
+                distinct_id=cloud_user_id,  # ty: ignore[possibly-unresolved-reference]
                 properties=cloud_props,
             )
     except Exception as e:
@@ -105,7 +105,7 @@ def get_anon_id_from_request(request: Any) -> str | None:
     if (cookie_value := request.cookies.get(cookie_name)) and (
         parsed := parse_posthog_cookie(cookie_value)
     ):
-        return parsed.get("distinct_id")
+        return parsed.get("distinct_id")  # ty: ignore[possibly-unresolved-reference]
 
     return None
 

--- a/backend/model_server/legacy/custom_models.py
+++ b/backend/model_server/legacy/custom_models.py
@@ -23,7 +23,7 @@
 # from shared_configs.model_server_models import IntentResponse
 
 # if TYPE_CHECKING:
-#     from setfit import SetFitModel  # type: ignore[import-untyped]
+#     from setfit import SetFitModel
 #     from transformers import PreTrainedTokenizer, BatchEncoding
 
 
@@ -423,7 +423,7 @@
 # def map_keywords(
 #     input_ids: torch.Tensor, tokenizer: "PreTrainedTokenizer", is_keyword: list[bool]
 # ) -> list[str]:
-#     tokens = tokenizer.convert_ids_to_tokens(input_ids)  # type: ignore
+#     tokens = tokenizer.convert_ids_to_tokens(input_ids)
 
 #     if not len(tokens) == len(is_keyword):
 #         raise ValueError("Length of tokens and keyword predictions must match")

--- a/backend/model_server/legacy/onyx_torch_model.py
+++ b/backend/model_server/legacy/onyx_torch_model.py
@@ -18,7 +18,7 @@
 #         super().__init__()
 #         config = DistilBertConfig()
 #         self.distilbert = DistilBertModel(config)
-#         config = self.distilbert.config  # type: ignore
+#         config = self.distilbert.config
 
 #         # Keyword tokenwise binary classification layer
 #         self.keyword_classifier = nn.Linear(config.dim, 2)
@@ -85,7 +85,7 @@
 
 #         self.config = config
 #         self.distilbert = DistilBertModel(config)
-#         config = self.distilbert.config  # type: ignore
+#         config = self.distilbert.config
 #         self.connector_global_classifier = nn.Linear(config.dim, 1)
 #         self.connector_match_classifier = nn.Linear(config.dim, 1)
 #         self.tokenizer = DistilBertTokenizer.from_pretrained("distilbert-base-uncased")

--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -7,8 +7,8 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from email.utils import make_msgid
 
-import sendgrid  # type: ignore
-from sendgrid.helpers.mail import Attachment  # type: ignore
+import sendgrid
+from sendgrid.helpers.mail import Attachment
 from sendgrid.helpers.mail import Content
 from sendgrid.helpers.mail import ContentId
 from sendgrid.helpers.mail import Disposition

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from jwt import decode as jwt_decode
 from jwt import InvalidTokenError
 from jwt import PyJWTError
-from jwt.algorithms import RSAAlgorithm
+from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
 from onyx.configs.app_configs import JWT_PUBLIC_KEY_URL
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -46,8 +46,10 @@ async def _test_expire_oauth_token(
 
         updated_data: Dict[str, Any] = {"expires_at": new_expires_at}
 
-        await user_manager.user_db.update_oauth_account(
-            user, cast(Any, oauth_account), updated_data
+        await user_manager.user_db.update_oauth_account(  # ty: ignore[invalid-argument-type]
+            user,  # ty: ignore[invalid-argument-type]
+            cast(Any, oauth_account),
+            updated_data,
         )
 
         return True
@@ -132,8 +134,10 @@ async def refresh_oauth_token(
                     )
 
             # Update the OAuth account
-            await user_manager.user_db.update_oauth_account(
-                user, cast(Any, oauth_account), updated_data
+            await user_manager.user_db.update_oauth_account(  # ty: ignore[invalid-argument-type]
+                user,  # ty: ignore[invalid-argument-type]
+                cast(Any, oauth_account),
+                updated_data,
             )
 
             logger.info(f"Successfully refreshed OAuth token for {user.email}")

--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -191,7 +191,7 @@ class OAuthTokenManager:
     @staticmethod
     def _unwrap_sensitive_str(value: SensitiveValue[str] | str) -> str:
         if isinstance(value, SensitiveValue):
-            return value.get_value(apply_mask=False)
+            return value.get_value(apply_mask=False)  # ty: ignore[invalid-return-type]
         return value
 
     @staticmethod
@@ -199,5 +199,7 @@ class OAuthTokenManager:
         token_data: SensitiveValue[dict[str, Any]] | dict[str, Any],
     ) -> dict[str, Any]:
         if isinstance(token_data, SensitiveValue):
-            return token_data.get_value(apply_mask=False)
+            return token_data.get_value(  # ty: ignore[invalid-return-type]
+                apply_mask=False
+            )
         return token_data

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -121,5 +121,7 @@ def require_permission(
 
         return user
 
-    dependency._is_require_permission = True  # type: ignore[attr-defined]  # sentinel for auth_check detection
+    dependency._is_require_permission = (  # ty: ignore[unresolved-attribute]
+        True  # sentinel for auth_check detection
+    )
     return dependency

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -45,7 +45,9 @@ from fastapi_users import UUIDIDMixin
 from fastapi_users.authentication import AuthenticationBackend
 from fastapi_users.authentication import CookieTransport
 from fastapi_users.authentication import JWTStrategy
-from fastapi_users.authentication import RedisStrategy
+from fastapi_users.authentication import (
+    RedisStrategy,  # ty: ignore[possibly-missing-import]
+)
 from fastapi_users.authentication import Strategy
 from fastapi_users.authentication.strategy.db import AccessTokenDatabase
 from fastapi_users.authentication.strategy.db import DatabaseStrategy
@@ -462,14 +464,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     self.user_db = tenant_user_db
 
                 if hasattr(user_create, "role"):
-                    user_create.role = UserRole.BASIC
+                    user_create.role = UserRole.BASIC  # ty: ignore[invalid-assignment]
 
                     user_count = await get_user_count()
                     if (
                         user_count == 0
                         or user_create.email in get_default_admin_user_emails()
                     ):
-                        user_create.role = UserRole.ADMIN
+                        user_create.role = (  # ty: ignore[invalid-assignment]
+                            UserRole.ADMIN
+                        )
 
                 # Check seat availability for new users (single-tenant only)
                 with get_session_with_current_tenant() as sync_db:
@@ -516,7 +520,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # Expire so the async session re-fetches the row updated by
                     # the sync session above.
                     self.user_db.session.expire(user)
-                    user = await self.user_db.get(user_id)  # type: ignore[assignment]
+                    user = await self.user_db.get(  # ty: ignore[invalid-assignment]
+                        user_id
+                    )
                 except exceptions.UserAlreadyExists:
                     user = await self.get_by_email(user_create.email)
 
@@ -544,7 +550,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # Expire so the async session re-fetches the row updated by
                     # the sync session above.
                     self.user_db.session.expire(user)
-                    user = await self.user_db.get(user_id)  # type: ignore[assignment]
+                    user = await self.user_db.get(  # ty: ignore[invalid-assignment]
+                        user_id
+                    )
                 if user_created:
                     await self._assign_default_pinned_assistants(user, db_session)
                 remove_user_from_invited_users(user_create.email)
@@ -592,7 +600,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         update nor the group assignment is visible without the other.
         """
         with get_session_with_current_tenant() as sync_db:
-            sync_user = sync_db.query(User).filter(User.id == user_id).first()  # type: ignore[arg-type]
+            sync_user = (
+                sync_db.query(User)
+                .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
+                .first()
+            )
             if sync_user:
                 sync_user.hashed_password = self.password_helper.hash(
                     user_create.password
@@ -613,7 +625,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     user_id,
                 )
 
-    async def validate_password(self, password: str, _: schemas.UC | models.UP) -> None:
+    async def validate_password(  # ty: ignore[invalid-method-override]
+        self, password: str, _: schemas.UC | models.UP
+    ) -> None:
         # Validate password according to configurable security policy (defined via environment variables)
         if len(password) < PASSWORD_MIN_LENGTH:
             raise exceptions.InvalidPasswordException(
@@ -644,7 +658,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         return
 
     @log_function_time(print_only=True)
-    async def oauth_callback(
+    async def oauth_callback(  # ty: ignore[invalid-method-override]
         self,
         oauth_name: str,
         access_token: str,
@@ -754,7 +768,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                                 user,
                                 # NOTE: OAuthAccount DOES implement the OAuthAccountProtocol
                                 # but the type checker doesn't know that :(
-                                existing_oauth_account,  # type: ignore
+                                existing_oauth_account,  # ty: ignore[invalid-argument-type]
                                 oauth_account_dict,
                             )
 
@@ -788,7 +802,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 # transaction so neither change is visible without the other.
                 was_inactive = not user.is_active
                 with get_session_with_current_tenant() as sync_db:
-                    sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
+                    sync_user = (
+                        sync_db.query(User)
+                        .filter(User.id == user.id)  # ty: ignore[invalid-argument-type]
+                        .first()
+                    )
                     if sync_user:
                         sync_user.is_verified = is_verified_by_default
                         sync_user.role = UserRole.BASIC
@@ -808,7 +826,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # otherwise, the oidc expiry will always be old, and the user will never be able to login
             if user.oidc_expiry is not None and not TRACK_EXTERNAL_IDP_EXPIRY:
                 await self.user_db.update(user, {"oidc_expiry": None})
-                user.oidc_expiry = None  # type: ignore
+                user.oidc_expiry = None  # ty: ignore[invalid-assignment]
             remove_user_from_invited_users(user.email)
             if token:
                 CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
@@ -925,7 +943,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             and (marketing_cookie_value := request.cookies.get(marketing_cookie_name))
             and (parsed_cookie := parse_posthog_cookie(marketing_cookie_value))
         ):
-            marketing_anonymous_id = parsed_cookie["distinct_id"]
+            marketing_anonymous_id = (
+                parsed_cookie[  # ty: ignore[possibly-unresolved-reference]
+                    "distinct_id"
+                ]
+            )
 
             # Technically, USER_SIGNED_UP is only fired from the cloud site when
             # it is the first user in a tenant. However, it is semantically correct
@@ -942,7 +964,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             }
 
             # Add all other values from the marketing cookie (featureFlags, etc.)
-            for key, value in parsed_cookie.items():
+            for (
+                key,
+                value,
+            ) in parsed_cookie.items():  # ty: ignore[possibly-unresolved-reference]
                 if key != "distinct_id":
                     properties.setdefault(key, value)
 
@@ -1504,7 +1529,7 @@ async def _sync_jwt_oidc_expiry(
 
     if user.oidc_expiry is not None:
         await user_manager.user_db.update(user, {"oidc_expiry": None})
-        user.oidc_expiry = None  # type: ignore
+        user.oidc_expiry = None  # ty: ignore[invalid-assignment]
 
 
 async def _get_or_create_user_from_jwt(
@@ -2232,7 +2257,7 @@ def get_oauth_router(
 
             # Proceed to authenticate or create the user
             try:
-                user = await user_manager.oauth_callback(
+                user = await user_manager.oauth_callback(  # ty: ignore[invalid-argument-type]
                     oauth_client.name,
                     token["access_token"],
                     account_id,

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -6,16 +6,16 @@ from typing import Any
 from typing import cast
 
 import sentry_sdk
-from celery import bootsteps  # type: ignore
+from celery import bootsteps  # ty: ignore[unresolved-import]
 from celery import Task
-from celery.app import trace
+from celery.app import trace  # ty: ignore[unresolved-import]
 from celery.exceptions import WorkerShutdown
 from celery.signals import before_task_publish
 from celery.signals import task_postrun
 from celery.signals import task_prerun
 from celery.states import READY_STATES
 from celery.utils.log import get_task_logger
-from celery.worker import strategy  # type: ignore
+from celery.worker import strategy  # ty: ignore[unresolved-import]
 from redis.lock import Lock as RedisLock
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sqlalchemy import text

--- a/backend/onyx/background/celery/apps/beat.py
+++ b/backend/onyx/background/celery/apps/beat.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from celery import Celery
 from celery import signals
-from celery.beat import PersistentScheduler  # type: ignore
+from celery.beat import PersistentScheduler  # ty: ignore[unresolved-import]
 from celery.signals import beat_init
 from celery.utils.log import get_task_logger
 

--- a/backend/onyx/background/celery/apps/client.py
+++ b/backend/onyx/background/celery/apps/client.py
@@ -4,4 +4,4 @@ import onyx.background.celery.apps.app_base as app_base
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.client")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]

--- a/backend/onyx/background/celery/apps/docfetching.py
+++ b/backend/onyx/background/celery/apps/docfetching.py
@@ -29,7 +29,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.docfetching")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -100,7 +100,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     logger.info("worker_init signal received.")
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_DOCFETCHING_APP_NAME)
-    pool_size = cast(int, sender.concurrency)  # type: ignore
+    pool_size = cast(int, sender.concurrency)  # ty: ignore[unresolved-attribute]
     SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -30,7 +30,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.docprocessing")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -106,7 +106,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     # "SSL connection has been closed unexpectedly"
     # actually setting the spawn method in the cloud fixes 95% of these.
     # setting pre ping might help even more, but not worrying about that yet
-    pool_size = cast(int, sender.concurrency)  # type: ignore
+    pool_size = cast(int, sender.concurrency)  # ty: ignore[unresolved-attribute]
     SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/heavy.py
+++ b/backend/onyx/background/celery/apps/heavy.py
@@ -27,7 +27,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.heavy")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -92,7 +92,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     logger.info("worker_init signal received.")
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_HEAVY_APP_NAME)
-    pool_size = cast(int, sender.concurrency)  # type: ignore
+    pool_size = cast(int, sender.concurrency)  # ty: ignore[unresolved-attribute]
     SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -29,7 +29,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.light")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -95,19 +95,26 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 
     logger.info("worker_init signal received.")
 
-    logger.info(f"Concurrency: {sender.concurrency}")  # type: ignore
+    logger.info(
+        f"Concurrency: {sender.concurrency}"  # ty: ignore[unresolved-attribute]
+    )
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_LIGHT_APP_NAME)
-    SqlEngine.init_engine(pool_size=sender.concurrency, max_overflow=EXTRA_CONCURRENCY)  # type: ignore
+    SqlEngine.init_engine(
+        pool_size=sender.concurrency,  # ty: ignore[unresolved-attribute]
+        max_overflow=EXTRA_CONCURRENCY,
+    )
 
     if MANAGED_VESPA:
         httpx_init_vespa_pool(
-            sender.concurrency + EXTRA_CONCURRENCY,  # type: ignore
+            sender.concurrency + EXTRA_CONCURRENCY,  # ty: ignore[unresolved-attribute]
             ssl_cert=VESPA_CLOUD_CERT_PATH,
             ssl_key=VESPA_CLOUD_KEY_PATH,
         )
     else:
-        httpx_init_vespa_pool(sender.concurrency + EXTRA_CONCURRENCY)  # type: ignore
+        httpx_init_vespa_pool(
+            sender.concurrency + EXTRA_CONCURRENCY  # ty: ignore[unresolved-attribute]
+        )
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -20,7 +20,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.monitoring")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -3,7 +3,7 @@ import os
 from typing import Any
 from typing import cast
 
-from celery import bootsteps  # type: ignore
+from celery import bootsteps  # ty: ignore[unresolved-import]
 from celery import Celery
 from celery import signals
 from celery import Task
@@ -46,7 +46,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.primary")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -85,7 +85,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     logger.info("worker_init signal received.")
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_PRIMARY_APP_NAME)
-    pool_size = cast(int, sender.concurrency)  # type: ignore
+    pool_size = cast(int, sender.concurrency)  # ty: ignore[unresolved-attribute]
     SqlEngine.init_engine(
         pool_size=pool_size, max_overflow=CELERY_WORKER_PRIMARY_POOL_OVERFLOW
     )
@@ -145,7 +145,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
         raise WorkerShutdown("Primary worker lock could not be acquired!")
 
     # tacking on our own user data to the sender
-    sender.primary_worker_lock = lock  # type: ignore
+    sender.primary_worker_lock = lock  # ty: ignore[unresolved-attribute]
 
     # As currently designed, when this worker starts as "primary", we reinitialize redis
     # to a clean state (for our purposes, anyway)

--- a/backend/onyx/background/celery/apps/user_file_processing.py
+++ b/backend/onyx/background/celery/apps/user_file_processing.py
@@ -22,7 +22,7 @@ logger = setup_logger()
 
 celery_app = Celery(__name__)
 celery_app.config_from_object("onyx.background.celery.configs.user_file_processing")
-celery_app.Task = app_base.TenantAwareTask  # type: ignore [misc]
+celery_app.Task = app_base.TenantAwareTask  # ty: ignore[invalid-assignment]
 
 
 @signals.task_prerun.connect
@@ -66,7 +66,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     # "SSL connection has been closed unexpectedly"
     # actually setting the spawn method in the cloud fixes 95% of these.
     # setting pre ping might help even more, but not worrying about that yet
-    pool_size = cast(int, sender.concurrency)  # type: ignore
+    pool_size = cast(int, sender.concurrency)  # ty: ignore[unresolved-attribute]
     SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)

--- a/backend/onyx/background/celery/celery_redis.py
+++ b/backend/onyx/background/celery/celery_redis.py
@@ -179,7 +179,7 @@ def celery_inspect_get_workers(name_filter: str | None, app: Celery) -> list[str
 
     # filter for and create an indexing specific inspect object
     inspect = app.control.inspect()
-    workers: dict[str, Any] = inspect.ping()  # type: ignore
+    workers: dict[str, Any] = inspect.ping()  # ty: ignore[invalid-assignment]
     if workers:
         for worker_name in list(workers.keys()):
             # if the name filter not set, return all worker names
@@ -208,7 +208,9 @@ def celery_inspect_get_reserved(worker_names: list[str], app: Celery) -> set[str
     inspect = app.control.inspect(destination=worker_names)
 
     # get the list of reserved tasks
-    reserved_tasks: dict[str, list] | None = inspect.reserved()  # type: ignore
+    reserved_tasks: dict[str, list] | None = (  # ty: ignore[invalid-assignment]
+        inspect.reserved()
+    )
     if reserved_tasks:
         for _, task_list in reserved_tasks.items():
             for task in task_list:
@@ -229,7 +231,9 @@ def celery_inspect_get_active(worker_names: list[str], app: Celery) -> set[str]:
     inspect = app.control.inspect(destination=worker_names)
 
     # get the list of reserved tasks
-    active_tasks: dict[str, list] | None = inspect.active()  # type: ignore
+    active_tasks: dict[str, list] | None = (  # ty: ignore[invalid-assignment]
+        inspect.active()
+    )
     if active_tasks:
         for _, task_list in active_tasks.items():
             for task in task_list:

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -810,7 +810,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
 
     # we need to use celery's redis client to access its redis data
     # (which lives on a different db number)
-    # redis_client_celery: Redis = self.app.broker_connection().channel().client  # type: ignore
+    # redis_client_celery: Redis = self.app.broker_connection().channel().client
 
     lock_beat: RedisLock = redis_client.lock(
         OnyxRedisLocks.CHECK_INDEXING_BEAT_LOCK,

--- a/backend/onyx/background/indexing/checkpointing_utils.py
+++ b/backend/onyx/background/indexing/checkpointing_utils.py
@@ -61,7 +61,9 @@ def load_checkpoint(
     checkpoint_io = file_store.read_file(checkpoint_pointer, mode="rb")
     checkpoint_data = checkpoint_io.read().decode("utf-8")
     if isinstance(connector, CheckpointedConnector):
-        return connector.validate_checkpoint_json(checkpoint_data)
+        return connector.validate_checkpoint_json(  # ty: ignore[invalid-return-type]
+            checkpoint_data
+        )
     return ConnectorCheckpoint.model_validate_json(checkpoint_data)
 
 

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -1164,7 +1164,10 @@ def run_llm_loop(
 
         emitter.emit(
             Packet(
-                placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
+                placement=Placement(
+                    turn_index=llm_cycle_count  # ty: ignore[possibly-unresolved-reference]
+                    + reasoning_cycles
+                ),
                 obj=OverallStop(type="stop"),
             )
         )

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -639,9 +639,11 @@ REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPINTVL] = 15
 REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPCNT] = 3
 
 if platform.system() == "Darwin":
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPALIVE] = 60  # type: ignore[attr-defined,unused-ignore]
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[
+        socket.TCP_KEEPALIVE  # ty: ignore[unresolved-attribute]
+    ] = 60
 else:
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPIDLE] = 60  # type: ignore[attr-defined,unused-ignore]
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPIDLE] = 60
 
 
 class OnyxCallTypes(str, Enum):

--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -547,7 +547,7 @@ class AirtableConnector(LoadConnector):
                 for record in batch_records:
                     # Capture the current context so that the thread gets the current tenant ID
                     current_context = contextvars.copy_context()
-                    future_to_record[
+                    future_to_record[  # ty: ignore[invalid-assignment]
                         executor.submit(
                             current_context.run,
                             self._process_record,

--- a/backend/onyx/connectors/asana/asana_api.py
+++ b/backend/onyx/connectors/asana/asana_api.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from typing import Dict
 
-import asana  # type: ignore
+import asana
 
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/connectors/axero/connector.py
+++ b/backend/onyx/connectors/axero/connector.py
@@ -327,7 +327,7 @@ class AxeroConnector(PollConnector):
                 )
 
                 all_axero_forums = _map_post_to_parent(
-                    posts=forums_posts,
+                    posts=forums_posts,  # ty: ignore[invalid-argument-type]
                     api_key=self.axero_key,
                     axero_base_url=self.base_url,
                 )

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -76,7 +76,9 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.bucket_region: Optional[str] = None
         self.european_residency: bool = european_residency
 
-    def set_allow_images(self, allow_images: bool) -> None:
+    def set_allow_images(  # ty: ignore[invalid-method-override]
+        self, allow_images: bool
+    ) -> None:
         """Set whether to process images in this connector."""
         logger.info(f"Setting allow_images to {allow_images}.")
         self._allow_images = allow_images
@@ -195,7 +197,9 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                     method="sts-assume-role",
                 )
                 botocore_session = get_session()
-                botocore_session._credentials = refreshable  # type: ignore[attr-defined]
+                botocore_session._credentials = (  # ty: ignore[unresolved-attribute]
+                    refreshable
+                )
                 session = boto3.Session(botocore_session=botocore_session)
                 self.s3_client = session.client("s3")
             elif authentication_method == "assume_role":

--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -95,11 +95,13 @@ class ClickupConnector(LoadConnector, PollConnector):
             params["date_updated_lt"] = end
 
         if self.connector_type == "list":
-            params["list_ids[]"] = self.connector_ids
+            params["list_ids[]"] = self.connector_ids  # ty: ignore[invalid-assignment]
         elif self.connector_type == "folder":
-            params["project_ids[]"] = self.connector_ids
+            params["project_ids[]"] = (  # ty: ignore[invalid-assignment]
+                self.connector_ids
+            )
         elif self.connector_type == "space":
-            params["space_ids[]"] = self.connector_ids
+            params["space_ids[]"] = self.connector_ids  # ty: ignore[invalid-assignment]
 
         url_endpoint = f"/team/{self.team_id}/task"
 

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -6,7 +6,7 @@ from datetime import timezone
 from typing import Any
 from urllib.parse import quote
 
-from atlassian.errors import ApiError  # type: ignore
+from atlassian.errors import ApiError
 from requests.exceptions import HTTPError
 from typing_extensions import override
 

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -26,7 +26,7 @@ from typing import TypeVar
 from urllib.parse import quote
 
 import bs4
-from atlassian import Confluence  # type:ignore
+from atlassian import Confluence
 from redis import Redis
 from requests import HTTPError
 
@@ -971,7 +971,7 @@ class OnyxConfluence:
         :return: Returns the user details
         """
 
-        from atlassian.errors import ApiPermissionError  # type:ignore
+        from atlassian.errors import ApiPermissionError
 
         url = "rest/api/user/current"
         params = {}

--- a/backend/onyx/connectors/connector_runner.py
+++ b/backend/onyx/connectors/connector_runner.py
@@ -165,7 +165,7 @@ class ConnectorRunner(Generic[CT]):
                 checkpoint_connector_generator = load_from_checkpoint(
                     start=self.time_range[0].timestamp(),
                     end=self.time_range[1].timestamp(),
-                    checkpoint=checkpoint,
+                    checkpoint=checkpoint,  # ty: ignore[invalid-argument-type]
                 )
                 next_checkpoint: CT | None = None
                 # this is guaranteed to always run at least once with next_checkpoint being non-None
@@ -174,7 +174,9 @@ class ConnectorRunner(Generic[CT]):
                     hierarchy_node,
                     failure,
                     next_checkpoint,
-                ) in CheckpointOutputWrapper[CT]()(checkpoint_connector_generator):
+                ) in CheckpointOutputWrapper[CT]()(
+                    checkpoint_connector_generator  # ty: ignore[invalid-argument-type]
+                ):
                     if document is not None:
                         self.doc_batch.append(document)
 

--- a/backend/onyx/connectors/credentials_provider.py
+++ b/backend/onyx/connectors/credentials_provider.py
@@ -83,7 +83,9 @@ class OnyxDBCredentialsProvider(
                         f"No credential found: credential={self._credential_id}"
                     )
 
-                credential.credential_json = credential_json  # type: ignore[assignment]
+                credential.credential_json = (  # ty: ignore[invalid-assignment]
+                    credential_json
+                )
                 db_session.commit()
             except Exception:
                 db_session.rollback()

--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -53,8 +53,10 @@ def _convert_message_to_document(
     if isinstance(message.channel, TextChannel) and (
         channel_name := message.channel.name
     ):
-        metadata["Channel"] = channel_name
-        semantic_substring += f" in Channel: #{channel_name}"
+        metadata["Channel"] = channel_name  # ty: ignore[possibly-unresolved-reference]
+        semantic_substring += (
+            f" in Channel: #{channel_name}"  # ty: ignore[possibly-unresolved-reference]
+        )
 
     # Single messages dont have a title
     title = ""

--- a/backend/onyx/connectors/dropbox/connector.py
+++ b/backend/onyx/connectors/dropbox/connector.py
@@ -2,10 +2,10 @@ from datetime import timezone
 from io import BytesIO
 from typing import Any
 
-from dropbox import Dropbox  # type: ignore[import-untyped]
-from dropbox.exceptions import ApiError  # type: ignore[import-untyped]
+from dropbox import Dropbox
+from dropbox.exceptions import ApiError
 from dropbox.exceptions import AuthError
-from dropbox.files import FileMetadata  # type: ignore[import-untyped]
+from dropbox.files import FileMetadata
 from dropbox.files import FolderMetadata
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-from googleapiclient.errors import HttpError  # type: ignore
+from googleapiclient.errors import HttpError
 
 from onyx.access.models import ExternalAccess
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -296,7 +296,9 @@ def _full_thread_from_id(
     try:
         thread = next(
             execute_single_retrieval(
-                retrieval_function=gmail_service.users().threads().get,
+                retrieval_function=gmail_service.users()  # ty: ignore[unresolved-attribute]
+                .threads()
+                .get,
                 list_key=None,
                 userId=user_email,
                 fields=THREAD_FIELDS,
@@ -394,7 +396,7 @@ class GmailConnector(
             admin_service = get_admin_service(self.creds, self.primary_admin_email)
             emails = []
             for user in execute_paginated_retrieval(
-                retrieval_function=admin_service.users().list,
+                retrieval_function=admin_service.users().list,  # ty: ignore[unresolved-attribute]
                 list_key="users",
                 fields=USER_FIELDS,
                 domain=self.google_domain,
@@ -438,7 +440,9 @@ class GmailConnector(
         try:
             for thread in execute_paginated_retrieval_with_max_pages(
                 max_num_pages=PAGES_PER_CHECKPOINT,
-                retrieval_function=gmail_service.users().threads().list,
+                retrieval_function=gmail_service.users()  # ty: ignore[unresolved-attribute]
+                .threads()
+                .list,
                 list_key="threads",
                 userId=user_email,
                 fields=THREAD_LIST_FIELDS,

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -110,7 +110,7 @@ class GongConnector(LoadConnector, PollConnector):
         # The batch_ids in the previous method appears to be batches of call_ids to process
         # In this method, we will retrieve transcripts for them in batches.
         transcripts: list[dict[str, Any]] = []
-        workspace_list = self.workspaces or [None]  # type: ignore
+        workspace_list = self.workspaces or [None]
         workspace_map = self._get_workspace_id_map() if self.workspaces else {}
 
         for workspace in workspace_list:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -18,7 +18,7 @@ from urllib.parse import urlunparse
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-from googleapiclient.errors import HttpError  # type: ignore
+from googleapiclient.errors import HttpError
 from typing_extensions import override
 
 from onyx.access.models import ExternalAccess
@@ -434,7 +434,7 @@ class GoogleDriveConnector(
         for is_admin in [True, False]:
             query = "isAdmin=true" if is_admin else "isAdmin=false"
             for user in execute_paginated_retrieval(
-                retrieval_function=admin_service.users().list,
+                retrieval_function=admin_service.users().list,  # ty: ignore[unresolved-attribute]
                 list_key="users",
                 fields=USER_FIELDS,
                 domain=self.google_domain,
@@ -719,7 +719,7 @@ class GoogleDriveConnector(
         )
         all_drive_ids: set[str] = set()
         for drive in execute_paginated_retrieval(
-            retrieval_function=drive_service.drives().list,
+            retrieval_function=drive_service.drives().list,  # ty: ignore[unresolved-attribute]
             list_key="drives",
             useDomainAdminAccess=is_service_account,
             fields="drives(id),nextPageToken",
@@ -907,7 +907,9 @@ class GoogleDriveConnector(
             # resume from a checkpoint
             if resuming and (drive_id := curr_stage.current_folder_or_drive_id):
                 resume_start = curr_stage.completed_until
-                for file_or_token in _yield_from_drive(drive_id, resume_start):
+                for file_or_token in _yield_from_drive(
+                    drive_id, resume_start  # ty: ignore[possibly-unresolved-reference]
+                ):
                     if isinstance(file_or_token, str):
                         checkpoint.completion_map[user_email].next_page_token = (
                             file_or_token
@@ -1302,7 +1304,9 @@ class GoogleDriveConnector(
             resume_start = checkpoint.completion_map[
                 self.primary_admin_email
             ].completed_until
-            yield from _yield_from_folder_crawl(folder_id, resume_start)
+            yield from _yield_from_folder_crawl(
+                folder_id, resume_start  # ty: ignore[possibly-unresolved-reference]
+            )
 
         # the times stored in the completion_map aren't used due to the crawling behavior
         # instead, the traversed_parent_ids are used to determine what we have left to retrieve
@@ -1883,7 +1887,9 @@ class GoogleDriveConnector(
 
         try:
             drive_service = get_drive_service(self._creds, self._primary_admin_email)
-            drive_service.files().list(pageSize=1, fields="files(id)").execute()
+            drive_service.files().list(  # ty: ignore[unresolved-attribute]
+                pageSize=1, fields="files(id)"
+            ).execute()
 
             if isinstance(self._creds, ServiceAccountCredentials):
                 # default is ~17mins of retries, don't do that here since this is called from

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -6,8 +6,8 @@ from typing import cast
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
-from googleapiclient.errors import HttpError  # type: ignore
-from googleapiclient.http import MediaIoBaseDownload  # type: ignore
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
 from pydantic import BaseModel
 
 from onyx.access.models import ExternalAccess
@@ -65,7 +65,7 @@ def _get_folder_info(
 
     try:
         folder = (
-            service.files()
+            service.files()  # ty: ignore[unresolved-attribute]
             .get(
                 fileId=folder_id,
                 fields="name, parents",
@@ -91,7 +91,11 @@ def _get_drive_name(service: GoogleDriveService, drive_id: str) -> str:
         return _folder_cache[cache_key][0]
 
     try:
-        drive = service.drives().get(driveId=drive_id).execute()
+        drive = (
+            service.drives()  # ty: ignore[unresolved-attribute]
+            .get(driveId=drive_id)
+            .execute()
+        )
         drive_name = drive.get("name", f"Shared Drive {drive_id}")
         _folder_cache[cache_key] = (drive_name, None)
         return drive_name
@@ -258,7 +262,9 @@ def download_request(
     """
     # For other file types, download the file
     # Use the correct API call for downloading files
-    request = service.files().get_media(fileId=file_id)
+    request = service.files().get_media(  # ty: ignore[unresolved-attribute]
+        fileId=file_id
+    )
     return _download_request(request, file_id, size_threshold)
 
 
@@ -331,7 +337,7 @@ def _download_and_extract_sections_basic(
     # For Google Docs, Sheets, and Slides, export via the Drive API
     if mime_type in GOOGLE_MIME_TYPES_TO_EXPORT:
         export_mime_type = GOOGLE_MIME_TYPES_TO_EXPORT[mime_type]
-        request = service.files().export_media(
+        request = service.files().export_media(  # ty: ignore[unresolved-attribute]
             fileId=file_id, mimeType=export_mime_type
         )
         response = _download_request(request, file_id, size_threshold)
@@ -455,7 +461,9 @@ def align_basic_advanced(
     for adv_ind in range(1, len(adv_sections)):
         heading = adv_sections[adv_ind].text.split(HEADING_DELIMITER)[0]
         # retrieve the longest part of the heading that is not a smart chip
-        heading_key = max(heading.split(SMART_CHIP_CHAR), key=len).strip()
+        heading_key = max(  # ty: ignore[unresolved-attribute]
+            heading.split(SMART_CHIP_CHAR), key=len
+        ).strip()
         if heading_key == "":
             logger.warning(
                 f"Cannot match heading: {heading}, its link will come from the following section"

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -7,9 +7,9 @@ from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
-from googleapiclient.discovery import Resource  # type: ignore
-from googleapiclient.errors import HttpError  # type: ignore
-from googleapiclient.http import BatchHttpRequest  # type: ignore
+from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
+from googleapiclient.http import BatchHttpRequest
 
 from onyx.access.models import ExternalAccess
 from onyx.connectors.google_drive.constants import DRIVE_FOLDER_TYPE
@@ -115,7 +115,7 @@ def _get_folders_in_parent(
         query += f" and '{parent_id}' in parents"
 
     for file in execute_paginated_retrieval(
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         list_key="files",
         continue_on_404_or_403=True,
         corpora="allDrives",
@@ -136,7 +136,7 @@ def get_folder_metadata(
     fields = _get_hierarchy_fields_for_file_type(field_type)
     try:
         return (
-            service.files()
+            service.files()  # ty: ignore[unresolved-attribute]
             .get(
                 fileId=folder_id,
                 fields=fields,
@@ -169,7 +169,11 @@ def get_shared_drive_name(
     folders. Only drives().get() returns the real user-assigned name.
     """
     try:
-        drive = service.drives().get(driveId=drive_id, fields="name").execute()
+        drive = (
+            service.drives()  # ty: ignore[unresolved-attribute]
+            .get(driveId=drive_id, fields="name")
+            .execute()
+        )
         return drive.get("name")
     except HttpError as e:
         if e.resp.status in (403, 404):
@@ -261,7 +265,7 @@ def _get_files_in_parent(
     kwargs = {ORDER_BY_KEY: GoogleFields.MODIFIED_TIME.value}
 
     for file in execute_paginated_retrieval(
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         list_key="files",
         continue_on_404_or_403=True,
         corpora="allDrives",
@@ -371,7 +375,7 @@ def get_files_in_shared_drive(
         folder_query = f"mimeType = '{DRIVE_FOLDER_TYPE}'"
         folder_query += " and trashed = false"
         for folder in execute_paginated_retrieval(
-            retrieval_function=service.files().list,
+            retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
             list_key="files",
             continue_on_404_or_403=True,
             corpora="drive",
@@ -389,7 +393,7 @@ def get_files_in_shared_drive(
     file_query += generate_time_range_filter(start, end)
 
     for file in execute_paginated_retrieval_with_max_pages(
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         max_num_pages=max_num_pages,
         list_key="files",
         continue_on_404_or_403=True,
@@ -436,7 +440,7 @@ def get_all_files_in_my_drive_and_shared(
             folder_query += " and 'me' in owners"
         found_folders = False
         for folder in execute_paginated_retrieval(
-            retrieval_function=service.files().list,
+            retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
             list_key="files",
             corpora="user",
             fields=_get_fields_for_file_type(field_type),
@@ -454,7 +458,7 @@ def get_all_files_in_my_drive_and_shared(
         file_query += " and 'me' in owners"
     file_query += generate_time_range_filter(start, end)
     yield from execute_paginated_retrieval_with_max_pages(
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         max_num_pages=max_num_pages,
         list_key="files",
         continue_on_404_or_403=False,
@@ -499,7 +503,7 @@ def get_all_files_for_oauth(
 
     yield from execute_paginated_retrieval_with_max_pages(
         max_num_pages=max_num_pages,
-        retrieval_function=service.files().list,
+        retrieval_function=service.files().list,  # ty: ignore[unresolved-attribute]
         list_key="files",
         continue_on_404_or_403=False,
         corpora=corpora,
@@ -516,7 +520,7 @@ def get_root_folder_id(service: Resource) -> str:
     # we dont paginate here because there is only one root folder per user
     # https://developers.google.com/drive/api/guides/v2-to-v3-reference
     return (
-        service.files()
+        service.files()  # ty: ignore[unresolved-attribute]
         .get(fileId="root", fields=GoogleFields.ID.value)
         .execute()[GoogleFields.ID.value]
     )
@@ -550,7 +554,7 @@ def get_file_by_web_view_link(
     """Retrieve a Google Drive file using its webViewLink."""
     file_id = _extract_file_id_from_web_view_link(web_view_link)
     return (
-        service.files()
+        service.files()  # ty: ignore[unresolved-attribute]
         .get(
             fileId=file_id,
             supportsAllDrives=True,
@@ -612,12 +616,17 @@ def _get_files_by_web_view_links_batch(
         else:
             result.files[request_id] = response
 
-    batch = cast(BatchHttpRequest, service.new_batch_http_request(callback=callback))
+    batch = cast(
+        BatchHttpRequest,
+        service.new_batch_http_request(  # ty: ignore[unresolved-attribute]
+            callback=callback
+        ),
+    )
 
     for web_view_link in web_view_links:
         try:
             file_id = _extract_file_id_from_web_view_link(web_view_link)
-            request = service.files().get(
+            request = service.files().get(  # ty: ignore[unresolved-attribute]
                 fileId=file_id,
                 supportsAllDrives=True,
                 fields=fields,

--- a/backend/onyx/connectors/google_drive/models.py
+++ b/backend/onyx/connectors/google_drive/models.py
@@ -199,7 +199,7 @@ class GoogleDriveCheckpoint(ConnectorCheckpoint):
         if isinstance(v, set):
             return ThreadSafeSet(v)
         if isinstance(v, list):
-            return ThreadSafeSet(set(v))
+            return ThreadSafeSet(set(v))  # ty: ignore[invalid-return-type]
         return ThreadSafeSet()
 
     @field_validator("fully_walked_hierarchy_node_raw_ids", mode="before")
@@ -209,5 +209,5 @@ class GoogleDriveCheckpoint(ConnectorCheckpoint):
         if isinstance(v, set):
             return ThreadSafeSet(v)
         if isinstance(v, list):
-            return ThreadSafeSet(set(v))
+            return ThreadSafeSet(set(v))  # ty: ignore[invalid-return-type]
         return ThreadSafeSet()

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -85,7 +85,9 @@ def get_document_sections(
 ) -> list[TextSection]:
     """Extracts sections from a Google Doc, including their headings and content"""
     # Fetch the document structure
-    http_request = docs_service.documents().get(documentId=doc_id)
+    http_request = docs_service.documents().get(  # ty: ignore[unresolved-attribute]
+        documentId=doc_id
+    )
 
     # Google has poor support for tabs in the docs api, see
     # https://cloud.google.com/python/docs/reference/cloudtasks/

--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -6,7 +6,7 @@ from urllib.parse import ParseResult
 from urllib.parse import urlparse
 
 from google.oauth2.credentials import Credentials as OAuthCredentials
-from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+from google_auth_oauthlib.flow import InstalledAppFlow
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import WEB_DOMAIN
@@ -63,7 +63,7 @@ def _load_google_json(raw: object) -> dict[str, Any]:
     ``str`` branch can be removed.
     """
     if isinstance(raw, dict):
-        return raw
+        return raw  # ty: ignore[invalid-return-type]
     if isinstance(raw, str):
         return json.loads(raw)
     raise ValueError(f"Unexpected Google credential payload type: {type(raw)!r}")
@@ -82,7 +82,7 @@ def _get_current_oauth_user(creds: OAuthCredentials, source: DocumentSource) -> 
     if source == DocumentSource.GOOGLE_DRIVE:
         drive_service = get_drive_service(creds)
         user_info = (
-            drive_service.about()
+            drive_service.about()  # ty: ignore[unresolved-attribute]
             .get(
                 fields="user(emailAddress)",
             )
@@ -92,7 +92,7 @@ def _get_current_oauth_user(creds: OAuthCredentials, source: DocumentSource) -> 
     elif source == DocumentSource.GMAIL:
         gmail_service = get_gmail_service(creds)
         user_info = (
-            gmail_service.users()
+            gmail_service.users()  # ty: ignore[unresolved-attribute]
             .getProfile(
                 userId="me",
                 fields="emailAddress",

--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -8,7 +8,7 @@ from datetime import timezone
 from enum import Enum
 from typing import Any
 
-from googleapiclient.errors import HttpError  # type: ignore
+from googleapiclient.errors import HttpError
 
 from onyx.connectors.google_drive.models import GoogleDriveFileType
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/connectors/google_utils/resources.py
+++ b/backend/onyx/connectors/google_utils/resources.py
@@ -4,7 +4,7 @@ from typing import Any
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-from googleapiclient.discovery import build  # type: ignore[import-untyped]
+from googleapiclient.discovery import build
 from googleapiclient.discovery import Resource
 
 from onyx.utils.logger import setup_logger
@@ -99,25 +99,33 @@ def get_google_docs_service(
     creds: ServiceAccountCredentials | OAuthCredentials,
     user_email: str | None = None,
 ) -> GoogleDocsService:
-    return _get_google_service("docs", "v1", creds, user_email)
+    return _get_google_service(  # ty: ignore[invalid-return-type]
+        "docs", "v1", creds, user_email
+    )
 
 
 def get_drive_service(
     creds: ServiceAccountCredentials | OAuthCredentials,
     user_email: str | None = None,
 ) -> GoogleDriveService:
-    return _get_google_service("drive", "v3", creds, user_email)
+    return _get_google_service(  # ty: ignore[invalid-return-type]
+        "drive", "v3", creds, user_email
+    )
 
 
 def get_admin_service(
     creds: ServiceAccountCredentials | OAuthCredentials,
     user_email: str | None = None,
 ) -> AdminService:
-    return _get_google_service("admin", "directory_v1", creds, user_email)
+    return _get_google_service(  # ty: ignore[invalid-return-type]
+        "admin", "directory_v1", creds, user_email
+    )
 
 
 def get_gmail_service(
     creds: ServiceAccountCredentials | OAuthCredentials,
     user_email: str | None = None,
 ) -> GmailService:
-    return _get_google_service("gmail", "v1", creds, user_email)
+    return _get_google_service(  # ty: ignore[invalid-return-type]
+        "gmail", "v1", creds, user_email
+    )

--- a/backend/onyx/connectors/highspot/connector.py
+++ b/backend/onyx/connectors/highspot/connector.py
@@ -244,12 +244,20 @@ class HighspotConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync)
                                     doc_batch = []
 
                             except HighspotClientError as e:
-                                item_id = "ID" if not item_id else item_id
+                                item_id = (
+                                    "ID"
+                                    if not item_id  # ty: ignore[possibly-unresolved-reference]
+                                    else item_id  # ty: ignore[possibly-unresolved-reference]
+                                )
                                 logger.error(
                                     f"Error retrieving item {item_id}: {str(e)}"
                                 )
                             except Exception as e:
-                                item_id = "ID" if not item_id else item_id
+                                item_id = (
+                                    "ID"
+                                    if not item_id  # ty: ignore[possibly-unresolved-reference]
+                                    else item_id  # ty: ignore[possibly-unresolved-reference]
+                                )
                                 logger.error(
                                     f"Unexpected error for item {item_id}: {str(e)}"
                                 )

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -8,7 +8,7 @@ from typing import cast
 from typing import TypeVar
 
 import requests
-from hubspot import HubSpot  # type: ignore
+from hubspot import HubSpot
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -98,8 +98,7 @@ class BaseConnector(abc.ABC, Generic[CT]):
         return NormalizationResult(normalized_url=None, use_default=True)
 
     def build_dummy_checkpoint(self) -> CT:
-        # TODO: find a way to make this work without type: ignore
-        return ConnectorCheckpoint(has_more=True)  # type: ignore
+        return ConnectorCheckpoint(has_more=True)  # ty: ignore[invalid-return-type]
 
 
 # Large set update or reindex, generally pulling a complete state or from a savestate file

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -184,13 +184,13 @@ def _handle_jira_search_error(e: Exception, jql: str) -> None:
         else:
             error_text = str(raw_text)
     elif hasattr(e, "response") and e.response is not None:
-        status_code = e.response.status_code
+        status_code = e.response.status_code  # ty: ignore[unresolved-attribute]
         # Try JSON first, fall back to text
         try:
-            error_json = e.response.json()
+            error_json = e.response.json()  # ty: ignore[unresolved-attribute]
             error_text = _format_error_text(error_json)
         except Exception:
-            error_text = e.response.text
+            error_text = e.response.text  # ty: ignore[unresolved-attribute]
 
     # Handle specific status codes
     if status_code == 400:
@@ -230,7 +230,9 @@ def enhanced_search_ids(
         "fields": "id",
     }
     try:
-        response = jira_client._session.get(enhanced_search_path, params=params)
+        response = jira_client._session.get(  # ty: ignore[unresolved-attribute]
+            enhanced_search_path, params=params
+        )
         response.raise_for_status()
         response_json = response.json()
     except Exception as e:
@@ -253,7 +255,9 @@ def _bulk_fetch_request(
     # to avoid reading unnecessary data
     payload["fields"] = fields.split(",") if fields else ["*all"]
 
-    resp = jira_client._session.post(bulk_fetch_path, json=payload)
+    resp = jira_client._session.post(  # ty: ignore[unresolved-attribute]
+        bulk_fetch_path, json=payload
+    )
     return resp.json()["issues"]
 
 
@@ -298,7 +302,11 @@ def bulk_fetch_issues(
             raise
 
     return [
-        Issue(jira_client._options, jira_client._session, raw=issue)
+        Issue(
+            jira_client._options,
+            jira_client._session,  # ty: ignore[invalid-argument-type]
+            raw=issue,
+        )
         for issue in raw_issues
     ]
 
@@ -415,18 +423,26 @@ def process_jira_issue(
     if creator is not None and (
         basic_expert_info := best_effort_basic_expert_info(creator)
     ):
-        people.add(basic_expert_info)
-        metadata_dict[_FIELD_REPORTER] = basic_expert_info.get_semantic_name()
-        if email := basic_expert_info.get_email():
+        people.add(basic_expert_info)  # ty: ignore[possibly-unresolved-reference]
+        metadata_dict[_FIELD_REPORTER] = (
+            basic_expert_info.get_semantic_name()  # ty: ignore[possibly-unresolved-reference]
+        )
+        if (
+            email := basic_expert_info.get_email()  # ty: ignore[possibly-unresolved-reference]
+        ):
             metadata_dict[_FIELD_REPORTER_EMAIL] = email
 
     assignee = best_effort_get_field_from_issue(issue, _FIELD_ASSIGNEE)
     if assignee is not None and (
         basic_expert_info := best_effort_basic_expert_info(assignee)
     ):
-        people.add(basic_expert_info)
-        metadata_dict[_FIELD_ASSIGNEE] = basic_expert_info.get_semantic_name()
-        if email := basic_expert_info.get_email():
+        people.add(basic_expert_info)  # ty: ignore[possibly-unresolved-reference]
+        metadata_dict[_FIELD_ASSIGNEE] = (
+            basic_expert_info.get_semantic_name()  # ty: ignore[possibly-unresolved-reference]
+        )
+        if (
+            email := basic_expert_info.get_email()  # ty: ignore[possibly-unresolved-reference]
+        ):
             metadata_dict[_FIELD_ASSIGNEE_EMAIL] = email
 
     metadata_dict[_FIELD_KEY] = issue.key
@@ -818,7 +834,7 @@ class JiraConnector(
                     # Add permission information to the document if requested
                     if include_permissions:
                         document.external_access = self._get_project_permissions(
-                            project_key,
+                            project_key,  # ty: ignore[invalid-argument-type]
                             add_prefix=True,  # Indexing path - prefix here
                         )
                     yield document

--- a/backend/onyx/connectors/loopio/connector.py
+++ b/backend/onyx/connectors/loopio/connector.py
@@ -5,7 +5,7 @@ from datetime import timezone
 from typing import Any
 
 from oauthlib.oauth2 import BackendApplicationClient
-from requests_oauthlib import OAuth2Session  # type: ignore
+from requests_oauthlib import OAuth2Session
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource

--- a/backend/onyx/connectors/mediawiki/family.py
+++ b/backend/onyx/connectors/mediawiki/family.py
@@ -9,10 +9,10 @@ from unittest import mock
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
-from pywikibot import family  # type: ignore[import-untyped]
+from pywikibot import family
 from pywikibot import pagegenerators
-from pywikibot.scripts import generate_family_file  # type: ignore[import-untyped]
-from pywikibot.scripts.generate_user_files import pywikibot  # type: ignore[import-untyped]
+from pywikibot.scripts import generate_family_file
+from pywikibot.scripts.generate_user_files import pywikibot
 
 from onyx.utils.logger import setup_logger
 
@@ -134,7 +134,7 @@ def family_class_dispatch(url: str, name: str) -> type[family.Family]:
 
     """
     if "wikipedia" in url:
-        import pywikibot.families.wikipedia_family  # type: ignore[import-untyped]
+        import pywikibot.families.wikipedia_family
 
         return pywikibot.families.wikipedia_family.Family
     # TODO: Support additional families pre-defined in `pywikibot.families.*_family.py` files
@@ -159,7 +159,9 @@ if __name__ == "__main__":
     all_pages = itertools.chain(
         pages,
         *[
-            pagegenerators.CategorizedPageGenerator(category, recurse=recursion_depth)
+            pagegenerators.CategorizedPageGenerator(
+                category, recurse=recursion_depth  # ty: ignore[invalid-argument-type]
+            )
             for category in categories
         ],
     )

--- a/backend/onyx/connectors/mediawiki/wiki.py
+++ b/backend/onyx/connectors/mediawiki/wiki.py
@@ -8,7 +8,7 @@ from typing import Any
 from typing import cast
 from typing import ClassVar
 
-import pywikibot.time  # type: ignore[import-untyped]
+import pywikibot.time
 from pywikibot import pagegenerators
 from pywikibot import textlib
 
@@ -46,7 +46,9 @@ def pywikibot_timestamp_to_utc_datetime(
 
 
 def get_doc_from_page(
-    page: pywikibot.Page, site: pywikibot.Site | None, source_type: DocumentSource
+    page: pywikibot.Page,
+    site: pywikibot.Site | None,  # ty: ignore[invalid-type-form]
+    source_type: DocumentSource,
 ) -> Document:
     """Generate Onyx Document from a MediaWiki page object.
 
@@ -178,7 +180,7 @@ class MediaWikiConnector(LoadConnector, PollConnector):
         # Pywikibot can handle batching for us, including only loading page contents when we finally request them.
         category_pages = [
             pagegenerators.PreloadingGenerator(
-                pagegenerators.EdittimeFilterPageGenerator(
+                pagegenerators.EdittimeFilterPageGenerator(  # ty: ignore[invalid-argument-type]
                     pagegenerators.CategorizedPageGenerator(
                         category, recurse=self.recurse_depth
                     ),

--- a/backend/onyx/connectors/microsoft_graph_env.py
+++ b/backend/onyx/connectors/microsoft_graph_env.py
@@ -11,7 +11,7 @@ resolves the matching ``AzureEnvironment`` value (and the implied SharePoint
 domain suffix) so callers can pass ``environment=…`` to ``GraphClient``.
 """
 
-from office365.graph_client import AzureEnvironment  # type: ignore[import-untyped]
+from office365.graph_client import AzureEnvironment
 from pydantic import BaseModel
 
 from onyx.connectors.exceptions import ConnectorValidationError

--- a/backend/onyx/connectors/salesforce/sqlite_functions.py
+++ b/backend/onyx/connectors/salesforce/sqlite_functions.py
@@ -73,7 +73,9 @@ class OnyxSalesforceSQLite:
 
         conn = sqlite3.connect(self.filename, timeout=60.0)
         if self.isolation_level is not None:
-            conn.isolation_level = self.isolation_level
+            conn.isolation_level = (  # ty: ignore[invalid-assignment]
+                self.isolation_level
+            )
 
         self._conn = conn
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -18,20 +18,20 @@ from urllib.parse import quote
 from urllib.parse import unquote
 from urllib.parse import urlsplit
 
-import msal  # type: ignore[import-untyped]
+import msal
 import requests
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
-from office365.graph_client import GraphClient  # type: ignore[import-untyped]
-from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore[import-untyped]
-from office365.onedrive.sites.site import Site  # type: ignore[import-untyped]
-from office365.onedrive.sites.sites_with_root import SitesWithRoot  # type: ignore[import-untyped]
-from office365.runtime.auth.token_response import TokenResponse  # type: ignore[import-untyped]
-from office365.runtime.client_request import ClientRequestException  # type: ignore
-from office365.runtime.paths.resource_path import ResourcePath  # type: ignore[import-untyped]
-from office365.runtime.queries.client_query import ClientQuery  # type: ignore[import-untyped]
-from office365.sharepoint.client_context import ClientContext  # type: ignore[import-untyped]
+from office365.graph_client import GraphClient
+from office365.onedrive.driveitems.driveItem import DriveItem
+from office365.onedrive.sites.site import Site
+from office365.onedrive.sites.sites_with_root import SitesWithRoot
+from office365.runtime.auth.token_response import TokenResponse
+from office365.runtime.client_request import ClientRequestException
+from office365.runtime.paths.resource_path import ResourcePath
+from office365.runtime.queries.client_query import ClientQuery
+from office365.sharepoint.client_context import ClientContext
 from pydantic import BaseModel
 from pydantic import Field
 from requests.exceptions import HTTPError
@@ -263,7 +263,11 @@ def sleep_and_retry(
                 logger.warning(
                     f"Rate limit exceeded on {method_name}, attempt {attempt + 1}/{max_retries + 1}, sleeping and retrying"
                 )
-                retry_after = e.response.headers.get("Retry-After")
+                retry_after = (
+                    e.response.headers.get(  # ty: ignore[unresolved-attribute]
+                        "Retry-After"
+                    )
+                )
                 if retry_after:
                     sleep_time = int(retry_after)
                 else:
@@ -829,7 +833,7 @@ def _convert_sitepage_to_document(
 
     if include_permissions:
         external_access = get_sharepoint_external_access(
-            ctx=ctx,
+            ctx=ctx,  # ty: ignore[invalid-argument-type]
             graph_client=graph_client,
             site_page=site_page,
             add_prefix=True,
@@ -897,7 +901,7 @@ def _convert_sitepage_to_slim_document(
         raise ValueError("Site page ID is required")
 
     external_access = get_sharepoint_external_access(
-        ctx=ctx,
+        ctx=ctx,  # ty: ignore[invalid-argument-type]
         graph_client=graph_client,
         site_page=site_page,
         treat_sharing_link_as_public=treat_sharing_link_as_public,

--- a/backend/onyx/connectors/sharepoint/connector_utils.py
+++ b/backend/onyx/connectors/sharepoint/connector_utils.py
@@ -1,8 +1,8 @@
 from typing import Any
 
-from office365.graph_client import GraphClient  # type: ignore[import-untyped]
-from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore[import-untyped]
-from office365.sharepoint.client_context import ClientContext  # type: ignore[import-untyped]
+from office365.graph_client import GraphClient
+from office365.onedrive.driveitems.driveItem import DriveItem
+from office365.sharepoint.client_context import ClientContext
 
 from onyx.connectors.models import ExternalAccess
 from onyx.utils.variable_functionality import (

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -995,7 +995,7 @@ class SlackConnector(
                     # Capture the current context so that the thread gets the current tenant ID
                     current_context = contextvars.copy_context()
                     futures.append(
-                        executor.submit(
+                        executor.submit(  # ty: ignore[invalid-argument-type]
                             current_context.run,
                             _process_message,
                             message=message,

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -6,12 +6,12 @@ from datetime import timezone
 from typing import Any
 from typing import cast
 
-import msal  # type: ignore
-from office365.graph_client import GraphClient  # type: ignore
-from office365.runtime.client_request_exception import ClientRequestException  # type: ignore
-from office365.runtime.http.request_options import RequestOptions  # type: ignore[import-untyped]
-from office365.teams.channels.channel import Channel  # type: ignore
-from office365.teams.team import Team  # type: ignore
+import msal
+from office365.graph_client import GraphClient
+from office365.runtime.client_request_exception import ClientRequestException
+from office365.runtime.http.request_options import RequestOptions
+from office365.teams.channels.channel import Channel
+from office365.teams.team import Team
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.exceptions import ConnectorValidationError
@@ -282,7 +282,7 @@ class TeamsConnector(
         start = start or 0
 
         teams = _collect_all_teams(
-            graph_client=self.graph_client,
+            graph_client=self.graph_client,  # ty: ignore[invalid-argument-type]
             requested=self.requested_team_list,
         )
 
@@ -305,11 +305,12 @@ class TeamsConnector(
                     continue
 
                 external_access = fetch_external_access(
-                    graph_client=self.graph_client, channel=channel
+                    graph_client=self.graph_client,  # ty: ignore[invalid-argument-type]
+                    channel=channel,
                 )
 
                 messages = fetch_messages(
-                    graph_client=self.graph_client,
+                    graph_client=self.graph_client,  # ty: ignore[invalid-argument-type]
                     team_id=team.id,
                     channel_id=channel.id,
                     start=start,

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from datetime import timezone
 from http import HTTPStatus
 
-from office365.graph_client import GraphClient  # type: ignore[import-untyped]
-from office365.teams.channels.channel import Channel  # type: ignore[import-untyped]
+from office365.graph_client import GraphClient
+from office365.teams.channels.channel import Channel
 from office365.teams.channels.channel import ConversationMember
 
 from onyx.access.models import ExternalAccess

--- a/backend/onyx/connectors/testrail/connector.py
+++ b/backend/onyx/connectors/testrail/connector.py
@@ -420,8 +420,12 @@ class TestRailConnector(LoadConnector, PollConnector):
         if isinstance(steps_separated, list) and steps_separated:
             rendered_steps: list[str] = []
             for idx, step_item in enumerate(steps_separated, start=1):
-                step_content = self._sanitize_rich_text(step_item.get("content"))
-                step_expected = self._sanitize_rich_text(step_item.get("expected"))
+                step_content = self._sanitize_rich_text(
+                    step_item.get("content")  # ty: ignore[unresolved-attribute]
+                )
+                step_expected = self._sanitize_rich_text(
+                    step_item.get("expected")  # ty: ignore[unresolved-attribute]
+                )
                 parts: list[str] = []
                 if step_content:
                     parts.append(f"Step {idx}: {step_content}")

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -18,7 +18,7 @@ from playwright.sync_api import BrowserContext
 from playwright.sync_api import Playwright
 from playwright.sync_api import sync_playwright
 from playwright.sync_api import TimeoutError
-from requests_oauthlib import OAuth2Session  # type:ignore
+from requests_oauthlib import OAuth2Session
 from urllib3.exceptions import MaxRetryError
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -429,7 +429,7 @@ def _handle_cookies(context: BrowserContext, url: str) -> None:
         # Add cookies to the context
         for cookie in cookies:
             try:
-                context.add_cookies([cookie])  # type: ignore
+                context.add_cookies([cookie])  # ty: ignore[invalid-argument-type]
             except Exception as e:
                 logger.debug(f"Failed to add cookie {cookie['name']} for {domain}: {e}")
     except Exception:

--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -127,7 +127,9 @@ def fetch_and_cache_channel_metadata(
                 response.validate()
 
                 # Cast response.data to dict for type checking
-                response_data: dict[str, Any] = response.data  # type: ignore
+                response_data: dict[str, Any] = (  # ty: ignore[invalid-assignment]
+                    response.data
+                )
                 for ch in response_data.get("channels", []):
                     channel_id = ch.get("id")
                     if not channel_id:
@@ -1267,8 +1269,10 @@ def slack_retrieval(
         for chunk in chunks:
             match_highlight = chunk.content
             for highlight in sorted_highlighted_texts:  # faster than re sub
-                match_highlight = match_highlight.replace(
-                    highlight, f"<hi>{highlight}</hi>"
+                match_highlight = (
+                    match_highlight.replace(  # ty: ignore[no-matching-overload]
+                        highlight, f"<hi>{highlight}</hi>"
+                    )
                 )
 
             # if nothing got replaced, the chunk is irrelevant

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -299,7 +299,7 @@ class SearchDoc(BaseModel):
             for item in items
         ]
 
-        return search_docs
+        return search_docs  # ty: ignore[invalid-return-type]
 
     # TODO - there is likely a way to clean this all up and not have the switch between these
     @classmethod
@@ -319,8 +319,12 @@ class SearchDoc(BaseModel):
             for saved_search_doc in saved_search_docs
         ]
 
-    def model_dump(self, *args: list, **kwargs: dict[str, Any]) -> dict[str, Any]:  # type: ignore
-        initial_dict = super().model_dump(*args, **kwargs)  # type: ignore
+    def model_dump(  # ty: ignore[invalid-method-override]
+        self, *args: list, **kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        initial_dict = super().model_dump(
+            *args, **kwargs  # ty: ignore[invalid-argument-type]
+        )
         initial_dict["updated_at"] = (
             self.updated_at.isoformat() if self.updated_at else None
         )

--- a/backend/onyx/context/search/retrieval/search_runner.py
+++ b/backend/onyx/context/search/retrieval/search_runner.py
@@ -208,7 +208,7 @@ def inference_sections_from_ids(
         chunks_by_doc_id.setdefault(chunk.document_id, []).append(chunk)
 
     inference_sections = [
-        section
+        section  # ty: ignore[possibly-unresolved-reference]
         for chunks in chunks_by_doc_id.values()
         if chunks
         and (

--- a/backend/onyx/db/_deprecated/pg_file_store.py
+++ b/backend/onyx/db/_deprecated/pg_file_store.py
@@ -16,7 +16,9 @@ logger = setup_logger()
 
 
 def get_pg_conn_from_session(db_session: Session) -> connection:
-    return db_session.connection().connection.connection  # type: ignore
+    return (
+        db_session.connection().connection.connection  # ty: ignore[unresolved-attribute]
+    )
 
 
 def create_populate_lobj(

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -139,7 +139,9 @@ def update_api_key(
 
     existing_api_key.name = api_key_args.name
     api_key_user = db_session.scalar(
-        select(User).where(User.id == existing_api_key.user_id)  # type: ignore
+        select(User).where(
+            User.id == existing_api_key.user_id  # ty: ignore[invalid-argument-type]
+        )
     )
     if api_key_user is None:
         raise RuntimeError("API Key does not have associated user.")
@@ -191,7 +193,9 @@ def regenerate_api_key(db_session: Session, api_key_id: int) -> ApiKeyDescriptor
         raise ValueError(f"API key with id {api_key_id} does not exist")
 
     api_key_user = db_session.scalar(
-        select(User).where(User.id == existing_api_key.user_id)  # type: ignore
+        select(User).where(
+            User.id == existing_api_key.user_id  # ty: ignore[invalid-argument-type]
+        )
     )
     if api_key_user is None:
         raise RuntimeError("API Key does not have associated user.")
@@ -220,7 +224,9 @@ def remove_api_key(db_session: Session, api_key_id: int) -> None:
         raise ValueError(f"API key with id {api_key_id} does not exist")
 
     user_associated_with_key = db_session.scalar(
-        select(User).where(User.id == existing_api_key.user_id)  # type: ignore
+        select(User).where(
+            User.id == existing_api_key.user_id  # ty: ignore[invalid-argument-type]
+        )
     )
     if user_associated_with_key is None:
         raise ValueError(

--- a/backend/onyx/db/auth.py
+++ b/backend/onyx/db/auth.py
@@ -55,11 +55,20 @@ def _add_live_user_count_where_clause(
     - System users (anonymous user, no-auth placeholder)
     - External permission users (unless only_admin_users is True)
     """
-    select_stmt = select_stmt.where(~User.email.endswith(get_api_key_email_pattern()))  # type: ignore
+    select_stmt = select_stmt.where(
+        ~User.email.endswith(
+            get_api_key_email_pattern()
+        )  # ty: ignore[invalid-argument-type]
+    )
 
     # Exclude system users (anonymous user, no-auth placeholder)
-    select_stmt = select_stmt.where(User.email != ANONYMOUS_USER_EMAIL)  # type: ignore
-    select_stmt = select_stmt.where(User.email != NO_AUTH_PLACEHOLDER_USER_EMAIL)  # type: ignore
+    select_stmt = select_stmt.where(
+        User.email != ANONYMOUS_USER_EMAIL  # ty: ignore[invalid-argument-type]
+    )
+    select_stmt = select_stmt.where(
+        User.email
+        != NO_AUTH_PLACEHOLDER_USER_EMAIL  # ty: ignore[invalid-argument-type]
+    )
 
     if only_admin_users:
         return select_stmt.where(User.role == UserRole.ADMIN)

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -305,7 +305,7 @@ def alter_credential(
         if credential.credential_json
         else {}
     )
-    credential.credential_json = {  # type: ignore[assignment]
+    credential.credential_json = {  # ty: ignore[invalid-assignment]
         **existing_json,
         **credential_json,
     }
@@ -327,7 +327,9 @@ def update_credential(
     if credential is None:
         return None
 
-    credential.credential_json = credential_data.credential_json  # type: ignore[assignment]
+    credential.credential_json = (  # ty: ignore[invalid-assignment]
+        credential_data.credential_json
+    )
     credential.user_id = user.id if user is not None else None
 
     db_session.commit()
@@ -346,7 +348,7 @@ def update_credential_json(
     if credential is None:
         return None
 
-    credential.credential_json = credential_json  # type: ignore[assignment]
+    credential.credential_json = credential_json  # ty: ignore[invalid-assignment]
     db_session.commit()
     # Expire to ensure credential_json is reloaded as SensitiveValue from DB
     db_session.expire(credential)
@@ -359,7 +361,7 @@ def backend_update_credential_json(
     db_session: Session,
 ) -> None:
     """This should not be used in any flows involving the frontend or users"""
-    credential.credential_json = credential_json  # type: ignore[assignment]
+    credential.credential_json = credential_json  # ty: ignore[invalid-assignment]
     db_session.commit()
 
 

--- a/backend/onyx/db/discord_bot.py
+++ b/backend/onyx/db/discord_bot.py
@@ -62,7 +62,7 @@ def delete_discord_bot_config(db_session: Session) -> bool:
     """Delete the Discord bot config. Returns True if deleted."""
     result = db_session.execute(delete(DiscordBotConfig))
     db_session.flush()
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return result.rowcount > 0  # ty: ignore[unresolved-attribute]
 
 
 # === Discord Service API Key ===
@@ -147,7 +147,9 @@ def delete_discord_service_api_key(db_session: Session) -> bool:
 
     # Also delete the associated user
     api_key_user = db_session.scalar(
-        select(User).where(User.id == existing_key.user_id)  # type: ignore[arg-type]
+        select(User).where(
+            User.id == existing_key.user_id  # ty: ignore[invalid-argument-type]
+        )
     )
 
     db_session.delete(existing_key)
@@ -252,7 +254,7 @@ def delete_guild_config(
         delete(DiscordGuildConfig).where(DiscordGuildConfig.id == internal_id)
     )
     db_session.flush()
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return result.rowcount > 0  # ty: ignore[unresolved-attribute]
 
 
 # === DiscordChannelConfig ===
@@ -334,7 +336,7 @@ def delete_discord_channel_config(
         )
     )
     db_session.flush()
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return result.rowcount > 0  # ty: ignore[unresolved-attribute]
 
 
 def create_channel_config(

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -500,7 +500,7 @@ def get_document_connector_counts(
         .where(DocumentByConnectorCredentialPair.id.in_(document_ids))
         .group_by(DocumentByConnectorCredentialPair.id)
     )
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def get_document_counts_for_cc_pairs(
@@ -572,7 +572,7 @@ def get_document_counts_for_all_cc_pairs(
             DocumentByConnectorCredentialPair.credential_id,
         )
     )
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def get_access_info_for_document(
@@ -643,7 +643,7 @@ def get_access_info_for_documents(
         .where(ConnectorCredentialPair.status != ConnectorCredentialPairStatus.DELETING)
         .group_by(DocumentByConnectorCredentialPair.id)
     )
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def upsert_documents(
@@ -1371,7 +1371,11 @@ def reset_all_document_kg_stages(db_session: Session) -> int:
 
     # The hasattr check is needed for type checking, even though rowcount
     # is guaranteed to exist at runtime for UPDATE operations
-    return result.rowcount if hasattr(result, "rowcount") else 0
+    return (
+        result.rowcount  # ty: ignore[invalid-return-type]
+        if hasattr(result, "rowcount")
+        else 0
+    )
 
 
 def update_document_kg_stages(
@@ -1394,7 +1398,11 @@ def update_document_kg_stages(
     result = db_session.execute(stmt)
     # The hasattr check is needed for type checking, even though rowcount
     # is guaranteed to exist at runtime for UPDATE operations
-    return result.rowcount if hasattr(result, "rowcount") else 0
+    return (
+        result.rowcount  # ty: ignore[invalid-return-type]
+        if hasattr(result, "rowcount")
+        else 0
+    )
 
 
 def get_skipped_kg_documents(db_session: Session) -> list[str]:

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -488,7 +488,7 @@ def delete_document_set_cc_pair_relationship__no_commit(
         )
     )
     result = db_session.execute(delete_stmt)
-    return result.rowcount  # type: ignore
+    return result.rowcount  # ty: ignore[unresolved-attribute]
 
 
 def fetch_document_sets(
@@ -748,7 +748,7 @@ def fetch_document_sets_for_documents(
         .where(Document.id.in_(document_ids))
         .group_by(Document.id)
     )
-    return db_session.execute(stmt).all()  # type: ignore
+    return db_session.execute(stmt).all()  # ty: ignore[invalid-return-type]
 
 
 def get_or_create_document_set_by_name(
@@ -795,7 +795,7 @@ def check_document_sets_are_public(
         db_session.query(ConnectorCredentialPair.id)
         .filter(
             ConnectorCredentialPair.id.in_(
-                connector_credential_pair_ids  # type:ignore
+                connector_credential_pair_ids  # ty: ignore[invalid-argument-type]
             ),
             ConnectorCredentialPair.access_type != AccessType.PUBLIC,
         )

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from typing import AsyncContextManager
 
-import asyncpg  # type: ignore
+import asyncpg
 from fastapi import HTTPException
 from sqlalchemy import event
 from sqlalchemy import pool
@@ -75,7 +75,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
         }
 
         if POSTGRES_USE_NULL_POOL:
-            engine_kwargs["poolclass"] = pool.NullPool
+            engine_kwargs["poolclass"] = pool.NullPool  # ty: ignore[invalid-assignment]
         else:
             engine_kwargs["pool_size"] = POSTGRES_API_SERVER_POOL_SIZE
             engine_kwargs["max_overflow"] = POSTGRES_API_SERVER_POOL_OVERFLOW

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -86,7 +86,7 @@ def build_connection_string(
 if LOG_POSTGRES_LATENCY:
 
     @event.listens_for(Engine, "before_cursor_execute")
-    def before_cursor_execute(  # type: ignore
+    def before_cursor_execute(
         conn,
         cursor,  # noqa: ARG001
         statement,  # noqa: ARG001
@@ -97,7 +97,7 @@ if LOG_POSTGRES_LATENCY:
         conn.info["query_start_time"] = time.time()
 
     @event.listens_for(Engine, "after_cursor_execute")
-    def after_cursor_execute(  # type: ignore
+    def after_cursor_execute(
         conn,
         cursor,  # noqa: ARG001
         statement,
@@ -117,7 +117,9 @@ if LOG_POSTGRES_CONN_COUNTS:
     checkin_count = 0
 
     @event.listens_for(Engine, "checkout")
-    def log_checkout(dbapi_connection, connection_record, connection_proxy):  # type: ignore  # noqa: ARG001
+    def log_checkout(
+        dbapi_connection, connection_record, connection_proxy  # noqa: ARG001
+    ):
         global checkout_count
         checkout_count += 1
 
@@ -133,7 +135,7 @@ if LOG_POSTGRES_CONN_COUNTS:
         )
 
     @event.listens_for(Engine, "checkin")
-    def log_checkin(dbapi_connection, connection_record):  # type: ignore  # noqa: ARG001
+    def log_checkin(dbapi_connection, connection_record):  # noqa: ARG001
         global checkin_count
         checkin_count += 1
         logger.debug(f"Total connection checkins: {checkin_count}")

--- a/backend/onyx/db/federated.py
+++ b/backend/onyx/db/federated.py
@@ -132,7 +132,7 @@ def update_federated_connector_oauth_token(
 
     if existing_token:
         # Update existing token
-        existing_token.token = token  # type: ignore[assignment]
+        existing_token.token = token  # ty: ignore[invalid-assignment]
         existing_token.expires_at = expires_at
         db_session.commit()
         return existing_token
@@ -307,7 +307,7 @@ def update_federated_connector(
             raise ValueError(
                 f"Invalid credentials for federated connector source: {federated_connector.source}"
             )
-        federated_connector.credentials = credentials  # type: ignore[assignment]
+        federated_connector.credentials = credentials  # ty: ignore[invalid-assignment]
 
     if config is not None:
         # Validate config using connector-specific validation

--- a/backend/onyx/db/file_content.py
+++ b/backend/onyx/db/file_content.py
@@ -46,7 +46,7 @@ def upsert_file_content(
     db_session.execute(stmt)
 
     # Return the merged ORM instance so callers can inspect the result
-    return db_session.get(FileContent, file_id)  # type: ignore[return-value]
+    return db_session.get(FileContent, file_id)  # ty: ignore[invalid-return-type]
 
 
 def transfer_file_content_file_id(

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -96,4 +96,4 @@ def upsert_filerecord(
     )
     db_session.execute(stmt)
 
-    return db_session.get(FileRecord, file_id)  # type: ignore[return-value]
+    return db_session.get(FileRecord, file_id)  # ty: ignore[invalid-return-type]

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -683,7 +683,7 @@ def remove_stale_hierarchy_node_cc_pair_entries(
             )
         )
 
-    result: CursorResult = db_session.execute(stmt)  # type: ignore[assignment]
+    result: CursorResult = db_session.execute(stmt)  # ty: ignore[invalid-assignment]
     deleted = result.rowcount
 
     if commit:

--- a/backend/onyx/db/hook.py
+++ b/backend/onyx/db/hook.py
@@ -151,7 +151,7 @@ def update_hook__no_commit(
     if not isinstance(endpoint_url, UnsetType):
         hook.endpoint_url = endpoint_url
     if not isinstance(api_key, UnsetType):
-        hook.api_key = api_key  # type: ignore[assignment]  # EncryptedString coerces str → SensitiveValue at the ORM level
+        hook.api_key = api_key  # EncryptedString coerces str → SensitiveValue at the ORM level  # ty: ignore[invalid-assignment]
     if fail_strategy is not None:
         hook.fail_strategy = fail_strategy
     if timeout_seconds is not None:
@@ -227,7 +227,7 @@ def cleanup_old_execution_logs__no_commit(
     cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         days=max_age_days
     )
-    result: CursorResult = db_session.execute(  # type: ignore[assignment]
+    result: CursorResult = db_session.execute(  # ty: ignore[invalid-assignment]
         delete(HookExecutionLog)
         .where(HookExecutionLog.created_at < cutoff)
         .execution_options(synchronize_session=False)

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -229,7 +229,7 @@ def transition_attempt_to_in_progress(
             )
 
         attempt.status = IndexingStatus.IN_PROGRESS
-        attempt.time_started = attempt.time_started or func.now()  # type: ignore
+        attempt.time_started = attempt.time_started or func.now()
         db_session.commit()
         return attempt
     except Exception:
@@ -250,7 +250,7 @@ def mark_attempt_in_progress(
         ).scalar_one()
 
         attempt.status = IndexingStatus.IN_PROGRESS
-        attempt.time_started = index_attempt.time_started or func.now()  # type: ignore
+        attempt.time_started = index_attempt.time_started or func.now()
         db_session.commit()
 
         # Add telemetry for index attempt status change

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -249,7 +249,9 @@ def upsert_llm_provider(
     api_base = llm_provider_upsert_request.api_base or None
     existing_llm_provider.provider = llm_provider_upsert_request.provider
     # EncryptedString accepts str for writes, returns SensitiveValue for reads
-    existing_llm_provider.api_key = llm_provider_upsert_request.api_key  # type: ignore[assignment]
+    existing_llm_provider.api_key = (  # ty: ignore[invalid-assignment]
+        llm_provider_upsert_request.api_key
+    )
     existing_llm_provider.api_base = api_base
     existing_llm_provider.api_version = llm_provider_upsert_request.api_version
     existing_llm_provider.custom_config = custom_config

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -81,7 +81,9 @@ def get_mcp_servers_accessible_to_user(
     user_id: UUID, db_session: Session
 ) -> list[MCPServer]:
     """Get all MCP servers accessible to a user (directly or through groups)"""
-    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    user = db_session.scalar(
+        select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+    )
     if not user:
         return []
     user = cast(User, user)
@@ -183,7 +185,9 @@ def get_all_mcp_tools_for_server(server_id: int, db_session: Session) -> list[To
 def add_user_to_mcp_server(server_id: int, user_id: UUID, db_session: Session) -> None:
     """Grant a user access to an MCP server"""
     server = get_mcp_server_by_id(server_id, db_session)
-    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    user = db_session.scalar(
+        select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+    )
     if not user:
         raise ValueError("User not found")
 
@@ -197,7 +201,9 @@ def remove_user_from_mcp_server(
 ) -> None:
     """Remove a user's access to an MCP server"""
     server = get_mcp_server_by_id(server_id, db_session)
-    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    user = db_session.scalar(
+        select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+    )
     if not user:
         raise ValueError("User not found")
 
@@ -287,7 +293,7 @@ def update_connection_config(
     config = get_connection_config_by_id(config_id, db_session)
 
     if config_data is not None:
-        config.config = config_data  # type: ignore[assignment]
+        config.config = config_data  # ty: ignore[invalid-assignment]
         # Force SQLAlchemy to detect the change by marking the field as modified
         flag_modified(config, "config")
 
@@ -305,7 +311,7 @@ def upsert_user_connection_config(
     existing_config = get_user_connection_config(server_id, user_email, db_session)
 
     if existing_config:
-        existing_config.config = config_data  # type: ignore[assignment]
+        existing_config.config = config_data  # ty: ignore[invalid-assignment]
         db_session.flush()  # Don't commit yet, let caller decide when to commit
         return existing_config
     else:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -181,8 +181,10 @@ class EncryptedString(_EncryptedBase):
             # Handle both raw strings and SensitiveValue wrappers
             if isinstance(value, SensitiveValue):
                 # Get raw value for storage
-                value = value.get_value(apply_mask=False)
-            return encrypt_string_to_bytes(value)
+                value = value.get_value(  # ty: ignore[invalid-assignment]
+                    apply_mask=False
+                )
+            return encrypt_string_to_bytes(value)  # ty: ignore[invalid-argument-type]
         return value
 
     def process_result_value(
@@ -210,7 +212,9 @@ class EncryptedJson(_EncryptedBase):
     ) -> bytes | None:
         if value is not None:
             if isinstance(value, SensitiveValue):
-                value = value.get_value(apply_mask=False)
+                value = value.get_value(  # ty: ignore[invalid-assignment]
+                    apply_mask=False
+                )
             json_str = json.dumps(value)
             return encrypt_string_to_bytes(json_str)
         return value
@@ -294,8 +298,8 @@ Auth/Authz (users, permissions, access) Tables
 
 class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
     # even an almost empty token from keycloak will not fit the default 1024 bytes
-    access_token: Mapped[str] = mapped_column(Text, nullable=False)  # type: ignore
-    refresh_token: Mapped[str] = mapped_column(Text, nullable=False)  # type: ignore
+    access_token: Mapped[str] = mapped_column(Text, nullable=False)
+    refresh_token: Mapped[str] = mapped_column(Text, nullable=False)
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -174,7 +174,11 @@ def batch_create_notifications(
 
     # rowcount returns number of rows inserted (excludes conflicts)
     # CursorResult has rowcount but session.execute type hints are too broad
-    return result.rowcount if result.rowcount >= 0 else 0  # type: ignore[attr-defined]
+    return (
+        result.rowcount  # ty: ignore[unresolved-attribute]
+        if result.rowcount >= 0  # ty: ignore[unresolved-attribute]
+        else 0
+    )
 
 
 def update_notification_last_shown(

--- a/backend/onyx/db/oauth_config.py
+++ b/backend/onyx/db/oauth_config.py
@@ -87,13 +87,13 @@ def update_oauth_config(
     if token_url is not None:
         oauth_config.token_url = token_url
     if clear_client_id:
-        oauth_config.client_id = ""  # type: ignore[assignment]
+        oauth_config.client_id = ""  # ty: ignore[invalid-assignment]
     elif client_id is not None:
-        oauth_config.client_id = client_id  # type: ignore[assignment]
+        oauth_config.client_id = client_id  # ty: ignore[invalid-assignment]
     if clear_client_secret:
-        oauth_config.client_secret = ""  # type: ignore[assignment]
+        oauth_config.client_secret = ""  # ty: ignore[invalid-assignment]
     elif client_secret is not None:
-        oauth_config.client_secret = client_secret  # type: ignore[assignment]
+        oauth_config.client_secret = client_secret  # ty: ignore[invalid-assignment]
     if scopes is not None:
         oauth_config.scopes = scopes
     if additional_params is not None:
@@ -154,7 +154,7 @@ def upsert_user_oauth_token(
 
     if existing_token:
         # Update existing token
-        existing_token.token_data = token_data  # type: ignore[assignment]
+        existing_token.token_data = token_data  # ty: ignore[invalid-assignment]
         db_session.commit()
         return existing_token
     else:

--- a/backend/onyx/db/pat.py
+++ b/backend/onyx/db/pat.py
@@ -41,7 +41,7 @@ async def fetch_user_for_pat(
         select(User)
         .join(PersonalAccessToken, PersonalAccessToken.user_id == User.id)
         .where(PersonalAccessToken.hashed_token == hashed_token)
-        .where(User.is_active)  # type: ignore
+        .where(User.is_active)  # ty: ignore[invalid-argument-type]
         .where(
             (PersonalAccessToken.expires_at.is_(None))
             | (PersonalAccessToken.expires_at > now)
@@ -95,7 +95,9 @@ def create_pat(
 
     Raises ValueError if user is inactive or not found.
     """
-    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    user = db_session.scalar(
+        select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+    )
     if not user or not user.is_active:
         raise ValueError("Cannot create PAT for inactive or non-existent user")
 

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -134,7 +134,7 @@ def mark_doc_permission_sync_attempt_in_progress(
             )
 
         attempt.status = PermissionSyncStatus.IN_PROGRESS
-        attempt.time_started = func.now()  # type: ignore
+        attempt.time_started = func.now()
         db_session.commit()
         return attempt
     except Exception:
@@ -157,9 +157,9 @@ def mark_doc_permission_sync_attempt_failed(
         ).scalar_one()
 
         if not attempt.time_started:
-            attempt.time_started = func.now()  # type: ignore
+            attempt.time_started = func.now()
         attempt.status = PermissionSyncStatus.FAILED
-        attempt.time_finished = func.now()  # type: ignore
+        attempt.time_finished = func.now()
         attempt.error_message = error_message
         db_session.commit()
 
@@ -217,7 +217,7 @@ def complete_doc_permission_sync_attempt(
         else:
             attempt.status = PermissionSyncStatus.SUCCESS
 
-        attempt.time_finished = func.now()  # type: ignore
+        attempt.time_finished = func.now()
         db_session.commit()
 
         # Add telemetry
@@ -341,7 +341,7 @@ def mark_external_group_sync_attempt_in_progress(
             )
 
         attempt.status = PermissionSyncStatus.IN_PROGRESS
-        attempt.time_started = func.now()  # type: ignore
+        attempt.time_started = func.now()
         db_session.commit()
         return attempt
     except Exception:
@@ -364,9 +364,9 @@ def mark_external_group_sync_attempt_failed(
         ).scalar_one()
 
         if not attempt.time_started:
-            attempt.time_started = func.now()  # type: ignore
+            attempt.time_started = func.now()
         attempt.status = PermissionSyncStatus.FAILED
-        attempt.time_finished = func.now()  # type: ignore
+        attempt.time_finished = func.now()
         attempt.error_message = error_message
         db_session.commit()
 
@@ -433,7 +433,7 @@ def complete_external_group_sync_attempt(
         else:
             attempt.status = PermissionSyncStatus.SUCCESS
 
-        attempt.time_finished = func.now()  # type: ignore
+        attempt.time_finished = func.now()
         db_session.commit()
 
         # Add telemetry

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -64,7 +64,7 @@ def recompute_user_permissions__no_commit(
     for uid, perms in perms_by_user.items():
         db_session.execute(
             update(User)
-            .where(User.id == uid)  # type: ignore[arg-type]
+            .where(User.id == uid)  # ty: ignore[invalid-argument-type]
             .values(effective_permissions=sorted(perms))
         )
 

--- a/backend/onyx/db/release_notes.py
+++ b/backend/onyx/db/release_notes.py
@@ -47,10 +47,14 @@ def create_release_notifications_for_versions(
     # Get active users and exclude API key users
     user_ids = list(
         db_session.scalars(
-            select(User.id).where(  # type: ignore
+            select(User.id).where(  # ty: ignore[no-matching-overload]
                 User.is_active == True,  # noqa: E712
                 User.account_type.notin_([AccountType.BOT, AccountType.EXT_PERM_USER]),
-                User.email.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN).is_(False),  # type: ignore[attr-defined]
+                User.email.endswith(
+                    DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+                ).is_(  # ty: ignore[unresolved-attribute]
+                    False
+                ),
             )
         ).all()
     )

--- a/backend/onyx/db/rotate_encryption_key.py
+++ b/backend/onyx/db/rotate_encryption_key.py
@@ -96,7 +96,7 @@ def rotate_encryption_key(
     totals: dict[str, int] = {}
 
     for model_cls, col_name, pk_names, is_json in encrypted_columns:
-        table_name: str = model_cls.__tablename__  # type: ignore[attr-defined]
+        table_name: str = model_cls.__tablename__  # ty: ignore[unresolved-attribute]
         col_attr = getattr(model_cls, col_name)
         pk_attrs = [getattr(model_cls, pk) for pk in pk_names]
 

--- a/backend/onyx/db/slack_bot.py
+++ b/backend/onyx/db/slack_bot.py
@@ -43,9 +43,9 @@ def update_slack_bot(
     # update the app
     slack_bot.name = name
     slack_bot.enabled = enabled
-    slack_bot.bot_token = bot_token  # type: ignore[assignment]
-    slack_bot.app_token = app_token  # type: ignore[assignment]
-    slack_bot.user_token = user_token  # type: ignore[assignment]
+    slack_bot.bot_token = bot_token  # ty: ignore[invalid-assignment]
+    slack_bot.app_token = app_token  # ty: ignore[invalid-assignment]
+    slack_bot.user_token = user_token  # ty: ignore[invalid-assignment]
 
     db_session.commit()
 

--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -127,7 +127,8 @@ def insert_slack_channel_config(
         existing_default = db_session.scalar(
             select(SlackChannelConfig).where(
                 SlackChannelConfig.slack_bot_id == slack_bot_id,
-                SlackChannelConfig.is_default is True,  # type: ignore
+                SlackChannelConfig.is_default  # ty: ignore[invalid-argument-type]
+                is True,
             )
         )
         if existing_default:

--- a/backend/onyx/db/sync_record.py
+++ b/backend/onyx/db/sync_record.py
@@ -138,7 +138,7 @@ def update_sync_record_status(
         sync_record.num_docs_synced = num_docs_synced
 
     if sync_status.is_terminal():
-        sync_record.sync_end_time = func.now()  # type: ignore
+        sync_record.sync_end_time = func.now()
 
     db_session.commit()
 

--- a/backend/onyx/db/tasks.py
+++ b/backend/onyx/db/tasks.py
@@ -128,7 +128,7 @@ def mark_task_start(
     if not task:
         raise ValueError(f"No task found with name {task_name}")
 
-    task.start_time = func.now()  # type: ignore
+    task.start_time = func.now()
     db_session.commit()
 
 

--- a/backend/onyx/db/user_preferences.py
+++ b/backend/onyx/db/user_preferences.py
@@ -121,7 +121,7 @@ def get_latest_access_token_for_user(
     try:
         result = db_session.execute(
             select(AccessToken)
-            .where(AccessToken.user_id == user_id)  # type: ignore
+            .where(AccessToken.user_id == user_id)  # ty: ignore[invalid-argument-type]
             .order_by(desc(Column("created_at")))
             .limit(1)
         )
@@ -139,7 +139,7 @@ def update_user_temperature_override_enabled(
     """Update user's temperature override enabled setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(temperature_override_enabled=temperature_override_enabled)
     )
     db_session.commit()
@@ -153,7 +153,7 @@ def update_user_shortcut_enabled(
     """Update user's shortcut enabled setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(shortcut_enabled=shortcut_enabled)
     )
     db_session.commit()
@@ -167,7 +167,7 @@ def update_user_auto_scroll(
     """Update user's auto scroll setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(auto_scroll=auto_scroll)
     )
     db_session.commit()
@@ -181,7 +181,7 @@ def update_user_default_model(
     """Update user's default model setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(default_model=default_model)
     )
     db_session.commit()
@@ -195,7 +195,7 @@ def update_user_theme_preference(
     """Update user's theme preference setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(theme_preference=theme_preference)
     )
     db_session.commit()
@@ -209,7 +209,7 @@ def update_user_chat_background(
     """Update user's chat background setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(chat_background=chat_background)
     )
     db_session.commit()
@@ -223,7 +223,7 @@ def update_user_default_app_mode(
     """Update user's default app mode setting."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(default_app_mode=default_app_mode)
     )
     db_session.commit()
@@ -242,7 +242,7 @@ def update_user_personalization(
 ) -> None:
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(
             personal_name=personal_name,
             personal_role=personal_role,
@@ -302,7 +302,7 @@ def update_user_pinned_assistants(
     """Update user's pinned assistants list."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(pinned_assistants=pinned_assistants)
     )
     db_session.commit()
@@ -318,7 +318,7 @@ def update_user_assistant_visibility(
     """Update user's assistant visibility settings."""
     db_session.execute(
         update(User)
-        .where(User.id == user_id)  # type: ignore
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(
             hidden_assistants=hidden_assistants,
             visible_assistants=visible_assistants,

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -141,14 +141,23 @@ def get_all_users(
     stmt = select(User)
 
     # Exclude system users (anonymous user, no-auth placeholder)
-    stmt = stmt.where(User.email != ANONYMOUS_USER_EMAIL)  # type: ignore
-    stmt = stmt.where(User.email != NO_AUTH_PLACEHOLDER_USER_EMAIL)  # type: ignore
+    stmt = stmt.where(
+        User.email != ANONYMOUS_USER_EMAIL  # ty: ignore[invalid-argument-type]
+    )
+    stmt = stmt.where(
+        User.email
+        != NO_AUTH_PLACEHOLDER_USER_EMAIL  # ty: ignore[invalid-argument-type]
+    )
 
     if not include_external:
         stmt = stmt.where(User.role != UserRole.EXT_PERM_USER)
 
     if email_filter_string is not None:
-        stmt = stmt.where(User.email.ilike(f"%{email_filter_string}%"))  # type: ignore
+        stmt = stmt.where(
+            User.email.ilike(  # ty: ignore[unresolved-attribute]
+                f"%{email_filter_string}%"
+            )
+        )
 
     return db_session.scalars(stmt).unique().all()
 
@@ -311,7 +320,11 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
 
 
 def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
-    return db_session.query(User).filter(User.id == user_id).first()  # type: ignore
+    return (
+        db_session.query(User)
+        .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .first()
+    )
 
 
 def _generate_slack_user(email: str) -> User:

--- a/backend/onyx/db/utils.py
+++ b/backend/onyx/db/utils.py
@@ -10,7 +10,10 @@ from onyx.db.models import Base
 
 
 def model_to_dict(model: Base) -> dict[str, Any]:
-    return {c.key: getattr(model, c.key) for c in inspect(model).mapper.column_attrs}  # type: ignore
+    return {
+        c.key: getattr(model, c.key)
+        for c in inspect(model).mapper.column_attrs  # ty: ignore[unresolved-attribute]
+    }
 
 
 RETRYABLE_PG_CODES = {

--- a/backend/onyx/db/voice.py
+++ b/backend/onyx/db/voice.py
@@ -94,7 +94,7 @@ def upsert_voice_provider(
 
     # Only update API key if explicitly changed or if provider has no key
     if api_key_changed or provider.api_key is None:
-        provider.api_key = api_key  # type: ignore[assignment]
+        provider.api_key = api_key  # ty: ignore[invalid-assignment]
 
     db_session.flush()
 
@@ -233,5 +233,9 @@ def update_user_voice_settings(
         )
 
     if values:
-        db_session.execute(update(User).where(User.id == user_id).values(**values))  # type: ignore[arg-type]
+        db_session.execute(
+            update(User)
+            .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+            .values(**values)
+        )
         db_session.flush()

--- a/backend/onyx/db/web_search.py
+++ b/backend/onyx/db/web_search.py
@@ -74,7 +74,7 @@ def _apply_search_provider_updates(
     provider.config = config
     if api_key_changed or provider.api_key is None:
         # EncryptedString accepts str for writes, returns SensitiveValue for reads
-        provider.api_key = api_key  # type: ignore[assignment]
+        provider.api_key = api_key  # ty: ignore[invalid-assignment]
 
 
 def upsert_web_search_provider(
@@ -230,7 +230,7 @@ def _apply_content_provider_updates(
     provider.config = config
     if api_key_changed or provider.api_key is None:
         # EncryptedString accepts str for writes, returns SensitiveValue for reads
-        provider.api_key = api_key  # type: ignore[assignment]
+        provider.api_key = api_key  # ty: ignore[invalid-assignment]
 
 
 def upsert_web_content_provider(

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -765,7 +765,7 @@ class DocumentQuery:
         if search_filters is not None:
             query["knn"][CONTENT_VECTOR_FIELD_NAME]["filter"] = {
                 "bool": {"filter": search_filters}
-            }
+            }  # ty: ignore[invalid-assignment]
 
         return query
 
@@ -962,7 +962,9 @@ class DocumentQuery:
                 acl_subclause: TermsQuery[str] = {
                     "terms": {ACCESS_CONTROL_LIST_FIELD_NAME: list(access_control_list)}
                 }
-                acl_visibility_filter["bool"]["should"].append(acl_subclause)
+                acl_visibility_filter["bool"]["should"].append(
+                    acl_subclause  # ty: ignore[invalid-argument-type]
+                )
             return acl_visibility_filter
 
         def _get_source_type_filter(

--- a/backend/onyx/document_index/vespa/indexing_utils.py
+++ b/backend/onyx/document_index/vespa/indexing_utils.py
@@ -390,7 +390,7 @@ class BaseHTTPXClientContext(ABC):
         pass
 
     @abstractmethod
-    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
+    def __exit__(self, exc_type, exc_value, traceback):
         pass
 
 
@@ -403,7 +403,7 @@ class GlobalHTTPXClientContext(BaseHTTPXClientContext):
     def __enter__(self) -> httpx.Client:
         return self._client  # Reuse the global client
 
-    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
+    def __exit__(self, exc_type, exc_value, traceback):
         pass  # Do nothing; don't close the global client
 
 
@@ -418,6 +418,6 @@ class TemporaryHTTPXClientContext(BaseHTTPXClientContext):
         self._client = self._client_factory()  # Create a new client
         return self._client
 
-    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
+    def __exit__(self, exc_type, exc_value, traceback):
         if self._client:
             self._client.close()

--- a/backend/onyx/evals/providers/braintrust.py
+++ b/backend/onyx/evals/providers/braintrust.py
@@ -150,7 +150,7 @@ class BraintrustEvalProvider(EvalProvider):
 
         metadata = configuration.model_dump()
 
-        Eval(  # type: ignore[misc]
+        Eval(
             name=project_name,
             experiment_name=experiment_name,
             data=eval_data,

--- a/backend/onyx/evals/providers/local.py
+++ b/backend/onyx/evals/providers/local.py
@@ -153,7 +153,11 @@ class LocalEvalProvider(EvalProvider):
         }
 
         message = eval_input.get("message", "(no message)")
-        truncated_message = message[:50] + "..." if len(message) > 50 else message
+        truncated_message = (
+            message[:50] + "..."  # ty: ignore[not-subscriptable]
+            if len(message) > 50  # ty: ignore[invalid-argument-type]
+            else message
+        )
 
         # Show model if specified
         model_info = ""

--- a/backend/onyx/federated_connectors/federated_retrieval.py
+++ b/backend/onyx/federated_connectors/federated_retrieval.py
@@ -255,11 +255,15 @@ def get_federated_retrieval_functions(
 
         connector = get_federated_connector(
             oauth_token.federated_connector.source,
-            oauth_token.federated_connector.credentials.get_value(apply_mask=False),
+            oauth_token.federated_connector.credentials.get_value(  # ty: ignore[unresolved-attribute]
+                apply_mask=False
+            ),
         )
 
         # Capture variables by value to avoid lambda closure issues
-        access_token = oauth_token.token.get_value(apply_mask=False)
+        access_token = oauth_token.token.get_value(  # ty: ignore[unresolved-attribute]
+            apply_mask=False
+        )
 
         def create_retrieval_function(
             conn: FederatedConnector,

--- a/backend/onyx/federated_connectors/slack/federated_connector.py
+++ b/backend/onyx/federated_connectors/slack/federated_connector.py
@@ -300,7 +300,9 @@ class SlackFederatedConnector(FederatedConnector):
             auth_response.validate()
 
             # Cast response.data to dict for type checking
-            auth_data: dict[str, Any] = auth_response.data  # type: ignore
+            auth_data: dict[str, Any] = (  # ty: ignore[invalid-assignment]
+                auth_response.data
+            )
             team_id = auth_data.get("team_id")
             logger.debug(f"Slack team_id: {team_id}")
         except Exception as e:

--- a/backend/onyx/file_processing/html_utils.py
+++ b/backend/onyx/file_processing/html_utils.py
@@ -54,8 +54,8 @@ def format_element_text(element_text: str, link_href: str | None) -> str:
 
 def parse_html_with_trafilatura(html_content: str) -> str:
     """Parse HTML content using trafilatura."""
-    import trafilatura  # type: ignore
-    from trafilatura.settings import use_config  # type: ignore
+    import trafilatura
+    from trafilatura.settings import use_config
 
     config = use_config()
     config.set("DEFAULT", "include_links", "True")

--- a/backend/onyx/file_processing/password_validation.py
+++ b/backend/onyx/file_processing/password_validation.py
@@ -62,7 +62,7 @@ def is_xlsx_protected(file: IO[Any]) -> bool:
 
 
 def is_office_file_protected(file: IO[Any]) -> bool:
-    import msoffcrypto  # type: ignore[import-untyped]
+    import msoffcrypto
 
     with preserve_position(file):
         office = msoffcrypto.OfficeFile(file)

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -276,7 +276,7 @@ class S3BackedFileStore(FileStore):
 
                 # For AWS S3, we need to handle region-specific bucket creation
                 region = (
-                    s3_client._client_config.region_name
+                    s3_client._client_config.region_name  # ty: ignore[unresolved-attribute]
                     if hasattr(s3_client, "_client_config")
                     else None
                 )

--- a/backend/onyx/key_value_store/interface.py
+++ b/backend/onyx/key_value_store/interface.py
@@ -13,7 +13,7 @@ def unwrap_str(val: JSON_ro) -> str:
     Also handles legacy plain-string values cached in Redis."""
     if isinstance(val, dict):
         try:
-            return cast(str, val["value"])
+            return cast(str, val["value"])  # ty: ignore[invalid-argument-type]
         except KeyError:
             raise ValueError(
                 f"Expected dict with 'value' key, got keys: {list(val.keys())}"

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -46,7 +46,7 @@ class PgRedisKVStore(KeyValueStore):
             obj = db_session.query(KVStore).filter_by(key=key).first()
             if obj:
                 obj.value = plain_val
-                obj.encrypted_value = encrypted_val  # type: ignore[assignment]
+                obj.encrypted_value = encrypted_val  # ty: ignore[invalid-assignment]
             else:
                 obj = KVStore(key=key, value=plain_val, encrypted_value=encrypted_val)
                 db_session.query(KVStore).filter_by(key=key).delete()  # just in case

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -591,7 +591,9 @@ def get_batch_documents_metadata(
     return batch_metadata
 
 
-def trackinfo_to_str(trackinfo: KGAttributeTrackInfo | None) -> str:
+def trackinfo_to_str(
+    trackinfo: KGAttributeTrackInfo | None,
+) -> str:  # ty: ignore[invalid-return-type]
     """Convert trackinfo to an LLM friendly string"""
     if trackinfo is None:
         return ""

--- a/backend/onyx/llm/litellm_singleton/config.py
+++ b/backend/onyx/llm/litellm_singleton/config.py
@@ -12,10 +12,10 @@ def configure_litellm_settings() -> None:
     # If a user configures a different model and it doesn't support all the same
     # parameters like frequency and presence, just ignore them
     litellm.drop_params = True
-    litellm.telemetry = False
+    litellm.telemetry = False  # ty: ignore[invalid-assignment]
     litellm.modify_params = True
     litellm.add_function_to_prompt = False
-    litellm.suppress_debug_info = True
+    litellm.suppress_debug_info = True  # ty: ignore[invalid-assignment]
 
 
 # TODO: We might not need to register ollama_chat in addition to ollama but let's just do it for good measure for now.

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -244,7 +244,9 @@ def _patch_ollama_chunk_parser() -> None:
         except Exception as e:
             raise e
 
-    OllamaChatCompletionResponseIterator.chunk_parser = _patched_chunk_parser  # type: ignore[method-assign]
+    OllamaChatCompletionResponseIterator.chunk_parser = (  # ty: ignore[invalid-assignment]
+        _patched_chunk_parser
+    )
 
 
 def _patch_openai_responses_parallel_tool_calls() -> None:
@@ -333,7 +335,9 @@ def _patch_openai_responses_parallel_tool_calls() -> None:
                     function=function_chunk,
                 )
                 if provider_specific_fields:
-                    tool_call_chunk.provider_specific_fields = provider_specific_fields  # type: ignore
+                    tool_call_chunk.provider_specific_fields = (  # ty: ignore[unresolved-attribute]
+                        provider_specific_fields
+                    )
 
                 return ModelResponseStream(
                     choices=[
@@ -402,7 +406,9 @@ def _patch_openai_responses_parallel_tool_calls() -> None:
                     function=function_chunk,
                 )
                 if provider_specific_fields:
-                    tool_call_chunk.provider_specific_fields = provider_specific_fields  # type: ignore
+                    tool_call_chunk.provider_specific_fields = (  # ty: ignore[unresolved-attribute]
+                        provider_specific_fields
+                    )
 
                 return ModelResponseStream(
                     choices=[
@@ -447,7 +453,9 @@ def _patch_openai_responses_parallel_tool_calls() -> None:
         )
 
     _patched_responses_chunk_parser.__name__ = "_patched_responses_chunk_parser"
-    OpenAiResponsesToChatCompletionStreamIterator.chunk_parser = _patched_responses_chunk_parser  # type: ignore[method-assign]
+    OpenAiResponsesToChatCompletionStreamIterator.chunk_parser = (  # ty: ignore[invalid-assignment]
+        _patched_responses_chunk_parser
+    )
 
 
 def _patch_openai_responses_transform_response() -> None:
@@ -547,13 +555,15 @@ def _patch_openai_responses_transform_response() -> None:
                                     if hasattr(choice, "message") and hasattr(
                                         choice.message, "reasoning_content"
                                     ):
-                                        choice.message.reasoning_content = combined_text
+                                        choice.message.reasoning_content = combined_text  # ty: ignore[invalid-assignment]
                     break  # Only process the first reasoning item
 
         return result
 
     _patched_transform_response.__name__ = "_patched_transform_response"
-    LiteLLMResponsesTransformationHandler.transform_response = _patched_transform_response  # type: ignore[method-assign]
+    LiteLLMResponsesTransformationHandler.transform_response = (  # ty: ignore[invalid-assignment]
+        _patched_transform_response
+    )
 
 
 def _patch_azure_responses_should_fake_stream() -> None:
@@ -587,7 +597,9 @@ def _patch_azure_responses_should_fake_stream() -> None:
         return False
 
     _patched_should_fake_stream.__name__ = "_patched_should_fake_stream"
-    AzureOpenAIResponsesAPIConfig.should_fake_stream = _patched_should_fake_stream  # type: ignore[method-assign]
+    AzureOpenAIResponsesAPIConfig.should_fake_stream = (  # ty: ignore[invalid-assignment]
+        _patched_should_fake_stream
+    )
 
 
 def _patch_responses_api_usage_format() -> None:
@@ -617,7 +629,7 @@ def _patch_responses_api_usage_format() -> None:
     if getattr(original_model_construct, "_is_patched", False):
         return
 
-    @classmethod  # type: ignore[misc]
+    @classmethod
     def _patched_model_construct(
         cls: Any,
         _fields_set: Optional[set[str]] = None,
@@ -649,10 +661,12 @@ def _patch_responses_api_usage_format() -> None:
                         )
 
         # Call original model_construct (need to call it as unbound method)
-        return original_model_construct.__func__(cls, _fields_set, **values)  # type: ignore[attr-defined]
+        return original_model_construct.__func__(cls, _fields_set, **values)
 
-    _patched_model_construct._is_patched = True  # type: ignore[attr-defined]
-    ResponsesAPIResponse.model_construct = _patched_model_construct  # type: ignore[method-assign, assignment]
+    _patched_model_construct._is_patched = True  # ty: ignore[unresolved-attribute]
+    ResponsesAPIResponse.model_construct = (  # ty: ignore[invalid-assignment]
+        _patched_model_construct
+    )
 
 
 def _patch_logging_assembled_streaming_response() -> None:
@@ -733,8 +747,12 @@ def _patch_logging_assembled_streaming_response() -> None:
         else:
             return None
 
-    _patched_get_assembled_streaming_response._is_patched = True  # type: ignore[attr-defined]
-    LiteLLMLoggingObj._get_assembled_streaming_response = _patched_get_assembled_streaming_response  # type: ignore[method-assign]
+    _patched_get_assembled_streaming_response._is_patched = (  # ty: ignore[unresolved-attribute]
+        True
+    )
+    LiteLLMLoggingObj._get_assembled_streaming_response = (  # ty: ignore[invalid-assignment]
+        _patched_get_assembled_streaming_response
+    )
 
 
 def _patch_responses_metadata_none() -> None:
@@ -771,7 +789,7 @@ def _patch_responses_metadata_none() -> None:
             kwargs["metadata"] = {}
         return original_responses(*args, **kwargs)
 
-    _patched_responses._metadata_patched = True  # type: ignore[attr-defined]
+    _patched_responses._metadata_patched = True  # ty: ignore[unresolved-attribute]
     _litellm.responses = _patched_responses
 
 

--- a/backend/onyx/llm/model_name_parser.py
+++ b/backend/onyx/llm/model_name_parser.py
@@ -112,8 +112,10 @@ def _infer_vendor_from_model_name(model_name: str) -> str | None:
 
         # Try to match against known prefixes (sorted by length to match longest first)
         for prefix in sorted(MODEL_PREFIX_TO_VENDOR.keys(), key=len, reverse=True):
-            if base_name.startswith(prefix):
-                return MODEL_PREFIX_TO_VENDOR[prefix]
+            if base_name.startswith(prefix):  # ty: ignore[invalid-argument-type]
+                return MODEL_PREFIX_TO_VENDOR[  # ty: ignore[invalid-argument-type]
+                    prefix
+                ]
     except Exception:
         pass
 

--- a/backend/onyx/llm/prompt_cache/cache_manager.py
+++ b/backend/onyx/llm/prompt_cache/cache_manager.py
@@ -170,10 +170,10 @@ def _make_json_serializable(obj: object) -> object:
     """
     if hasattr(obj, "model_dump"):
         # Pydantic v2 model
-        return obj.model_dump(mode="json")
+        return obj.model_dump(mode="json")  # ty: ignore[call-non-callable]
     elif hasattr(obj, "dict"):
         # Pydantic v1 model or similar
-        return _make_json_serializable(obj.dict())
+        return _make_json_serializable(obj.dict())  # ty: ignore[call-non-callable]
     elif isinstance(obj, dict):
         return {k: _make_json_serializable(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -208,9 +208,9 @@ def litellm_exception_to_error_msg(
             api_error = core_exception.api_error
             if isinstance(api_error, dict):
                 upstream_detail = (
-                    api_error.get("message")
-                    or api_error.get("detail")
-                    or api_error.get("error")
+                    api_error.get("message")  # ty: ignore[invalid-argument-type]
+                    or api_error.get("detail")  # ty: ignore[invalid-argument-type]
+                    or api_error.get("error")  # ty: ignore[invalid-argument-type]
                 )
         if not upstream_detail:
             upstream_detail = str(core_exception)

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -12,10 +12,10 @@ from types import TracebackType
 from typing import Any
 from typing import cast
 
-import aioboto3  # type: ignore
+import aioboto3
 import httpx
 import requests
-import voyageai  # type: ignore[import-untyped]
+import voyageai
 from cohere import AsyncClient as CohereAsyncClient
 from cohere.core.api_error import ApiError
 from google.oauth2 import service_account

--- a/backend/onyx/natural_language_processing/utils.py
+++ b/backend/onyx/natural_language_processing/utils.py
@@ -3,7 +3,7 @@ from abc import ABC
 from abc import abstractmethod
 from copy import copy
 
-from tokenizers import Encoding  # type: ignore[import-untyped]
+from tokenizers import Encoding
 from tokenizers import Tokenizer
 
 from onyx.configs.model_configs import DOCUMENT_ENCODER_MODEL

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import cast
 
 import pytz
-import timeago  # type: ignore
+import timeago
 from slack_sdk.models.blocks import ActionsBlock
 from slack_sdk.models.blocks import Block
 from slack_sdk.models.blocks import ButtonElement

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -63,7 +63,7 @@ def schedule_feedback_reminder(
     try:
         permalink = client.chat_getPermalink(
             channel=details.channel_to_respond,
-            message_ts=details.msg_to_respond,  # type:ignore
+            message_ts=details.msg_to_respond,  # ty: ignore[invalid-argument-type]
         )
     except SlackApiError as e:
         logger.error(f"Unable to generate the feedback reminder permalink: {e}")
@@ -74,18 +74,22 @@ def schedule_feedback_reminder(
 
     try:
         response = client.chat_scheduleMessage(
-            channel=details.sender_id,  # type:ignore
+            channel=details.sender_id,  # ty: ignore[invalid-argument-type]
             post_at=int(future.timestamp()),
             blocks=[
                 get_feedback_reminder_blocks(
-                    thread_link=permalink.data["permalink"],  # type:ignore
+                    thread_link=permalink.data[  # ty: ignore[invalid-argument-type]
+                        "permalink"
+                    ],
                     include_followup=include_followup,
                 )
             ],
             text="",
         )
         logger.info("Scheduled feedback reminder configured")
-        return response.data["scheduled_message_id"]  # type:ignore
+        return response.data[  # ty: ignore[invalid-argument-type]
+            "scheduled_message_id"
+        ]
     except SlackApiError as e:
         logger.error(f"Unable to generate the feedback reminder message: {e}")
         return None
@@ -98,7 +102,7 @@ def remove_scheduled_feedback_reminder(
 
     try:
         client.chat_deleteScheduledMessage(
-            channel=channel,  # type:ignore
+            channel=channel,  # ty: ignore[invalid-argument-type]
             scheduled_message_id=msg_id,
         )
         logger.info("Scheduled feedback reminder deleted")

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -520,7 +520,9 @@ class SlackbotHandler:
 
         # Append the event handler
         process_slack_event = create_process_slack_event()
-        socket_client.socket_mode_request_listeners.append(process_slack_event)  # type: ignore
+        socket_client.socket_mode_request_listeners.append(
+            process_slack_event  # ty: ignore[invalid-argument-type]
+        )
 
         # Establish a WebSocket connection to the Socket Mode servers
         # logger.debug(

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -451,7 +451,9 @@ def fetch_slack_user_ids_from_emails(
     for email in user_emails:
         try:
             user = client.users_lookupByEmail(email=email)
-            user_ids.append(user.data["user"]["id"])  # type: ignore
+            user_ids.append(
+                user.data["user"]["id"]  # ty: ignore[invalid-argument-type]
+            )
         except Exception:
             logger.error(f"Was not able to find slack user by email: {email}")
             failed_to_find.append(email)
@@ -612,7 +614,11 @@ def read_slack_thread(
                 # useful portion is
                 message = reply.get("text")
                 if not message:
-                    message = blocks[0].get("text", {}).get("text")
+                    message = (
+                        blocks[0]  # ty: ignore[possibly-unresolved-reference]
+                        .get("text", {})
+                        .get("text")
+                    )
 
             if not message:
                 logger.warning("Skipping Slack thread message, no text found")
@@ -633,7 +639,8 @@ def slack_usage_report(action: str, sender_id: str | None, client: WebClient) ->
     onyx_user = None
     sender_email = None
     try:
-        sender_email = client.users_info(user=sender_id).data["user"]["profile"]["email"]  # type: ignore
+        resp = client.users_info(user=sender_id)  # ty: ignore[invalid-argument-type]
+        sender_email = resp.data["user"]["profile"]["email"]  # type: ignore
     except Exception:
         logger.warning("Unable to find sender email")
 

--- a/backend/onyx/redis/redis_hierarchy.py
+++ b/backend/onyx/redis/redis_hierarchy.py
@@ -292,7 +292,9 @@ def is_cache_populated(redis_client: Redis, source: DocumentSource) -> bool:
     """Check if the cache has any entries for this source."""
     cache_key = _cache_key(source)
     # redis.exists returns int (number of keys that exist)
-    exists_result: int = redis_client.exists(cache_key)  # type: ignore[assignment]
+    exists_result: int = redis_client.exists(  # ty: ignore[invalid-assignment]
+        cache_key
+    )
     return exists_result > 0
 
 

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -479,7 +479,7 @@ def restore_session(
                             session_id=session_id,
                             snapshot_storage_path=snapshot.storage_path,
                             tenant_id=tenant_id,
-                            nextjs_port=session.nextjs_port,
+                            nextjs_port=session.nextjs_port,  # ty: ignore[invalid-argument-type]
                             llm_config=llm_config,
                             use_demo_data=session.demo_data_enabled,
                         )
@@ -498,7 +498,7 @@ def restore_session(
                         sandbox_id=sandbox.id,
                         session_id=session_id,
                         llm_config=llm_config,
-                        nextjs_port=session.nextjs_port,
+                        nextjs_port=session.nextjs_port,  # ty: ignore[invalid-argument-type]
                     )
                     session.status = BuildSessionStatus.ACTIVE
                     db_session.commit()

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
@@ -40,10 +40,10 @@ from acp.schema import Error
 from acp.schema import PromptResponse
 from acp.schema import ToolCallProgress
 from acp.schema import ToolCallStart
-from kubernetes import client  # type: ignore
+from kubernetes import client
 from kubernetes import config
-from kubernetes.stream import stream as k8s_stream  # type: ignore
-from kubernetes.stream.ws_client import WSClient  # type: ignore
+from kubernetes.stream import stream as k8s_stream
+from kubernetes.stream.ws_client import WSClient
 from pydantic import BaseModel
 from pydantic import ValidationError
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -51,10 +51,10 @@ from uuid import UUID
 from uuid import uuid4
 
 from acp.schema import PromptResponse
-from kubernetes import client  # type: ignore
+from kubernetes import client
 from kubernetes import config
-from kubernetes.client.rest import ApiException  # type: ignore
-from kubernetes.stream import stream as k8s_stream  # type: ignore
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream as k8s_stream
 
 from onyx.db.enums import SandboxStatus
 from onyx.server.features.build.api.packet_logger import get_packet_logger

--- a/backend/onyx/server/features/build/sandbox/local/test_agent_client.py
+++ b/backend/onyx/server/features/build/sandbox/local/test_agent_client.py
@@ -29,7 +29,7 @@ from acp.schema import ToolCallStart
 try:
     from onyx.server.features.build.sandbox.local.agent_client import ACPAgentClient
 except ImportError:
-    from agent_client import ACPAgentClient  # type: ignore
+    from agent_client import ACPAgentClient  # ty: ignore[unresolved-import]
 
 
 def test_with_opencode_acp(message: str, working_dir: str | None = None) -> None:

--- a/backend/onyx/server/features/build/sandbox/local/test_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/test_manager.py
@@ -96,7 +96,9 @@ def test_user(
     from sqlalchemy import select
 
     # Check if user already exists
-    stmt = select(User).where(User.email == TEST_USER_EMAIL)  # type: ignore[arg-type]
+    stmt = select(User).where(
+        User.email == TEST_USER_EMAIL  # ty: ignore[invalid-argument-type]
+    )
     existing_user = db_session.execute(stmt).unique().scalar_one_or_none()
 
     if existing_user:

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -207,8 +207,8 @@ def _list_session_directories(
     Returns:
         List of session ID strings (directory names)
     """
-    from kubernetes.client.rest import ApiException  # type: ignore
-    from kubernetes.stream import stream as k8s_stream  # type: ignore
+    from kubernetes.client.rest import ApiException
+    from kubernetes.stream import stream as k8s_stream
 
     pod_name = sandbox_manager._get_pod_name(str(sandbox_id))
 

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -1695,7 +1695,7 @@ class SessionManager:
             raise ValueError("Only markdown (.md) files can be exported as DOCX")
 
         import tempfile
-        import pypandoc  # type: ignore
+        import pypandoc
 
         md_text = content_bytes.decode("utf-8")
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -218,7 +218,9 @@ class OnyxTokenStorage(TokenStorage):
                         )
             return None
 
-    async def set_client_info(self, info: OAuthClientInformationFull) -> None:
+    async def set_client_info(  # ty: ignore[invalid-method-override]
+        self, info: OAuthClientInformationFull
+    ) -> None:
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -448,7 +448,7 @@ def bulk_invite_users(
     except (EmailUndeliverableError, EmailNotValidError) as e:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid email address: {email} - {str(e)}",
+            detail=f"Invalid email address: {email} - {str(e)}",  # ty: ignore[possibly-unresolved-reference]
         )
 
     # Count only new users (not already invited or existing) that need seats

--- a/backend/onyx/server/manage/voice/api.py
+++ b/backend/onyx/server/manage/voice/api.py
@@ -252,7 +252,7 @@ async def test_voice_provider(
         api_base=api_base,
         custom_config=request.custom_config or {},
     )
-    temp_provider.api_key = api_key  # type: ignore[assignment]
+    temp_provider.api_key = api_key  # ty: ignore[invalid-assignment]
 
     try:
         provider = get_voice_provider(temp_provider)

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -502,7 +502,7 @@ async def handle_streaming_synthesis(
                 logger.info("Streaming synthesis: client disconnected")
                 break
 
-            msg_type = message.get("type", "unknown")  # type: ignore[possibly-undefined]
+            msg_type = message.get("type", "unknown")
 
             if msg_type == "websocket.disconnect":
                 logger.info("Streaming synthesis: client disconnected")
@@ -650,7 +650,7 @@ async def handle_chunked_synthesis(
                 )
                 continue
 
-            msg_data_type = data.get("type")  # type: ignore[possibly-undefined]
+            msg_data_type = data.get("type")
             if msg_data_type == "synthesize":
                 text = data.get("text", "")
                 # Enforce per-text size limit

--- a/backend/onyx/server/metrics/indexing_pipeline.py
+++ b/backend/onyx/server/metrics/indexing_pipeline.py
@@ -208,7 +208,9 @@ class QueueDepthCollector(_CachedCollector):
         inaccurate, which is the safest behavior for alerting.
         """
         try:
-            raw: bytes | str | None = redis_client.lindex(queue_name, -1)  # type: ignore[assignment]
+            raw: bytes | str | None = redis_client.lindex(
+                queue_name, -1
+            )  # ty: ignore[invalid-assignment]
             if raw is None:
                 return None
             msg = json.loads(raw)
@@ -267,14 +269,18 @@ class RedisHealthCollector(_CachedCollector):
         )
 
         try:
-            mem_info: dict = redis_client.info("memory")  # type: ignore[assignment]
+            mem_info: dict = redis_client.info(  # ty: ignore[invalid-assignment]
+                "memory"
+            )
             memory_used.add_metric([], mem_info.get("used_memory", 0))
             memory_peak.add_metric([], mem_info.get("used_memory_peak", 0))
             frag = mem_info.get("mem_fragmentation_ratio")
             if frag is not None:
                 memory_frag.add_metric([], frag)
 
-            client_info: dict = redis_client.info("clients")  # type: ignore[assignment]
+            client_info: dict = redis_client.info(  # ty: ignore[invalid-assignment]
+                "clients"
+            )
             connected_clients.add_metric([], client_info.get("connected_clients", 0))
         except Exception:
             logger.debug("Failed to collect Redis health metrics", exc_info=True)

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -232,8 +232,12 @@ class ChatMessageDetail(BaseModel):
     preferred_response_id: int | None = None
     model_display_name: str | None = None
 
-    def model_dump(self, *args: list, **kwargs: dict[str, Any]) -> dict[str, Any]:  # type: ignore
-        initial_dict = super().model_dump(mode="json", *args, **kwargs)  # type: ignore
+    def model_dump(  # ty: ignore[invalid-method-override]
+        self, *args: list, **kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        initial_dict = super().model_dump(
+            mode="json", *args, **kwargs  # ty: ignore[invalid-argument-type]
+        )
         initial_dict["time_sent"] = self.time_sent.isoformat()
         return initial_dict
 

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -13,7 +13,7 @@ from fastapi import Response
 from fastapi import status
 from fastapi_users import exceptions
 from fastapi_users.authentication import Strategy
-from onelogin.saml2.auth import OneLogin_Saml2_Auth  # type: ignore
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from pydantic import BaseModel
 
 from onyx.auth.schemas import UserCreate

--- a/backend/onyx/server/utils.py
+++ b/backend/onyx/server/utils.py
@@ -17,7 +17,7 @@ class BasicAuthenticationError(HTTPException):
 class OnyxJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that converts datetime and UUID objects to strings."""
 
-    def default(self, obj: Any) -> Any:
+    def default(self, obj: Any) -> Any:  # ty: ignore[invalid-method-override]
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, UUID):

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -378,7 +378,9 @@ if __name__ == "__main__":
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Can you fetch assistant with ID 10"},
         ],
-        tools=[tool.tool_definition() for tool in tools],  # type: ignore
+        tools=[  # ty: ignore[invalid-argument-type]
+            tool.tool_definition() for tool in tools
+        ],
     )
     choice = response.choices[0]
     if choice.message.tool_calls:

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -148,7 +148,7 @@ def _create_mcp_client_function_runner(
                 read, write, _ = client_tuple
             elif len(client_tuple) == 2:
                 assert isinstance(client_tuple, tuple)  # mypy
-                read, write = client_tuple
+                read, write = client_tuple  # ty: ignore[invalid-assignment]
             else:
                 raise ValueError(
                     f"Unexpected number of client tuple elements: {len(client_tuple)}"
@@ -220,14 +220,20 @@ def process_mcp_result(call_tool_result: CallToolResult) -> str:
     parts = []
     for content_block in call_tool_result.content:
         if content_block.type == ContentBlockTypes.TEXT.value:
-            parts.append(content_block.text or "")
+            parts.append(content_block.text or "")  # ty: ignore[unresolved-attribute]
         if content_block.type == ContentBlockTypes.RESOURCE.value:
-            if isinstance(content_block.resource, TextResourceContents):
-                parts.append(content_block.resource.text or "")
+            if isinstance(
+                content_block.resource,  # ty: ignore[unresolved-attribute]
+                TextResourceContents,
+            ):
+                parts.append(
+                    content_block.resource.text  # ty: ignore[unresolved-attribute]
+                    or ""
+                )
             # TODO: handle blob resource content
         if content_block.type == ContentBlockTypes.RESOURCE_LINK.value:
             parts.append(
-                f"link: {content_block.uri} title: {content_block.title} description: {content_block.description}"
+                f"link: {content_block.uri} title: {content_block.title} description: {content_block.description}"  # ty: ignore[unresolved-attribute]
             )
         # TODO: handle other content block types
 

--- a/backend/onyx/tools/tool_implementations/open_url/snippet_matcher.py
+++ b/backend/onyx/tools/tool_implementations/open_url/snippet_matcher.py
@@ -171,7 +171,7 @@ def _normalize_text_with_mapping(text: str) -> tuple[str, list[int]]:
         # Check for HTML entities first (greedy match)
         for entity in sorted_entities:
             if text[i : i + len(entity)] == entity:
-                output = html_entities[entity]
+                output = html_entities[entity]  # ty: ignore[invalid-argument-type]
                 step = len(entity)
                 break
 

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -62,7 +62,7 @@ def convert_inference_sections_to_llm_string(
         if updated_at_str is not None:
             result["updated_at"] = updated_at_str
         if authors is not None:
-            result["authors"] = authors
+            result["authors"] = authors  # ty: ignore[invalid-assignment]
         if include_source_type:
             result["source_type"] = chunk.source_type.value
         if include_link:

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -217,39 +217,47 @@ class LangfuseTracingProcessor(TracingProcessor):
             # Create spans using trace_context (thread-safe ID-based approach)
             # In Langfuse SDK v3, use start_observation with as_type parameter
             if isinstance(data, GenerationSpanData):
-                langfuse_span = client.start_observation(  # type: ignore[call-overload]
-                    trace_context=trace_context,
-                    name=self._get_generation_name(data),
-                    as_type="generation",
-                    metadata=trace_metadata,
-                    model=data.model,
-                    model_parameters=self._get_model_parameters(data),
+                langfuse_span = (
+                    client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=self._get_generation_name(data),
+                        as_type="generation",
+                        metadata=trace_metadata,
+                        model=data.model,
+                        model_parameters=self._get_model_parameters(data),
+                    )
                 )
             elif isinstance(data, FunctionSpanData):
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="tool",
-                    metadata=trace_metadata,
+                langfuse_span = (
+                    client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="tool",
+                        metadata=trace_metadata,
+                    )
                 )
             elif isinstance(data, AgentSpanData):
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="agent",
-                    metadata={
-                        **(trace_metadata or {}),
-                        "tools": data.tools,
-                        "handoffs": data.handoffs,
-                        "output_type": data.output_type,
-                    },
+                langfuse_span = (
+                    client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="agent",
+                        metadata={
+                            **(trace_metadata or {}),
+                            "tools": data.tools,
+                            "handoffs": data.handoffs,
+                            "output_type": data.output_type,
+                        },
+                    )
                 )
             else:
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.type if hasattr(data, "type") else "unknown",
-                    as_type="span",
-                    metadata=trace_metadata,
+                langfuse_span = (
+                    client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.type if hasattr(data, "type") else "unknown",
+                        as_type="span",
+                        metadata=trace_metadata,
+                    )
                 )
 
             with self._lock:

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -114,7 +114,9 @@ def record_llm_span_output(
     elif isinstance(output, str):
         output_dict = {"role": "assistant", "content": output}
         if tool_calls:
-            output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+            output_dict["tool_calls"] = [  # ty: ignore[invalid-assignment]
+                tc.model_dump() for tc in tool_calls
+            ]
         span.span_data.output = [output_dict]
     else:
         span.span_data.output = cast(Sequence[Mapping[str, Any]], output)

--- a/backend/onyx/utils/jsonriver/parse.py
+++ b/backend/onyx/utils/jsonriver/parse.py
@@ -408,12 +408,12 @@ class _Parser:
         elif token_type == JsonTokenType.ArrayStart:
             array_state = _InArrayState()
             self._state_stack.append(array_state)
-            return array_state.value
+            return array_state.value  # ty: ignore[invalid-return-type]
 
         elif token_type == JsonTokenType.ObjectStart:
             object_state = _InObjectExpectingKeyState()
             self._state_stack.append(object_state)
-            return object_state.value
+            return object_state.value  # ty: ignore[invalid-return-type]
 
         else:
             raise ValueError(

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -228,7 +228,11 @@ def setup_logger(
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)
 
-    logger.notice = lambda msg, *args, **kwargs: logger.log(logging.getLevelName("NOTICE"), msg, *args, **kwargs)  # type: ignore
+    logger.notice = (  # type: ignore
+        lambda msg, *args, **kwargs: logger.log(
+            logging.getLevelName("NOTICE"), msg, *args, **kwargs
+        )
+    )
 
     # After handler configuration, disable propagation to avoid duplicate logs
     # Prevent messages from propagating to the root logger which can cause

--- a/backend/onyx/utils/object_size_check.py
+++ b/backend/onyx/utils/object_size_check.py
@@ -18,9 +18,13 @@ def deep_getsizeof(obj: T, seen: set[int] | None = None) -> int:
 
     if isinstance(obj, dict):
         size += sum(
-            deep_getsizeof(k, seen) + deep_getsizeof(v, seen) for k, v in obj.items()
+            deep_getsizeof(k, seen)  # ty: ignore[invalid-argument-type]
+            + deep_getsizeof(v, seen)  # ty: ignore[invalid-argument-type]
+            for k, v in obj.items()
         )
     elif isinstance(obj, (list, tuple, set, frozenset)):
-        size += sum(deep_getsizeof(i, seen) for i in obj)
+        size += sum(
+            deep_getsizeof(i, seen) for i in obj  # ty: ignore[invalid-argument-type]
+        )
 
     return size

--- a/backend/onyx/utils/sensitive.py
+++ b/backend/onyx/utils/sensitive.py
@@ -42,7 +42,7 @@ def make_mock_sensitive_value(value: dict[str, Any] | str | None) -> MagicMock:
         >>> # Now mock_credential.credential_json.get_value(apply_mask=False) returns {"api_key": "secret"}
     """
     if value is None:
-        return None  # type: ignore[return-value]
+        return None  # ty: ignore[invalid-return-type]
 
     mock = MagicMock(spec=SensitiveValue)
     mock.get_value.return_value = value
@@ -104,9 +104,9 @@ class SensitiveValue(Generic[T]):
             if self._is_json:
                 self._decrypted_value = json.loads(decrypted_str)
             else:
-                self._decrypted_value = decrypted_str  # type: ignore[assignment]
+                self._decrypted_value = decrypted_str  # ty: ignore[invalid-assignment]
         # The return type should always match T based on is_json flag
-        return self._decrypted_value  # type: ignore[return-value]
+        return self._decrypted_value  # ty: ignore[invalid-return-type]
 
     def get_value(
         self,
@@ -140,9 +140,9 @@ class SensitiveValue(Generic[T]):
         # Type narrowing doesn't work well here due to the generic T,
         # but at runtime the types will match
         if isinstance(value, dict):
-            return mask_credential_dict(value)
+            return mask_credential_dict(value)  # ty: ignore[invalid-return-type]
         elif isinstance(value, str):
-            return mask_string(value)
+            return mask_string(value)  # ty: ignore[invalid-return-type]
         else:
             raise ValueError(f"Cannot mask value of type {type(value)}")
 

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -124,7 +124,9 @@ class ThreadSafeDict(MutableMapping[KT, VT]):
                 return self._dict.pop(key)
             return self._dict.pop(key, default)
 
-    def setdefault(self, key: KT, default: VT) -> VT:
+    def setdefault(  # ty: ignore[invalid-method-override]
+        self, key: KT, default: VT
+    ) -> VT:
         """Set a default value if key is missing, atomically."""
         with self.lock:
             return self._dict.setdefault(key, default)
@@ -451,7 +453,7 @@ def run_async_sync_no_cancel(coro: Awaitable[T]) -> T:
     context = contextvars.copy_context()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future: concurrent.futures.Future[T] = executor.submit(
-            context.run,  # type: ignore[arg-type]
+            context.run,
             asyncio.run,
             coro,
         )
@@ -498,7 +500,7 @@ class TimeoutThread(threading.Thread, Generic[R]):
 
     def end(self) -> None:
         raise TimeoutError(
-            f"Function {self.func.__name__} timed out after {self.timeout} seconds"
+            f"Function {self.func.__name__} timed out after {self.timeout} seconds"  # ty: ignore[unresolved-attribute]
         )
 
 
@@ -567,10 +569,12 @@ def parallel_yield(gens: list[Iterator[R]], max_workers: int = 10) -> Iterator[R
     for some extra generator code to run and not have the result(s) yielded.
     """
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_index: dict[Future[tuple[int, R | None]], int] = {
-            executor.submit(_next_or_none, ind, gen): ind
-            for ind, gen in enumerate(gens)
-        }
+        future_to_index: dict[Future[tuple[int, R | None]], int] = (  # type: ignore
+            {
+                executor.submit(_next_or_none, ind, gen): ind
+                for ind, gen in enumerate(gens)
+            }
+        )
 
         next_ind = len(gens)
         while future_to_index:
@@ -580,7 +584,7 @@ def parallel_yield(gens: list[Iterator[R]], max_workers: int = 10) -> Iterator[R
                 if result is not None:
                     yield result
                     future_to_index[executor.submit(_next_or_none, ind, gens[ind])] = (
-                        next_ind
+                        next_ind  # ty: ignore[invalid-assignment]
                     )
                     next_ind += 1
                 del future_to_index[future]

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -137,7 +137,7 @@ def _validate_and_resolve_url(url: str) -> tuple[str, str, int]:
     if validated_ip is None:
         raise SSRFException(f"Could not resolve hostname '{hostname}'")
 
-    return validated_ip, hostname, port
+    return validated_ip, hostname, port  # ty: ignore[invalid-return-type]
 
 
 def validate_outbound_http_url(

--- a/backend/onyx/voice/factory.py
+++ b/backend/onyx/voice/factory.py
@@ -25,7 +25,7 @@ def get_voice_provider(provider: VoiceProvider) -> VoiceProviderInterface:
         api_key = provider.api_key.get_value(apply_mask=False)
     else:
         # Plain string from temporary model
-        api_key = provider.api_key  # type: ignore[assignment]
+        api_key = provider.api_key
     api_base = provider.api_base
     custom_config = provider.custom_config
     stt_model = provider.stt_model

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -86,7 +86,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
     async def connect(self) -> None:
         """Initialize Azure Speech recognizer with push stream."""
         try:
-            import azure.cognitiveservices.speech as speechsdk  # type: ignore
+            import azure.cognitiveservices.speech as speechsdk
         except ImportError as e:
             raise RuntimeError(
                 "Azure Speech SDK is required for streaming STT. Install `azure-cognitiveservices-speech`."
@@ -575,7 +575,7 @@ class AzureVoiceProvider(VoiceProviderInterface):
         """Azure supports real-time streaming TTS via Speech SDK."""
         return True
 
-    async def create_streaming_transcriber(
+    async def create_streaming_transcriber(  # ty: ignore[invalid-method-override]
         self, _audio_format: str = "webm"
     ) -> AzureStreamingTranscriber:
         """Create a streaming transcription session."""

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -830,7 +830,7 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
         """ElevenLabs supports real-time streaming TTS via WebSocket."""
         return True
 
-    async def create_streaming_transcriber(
+    async def create_streaming_transcriber(  # ty: ignore[invalid-method-override]
         self, _audio_format: str = "webm"
     ) -> ElevenLabsStreamingTranscriber:
         """Create a streaming transcription session."""

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -602,7 +602,7 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         """OpenAI supports real-time streaming TTS via Realtime API."""
         return True
 
-    async def create_streaming_transcriber(
+    async def create_streaming_transcriber(  # ty: ignore[invalid-method-override]
         self, _audio_format: str = "webm"
     ) -> OpenAIStreamingTranscriber:
         """Create a streaming transcription session using Realtime API."""

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -487,14 +487,10 @@ multidict==6.7.0
     #   yarl
 mwparserfromhell==0.7.2
     # via pywikibot
-mypy==1.13.0
-    # via sqlalchemy
 mypy-boto3-s3==1.39.5
     # via boto3-stubs
 mypy-extensions==1.0.0
-    # via
-    #   mypy
-    #   typing-inspect
+    # via typing-inspect
 nest-asyncio==1.6.0
 nltk==3.9.4
     # via unstructured
@@ -960,7 +956,6 @@ typing-extensions==4.15.0
     #   jira
     #   langchain-core
     #   mcp
-    #   mypy
     #   mypy-boto3-s3
     #   office365-rest-python-client
     #   openai

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -241,11 +241,8 @@ multidict==6.7.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-mypy==1.13.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
+    # via black
 nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.9.1
@@ -473,6 +470,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 trove-classifiers==2025.12.1.14
     # via hatchling
+ty==0.0.31
 typer==0.20.0
     # via huggingface-hub
 types-beautifulsoup4==4.12.0.3
@@ -504,7 +502,6 @@ typing-extensions==4.15.0
     #   huggingface-hub
     #   ipython
     #   mcp
-    #   mypy
     #   openai
     #   pydantic
     #   pydantic-core

--- a/backend/scripts/chat_feedback_dump.py
+++ b/backend/scripts/chat_feedback_dump.py
@@ -204,7 +204,7 @@ def process_all_chat_feedback(onyx_url: str, api_key: str | None) -> None:
             except requests.exceptions.HTTPError:
                 logger.exception("get_session_history failed.")
 
-            for m in s.messages:
+            for m in s.messages:  # ty: ignore[possibly-unresolved-reference]
                 logger.info(
                     f"user={user_id} "
                     f"session={session.id} "

--- a/backend/scripts/debugging/litellm/call_litellm.py
+++ b/backend/scripts/debugging/litellm/call_litellm.py
@@ -200,7 +200,9 @@ def _pretty_print_event(event: Any) -> str:
                 if isinstance(item, dict):
                     lines.append(f"{prefix}  [{i}]:")
                     for k, v in item.items():
-                        _format_value(k, v, indent + 2)
+                        _format_value(
+                            k, v, indent + 2  # ty: ignore[invalid-argument-type]
+                        )
                 else:
                     lines.append(f"{prefix}  [{i}]: {item}")
         else:

--- a/backend/scripts/debugging/opensearch/query_hierarchy_debug.py
+++ b/backend/scripts/debugging/opensearch/query_hierarchy_debug.py
@@ -30,7 +30,7 @@ except ImportError as e:
     sys.exit(1)
 
 
-def get_client() -> OpenSearch:
+def get_client() -> OpenSearch:  # ty: ignore[possibly-unresolved-reference]
     """Create OpenSearch client from environment variables."""
     host = os.environ.get("OPENSEARCH_HOST", "localhost")
     port = int(os.environ.get("OPENSEARCH_PORT", "9200"))
@@ -41,7 +41,11 @@ def get_client() -> OpenSearch:
     )
 
 
-def query_document(client: OpenSearch, index: str, doc_id: str) -> None:
+def query_document(
+    client: OpenSearch,  # ty: ignore[possibly-unresolved-reference]
+    index: str,
+    doc_id: str,
+) -> None:
     """Query a specific document and view its hierarchy ancestor node IDs."""
     query = {"query": {"term": {"document_id": doc_id}}, "size": 10}
 
@@ -68,7 +72,11 @@ def query_document(client: OpenSearch, index: str, doc_id: str) -> None:
         print()
 
 
-def list_with_hierarchy(client: OpenSearch, index: str, limit: int = 10) -> None:
+def list_with_hierarchy(
+    client: OpenSearch,  # ty: ignore[possibly-unresolved-reference]
+    index: str,
+    limit: int = 10,
+) -> None:
     """List documents that have hierarchy data."""
     query = {
         "query": {"exists": {"field": "ancestor_hierarchy_node_ids"}},
@@ -95,7 +103,9 @@ def list_with_hierarchy(client: OpenSearch, index: str, limit: int = 10) -> None
         print(f"    Ancestors: {ancestor_ids}\n")
 
 
-def list_indices(client: OpenSearch) -> None:
+def list_indices(
+    client: OpenSearch,  # ty: ignore[possibly-unresolved-reference]
+) -> None:
     """List available indices."""
     indices = client.indices.get_alias(index="*")
     print("Available indices:")

--- a/backend/scripts/get_wikidocs.py
+++ b/backend/scripts/get_wikidocs.py
@@ -12,8 +12,8 @@ import re
 import zipfile
 from pathlib import Path
 
-from datasets import load_dataset  # type: ignore
-from tqdm import tqdm  # type: ignore
+from datasets import load_dataset  # ty: ignore[unresolved-import]
+from tqdm import tqdm
 
 
 def sanitize_filename(title: str) -> str:
@@ -137,7 +137,9 @@ def stream_wikipedia_to_zips(
         print(f"\nCompleted: {zip_path} ({pages_in_current_zip} pages)")
 
     print(f"\nSuccessfully created {current_zip_index} zip file(s) in {output_dir}")
-    print(f"Total pages processed: {min(total_pages, idx + 1)}")
+    print(
+        f"Total pages processed: {min(total_pages, idx + 1)}"  # ty: ignore[possibly-unresolved-reference]
+    )
 
 
 def main() -> int:

--- a/backend/scripts/run_industryrag_bench_questions.py
+++ b/backend/scripts/run_industryrag_bench_questions.py
@@ -270,8 +270,10 @@ def extract_document_ids(citation_info: object) -> list[str]:
 def _is_valid_citation(citation: object) -> TypeGuard[Citation]:
     return (
         isinstance(citation, dict)
-        and isinstance(citation.get("document_id"), str)
-        and bool(citation["document_id"])
+        and isinstance(
+            citation.get("document_id"), str  # ty: ignore[invalid-argument-type]
+        )
+        and bool(citation["document_id"])  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/backend/scripts/test-openapi-key.py
+++ b/backend/scripts/test-openapi-key.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         ]
         response = client.chat.completions.create(
             model=model_version,
-            messages=messages,  # type:ignore
+            messages=messages,  # ty: ignore[invalid-argument-type]
             max_tokens=5,
             temperature=2,
         )

--- a/backend/scripts/upload_files_as_connectors.py
+++ b/backend/scripts/upload_files_as_connectors.py
@@ -41,7 +41,7 @@ def _timed_request(label: str, fn: object) -> requests.Response:
     t = threading.Thread(target=_elapsed_printer, args=(label, stop), daemon=True)
     t.start()
     try:
-        resp = fn()  # type: ignore[operator]
+        resp = fn()  # ty: ignore[call-non-callable]
     finally:
         stop.set()
         t.join()

--- a/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
@@ -19,13 +19,15 @@ class MockCredentialsProvider(CredentialsProviderInterface):
     def get_credentials(self) -> dict[str, str]:
         return {"confluence_access_token": "test_token"}
 
-    def set_credentials(self, credentials: dict[str, str]) -> None:
+    def set_credentials(  # ty: ignore[invalid-method-override]
+        self, credentials: dict[str, str]
+    ) -> None:
         pass
 
     def __enter__(self) -> "MockCredentialsProvider":
         return self
 
-    def __exit__(
+    def __exit__(  # ty: ignore[invalid-method-override]
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,

--- a/backend/tests/daily/connectors/file/test_file_connector.py
+++ b/backend/tests/daily/connectors/file/test_file_connector.py
@@ -71,8 +71,14 @@ def test_single_text_file_with_metadata(
     assert doc.sections[0].text == "Test answer is 12345"
     assert doc.sections[0].link == "https://onyx.app"
     assert doc.semantic_identifier == "my display name"
-    assert doc.primary_owners[0].display_name == "wenxi@onyx.app"  # type: ignore
-    assert doc.secondary_owners[0].display_name == "founders@onyx.app"  # type: ignore
+    assert (
+        doc.primary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "wenxi@onyx.app"
+    )
+    assert (
+        doc.secondary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "founders@onyx.app"
+    )
     assert doc.doc_updated_at == datetime(2001, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
@@ -133,12 +139,24 @@ def test_two_text_files_with_zip_metadata(
     assert doc1.sections[0].text == "File 1 content"
     assert doc1.sections[0].link == "https://onyx.app/1"
     assert doc1.semantic_identifier == "display 1"
-    assert doc1.primary_owners[0].display_name == "alice@onyx.app"  # type: ignore
-    assert doc1.secondary_owners[0].display_name == "bob@onyx.app"  # type: ignore
+    assert (
+        doc1.primary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "alice@onyx.app"
+    )
+    assert (
+        doc1.secondary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "bob@onyx.app"
+    )
     assert doc1.doc_updated_at == datetime(2022, 2, 2, 0, 0, 0, tzinfo=timezone.utc)
     assert doc2.sections[0].text == "File 2 content"
     assert doc2.sections[0].link == "https://onyx.app/2"
     assert doc2.semantic_identifier == "display 2"
-    assert doc2.primary_owners[0].display_name == "carol@onyx.app"  # type: ignore
-    assert doc2.secondary_owners[0].display_name == "dave@onyx.app"  # type: ignore
+    assert (
+        doc2.primary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "carol@onyx.app"
+    )
+    assert (
+        doc2.secondary_owners[0].display_name  # ty: ignore[not-subscriptable]
+        == "dave@onyx.app"
+    )
     assert doc2.doc_updated_at == datetime(2023, 3, 3, 0, 0, 0, tzinfo=timezone.utc)

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -92,7 +92,7 @@ def _build_connector(
         my_drive_emails=None,
     )
     # don't need this anymore, it's been called in the factory
-    connector.load_credentials = MagicMock()  # type: ignore
+    connector.load_credentials = MagicMock()  # ty: ignore[invalid-assignment]
     return connector
 
 

--- a/backend/tests/daily/connectors/google_drive/test_link_visibility_filter.py
+++ b/backend/tests/daily/connectors/google_drive/test_link_visibility_filter.py
@@ -34,7 +34,7 @@ def _prepare_connector(exclude: bool) -> GoogleDriveConnector:
         include_shared_drives=True,
         exclude_domain_link_only=exclude,
     )
-    connector._creds = object()  # type: ignore[assignment]
+    connector._creds = object()  # ty: ignore[invalid-assignment]
     connector._primary_admin_email = "admin@example.com"
     return connector
 

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -548,7 +548,9 @@ def test_resolve_tenant_domain_from_site_urls(
     # The tenant domain should match the first label of the site URL hostname
     from urllib.parse import urlsplit
 
-    expected = urlsplit(site_url).hostname.split(".")[0]  # type: ignore
+    hostname = urlsplit(site_url).hostname
+    assert hostname is not None
+    expected = hostname.split(".")[0]
     assert connector.sp_tenant_domain == expected
 
 

--- a/backend/tests/daily/connectors/utils.py
+++ b/backend/tests/daily/connectors/utils.py
@@ -70,7 +70,9 @@ def load_all_from_connector(
             else connector.load_from_checkpoint
         )
         doc_batch_generator = CheckpointOutputWrapper[CT]()(
-            load_from_checkpoint_generator(start, end, checkpoint)
+            load_from_checkpoint_generator(  # ty: ignore[invalid-argument-type]
+                start, end, checkpoint  # ty: ignore[invalid-argument-type]
+            )
         )
 
         # Collect hierarchy nodes from this batch (for end-of-batch validation)

--- a/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
@@ -195,7 +195,7 @@ class TestDeletePerFileGuardKey:
             assert redis_client.exists(
                 guard_key
             ), "Guard key should be set in Redis after enqueue"
-            ttl = int(redis_client.ttl(guard_key))  # type: ignore[arg-type]
+            ttl = int(redis_client.ttl(guard_key))  # ty: ignore[invalid-argument-type]
             assert (
                 0 < ttl <= CELERY_USER_FILE_DELETE_TASK_EXPIRES
             ), f"Guard key TTL {ttl}s is outside the expected range (0, {CELERY_USER_FILE_DELETE_TASK_EXPIRES}]"

--- a/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
@@ -194,7 +194,7 @@ class TestPerFileGuardKey:
             assert redis_client.exists(
                 guard_key
             ), "Guard key should be set in Redis after enqueue"
-            ttl = int(redis_client.ttl(guard_key))  # type: ignore[arg-type]
+            ttl = int(redis_client.ttl(guard_key))  # ty: ignore[invalid-argument-type]
             assert (
                 0 < ttl <= CELERY_USER_FILE_PROCESSING_TASK_EXPIRES
             ), f"Guard key TTL {ttl}s is outside the expected range (0, {CELERY_USER_FILE_PROCESSING_TASK_EXPIRES}]"

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -16,10 +16,10 @@ from uuid import UUID
 from uuid import uuid4
 
 import pytest
-from kubernetes import client  # type: ignore[import-untyped]
+from kubernetes import client
 from kubernetes import config
-from kubernetes.client.rest import ApiException  # type: ignore[import-untyped]
-from kubernetes.stream import stream as k8s_stream  # type: ignore[import-untyped]
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream as k8s_stream
 
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.enums import SandboxStatus

--- a/backend/tests/external_dependency_unit/db/test_credential_sensitive_value.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_sensitive_value.py
@@ -65,7 +65,7 @@ def test_reassign_same_nested_json_not_dirty(db_session: Session) -> None:
     _ = credential.credential_json  # force reload
 
     # Re-assign identical value
-    credential.credential_json = _NESTED_CRED_JSON  # type: ignore[assignment]
+    credential.credential_json = _NESTED_CRED_JSON  # ty: ignore[invalid-assignment]
     assert not db_session.is_modified(credential)
 
     db_session.rollback()
@@ -84,7 +84,7 @@ def test_assign_different_nested_json_is_dirty(db_session: Session) -> None:
     _ = credential.credential_json  # force reload
 
     modified_cred = {**_NESTED_CRED_JSON, "scopes": ["read"]}
-    credential.credential_json = modified_cred  # type: ignore[assignment]
+    credential.credential_json = modified_cred  # ty: ignore[invalid-assignment]
     assert db_session.is_modified(credential)
 
     db_session.rollback()

--- a/backend/tests/external_dependency_unit/db/test_rotate_encryption_key.py
+++ b/backend/tests/external_dependency_unit/db/test_rotate_encryption_key.py
@@ -79,7 +79,11 @@ class TestDiscoverEncryptedColumns:
     def test_discovers_credential_json(self) -> None:
         results = _discover_encrypted_columns()
         found = {
-            (model_cls.__tablename__, col_name, is_json)  # type: ignore[attr-defined]
+            (
+                model_cls.__tablename__,  # ty: ignore[unresolved-attribute]
+                col_name,
+                is_json,
+            )
             for model_cls, col_name, _, is_json in results
         }
         assert ("credential", "credential_json", True) in found
@@ -87,7 +91,11 @@ class TestDiscoverEncryptedColumns:
     def test_discovers_internet_search_provider_api_key(self) -> None:
         results = _discover_encrypted_columns()
         found = {
-            (model_cls.__tablename__, col_name, is_json)  # type: ignore[attr-defined]
+            (
+                model_cls.__tablename__,  # ty: ignore[unresolved-attribute]
+                col_name,
+                is_json,
+            )
             for model_cls, col_name, _, is_json in results
         }
         assert ("internet_search_provider", "api_key", False) in found
@@ -98,7 +106,7 @@ class TestDiscoverEncryptedColumns:
             col = getattr(model_cls, col_name).property.columns[0]
             if isinstance(col.type, EncryptedString):
                 assert not is_json, (
-                    f"{model_cls.__tablename__}.{col_name} is EncryptedString "  # type: ignore[attr-defined]
+                    f"{model_cls.__tablename__}.{col_name} is EncryptedString "  # ty: ignore[unresolved-attribute]
                     f"but is_json={is_json}"
                 )
 
@@ -108,7 +116,7 @@ class TestDiscoverEncryptedColumns:
             col = getattr(model_cls, col_name).property.columns[0]
             if isinstance(col.type, EncryptedJson):
                 assert is_json, (
-                    f"{model_cls.__tablename__}.{col_name} is EncryptedJson "  # type: ignore[attr-defined]
+                    f"{model_cls.__tablename__}.{col_name} is EncryptedJson "  # ty: ignore[unresolved-attribute]
                     f"but is_json={is_json}"
                 )
 

--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -149,7 +149,7 @@ def file_store(
             objects_to_delete = [{"Key": obj["Key"]} for obj in response["Contents"]]
             s3_client.delete_objects(
                 Bucket=actual_bucket_name,
-                Delete={"Objects": objects_to_delete},  # type: ignore[typeddict-item]
+                Delete={"Objects": objects_to_delete},
             )
             logger.info(
                 f"Cleaned up {len(objects_to_delete)} test objects from {backend_config['backend_name']}"

--- a/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
@@ -51,7 +51,7 @@ def pg_file_store(
         created_ids.append(file_id)
         return file_id
 
-    store.save_file = _tracking_save  # type: ignore[method-assign]
+    store.save_file = _tracking_save  # ty: ignore[invalid-assignment]
 
     yield store
 

--- a/backend/tests/external_dependency_unit/mock_content_provider.py
+++ b/backend/tests/external_dependency_unit/mock_content_provider.py
@@ -35,7 +35,9 @@ class MockContentProvider(WebContentProvider, ContentProviderController):
     def __init__(self) -> None:
         self._contents: list[MockWebContent] = []
 
-    def add_content(self, web_content: MockWebContent) -> None:
+    def add_content(  # ty: ignore[invalid-method-override]
+        self, web_content: MockWebContent
+    ) -> None:
         self._contents.append(web_content)
 
     def contents(self, urls: Sequence[str]) -> list[WebContent]:

--- a/backend/tests/external_dependency_unit/mock_image_provider.py
+++ b/backend/tests/external_dependency_unit/mock_image_provider.py
@@ -50,7 +50,7 @@ class MockImageGenerationProvider(
         return True
 
     @classmethod
-    def _build_from_credentials(
+    def _build_from_credentials(  # ty: ignore[invalid-method-override]
         cls,
         _: ImageGenerationProviderCredentials,
     ) -> ImageGenerationProvider:

--- a/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
+++ b/backend/tests/external_dependency_unit/slack_bot/test_slack_bot_federated_search.py
@@ -377,7 +377,7 @@ class TestSlackBotFederatedSearch:
             available_channels: list | None = None,  # noqa: ARG001
             channel_metadata_dict: dict | None = None,  # noqa: ARG001
         ) -> SlackQueryResult:
-            self._captured_filtering_params = {
+            self._captured_filtering_params = {  # ty: ignore[unresolved-attribute]
                 "allowed_private_channel": allowed_private_channel,
                 "include_dm": include_dm,
                 "channel_name": channel_name,
@@ -500,13 +500,14 @@ class TestSlackBotFederatedSearch:
             params = self._captured_filtering_params
 
             assert (
-                params["allowed_private_channel"] is None
+                params["allowed_private_channel"]  # ty: ignore[not-subscriptable]
+                is None
             ), "Public channels should not have private channel access"
             assert (
-                params["include_dm"] is False
+                params["include_dm"] is False  # ty: ignore[not-subscriptable]
             ), "Public channels should not include DMs"
             assert (
-                params["channel_name"] == "general"
+                params["channel_name"] == "general"  # ty: ignore[not-subscriptable]
             ), "Should be testing general channel"
 
         finally:
@@ -558,13 +559,14 @@ class TestSlackBotFederatedSearch:
             params = self._captured_filtering_params
 
             assert (
-                params["allowed_private_channel"] == "C9999999999"
+                params["allowed_private_channel"]  # ty: ignore[not-subscriptable]
+                == "C9999999999"
             ), "Private channels should have access to their specific private channel"
             assert (
-                params["include_dm"] is False
+                params["include_dm"] is False  # ty: ignore[not-subscriptable]
             ), "Private channels should not include DMs"
             assert (
-                params["channel_name"] == "dev-team"
+                params["channel_name"] == "dev-team"  # ty: ignore[not-subscriptable]
             ), "Should be testing dev-team channel"
 
         finally:
@@ -616,11 +618,15 @@ class TestSlackBotFederatedSearch:
             params = self._captured_filtering_params
 
             assert (
-                params["allowed_private_channel"] is None
+                params["allowed_private_channel"]  # ty: ignore[not-subscriptable]
+                is None
             ), "DMs should not have private channel access"
-            assert params["include_dm"] is True, "DMs should include DM messages"
             assert (
-                params["channel_name"] == "directmessage"
+                params["include_dm"] is True  # ty: ignore[not-subscriptable]
+            ), "DMs should include DM messages"
+            assert (
+                params["channel_name"]  # ty: ignore[not-subscriptable]
+                == "directmessage"
             ), "Should be testing directmessage channel"
 
         finally:

--- a/backend/tests/external_dependency_unit/tools/test_memory_tool_integration.py
+++ b/backend/tests/external_dependency_unit/tools/test_memory_tool_integration.py
@@ -15,7 +15,7 @@ from tests.external_dependency_unit.conftest import create_test_user
 
 
 @pytest.fixture()
-def test_user(db_session: Session):  # type: ignore
+def test_user(db_session: Session):
     """Create a test user with use_memories enabled."""
     user = create_test_user(db_session, "memory_test")
     user.use_memories = True
@@ -25,7 +25,7 @@ def test_user(db_session: Session):  # type: ignore
 
 
 @pytest.fixture()
-def test_user_no_memories(db_session: Session):  # type: ignore
+def test_user_no_memories(db_session: Session):
     """Create a test user with use_memories disabled."""
     user = create_test_user(db_session, "memory_test_off")
     user.use_memories = False

--- a/backend/tests/external_dependency_unit/tools/test_python_tool.py
+++ b/backend/tests/external_dependency_unit/tools/test_python_tool.py
@@ -120,7 +120,7 @@
 
 #     # Verify streaming packets were emitted
 #     mock_emitter = mock_run_context.context.run_dependencies.emitter
-#     emitter_calls = mock_emitter.emit.call_args_list  # type: ignore
+#     emitter_calls = mock_emitter.emit.call_args_list
 #     assert len(emitter_calls) >= 2  # At least start and delta
 
 #     # Check for PythonToolStart packet
@@ -408,7 +408,7 @@
 
 #     # Verify packets were emitted with correct index
 #     mock_emitter = mock_run_context.context.run_dependencies.emitter
-#     emitter_calls = mock_emitter.emit.call_args_list  # type: ignore
+#     emitter_calls = mock_emitter.emit.call_args_list
 #     for call in emitter_calls:
 #         packet = call[0][0]
 #         assert isinstance(packet, Packet)
@@ -459,8 +459,8 @@
 #             mock_client_class.return_value = code_interpreter_client
 
 #             # Call the function tool wrapper
-#             result_coro = python.on_invoke_tool(mock_run_context, json.dumps({"code": code}))  # type: ignore
-#             result_json: str = asyncio.run(result_coro)  # type: ignore
+#             result_coro = python.on_invoke_tool(mock_run_context, json.dumps({"code": code}))
+#             result_json: str = asyncio.run(result_coro)
 
 #     # Verify result is JSON string
 #     assert isinstance(result_json, str)
@@ -604,7 +604,7 @@
 
 #     # Verify error delta was emitted
 #     mock_emitter = mock_run_context.context.run_dependencies.emitter
-#     emitter_calls = mock_emitter.emit.call_args_list  # type: ignore
+#     emitter_calls = mock_emitter.emit.call_args_list
 #     delta_packets = [
 #         call[0][0]
 #         for call in emitter_calls
@@ -720,8 +720,8 @@
 #     # Verify some sample data
 #     segments = [row[0] for row in rows]
 #     countries = [row[1] for row in rows]
-#     units_sold = [float(row[3]) if row[3] is not None else 0.0 for row in rows]  # type: ignore
-#     profits = [float(row[10]) if row[10] is not None else 0.0 for row in rows]  # type: ignore
+#     units_sold = [float(row[3]) if row[3] is not None else 0.0 for row in rows]
+#     profits = [float(row[10]) if row[10] is not None else 0.0 for row in rows]
 
 #     assert "Government" in segments
 #     assert "Canada" in countries
@@ -1083,7 +1083,7 @@ class MockCodeInterpreterServer(HTTPServer):
 
     @property
     def url(self) -> str:
-        host, port = self.server_address
+        host, port = self.server_address  # ty: ignore[invalid-assignment]
         return f"http://{host!s}:{port}"
 
     def start(self) -> None:

--- a/backend/tests/integration/common_utils/config.py
+++ b/backend/tests/integration/common_utils/config.py
@@ -1,4 +1,4 @@
-import generated.onyx_openapi_client.onyx_openapi_client as onyx_api  # type: ignore[import-untyped,unused-ignore]
+import generated.onyx_openapi_client.onyx_openapi_client as onyx_api  # ty: ignore[unresolved-import]
 from tests.integration.common_utils.constants import API_SERVER_URL
 
 api_config = onyx_api.Configuration(host=API_SERVER_URL)

--- a/backend/tests/integration/common_utils/managers/cc_pair.py
+++ b/backend/tests/integration/common_utils/managers/cc_pair.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import requests
 
-import generated.onyx_openapi_client.onyx_openapi_client as api  # type: ignore[import-untyped,unused-ignore]
+import generated.onyx_openapi_client.onyx_openapi_client as api  # ty: ignore[unresolved-import]
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus

--- a/backend/tests/integration/common_utils/managers/chat.py
+++ b/backend/tests/integration/common_utils/managers/chat.py
@@ -269,7 +269,9 @@ class ChatSessionManager:
                 )
                 is not None
             ):
-                packet_type_str = str(packet_type)
+                packet_type_str = str(
+                    packet_type  # ty: ignore[possibly-unresolved-reference]
+                )
                 if packet_type_str == StreamingType.MESSAGE_START.value:
                     final_docs = data_obj.get("final_documents")
                     if isinstance(final_docs, list):
@@ -283,12 +285,16 @@ class ChatSessionManager:
                         if data_obj.get("is_internet_search", False)
                         else ToolName.INTERNAL_SEARCH
                     )
-                    ind_to_tool_use[ind] = ToolResult(
-                        tool_name=tool_name,
+                    ind_to_tool_use[ind] = (  # type: ignore
+                        ToolResult(
+                            tool_name=tool_name,
+                        )
                     )
                 elif packet_type_str == StreamingType.IMAGE_GENERATION_START.value:
-                    ind_to_tool_use[ind] = ToolResult(
-                        tool_name=ToolName.IMAGE_GENERATION,
+                    ind_to_tool_use[ind] = (  # type: ignore
+                        ToolResult(
+                            tool_name=ToolName.IMAGE_GENERATION,
+                        )
                     )
                 elif packet_type_str == StreamingType.IMAGE_GENERATION_HEARTBEAT.value:
                     # Track heartbeat packets for debugging/testing
@@ -299,11 +305,13 @@ class ChatSessionManager:
                     )
 
                     images = data_obj.get("images", [])
-                    ind_to_tool_use[ind].images.extend(
-                        [GeneratedImage(**img) for img in images]
-                    )
+                    ind_to_tool_use[
+                        ind  # ty: ignore[possibly-unresolved-reference]
+                    ].images.extend([GeneratedImage(**img) for img in images])
                 elif packet_type_str == StreamingType.SEARCH_TOOL_QUERIES_DELTA.value:
-                    ind_to_tool_use[ind].queries.extend(data_obj.get("queries", []))
+                    ind_to_tool_use[
+                        ind  # ty: ignore[possibly-unresolved-reference]
+                    ].queries.extend(data_obj.get("queries", []))
                 elif packet_type_str == StreamingType.SEARCH_TOOL_DOCUMENTS_DELTA.value:
                     docs = []
                     for doc in data_obj.get("documents", []):
@@ -316,7 +324,9 @@ class ChatSessionManager:
                             docs.append(
                                 SavedSearchDoc.from_search_doc(search_doc, db_doc_id=0)
                             )
-                    ind_to_tool_use[ind].documents.extend(docs)
+                    ind_to_tool_use[
+                        ind  # ty: ignore[possibly-unresolved-reference]
+                    ].documents.extend(docs)
                 elif packet_type_str == StreamingType.TOOL_CALL_DEBUG.value:
                     tool_call_debug.append(
                         ToolCallDebug(
@@ -336,7 +346,10 @@ class ChatSessionManager:
             top_documents=top_documents,
             used_tools=list(ind_to_tool_use.values()),
             tool_call_debug=tool_call_debug,
-            heartbeat_packets=[dict(packet) for packet in heartbeat_packets],
+            heartbeat_packets=[
+                dict(packet)  # ty: ignore[no-matching-overload]
+                for packet in heartbeat_packets
+            ],
             error=error,
         )
 

--- a/backend/tests/integration/common_utils/managers/user.py
+++ b/backend/tests/integration/common_utils/managers/user.py
@@ -219,7 +219,7 @@ class UserManager:
         elif target_status is False:
             url_substring = "deactivate"
         response = requests.patch(
-            url=f"{API_SERVER_URL}/manage/admin/{url_substring}-user",
+            url=f"{API_SERVER_URL}/manage/admin/{url_substring}-user",  # ty: ignore[possibly-unresolved-reference]
             json={"user_email": user_to_set.email},
             headers=user_performing_action.headers,
         )

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -48,8 +48,8 @@ def _run_migrations(
     alembic_cfg.attributes["configure_logger"] = False
     alembic_cfg.config_ini_section = config_name
 
-    alembic_cfg.cmd_opts = SimpleNamespace()  # type: ignore
-    alembic_cfg.cmd_opts.x = [f"schema={schema}"]  # type: ignore
+    alembic_cfg.cmd_opts = SimpleNamespace()  # ty: ignore[invalid-assignment]
+    alembic_cfg.cmd_opts.x = [f"schema={schema}"]  # ty: ignore[invalid-assignment]
 
     # Set the SQLAlchemy URL in the Alembic configuration
     alembic_cfg.set_main_option("sqlalchemy.url", database_url)

--- a/backend/tests/integration/common_utils/timeout.py
+++ b/backend/tests/integration/common_utils/timeout.py
@@ -58,13 +58,19 @@ def run_with_timeout_multiproc(
 
     if p.is_alive():
         p.terminate()
-        raise TimeoutError(f"{task.__name__} timed out after {timeout} seconds")
+        raise TimeoutError(
+            f"{task.__name__} timed out after {timeout} seconds"  # ty: ignore[unresolved-attribute]
+        )
 
     if not q.empty():
         status, result = q.get()
         if status == "success":
             return result
         else:
-            raise RuntimeError(f"{task.__name__} failed:\n{result}")
+            raise RuntimeError(
+                f"{task.__name__} failed:\n{result}"  # ty: ignore[unresolved-attribute]
+            )
     else:
-        raise RuntimeError(f"{task.__name__} returned no result")
+        raise RuntimeError(
+            f"{task.__name__} returned no result"  # ty: ignore[unresolved-attribute]
+        )

--- a/backend/tests/integration/common_utils/vespa.py
+++ b/backend/tests/integration/common_utils/vespa.py
@@ -21,7 +21,7 @@ class vespa_fixture:
         }
         response = requests.get(
             self.vespa_document_url,
-            params=params,  # type: ignore
+            params=params,
         )
         response.raise_for_status()
         return response.json()

--- a/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
+++ b/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
@@ -41,7 +41,11 @@ class GoogleDriveManager:
         service = get_drive_service(credentials, impersonated_user_email)
 
         # Verify impersonation
-        about = service.about().get(fields="user").execute()
+        about = (
+            service.about()  # ty: ignore[unresolved-attribute]
+            .get(fields="user")
+            .execute()
+        )
         if about.get("user", {}).get("emailAddress") != impersonated_user_email:
             raise ValueError(
                 f"Failed to impersonate {impersonated_user_email}. Instead got {about.get('user', {}).get('emailAddress')}"
@@ -56,7 +60,11 @@ class GoogleDriveManager:
         Creates a shared drive and returns the drive's ID
         """
         try:
-            about = drive_service.about().get(fields="user").execute()
+            about = (
+                drive_service.about()  # ty: ignore[unresolved-attribute]
+                .get(fields="user")
+                .execute()
+            )
             creating_user = about["user"]["emailAddress"]
 
             # Verify we're still impersonating the admin
@@ -69,7 +77,7 @@ class GoogleDriveManager:
 
             request_id = str(uuid4())
             drive = (
-                drive_service.drives()
+                drive_service.drives()  # ty: ignore[unresolved-attribute]
                 .create(
                     body=drive_metadata,
                     requestId=request_id,
@@ -110,7 +118,7 @@ class GoogleDriveManager:
     ) -> None:
         docs_service = _create_doc_service(drive_service)
 
-        docs_service.documents().batchUpdate(
+        docs_service.documents().batchUpdate(  # ty: ignore[unresolved-attribute]
             documentId=doc_id,
             body={
                 "requests": [{"insertText": {"location": {"index": 1}, "text": text}}]

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
@@ -199,7 +199,10 @@ if __name__ == "__main__":
     print(f"Scopes Supported: {scopes_supported}")
 
     # Apply middleware at the parent app so it wraps mounted sub-apps too
-    app.add_middleware(WWWAuthenticateMiddleware, protected_prefixes=["/mcp", "/sse"])
+    app.add_middleware(
+        WWWAuthenticateMiddleware,  # ty: ignore[invalid-argument-type]
+        protected_prefixes=["/mcp", "/sse"],
+    )
 
     # 3) Mount MCP apps
     # Streamable HTTP transport (recommended for modern MCP clients)

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -60,10 +60,10 @@ def _is_user_already_exists_detail(detail: object) -> bool:
             or "register_user_already_exists" in normalized
         )
     if isinstance(detail, dict):
-        code = detail.get("code")
+        code = detail.get("code")  # ty: ignore[invalid-argument-type]
         if isinstance(code, str) and code.lower() == "register_user_already_exists":
             return True
-        message = detail.get("message")
+        message = detail.get("message")  # ty: ignore[invalid-argument-type]
         if isinstance(message, str) and "already exists" in message.lower():
             return True
     return False

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -164,7 +164,9 @@ def test_connector_deletion(
     doc_set_2.cc_pair_ids = [cc_pair_2.id]
     cc_pair_1.groups = []
     if is_ee:
-        cc_pair_2.groups = [user_group_2.id]
+        cc_pair_2.groups = [
+            user_group_2.id  # ty: ignore[possibly-unresolved-reference]
+        ]
     else:
         cc_pair_2.groups = []
 
@@ -184,7 +186,9 @@ def test_connector_deletion(
 
     cc_pair_2_group_name_expected = []
     if is_ee:
-        cc_pair_2_group_name_expected = [user_group_2.name]
+        cc_pair_2_group_name_expected = [
+            user_group_2.name  # ty: ignore[possibly-unresolved-reference]
+        ]
 
     DocumentManager.verify(
         vespa_client=vespa_client,
@@ -212,16 +216,18 @@ def test_connector_deletion(
     )
 
     if is_ee:
-        user_group_1.cc_pair_ids = []
-        user_group_2.cc_pair_ids = [cc_pair_2.id]
+        user_group_1.cc_pair_ids = []  # ty: ignore[possibly-unresolved-reference]
+        user_group_2.cc_pair_ids = [  # ty: ignore[possibly-unresolved-reference]
+            cc_pair_2.id
+        ]
 
         # validate user groups
         UserGroupManager.verify(
-            user_group=user_group_1,
+            user_group=user_group_1,  # ty: ignore[possibly-unresolved-reference]
             user_performing_action=admin_user,
         )
         UserGroupManager.verify(
-            user_group=user_group_2,
+            user_group=user_group_2,  # ty: ignore[possibly-unresolved-reference]
             user_performing_action=admin_user,
         )
 
@@ -387,7 +393,9 @@ def test_connector_deletion_for_overlapping_connectors(
     # verify the document is only in user group 2
     group_names_expected = []
     if is_ee:
-        group_names_expected = [user_group_2.name]
+        group_names_expected = [
+            user_group_2.name  # ty: ignore[possibly-unresolved-reference]
+        ]
 
     DocumentManager.verify(
         vespa_client=vespa_client,

--- a/backend/tests/integration/tests/migrations/test_alembic_main.py
+++ b/backend/tests/integration/tests/migrations/test_alembic_main.py
@@ -13,9 +13,9 @@ Usage:
 See: https://github.com/schireson/pytest-alembic
 """
 
-from pytest_alembic.tests import test_single_head_revision  # type: ignore[import-not-found,unused-ignore]
-from pytest_alembic.tests import test_up_down_consistency  # type: ignore[import-not-found,unused-ignore]
-from pytest_alembic.tests import test_upgrade  # type: ignore[import-not-found,unused-ignore]
+from pytest_alembic.tests import test_single_head_revision
+from pytest_alembic.tests import test_up_down_consistency
+from pytest_alembic.tests import test_upgrade
 
 __all__ = [
     "test_single_head_revision",

--- a/backend/tests/integration/tests/migrations/test_alembic_tenants.py
+++ b/backend/tests/integration/tests/migrations/test_alembic_tenants.py
@@ -15,10 +15,10 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
-from pytest_alembic import create_alembic_fixture  # type: ignore[import-not-found,unused-ignore]
-from pytest_alembic.tests import test_single_head_revision  # type: ignore[import-not-found,unused-ignore]
-from pytest_alembic.tests import test_up_down_consistency  # type: ignore[import-not-found,unused-ignore]
-from pytest_alembic.tests import test_upgrade  # type: ignore[import-not-found,unused-ignore]
+from pytest_alembic import create_alembic_fixture
+from pytest_alembic.tests import test_single_head_revision
+from pytest_alembic.tests import test_up_down_consistency
+from pytest_alembic.tests import test_upgrade
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 

--- a/backend/tests/integration/tests/permissions/test_cc_pair_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_cc_pair_permissions.py
@@ -6,7 +6,7 @@ the permissions of the curator manipulating connector-credential pairs.
 import os
 
 import pytest
-from onyx_openapi_client.exceptions import ApiException  # type: ignore[import-untyped,unused-ignore,import-not-found]
+from onyx_openapi_client.exceptions import ApiException  # ty: ignore[unresolved-import]
 
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource

--- a/backend/tests/regression/search_quality/utils.py
+++ b/backend/tests/regression/search_quality/utils.py
@@ -6,13 +6,13 @@ from typing import Any
 from typing import cast
 from typing import TextIO
 
-from ragas import evaluate  # type: ignore[import-not-found,unused-ignore]
-from ragas import EvaluationDataset  # type: ignore[import-not-found,unused-ignore]
-from ragas import SingleTurnSample  # type: ignore[import-not-found,unused-ignore]
-from ragas.dataset_schema import EvaluationResult  # type: ignore[import-not-found,unused-ignore]
-from ragas.metrics import FactualCorrectness  # type: ignore[import-not-found,unused-ignore]
-from ragas.metrics import Faithfulness  # type: ignore[import-not-found,unused-ignore]
-from ragas.metrics import ResponseRelevancy  # type: ignore[import-not-found,unused-ignore]
+from ragas import evaluate  # ty: ignore[unresolved-import]
+from ragas import EvaluationDataset  # ty: ignore[unresolved-import]
+from ragas import SingleTurnSample  # ty: ignore[unresolved-import]
+from ragas.dataset_schema import EvaluationResult  # ty: ignore[unresolved-import]
+from ragas.metrics import FactualCorrectness  # ty: ignore[unresolved-import]
+from ragas.metrics import Faithfulness  # ty: ignore[unresolved-import]
+from ragas.metrics import ResponseRelevancy  # ty: ignore[unresolved-import]
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -119,7 +119,7 @@ def _mock_graph_get_for_enumeration(
             return _make_graph_page(members_by_group.get(group_id, []))
         return _make_graph_page(groups)
 
-    return side_effect  # type: ignore[return-value]
+    return side_effect  # ty: ignore[invalid-return-type]
 
 
 @patch(f"{MODULE}._graph_api_get")

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -115,7 +115,7 @@ class TestLicenseEnforcementMiddleware:
             response.status_code = 200
             return response
 
-        return captured_middleware, call_next
+        return captured_middleware, call_next  # ty: ignore[invalid-return-type]
 
     @pytest.mark.asyncio
     @patch(

--- a/backend/tests/unit/file_store/test_postgres_file_store.py
+++ b/backend/tests/unit/file_store/test_postgres_file_store.py
@@ -29,7 +29,7 @@ def _make_session_ctx(
     from contextlib import contextmanager
 
     @contextmanager
-    def _ctx(session: Any = None):  # type: ignore
+    def _ctx(session: Any = None):
         yield session if session is not None else mock_session
 
     return _ctx

--- a/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
@@ -195,7 +195,7 @@ async def test_get_or_create_user_provisions_new_user(
         async def get_by_email(self, _email: str) -> MagicMock:
             raise users_module.exceptions.UserNotExists()
 
-        async def create(self, user_create, safe=False, request=None):  # type: ignore[no-untyped-def]  # noqa: ARG002
+        async def create(self, user_create, safe=False, request=None):  # noqa: ARG002
             recorded["user_create"] = user_create
             recorded["request"] = request
             return created_user

--- a/backend/tests/unit/onyx/auth/test_oidc_pkce.py
+++ b/backend/tests/unit/onyx/auth/test_oidc_pkce.py
@@ -89,7 +89,9 @@ def _build_test_client(
     if login_status_code in {301, 302, 303, 307, 308}:
         login_response.headers["location"] = "/app"
     login_response.set_cookie("testsession", "session-token")
-    backend.login = AsyncMock(return_value=login_response)  # type: ignore[method-assign]
+    backend.login = AsyncMock(  # ty: ignore[invalid-assignment]
+        return_value=login_response
+    )
 
     user = MagicMock()
     user.is_active = True

--- a/backend/tests/unit/onyx/chat/test_compression.py
+++ b/backend/tests/unit/onyx/chat/test_compression.py
@@ -79,7 +79,7 @@ def test_get_messages_returns_summary_content() -> None:
         create_mock_message(2, "msg2", 100),
     ]
     result = get_messages_to_summarize(
-        chat_history=messages,  # type: ignore[arg-type]
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
         existing_summary=None,
         tokens_for_recent=50,
     )
@@ -100,7 +100,7 @@ def test_messages_after_summary_cutoff_only() -> None:
     existing_summary.last_summarized_message_id = 2
 
     result = get_messages_to_summarize(
-        chat_history=messages,  # type: ignore[arg-type]
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
         existing_summary=existing_summary,
         tokens_for_recent=50,
     )
@@ -120,7 +120,7 @@ def test_no_summary_considers_all_messages() -> None:
     ]
 
     result = get_messages_to_summarize(
-        chat_history=messages,  # type: ignore[arg-type]
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
         existing_summary=None,
         tokens_for_recent=50,
     )
@@ -138,7 +138,7 @@ def test_empty_messages_filtered_out() -> None:
     ]
 
     result = get_messages_to_summarize(
-        chat_history=messages,  # type: ignore[arg-type]
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
         existing_summary=None,
         tokens_for_recent=50,
     )
@@ -179,7 +179,9 @@ def test_find_summary_for_branch_returns_matching_branch() -> None:
         matching_summary
     ]
 
-    result = find_summary_for_branch(mock_db, branch_history)  # type: ignore[arg-type]
+    result = find_summary_for_branch(
+        mock_db, branch_history  # ty: ignore[invalid-argument-type]
+    )
 
     assert result == matching_summary
 
@@ -208,7 +210,9 @@ def test_find_summary_for_branch_ignores_other_branch() -> None:
         other_branch_summary
     ]
 
-    result = find_summary_for_branch(mock_db, branch_b_history)  # type: ignore[arg-type]
+    result = find_summary_for_branch(
+        mock_db, branch_b_history  # ty: ignore[invalid-argument-type]
+    )
 
     assert result is None
 
@@ -231,7 +235,7 @@ def test_cutoff_always_before_user_message() -> None:
     # Token budget that would normally cut between messages 3 and 4
     # (keeping ~300 tokens = messages 4, 5, 6)
     result = get_messages_to_summarize(
-        chat_history=messages,  # type: ignore[arg-type]
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
         existing_summary=None,
         tokens_for_recent=300,
     )
@@ -255,7 +259,9 @@ def test__build_llm_messages_for_summarization_user_messages() -> None:
         create_mock_message(2, "How are you?", 15, MessageType.USER),
     ]
 
-    result = _build_llm_messages_for_summarization(messages, {})  # type: ignore[arg-type]
+    result = _build_llm_messages_for_summarization(
+        messages, {}  # ty: ignore[invalid-argument-type]
+    )
 
     assert len(result) == 2
     assert all(isinstance(m, UserMessage) for m in result)
@@ -269,7 +275,9 @@ def test__build_llm_messages_for_summarization_assistant_messages() -> None:
         create_mock_message(1, "I'm doing great!", 20, MessageType.ASSISTANT),
     ]
 
-    result = _build_llm_messages_for_summarization(messages, {})  # type: ignore[arg-type]
+    result = _build_llm_messages_for_summarization(
+        messages, {}  # ty: ignore[invalid-argument-type]
+    )
 
     assert len(result) == 1
     assert isinstance(result[0], AssistantMessage)
@@ -303,7 +311,9 @@ def test__build_llm_messages_for_summarization_skips_tool_responses() -> None:
         create_mock_message(3, "Assistant answer", 20, MessageType.ASSISTANT),
     ]
 
-    result = _build_llm_messages_for_summarization(messages, {})  # type: ignore[arg-type]
+    result = _build_llm_messages_for_summarization(
+        messages, {}  # ty: ignore[invalid-argument-type]
+    )
 
     assert len(result) == 2
     assert isinstance(result[0], UserMessage)
@@ -318,7 +328,9 @@ def test__build_llm_messages_for_summarization_skips_empty() -> None:
         create_mock_message(3, "Also has content", 10, MessageType.ASSISTANT),
     ]
 
-    result = _build_llm_messages_for_summarization(messages, {})  # type: ignore[arg-type]
+    result = _build_llm_messages_for_summarization(
+        messages, {}  # ty: ignore[invalid-argument-type]
+    )
 
     assert len(result) == 2
 
@@ -340,8 +352,8 @@ def test_generate_summary_initial_system_prompt() -> None:
 
     with patch("onyx.chat.compression.llm_generation_span"):
         result = generate_summary(
-            older_messages=older_messages,  # type: ignore[arg-type]
-            recent_messages=recent_messages,  # type: ignore[arg-type]
+            older_messages=older_messages,  # ty: ignore[invalid-argument-type]
+            recent_messages=recent_messages,  # ty: ignore[invalid-argument-type]
             llm=mock_llm,
             tool_id_to_name={},
             existing_summary=None,
@@ -386,8 +398,8 @@ def test_generate_summary_progressive_system_prompt() -> None:
 
     with patch("onyx.chat.compression.llm_generation_span"):
         result = generate_summary(
-            older_messages=older_messages,  # type: ignore[arg-type]
-            recent_messages=recent_messages,  # type: ignore[arg-type]
+            older_messages=older_messages,  # ty: ignore[invalid-argument-type]
+            recent_messages=recent_messages,  # ty: ignore[invalid-argument-type]
             llm=mock_llm,
             tool_id_to_name={},
             existing_summary=existing_summary,
@@ -429,8 +441,8 @@ def test_generate_summary_cutoff_marker_as_separate_message() -> None:
 
     with patch("onyx.chat.compression.llm_generation_span"):
         generate_summary(
-            older_messages=older_messages,  # type: ignore[arg-type]
-            recent_messages=recent_messages,  # type: ignore[arg-type]
+            older_messages=older_messages,  # ty: ignore[invalid-argument-type]
+            recent_messages=recent_messages,  # ty: ignore[invalid-argument-type]
             llm=mock_llm,
             tool_id_to_name={},
             existing_summary=None,
@@ -466,8 +478,8 @@ def test_generate_summary_messages_are_separate() -> None:
 
     with patch("onyx.chat.compression.llm_generation_span"):
         generate_summary(
-            older_messages=older_messages,  # type: ignore[arg-type]
-            recent_messages=recent_messages,  # type: ignore[arg-type]
+            older_messages=older_messages,  # ty: ignore[invalid-argument-type]
+            recent_messages=recent_messages,  # ty: ignore[invalid-argument-type]
             llm=mock_llm,
             tool_id_to_name={},
             existing_summary=None,

--- a/backend/tests/unit/onyx/chat/test_stop_signal_checker.py
+++ b/backend/tests/unit/onyx/chat/test_stop_signal_checker.py
@@ -96,7 +96,7 @@ class TestSetFence:
             calls.append({"key": key, "ex": ex})
             original_set(key, value, ex=ex)
 
-        cache.set = tracking_set  # type: ignore[method-assign]
+        cache.set = tracking_set  # ty: ignore[invalid-assignment]
 
         set_fence(uuid4(), cache, True)
         assert len(calls) == 1

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -1391,7 +1391,7 @@ class TestLoadFromCheckpoint:
             current_course_index=0,
             stage=CanvasStage.PAGES,
         )
-        cp.stage = "invalid"  # type: ignore[assignment]
+        cp.stage = "invalid"  # ty: ignore[invalid-assignment]
 
         with pytest.raises(ValueError, match="Invalid checkpoint stage"):
             _run_checkpoint(connector, cp)

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -151,12 +151,12 @@ def test_load_from_checkpoint_happy_path(
     assert confluence_client is not None, "bad test setup"
 
     # Mock space retrieval for hierarchy nodes (called at start of first batch)
-    confluence_client.retrieve_confluence_spaces = MagicMock(  # type: ignore
-        return_value=iter([{"key": "TEST", "name": "Test Space"}])
+    confluence_client.retrieve_confluence_spaces = (  # ty: ignore[invalid-assignment]
+        MagicMock(return_value=iter([{"key": "TEST", "name": "Test Space"}]))
     )
 
     get_mock = MagicMock()
-    confluence_client.get = get_mock  # type: ignore
+    confluence_client.get = get_mock  # ty: ignore[unresolved-attribute]
     get_mock.side_effect = [
         # First page response
         MagicMock(
@@ -222,12 +222,12 @@ def test_load_from_checkpoint_with_page_processing_error(
     assert confluence_client is not None, "bad test setup"
 
     # Mock space retrieval for hierarchy nodes (called at start of first batch)
-    confluence_client.retrieve_confluence_spaces = MagicMock(  # type: ignore
-        return_value=iter([{"key": "TEST", "name": "Test Space"}])
+    confluence_client.retrieve_confluence_spaces = (  # ty: ignore[invalid-assignment]
+        MagicMock(return_value=iter([{"key": "TEST", "name": "Test Space"}]))
     )
 
     get_mock = MagicMock()
-    confluence_client.get = get_mock  # type: ignore
+    confluence_client.get = get_mock  # ty: ignore[unresolved-attribute]
     get_mock.side_effect = [
         # First page response
         MagicMock(
@@ -317,12 +317,12 @@ def test_retrieve_all_slim_docs_perm_sync(
     assert confluence_client is not None, "bad test setup"
 
     # Mock space retrieval for hierarchy nodes
-    confluence_client.retrieve_confluence_spaces = MagicMock(  # type: ignore
-        return_value=iter([{"key": "TEST", "name": "Test Space"}])
+    confluence_client.retrieve_confluence_spaces = (  # ty: ignore[invalid-assignment]
+        MagicMock(return_value=iter([{"key": "TEST", "name": "Test Space"}]))
     )
 
     get_mock = MagicMock()
-    confluence_client.get = get_mock  # type: ignore
+    confluence_client.get = get_mock  # ty: ignore[unresolved-attribute]
     get_mock.side_effect = [
         # First page response
         MagicMock(
@@ -442,12 +442,12 @@ def test_checkpoint_progress(
     assert confluence_client is not None, "bad test setup"
 
     # Mock space retrieval for hierarchy nodes (called at start of first batch)
-    confluence_client.retrieve_confluence_spaces = MagicMock(  # type: ignore
-        return_value=iter([{"key": "TEST", "name": "Test Space"}])
+    confluence_client.retrieve_confluence_spaces = (  # ty: ignore[invalid-assignment]
+        MagicMock(return_value=iter([{"key": "TEST", "name": "Test Space"}]))
     )
 
     get_mock = MagicMock()
-    confluence_client.get = get_mock  # type: ignore
+    confluence_client.get = get_mock  # ty: ignore[unresolved-attribute]
     get_mock.side_effect = [
         # First page response
         MagicMock(

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -22,7 +22,9 @@ def _create_mock_response(
     response.status_code = status_code
     response.url = url
     if json_data is not None:
-        response.json = mock.Mock(return_value=json_data)  # type: ignore
+        response.json = mock.Mock(  # ty: ignore[invalid-assignment]
+            return_value=json_data
+        )
     if status_code >= 400:
         response.reason = "Mock Error"
     return response
@@ -35,7 +37,9 @@ def _create_http_error(
     url: str = "",
 ) -> requests.Response:
     response = _create_mock_response(status_code, json_data, url)
-    response.raise_for_status = mock.Mock(side_effect=HTTPError(response=response))  # type: ignore
+    response.raise_for_status = mock.Mock(  # ty: ignore[invalid-assignment]
+        side_effect=HTTPError(response=response)
+    )
     return response
 
 
@@ -296,7 +300,9 @@ def test_cql_paginate_all_expansions_handles_internal_pagination_error(
         print(f"!!! Unexpected GET path in mock: {path}")
         raise RuntimeError(f"Unexpected GET path in mock: {path}")
 
-    confluence_server_client._confluence.get.side_effect = get_side_effect
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
 
     # --- Execute ---
     # Consume the iterator to trigger the calls
@@ -359,9 +365,17 @@ def test_cql_paginate_all_expansions_handles_internal_pagination_error(
     # Ensure the result is correct
     # NOTE: size does not get updated during _traverse_and_update
     final_results = copy.deepcopy(top_level_raw_response)
-    final_results["results"][0]["child_items"]["results"] = [{"child_id": 101}, {"child_id": 102}]  # type: ignore
-    final_results["results"][1]["child_items"]["results"] = [{"child_id": 201}, {"child_id": 203}]  # type: ignore
-    final_results["results"][2]["child_items"]["results"] = [{"child_id": 301}]  # type: ignore
+    final_results["results"][0]["child_items"]["results"] = [  # type: ignore
+        {"child_id": 101},
+        {"child_id": 102},
+    ]
+    final_results["results"][1]["child_items"]["results"] = [  # type: ignore
+        {"child_id": 201},
+        {"child_id": 203},
+    ]
+    final_results["results"][2]["child_items"]["results"] = [  # type: ignore
+        {"child_id": 301}
+    ]
     assert result == final_results["results"]
 
 
@@ -515,7 +529,9 @@ def test_paginated_cql_retrieval_handles_pagination_error(
             print(f"!!! Unexpected GET path in mock: {path}")
             raise RuntimeError(f"Unexpected GET path in mock: {path}")
 
-    confluence_server_client._confluence.get.side_effect = get_side_effect
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
 
     # --- Execute ---
     results = list(
@@ -644,7 +660,9 @@ def test_paginated_cql_retrieval_skips_completely_failing_page(
             print(f"!!! Unexpected GET path in mock: {path}")
             raise RuntimeError(f"Unexpected GET path in mock: {path}")
 
-    confluence_server_client._confluence.get.side_effect = get_side_effect
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
 
     # --- Execute ---
     results = list(
@@ -859,7 +877,9 @@ def test_paginate_url_reduces_limit_on_500_server(
 
         raise RuntimeError(f"Unexpected path: {path}")
 
-    confluence_server_client._confluence.get.side_effect = get_side_effect
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
 
     results = list(
         confluence_server_client.paginated_cql_retrieval(
@@ -920,7 +940,9 @@ def test_paginate_url_server_falls_back_to_one_by_one_after_limit_floor(
 
         raise RuntimeError(f"Unexpected path: {path}")
 
-    confluence_server_client._confluence.get.side_effect = get_side_effect
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
 
     results = list(
         confluence_server_client.paginated_cql_retrieval(

--- a/backend/tests/unit/onyx/connectors/google_utils/test_rate_limit_detection.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_rate_limit_detection.py
@@ -1,7 +1,7 @@
 import json
 
-import httplib2  # type: ignore[import-untyped]
-from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
+import httplib2
+from googleapiclient.errors import HttpError
 
 from onyx.connectors.google_utils.google_utils import _is_rate_limit_error
 

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_error_handling.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_error_handling.py
@@ -40,7 +40,7 @@ def test_nonexistent_project_error_during_indexing(
     # Mock search_issues to raise this error
     jira_client = jira_connector_with_invalid_project._jira_client
     assert jira_client is not None
-    jira_client.search_issues.side_effect = error  # type: ignore
+    jira_client.search_issues.side_effect = error  # ty: ignore[unresolved-attribute]
 
     # Attempt to load from checkpoint - should raise ConnectorValidationError
     end_time = time.time()
@@ -70,7 +70,7 @@ def test_invalid_jql_error_during_indexing(
     # Mock search_issues to raise this error
     jira_client = jira_connector_with_invalid_project._jira_client
     assert jira_client is not None
-    jira_client.search_issues.side_effect = error  # type: ignore
+    jira_client.search_issues.side_effect = error  # ty: ignore[unresolved-attribute]
 
     # Attempt to load from checkpoint - should raise ConnectorValidationError
     end_time = time.time()
@@ -96,7 +96,7 @@ def test_credential_expired_error_during_indexing(
     # Mock search_issues to raise this error
     jira_client = jira_connector_with_invalid_project._jira_client
     assert jira_client is not None
-    jira_client.search_issues.side_effect = error  # type: ignore
+    jira_client.search_issues.side_effect = error  # ty: ignore[unresolved-attribute]
 
     # Attempt to load from checkpoint - should raise CredentialExpiredError
     end_time = time.time()
@@ -122,7 +122,7 @@ def test_insufficient_permissions_error_during_indexing(
     # Mock search_issues to raise this error
     jira_client = jira_connector_with_invalid_project._jira_client
     assert jira_client is not None
-    jira_client.search_issues.side_effect = error  # type: ignore
+    jira_client.search_issues.side_effect = error  # ty: ignore[unresolved-attribute]
 
     # Attempt to load from checkpoint - should raise InsufficientPermissionsError
     end_time = time.time()

--- a/backend/tests/unit/onyx/connectors/mediawiki/test_mediawiki_family.py
+++ b/backend/tests/unit/onyx/connectors/mediawiki/test_mediawiki_family.py
@@ -2,8 +2,8 @@ from typing import Final
 
 import pytest
 from pytest_mock import MockFixture
-from pywikibot.families.wikipedia_family import Family as WikipediaFamily  # type: ignore[import-untyped]
-from pywikibot.family import Family  # type: ignore[import-untyped]
+from pywikibot.families.wikipedia_family import Family as WikipediaFamily
+from pywikibot.family import Family
 
 from onyx.connectors.mediawiki import family
 

--- a/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
+++ b/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
@@ -5,7 +5,7 @@ import tempfile
 from collections.abc import Iterable
 
 import pytest
-import pywikibot  # type: ignore[import-untyped]
+import pywikibot
 from pytest_mock import MockFixture
 
 from onyx.connectors.mediawiki import wiki
@@ -16,7 +16,7 @@ pywikibot.config.base_dir = tempfile.TemporaryDirectory().name
 
 
 @pytest.fixture
-def site() -> pywikibot.Site:
+def site() -> pywikibot.Site:  # ty: ignore[invalid-type-form]
     return pywikibot.Site("en", "wikipedia")
 
 
@@ -37,7 +37,10 @@ def test_pywikibot_timestamp_to_utc_datetime() -> None:
 
 class MockPage(pywikibot.Page):
     def __init__(
-        self, site: pywikibot.Site, title: str, _has_categories: bool = False
+        self,
+        site: pywikibot.Site,  # ty: ignore[invalid-type-form]
+        title: str,
+        _has_categories: bool = False,
     ) -> None:
         super().__init__(site, title)
         self._has_categories = _has_categories
@@ -86,7 +89,9 @@ class MockPage(pywikibot.Page):
 
 
 @pytest.mark.skip(reason="Test disabled")
-def test_get_doc_from_page(site: pywikibot.Site) -> None:
+def test_get_doc_from_page(
+    site: pywikibot.Site,  # ty: ignore[invalid-type-form]
+) -> None:
     test_page = MockPage(site, "Test Page", _has_categories=True)
     doc = wiki.get_doc_from_page(test_page, site, wiki.DocumentSource.MEDIAWIKI)
     assert doc.source == wiki.DocumentSource.MEDIAWIKI

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
@@ -112,7 +112,7 @@ def _build_ready_checkpoint(
 def _setup_connector(monkeypatch: pytest.MonkeyPatch) -> SharepointConnector:
     """Create a connector with common methods mocked."""
     connector = SharepointConnector()
-    connector._graph_client = object()
+    connector._graph_client = object()  # ty: ignore[invalid-assignment]
     connector.include_site_pages = False
 
     def fake_resolve_drive(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -71,7 +71,7 @@ _SAMPLE_ITEM = DriveItemData(
 
 def _build_connector(drives: Sequence[_FakeDrive]) -> SharepointConnector:
     connector = SharepointConnector()
-    connector._graph_client = _FakeGraphClient(drives)
+    connector._graph_client = _FakeGraphClient(drives)  # ty: ignore[invalid-assignment]
     return connector
 
 
@@ -169,7 +169,7 @@ def test_get_drive_items_for_drive_id_matches_map(
 
 def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -> None:
     connector = SharepointConnector()
-    connector._graph_client = object()
+    connector._graph_client = object()  # ty: ignore[invalid-assignment]
     connector.include_site_pages = False
 
     captured_drive_names: list[str] = []

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -64,7 +64,9 @@ def _setup_connector(
             ),
         },
     )()
-    connector._graph_client = type("FakeGraphClient", (), {"sites": mock_sites})()
+    connector._graph_client = type(  # ty: ignore[invalid-assignment]
+        "FakeGraphClient", (), {"sites": mock_sites}
+    )()
 
     return connector
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_rest_client_context_caching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_rest_client_context_caching.py
@@ -30,7 +30,7 @@ def _noop_load_credentials(connector: SharepointConnector) -> MagicMock:
         connector.msal_app = MagicMock()
 
     mock = MagicMock(side_effect=_fake_load)
-    connector.load_credentials = mock  # type: ignore[method-assign]
+    connector.load_credentials = mock  # ty: ignore[invalid-assignment]
     return mock
 
 

--- a/backend/tests/unit/onyx/connectors/test_microsoft_graph_env.py
+++ b/backend/tests/unit/onyx/connectors/test_microsoft_graph_env.py
@@ -1,5 +1,5 @@
 import pytest
-from office365.graph_client import AzureEnvironment  # type: ignore[import-untyped]
+from office365.graph_client import AzureEnvironment
 
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.microsoft_graph_env import resolve_microsoft_environment

--- a/backend/tests/unit/onyx/db/test_voice.py
+++ b/backend/tests/unit/onyx/db/test_voice.py
@@ -212,7 +212,7 @@ class TestUpsertVoiceProvider:
         self, mock_db_session: MagicMock
     ) -> None:
         existing_provider = _make_voice_provider(id=1)
-        existing_provider.api_key = "original-key"  # type: ignore[assignment]
+        existing_provider.api_key = "original-key"  # ty: ignore[invalid-assignment]
         original_api_key = existing_provider.api_key
         mock_db_session.scalar.return_value = existing_provider
         mock_db_session.flush.return_value = None

--- a/backend/tests/unit/onyx/document_index/test_disabled_document_index.py
+++ b/backend/tests/unit/onyx/document_index/test_disabled_document_index.py
@@ -74,7 +74,7 @@ def test_index_raises(disabled_index: DisabledDocumentIndex) -> None:
     with pytest.raises(RuntimeError, match=ESCAPED_ERROR):
         disabled_index.index(
             chunks=[],
-            index_batch_params=_StubBatchParams(),  # type: ignore
+            index_batch_params=_StubBatchParams(),  # ty: ignore[invalid-argument-type]
         )
 
 

--- a/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
+++ b/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
@@ -61,7 +61,7 @@ class _MemoryCacheBackend(CacheBackend):
         raise NotImplementedError
 
 
-def _patched(cache: _MemoryCacheBackend):  # type: ignore[no-untyped-def]
+def _patched(cache: _MemoryCacheBackend):
     return patch(
         "onyx.federated_connectors.oauth_utils.get_cache_backend",
         return_value=cache,

--- a/backend/tests/unit/onyx/file_processing/test_image_summarization_litellm_errors.py
+++ b/backend/tests/unit/onyx/file_processing/test_image_summarization_litellm_errors.py
@@ -25,11 +25,11 @@ def _make_litellm_style_error(
     """Create an exception with LiteLLM-style attributes."""
     exc = RuntimeError(message)
     if status_code is not None:
-        exc.status_code = status_code  # type: ignore[attr-defined]
+        exc.status_code = status_code  # ty: ignore[unresolved-attribute]
     if llm_provider is not None:
-        exc.llm_provider = llm_provider  # type: ignore[attr-defined]
+        exc.llm_provider = llm_provider  # ty: ignore[unresolved-attribute]
     if model is not None:
-        exc.model = model  # type: ignore[attr-defined]
+        exc.model = model  # ty: ignore[unresolved-attribute]
     return exc
 
 

--- a/backend/tests/unit/onyx/file_processing/test_pptx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_pptx_to_text.py
@@ -1,9 +1,9 @@
 import io
 
-from pptx import Presentation  # type: ignore[import-untyped]
-from pptx.chart.data import CategoryChartData  # type: ignore[import-untyped]
-from pptx.enum.chart import XL_CHART_TYPE  # type: ignore[import-untyped]
-from pptx.util import Inches  # type: ignore[import-untyped]
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.util import Inches
 
 from onyx.file_processing.extract_file_text import pptx_to_text
 

--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -84,7 +84,13 @@ class TestIsTrueOpenAIModel:
     def test_none_values_handled(self) -> None:
         """Test that None values are handled gracefully."""
         # Should not crash with None values
-        assert is_true_openai_model(LlmProviderNames.OPENAI, None) is False  # type: ignore
+        assert (
+            is_true_openai_model(
+                LlmProviderNames.OPENAI,
+                None,  # ty: ignore[invalid-argument-type]
+            )
+            is False
+        )
 
     def test_litellm_proxy_custom_model(self) -> None:
         """Test that custom models via LiteLLM proxy return False."""

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 import pytz
-import timeago  # type: ignore
+import timeago
 
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import SavedSearchDoc

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -65,7 +65,7 @@ _COMMON_PATCHES = [
 
 def _with_common_patches(fn: object) -> object:
     for p in reversed(_COMMON_PATCHES):
-        fn = p(fn)  # type: ignore
+        fn = p(fn)  # ty: ignore[no-matching-overload]
     return fn
 
 

--- a/backend/tests/unit/onyx/server/scim/conftest.py
+++ b/backend/tests/unit/onyx/server/scim/conftest.py
@@ -149,7 +149,9 @@ def parse_scim_user(result: object, *, status: int = 200) -> ScimUserResource:
         result, ScimJSONResponse
     ), f"Expected ScimJSONResponse, got {type(result).__name__}"
     assert result.status_code == status
-    return ScimUserResource.model_validate(json.loads(result.body))
+    return ScimUserResource.model_validate(
+        json.loads(result.body)  # ty: ignore[invalid-argument-type]
+    )
 
 
 def parse_scim_group(result: object, *, status: int = 200) -> ScimGroupResource:
@@ -158,7 +160,9 @@ def parse_scim_group(result: object, *, status: int = 200) -> ScimGroupResource:
         result, ScimJSONResponse
     ), f"Expected ScimJSONResponse, got {type(result).__name__}"
     assert result.status_code == status
-    return ScimGroupResource.model_validate(json.loads(result.body))
+    return ScimGroupResource.model_validate(
+        json.loads(result.body)  # ty: ignore[invalid-argument-type]
+    )
 
 
 def parse_scim_list(result: object) -> ScimListResponse:
@@ -167,4 +171,6 @@ def parse_scim_list(result: object) -> ScimListResponse:
         result, ScimJSONResponse
     ), f"Expected ScimJSONResponse, got {type(result).__name__}"
     assert result.status_code == 200
-    return ScimListResponse.model_validate(json.loads(result.body))
+    return ScimListResponse.model_validate(
+        json.loads(result.body)  # ty: ignore[invalid-argument-type]
+    )

--- a/backend/tests/unit/onyx/server/scim/test_admin.py
+++ b/backend/tests/unit/onyx/server/scim/test_admin.py
@@ -50,7 +50,9 @@ def _make_token(token_id: int, name: str, *, is_active: bool = True) -> ScimToke
 class TestGetActiveToken:
     def test_returns_token_metadata(self, scim_dal: ScimDAL, admin_user: User) -> None:
         token = _make_token(1, "prod-token")
-        scim_dal._session.scalar.return_value = token  # type: ignore[attr-defined]
+        scim_dal._session.scalar.return_value = (  # ty: ignore[unresolved-attribute]
+            token
+        )
 
         result = get_active_scim_token(_=admin_user, dal=scim_dal)
 
@@ -61,7 +63,7 @@ class TestGetActiveToken:
     def test_raises_404_when_no_active_token(
         self, scim_dal: ScimDAL, admin_user: User
     ) -> None:
-        scim_dal._session.scalar.return_value = None  # type: ignore[attr-defined]
+        scim_dal._session.scalar.return_value = None  # ty: ignore[unresolved-attribute]
 
         with pytest.raises(HTTPException) as exc_info:
             get_active_scim_token(_=admin_user, dal=scim_dal)
@@ -81,7 +83,9 @@ class TestCreateToken:
 
         # Simulate one existing active token that should get revoked
         existing = _make_token(1, "old-token", is_active=True)
-        scim_dal._session.scalars.return_value.all.return_value = [existing]  # type: ignore[attr-defined]
+        scim_dal._session.scalars.return_value.all.return_value = (  # type: ignore
+            [existing]
+        )
 
         # Simulate DB defaults that would be set on INSERT/flush
         def fake_add(obj: ScimToken) -> None:
@@ -89,7 +93,7 @@ class TestCreateToken:
             obj.is_active = True
             obj.created_at = datetime(2026, 2, 1)
 
-        scim_dal._session.add.side_effect = fake_add  # type: ignore[attr-defined]
+        scim_dal._session.add.side_effect = fake_add  # ty: ignore[unresolved-attribute]
 
         body = ScimTokenCreate(name="new-token")
         result = create_scim_token(body=body, user=admin_user, dal=scim_dal)
@@ -103,7 +107,7 @@ class TestCreateToken:
         assert result.is_active is True
 
         # Session was committed
-        scim_dal._session.commit.assert_called_once()  # type: ignore[attr-defined]
+        scim_dal._session.commit.assert_called_once()  # ty: ignore[unresolved-attribute]
 
     @patch("ee.onyx.server.enterprise_settings.api.generate_scim_token")
     def test_creates_first_token_when_none_exist(
@@ -115,14 +119,16 @@ class TestCreateToken:
         mock_generate.return_value = ("raw_token_val", "hashed_val", "****abcd")
 
         # No existing tokens
-        scim_dal._session.scalars.return_value.all.return_value = []  # type: ignore[attr-defined]
+        scim_dal._session.scalars.return_value.all.return_value = (  # ty: ignore[unresolved-attribute]
+            []
+        )
 
         def fake_add(obj: ScimToken) -> None:
             obj.id = 1
             obj.is_active = True
             obj.created_at = datetime(2026, 2, 1)
 
-        scim_dal._session.add.side_effect = fake_add  # type: ignore[attr-defined]
+        scim_dal._session.add.side_effect = fake_add  # ty: ignore[unresolved-attribute]
 
         body = ScimTokenCreate(name="first-token")
         result = create_scim_token(body=body, user=admin_user, dal=scim_dal)

--- a/backend/tests/unit/onyx/server/scim/test_entra.py
+++ b/backend/tests/unit/onyx/server/scim/test_entra.py
@@ -74,7 +74,7 @@ class TestEntraServiceDiscovery:
     def test_resource_types_include_enterprise_extension(self) -> None:
         result = get_resource_types()
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert "Resources" in parsed
         user_type = next(rt for rt in parsed["Resources"] if rt["id"] == "User")
         extension_schemas = [ext["schema"] for ext in user_type["schemaExtensions"]]
@@ -83,14 +83,14 @@ class TestEntraServiceDiscovery:
     def test_schemas_include_enterprise_user(self) -> None:
         result = get_schemas()
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         schema_ids = [s["id"] for s in parsed["Resources"]]
         assert SCIM_ENTERPRISE_USER_SCHEMA in schema_ids
 
     def test_enterprise_schema_has_expected_attributes(self) -> None:
         result = get_schemas()
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         enterprise = next(
             s for s in parsed["Resources"] if s["id"] == SCIM_ENTERPRISE_USER_SCHEMA
         )
@@ -264,7 +264,7 @@ class TestEntraUserLifecycle:
         patch_req = ScimPatchRequest(
             Operations=[
                 ScimPatchOperation(
-                    op="Replace",  # type: ignore[arg-type]
+                    op="Replace",  # ty: ignore[invalid-argument-type]
                     path="active",
                     value=False,
                 )
@@ -298,7 +298,7 @@ class TestEntraUserLifecycle:
         patch_req = ScimPatchRequest(
             Operations=[
                 ScimPatchOperation(
-                    op="Add",  # type: ignore[arg-type]
+                    op="Add",  # ty: ignore[invalid-argument-type]
                     path="externalId",
                     value="entra-ext-999",
                 )
@@ -675,7 +675,7 @@ class TestEntraGroupLifecycle:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert parsed["totalResults"] == 1
         resource = parsed["Resources"][0]
         assert "members" not in resource
@@ -703,7 +703,7 @@ class TestEntraGroupLifecycle:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert "members" not in parsed
         assert parsed["displayName"] == "Engineering"
 
@@ -733,7 +733,7 @@ class TestEntraGroupLifecycle:
         patch_req = ScimPatchRequest(
             Operations=[
                 ScimPatchOperation(
-                    op="Add",  # type: ignore[arg-type]
+                    op="Add",  # ty: ignore[invalid-argument-type]
                     path="members",
                     value=[ScimGroupMember(value=uid)],
                 )
@@ -772,7 +772,7 @@ class TestEntraGroupLifecycle:
         patch_req = ScimPatchRequest(
             Operations=[
                 ScimPatchOperation(
-                    op="Remove",  # type: ignore[arg-type]
+                    op="Remove",  # ty: ignore[invalid-argument-type]
                     path=f'members[value eq "{uid}"]',
                 )
             ]
@@ -821,7 +821,7 @@ class TestExcludedAttributes:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         resource = parsed["Resources"][0]
         assert "members" not in resource
         assert "displayName" in resource
@@ -847,7 +847,7 @@ class TestExcludedAttributes:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert "members" not in parsed
         assert "displayName" in parsed
 
@@ -874,7 +874,7 @@ class TestExcludedAttributes:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         resource = parsed["Resources"][0]
         assert "groups" not in resource
         assert "userName" in resource
@@ -899,7 +899,7 @@ class TestExcludedAttributes:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert "groups" not in parsed
         assert "userName" in parsed
 
@@ -923,7 +923,7 @@ class TestExcludedAttributes:
         )
 
         assert isinstance(result, ScimJSONResponse)
-        parsed = json.loads(result.body)
+        parsed = json.loads(result.body)  # ty: ignore[invalid-argument-type]
         assert "members" not in parsed
         assert "externalId" not in parsed
         assert "displayName" in parsed

--- a/backend/tests/unit/onyx/server/scim/test_patch.py
+++ b/backend/tests/unit/onyx/server/scim/test_patch.py
@@ -223,14 +223,22 @@ class TestApplyUserPatch:
     def test_entra_capitalized_replace_op(self) -> None:
         """Entra ID sends ``"Replace"`` instead of ``"replace"``."""
         user = _make_user()
-        op = ScimPatchOperation(op="Replace", path="active", value=False)  # type: ignore[arg-type]
+        op = ScimPatchOperation(
+            op="Replace",  # ty: ignore[invalid-argument-type]
+            path="active",
+            value=False,
+        )
         result, _ = apply_user_patch([op], user)
         assert result.active is False
 
     def test_entra_capitalized_add_op(self) -> None:
         """Entra ID sends ``"Add"`` instead of ``"add"``."""
         user = _make_user()
-        op = ScimPatchOperation(op="Add", path="externalId", value="ext-999")  # type: ignore[arg-type]
+        op = ScimPatchOperation(
+            op="Add",  # ty: ignore[invalid-argument-type]
+            path="externalId",
+            value="ext-999",
+        )
         result, _ = apply_user_patch([op], user)
         assert result.externalId == "ext-999"
 

--- a/backend/tests/unit/onyx/server/test_projects_file_utils.py
+++ b/backend/tests/unit/onyx/server/test_projects_file_utils.py
@@ -12,13 +12,13 @@ from onyx.server.settings.models import Settings
 
 
 class _Tokenizer(BaseTokenizer):
-    def encode(self, text: str) -> list[int]:
+    def encode(self, text: str) -> list[int]:  # ty: ignore[invalid-method-override]
         return [1] * len(text)
 
-    def tokenize(self, text: str) -> list[str]:
+    def tokenize(self, text: str) -> list[str]:  # ty: ignore[invalid-method-override]
         return list(text)
 
-    def decode(self, _tokens: list[int]) -> str:
+    def decode(self, _tokens: list[int]) -> str:  # ty: ignore[invalid-method-override]
         return ""
 
 
@@ -317,15 +317,19 @@ def test_count_tokens_with_token_limit_exits_early(
     original_tokenizer = _Tokenizer()
 
     class _CountingTokenizer(BaseTokenizer):
-        def encode(self, text: str) -> list[int]:
+        def encode(self, text: str) -> list[int]:  # ty: ignore[invalid-method-override]
             nonlocal encode_call_count
             encode_call_count += 1
             return original_tokenizer.encode(text)
 
-        def tokenize(self, text: str) -> list[str]:
+        def tokenize(  # ty: ignore[invalid-method-override]
+            self, text: str
+        ) -> list[str]:
             return list(text)
 
-        def decode(self, _tokens: list[int]) -> str:
+        def decode(  # ty: ignore[invalid-method-override]
+            self, _tokens: list[int]
+        ) -> str:
             return ""
 
     tokenizer = _CountingTokenizer()
@@ -380,15 +384,19 @@ def test_categorize_early_exits_tokenization_for_large_text(
     original_tokenizer = _Tokenizer()
 
     class _CountingTokenizer(BaseTokenizer):
-        def encode(self, text: str) -> list[int]:
+        def encode(self, text: str) -> list[int]:  # ty: ignore[invalid-method-override]
             nonlocal encode_call_count
             encode_call_count += 1
             return original_tokenizer.encode(text)
 
-        def tokenize(self, text: str) -> list[str]:
+        def tokenize(  # ty: ignore[invalid-method-override]
+            self, text: str
+        ) -> list[str]:
             return list(text)
 
-        def decode(self, _tokens: list[int]) -> str:
+        def decode(  # ty: ignore[invalid-method-override]
+            self, _tokens: list[int]
+        ) -> str:
             return ""
 
     monkeypatch.setattr(utils, "get_tokenizer", lambda **_kwargs: _CountingTokenizer())

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler.py
@@ -213,7 +213,7 @@ def _make_mock_response(
     if delay:
         original_content = content
 
-        @property  # type: ignore[misc]
+        @property
         def _delayed_content(_self: object) -> bytes:
             time.sleep(delay)
             return original_content

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
@@ -146,7 +146,9 @@ def test_execute_streaming_fallback_preserves_files_param() -> None:
 
     def mock_post(url: str, **kwargs: object) -> MagicMock:
         if "json" in kwargs:
-            captured_payloads.append(kwargs["json"])  # type: ignore[arg-type]
+            captured_payloads.append(
+                kwargs["json"]  # ty: ignore[invalid-argument-type]
+            )
         if url.endswith("/v1/execute/stream"):
             return stream_resp
         if url.endswith("/v1/execute"):

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_brave_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_brave_client.py
@@ -176,7 +176,7 @@ def test_test_connection_maps_invalid_key_errors() -> None:
     def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
         raise ValueError("Brave search failed (status 401): Unauthorized")
 
-    client.search = _mock_search  # type: ignore[method-assign]
+    client.search = _mock_search  # ty: ignore[invalid-assignment]
 
     with pytest.raises(HTTPException, match="Invalid Brave API key"):
         client.test_connection()
@@ -188,7 +188,7 @@ def test_test_connection_maps_rate_limit_errors() -> None:
     def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
         raise ValueError("Brave search failed (status 429): Too many requests")
 
-    client.search = _mock_search  # type: ignore[method-assign]
+    client.search = _mock_search  # ty: ignore[invalid-assignment]
 
     with pytest.raises(HTTPException, match="rate limit exceeded"):
         client.test_connection()
@@ -200,7 +200,7 @@ def test_test_connection_propagates_unexpected_errors() -> None:
     def _mock_search(query: str) -> list[Any]:  # noqa: ARG001
         raise RuntimeError("unexpected parsing bug")
 
-    client.search = _mock_search  # type: ignore[method-assign]
+    client.search = _mock_search  # ty: ignore[invalid-assignment]
 
     with pytest.raises(RuntimeError, match="unexpected parsing bug"):
         client.test_connection()

--- a/backend/tests/unit/onyx/utils/test_postgres_sanitization.py
+++ b/backend/tests/unit/onyx/utils/test_postgres_sanitization.py
@@ -215,7 +215,7 @@ def test_index_doc_batch_prepare_sanitizes_before_db_ops(
     context = indexing_pipeline.index_doc_batch_prepare(
         documents=[document],
         index_attempt_metadata=IndexAttemptMetadata(connector_id=1, credential_id=2),
-        db_session=object(),  # type: ignore[arg-type]
+        db_session=object(),  # ty: ignore[invalid-argument-type]
         ignore_time_skip=True,
     )
 
@@ -227,4 +227,4 @@ def test_index_doc_batch_prepare_sanitizes_before_db_ops(
 
     upsert_documents = captured["upsert_documents"]
     assert isinstance(upsert_documents, list)
-    assert upsert_documents[0].id == "docid"
+    assert upsert_documents[0].id == "docid"  # ty: ignore[unresolved-attribute]

--- a/backend/tests/unit/onyx/utils/test_sensitive.py
+++ b/backend/tests/unit/onyx/utils/test_sensitive.py
@@ -96,7 +96,7 @@ class TestSensitiveValueString:
             is_json=False,
         )
         with pytest.raises(SensitiveAccessError):
-            for _ in sensitive:  # type: ignore[attr-defined]
+            for _ in sensitive:
                 pass
 
     def test_getitem_raises_error(self) -> None:
@@ -208,7 +208,7 @@ class TestSensitiveValueJson:
             is_json=True,
         )
         with pytest.raises(SensitiveAccessError):
-            for _ in sensitive:  # type: ignore[attr-defined]
+            for _ in sensitive:
                 pass
 
 

--- a/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
@@ -306,7 +306,9 @@ def test_parallel_yield_basic() -> None:
     results: list[tuple[float, int]] = []
     start_time = time.time()
 
-    for value in parallel_yield([gen1, gen2, gen3]):
+    for value in parallel_yield(
+        [gen1, gen2, gen3]  # ty: ignore[invalid-argument-type]
+    ):
         results.append((time.time() - start_time, value))
 
     # Verify all values were yielded

--- a/backend/tests/unit/onyx/utils/test_vespa_tasks.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_tasks.py
@@ -71,8 +71,10 @@ def test_monitor_preserves_federated_only_document_set(monkeypatch: Any) -> None
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_1",
-        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]  # noqa: ARG005
-        db_session=SimpleNamespace(),  # type: ignore[arg-type]
+        r=SimpleNamespace(  # ty: ignore[invalid-argument-type]
+            scard=lambda key: 0  # noqa: ARG005
+        ),
+        db_session=SimpleNamespace(),  # ty: ignore[invalid-argument-type]
     )
 
     assert calls["synced"] is True
@@ -90,8 +92,10 @@ def test_monitor_deletes_document_set_with_no_connectors(monkeypatch: Any) -> No
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_2",
-        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]  # noqa: ARG005
-        db_session=SimpleNamespace(),  # type: ignore[arg-type]
+        r=SimpleNamespace(  # ty: ignore[invalid-argument-type]
+            scard=lambda key: 0  # noqa: ARG005
+        ),
+        db_session=SimpleNamespace(),  # ty: ignore[invalid-argument-type]
     )
 
     assert calls["deleted"] is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ backend = [
     "rfc3986==1.5.0",
     "simple-salesforce==1.12.6",
     "slack-sdk==3.20.2",
-    "SQLAlchemy[mypy]==2.0.15",
+    "SQLAlchemy==2.0.15",
     "starlette==0.49.3",
     "supervisor==4.3.0",
     "RapidFuzz==3.13.0",
@@ -146,8 +146,7 @@ dev = [
     "ipykernel==6.29.5",
     "manygo==0.2.0",
     "matplotlib==3.10.8",
-    "mypy-extensions==1.0.0",
-    "mypy==1.13.0",
+    "ty==0.0.31",
     "onyx-devtools==0.7.5",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
@@ -198,34 +197,37 @@ model_server = [
 [tool.uv]
 default-groups = ["backend", "dev", "ee", "model_server"]
 
-[tool.mypy]
-plugins = "sqlalchemy.ext.mypy.plugin"
-mypy_path = "backend"
-explicit_package_bases = true
-disallow_untyped_defs = true
-warn_unused_ignores = true
-enable_error_code = ["possibly-undefined"]
-strict_equality = true
-# Patterns match paths whether mypy is run from backend/ (CI) or repo root (e.g. VS Code extension with target ./backend)
+[tool.ty.environment]
+python-version = "3.11"
+root = ["./backend"]
+
+[tool.ty.src]
+include = ["backend"]
 exclude = [
-  "(?:^|/)generated/",
-  "(?:^|/)\\.venv/",
-  "(?:^|/)onyx/server/features/build/sandbox/kubernetes/docker/skills/",
-  "(?:^|/)onyx/server/features/build/sandbox/kubernetes/docker/templates/",
+    "**/generated/**",
+    "**/.venv/**",
+    "**/onyx/server/features/build/sandbox/kubernetes/docker/skills/**",
+    "**/onyx/server/features/build/sandbox/kubernetes/docker/templates/**",
+    "**/alembic/versions/**",
+    "**/alembic_tenants/versions/**",
 ]
 
-[[tool.mypy.overrides]]
-module = "alembic.versions.*"
-disable_error_code = ["var-annotated"]
+[tool.ty.rules]
+# Strict: all rules are errors. Existing false positives are suppressed per-line
+# with # ty: ignore[rule] comments. New code that introduces these errors will
+# fail CI.
+all = "error"
 
-[[tool.mypy.overrides]]
-module = "alembic_tenants.versions.*"
-disable_error_code = ["var-annotated"]
+# Track stale suppression comments as ty improves and false positives are resolved.
+unused-type-ignore-comment = "warn"
 
-[[tool.mypy.overrides]]
-module = "generated.*"
-follow_imports = "silent"
-ignore_errors = true
+# TODO: 28x datetime.utcnow() + 7x datetime.utcfromtimestamp() are real Python 3.12+
+# deprecations worth cleaning up. Set to "warn" so they show but don't block CI.
+deprecated = "warn"
+
+# Low-priority warnings -- show but don't block CI
+redundant-cast = "warn"
+possibly-missing-submodule = "warn"
 
 [tool.uv.workspace]
 members = ["tools/ods"]

--- a/uv.lock
+++ b/uv.lock
@@ -3851,34 +3851,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/21/7e9e523537991d145ab8a0a2fd98548d67646dc2aaaf6091c31ad883e7c1/mypy-1.13.0.tar.gz", hash = "sha256:0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e", size = 3152532, upload-time = "2024-10-22T21:55:47.458Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/19/de0822609e5b93d02579075248c7aa6ceaddcea92f00bf4ea8e4c22e3598/mypy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:581665e6f3a8a9078f28d5502f4c334c0c8d802ef55ea0e7276a6e409bc0d82d", size = 10939027, upload-time = "2024-10-22T21:55:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/71/6950fcc6ca84179137e4cbf7cf41e6b68b4a339a1f5d3e954f8c34e02d66/mypy-1.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ddb5b9bf82e05cc9a627e84707b528e5c7caaa1c55c69e175abb15a761cec2d", size = 10108699, upload-time = "2024-10-22T21:55:34.646Z" },
-    { url = "https://files.pythonhosted.org/packages/26/50/29d3e7dd166e74dc13d46050b23f7d6d7533acf48f5217663a3719db024e/mypy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20c7ee0bc0d5a9595c46f38beb04201f2620065a93755704e141fcac9f59db2b", size = 12506263, upload-time = "2024-10-22T21:54:51.807Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/1d/676e76f07f7d5ddcd4227af3938a9c9640f293b7d8a44dd4ff41d4db25c1/mypy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3790ded76f0b34bc9c8ba4def8f919dd6a46db0f5a6610fb994fe8efdd447f73", size = 12984688, upload-time = "2024-10-22T21:55:08.476Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/03/5a85a30ae5407b1d28fab51bd3e2103e52ad0918d1e68f02a7778669a307/mypy-1.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:51f869f4b6b538229c1d1bcc1dd7d119817206e2bc54e8e374b3dfa202defcca", size = 9626811, upload-time = "2024-10-22T21:54:59.152Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/31/c526a7bd2e5c710ae47717c7a5f53f616db6d9097caf48ad650581e81748/mypy-1.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5c7051a3461ae84dfb5dd15eff5094640c61c5f22257c8b766794e6dd85e72d5", size = 11077900, upload-time = "2024-10-22T21:55:37.103Z" },
-    { url = "https://files.pythonhosted.org/packages/83/67/b7419c6b503679d10bd26fc67529bc6a1f7a5f220bbb9f292dc10d33352f/mypy-1.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39bb21c69a5d6342f4ce526e4584bc5c197fd20a60d14a8624d8743fffb9472e", size = 10074818, upload-time = "2024-10-22T21:55:11.513Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/07/37d67048786ae84e6612575e173d713c9a05d0ae495dde1e68d972207d98/mypy-1.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:164f28cb9d6367439031f4c81e84d3ccaa1e19232d9d05d37cb0bd880d3f93c2", size = 12589275, upload-time = "2024-10-22T21:54:37.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/17/b1018c6bb3e9f1ce3956722b3bf91bff86c1cefccca71cec05eae49d6d41/mypy-1.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4c1bfcdbce96ff5d96fc9b08e3831acb30dc44ab02671eca5953eadad07d6d0", size = 13037783, upload-time = "2024-10-22T21:55:42.852Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/32/cd540755579e54a88099aee0287086d996f5a24281a673f78a0e14dba150/mypy-1.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0affb3a79a256b4183ba09811e3577c5163ed06685e4d4b46429a271ba174d2", size = 9726197, upload-time = "2024-10-22T21:54:43.68Z" },
-    { url = "https://files.pythonhosted.org/packages/11/bb/ab4cfdc562cad80418f077d8be9b4491ee4fb257440da951b85cbb0a639e/mypy-1.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a7b44178c9760ce1a43f544e595d35ed61ac2c3de306599fa59b38a6048e1aa7", size = 11069721, upload-time = "2024-10-22T21:54:22.321Z" },
-    { url = "https://files.pythonhosted.org/packages/59/3b/a393b1607cb749ea2c621def5ba8c58308ff05e30d9dbdc7c15028bca111/mypy-1.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d5092efb8516d08440e36626f0153b5006d4088c1d663d88bf79625af3d1d62", size = 10063996, upload-time = "2024-10-22T21:54:46.023Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1f/6b76be289a5a521bb1caedc1f08e76ff17ab59061007f201a8a18cc514d1/mypy-1.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2904956dac40ced10931ac967ae63c5089bd498542194b436eb097a9f77bc8", size = 12584043, upload-time = "2024-10-22T21:55:06.231Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/83/5a85c9a5976c6f96e3a5a7591aa28b4a6ca3a07e9e5ba0cec090c8b596d6/mypy-1.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7bfd8836970d33c2105562650656b6846149374dc8ed77d98424b40b09340ba7", size = 13036996, upload-time = "2024-10-22T21:55:25.811Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/59/c39a6f752f1f893fccbcf1bdd2aca67c79c842402b5283563d006a67cf76/mypy-1.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9f73dba9ec77acb86457a8fc04b5239822df0c14a082564737833d2963677dbc", size = 9737709, upload-time = "2024-10-22T21:55:21.246Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/72ce7f57431d87a7ff17d442f521146a6585019eb8f4f31b7c02801f78ad/mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a", size = 2647043, upload-time = "2024-10-22T21:55:16.617Z" },
-]
-
-[[package]]
 name = "mypy-boto3-s3"
 version = "1.39.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4328,7 +4300,7 @@ backend = [
     { name = "shapely" },
     { name = "simple-salesforce" },
     { name = "slack-sdk" },
-    { name = "sqlalchemy", extra = ["mypy"] },
+    { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "stripe" },
     { name = "supervisor" },
@@ -4350,8 +4322,6 @@ dev = [
     { name = "ipykernel" },
     { name = "manygo" },
     { name = "matplotlib" },
-    { name = "mypy" },
-    { name = "mypy-extensions" },
     { name = "onyx-devtools" },
     { name = "openapi-generator-cli" },
     { name = "pandas-stubs" },
@@ -4365,6 +4335,7 @@ dev = [
     { name = "release-tag" },
     { name = "reorder-python-imports-black" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-beautifulsoup4" },
     { name = "types-html5lib" },
     { name = "types-oauthlib" },
@@ -4502,7 +4473,7 @@ backend = [
     { name = "shapely", specifier = "==2.0.6" },
     { name = "simple-salesforce", specifier = "==1.12.6" },
     { name = "slack-sdk", specifier = "==3.20.2" },
-    { name = "sqlalchemy", extras = ["mypy"], specifier = "==2.0.15" },
+    { name = "sqlalchemy", specifier = "==2.0.15" },
     { name = "starlette", specifier = "==0.49.3" },
     { name = "stripe", specifier = "==10.12.0" },
     { name = "supervisor", specifier = "==4.3.0" },
@@ -4524,8 +4495,6 @@ dev = [
     { name = "ipykernel", specifier = "==6.29.5" },
     { name = "manygo", specifier = "==0.2.0" },
     { name = "matplotlib", specifier = "==3.10.8" },
-    { name = "mypy", specifier = "==1.13.0" },
-    { name = "mypy-extensions", specifier = "==1.0.0" },
     { name = "onyx-devtools", specifier = "==0.7.5" },
     { name = "openapi-generator-cli", specifier = "==7.17.0" },
     { name = "pandas-stubs", specifier = "~=2.3.3" },
@@ -4539,6 +4508,7 @@ dev = [
     { name = "release-tag", specifier = "==0.5.2" },
     { name = "reorder-python-imports-black", specifier = "==3.14.0" },
     { name = "ruff", specifier = "==0.12.0" },
+    { name = "ty", specifier = "==0.0.31" },
     { name = "types-beautifulsoup4", specifier = "==4.12.0.3" },
     { name = "types-html5lib", specifier = "==1.1.11.13" },
     { name = "types-oauthlib", specifier = "==3.2.0.9" },
@@ -7018,9 +6988,6 @@ wheels = [
 asyncio = [
     { name = "greenlet" },
 ]
-mypy = [
-    { name = "mypy" },
-]
 
 [[package]]
 name = "sse-starlette"
@@ -7383,6 +7350,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/80/e1/000add3b3e0725ce7ee0ea6ea4543f1e1d9519742f3b2320de41eeefa7c7/trove_classifiers-2025.12.1.14.tar.gz", hash = "sha256:a74f0400524fc83620a9be74a07074b5cbe7594fd4d97fd4c2bfde625fdc1633", size = 16985, upload-time = "2025-12-01T14:47:11.456Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/7e/bc19996fa86cad8801e8ffe6f1bba5836ca0160df76d0410d27432193712/trove_classifiers-2025.12.1.14-py3-none-any.whl", hash = "sha256:a8206978ede95937b9959c3aff3eb258bbf7b07dff391ddd4ea7e61f316635ab", size = 14184, upload-time = "2025-12-01T14:47:10.113Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description



## How Has This Been Tested?



## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `mypy` with `ty` for Python type checking across CI, pre-commit, and code annotations. Faster checks with no runtime changes.

- **Refactors**
  - CI: kept job name `mypy-check` for branch protection; now runs `ty check --output-format github`, switched to `runner=2cpu-linux-arm64`, removed S3 cache and OpenAPI/client generation steps plus mypy cache, timeout now 15m.
  - Pre-commit: added optional `ty` hook via `uv-run` with `--active ty check` and `pass_filenames: false` (pre-release v0.0.31).
  - Code: replaced `type: ignore` with granular `ty: ignore[...]`; removed many untyped-import ignores for `googleapiclient`, `office365`, `dropbox`, `asana`, `hubspot`, `msal`, `pywikibot`; added targeted `ty` ignores (e.g., invalid-argument-type/return-type, unresolved-attribute, invalid-assignment, possibly-missing-import) across connectors, Celery apps, Alembic, DB, auth, and Google services; no functional changes.

- **Migration**
  - Run `ty check` locally for type checks.
  - Optionally enable the pre-commit hook by uncommenting the `uv-run` `ty` entry in `.pre-commit-config.yaml`.

<sup>Written for commit 65470ea2a7e85d94cf91fa9453ec8c30c3ed0469. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

