### PR TITLE
feat(celery): Monitoring for Primary Worker

### DIFF
--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -38,6 +38,12 @@ from onyx.redis.redis_connector_stop import RedisConnectorStop
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_usergroup import RedisUserGroup
+from onyx.server.metrics.celery_task_metrics import on_celery_task_postrun
+from onyx.server.metrics.celery_task_metrics import on_celery_task_prerun
+from onyx.server.metrics.celery_task_metrics import on_celery_task_rejected
+from onyx.server.metrics.celery_task_metrics import on_celery_task_retry
+from onyx.server.metrics.celery_task_metrics import on_celery_task_revoked
+from onyx.server.metrics.metrics_server import start_metrics_server
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
@@ -59,6 +65,7 @@ def on_task_prerun(
     **kwds: Any,
 ) -> None:
     app_base.on_task_prerun(sender, task_id, task, args, kwargs, **kwds)
+    on_celery_task_prerun(task_id, task)
 
 
 @signals.task_postrun.connect
@@ -73,6 +80,31 @@ def on_task_postrun(
     **kwds: Any,
 ) -> None:
     app_base.on_task_postrun(sender, task_id, task, args, kwargs, retval, state, **kwds)
+    on_celery_task_postrun(task_id, task, state)
+
+
+@signals.task_retry.connect
+def on_task_retry(sender: Any | None = None, **kwargs: Any) -> None:  # noqa: ARG001
+    task_id = getattr(getattr(sender, "request", None), "id", None)
+    on_celery_task_retry(task_id, sender)
+
+
+@signals.task_revoked.connect
+def on_task_revoked(sender: Any | None = None, **kwargs: Any) -> None:
+    task_name = getattr(sender, "name", None) or str(sender)
+    on_celery_task_revoked(kwargs.get("task_id"), task_name)
+
+
+@signals.task_rejected.connect
+def on_task_rejected(sender: Any | None = None, **kwargs: Any) -> None:  # noqa: ARG001
+    message = kwargs.get("message")
+    task_name: str | None = None
+    if message is not None:
+        headers = getattr(message, "headers", None) or {}
+        task_name = headers.get("task")
+    if task_name is None:
+        task_name = "unknown"
+    on_celery_task_rejected(None, task_name)
 
 
 @celeryd_init.connect
@@ -212,6 +244,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 
 @worker_ready.connect
 def on_worker_ready(sender: Any, **kwargs: Any) -> None:
+    start_metrics_server("primary")
     app_base.on_worker_ready(sender, **kwargs)
 
 

--- a/backend/onyx/server/metrics/metrics_server.py
+++ b/backend/onyx/server/metrics/metrics_server.py
@@ -28,6 +28,7 @@ _DEFAULT_PORTS: dict[str, int] = {
     "docprocessing": 9093,
     "heavy": 9094,
     "light": 9095,
+    "primary": 9097,
 }
 
 _server_started = False

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-metrics-service.yaml
@@ -1,0 +1,26 @@
+{{- /* Metrics port must match the default in metrics_server.py (_DEFAULT_PORTS).
+       Do NOT use PROMETHEUS_METRICS_PORT env var in Helm — each worker needs its own port. */ -}}
+{{- if gt (int .Values.celery_worker_primary.replicaCount) 0 }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "onyx.fullname" . }}-celery-worker-primary-metrics
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    {{- if .Values.celery_worker_primary.deploymentLabels }}
+    {{- toYaml .Values.celery_worker_primary.deploymentLabels | nindent 4 }}
+    {{- end }}
+    metrics: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9097
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "onyx.selectorLabels" . | nindent 4 }}
+    {{- if .Values.celery_worker_primary.deploymentLabels }}
+    {{- toYaml .Values.celery_worker_primary.deploymentLabels | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -70,6 +70,10 @@ spec:
               "-Q",
               "celery,periodic_tasks",
             ]
+          ports:
+            - name: metrics
+              containerPort: 9097
+              protocol: TCP
           resources:
             {{- toYaml .Values.celery_worker_primary.resources | nindent 12 }}
           envFrom:

--- a/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
@@ -124,4 +124,29 @@ spec:
       interval: 30s
       scrapeTimeout: 10s
 {{- end }}
+{{- if gt (int .Values.celery_worker_primary.replicaCount) 0 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "onyx.fullname" . }}-celery-worker-primary
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitors.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Values.celery_worker_primary.deploymentLabels.app }}
+      metrics: "true"
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding new metrics for the primary worker

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Following previous examples

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds metrics instrumentation for the primary Celery worker and exposes Prometheus metrics on port 9097. Adds Helm Service and ServiceMonitor so Prometheus can auto-discover the endpoint.

- **New Features**
  - Hooked Celery signals to `on_celery_task_prerun/postrun/retry/revoked/rejected` in `primary` app.
  - Starts metrics server with `start_metrics_server("primary")` when the worker is ready.
  - Registers `primary: 9097` in the metrics server port map.
  - Helm: adds container metrics port `9097`, a ClusterIP metrics `Service`, and a `ServiceMonitor` for `celery_worker_primary`.

- **Migration**
  - If not using the Prometheus Operator, add a scrape for http://<host>:9097/metrics; otherwise ServiceMonitor handles discovery.

<sup>Written for commit 84ee291fa4fca105817ba45664f433d01d0126a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

