### PR TITLE
feat(connectors): convert Gong connector from poll to checkpointed

### DIFF
--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -1,6 +1,7 @@
 import base64
 import copy
 import time
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -37,6 +38,8 @@ class GongConnectorCheckpoint(ConnectorCheckpoint):
     workspace_index: int = 0
     # Gong API cursor for current workspace's transcript pagination
     cursor: str | None = None
+    # Cached time range — computed once, reused across checkpoint calls
+    time_range: tuple[str, str] | None = None
 
 
 class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
@@ -164,6 +167,50 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         return call_to_metadata
 
+    def _fetch_call_details_with_retry(self, call_ids: list[str]) -> dict[str, Any]:
+        """Fetch call details with retry for the Gong API race condition.
+
+        The Gong API has a known race where transcript call IDs don't immediately
+        appear in /v2/calls/extensive. Retries with exponential backoff, only
+        re-requesting the missing IDs on each attempt.
+        """
+        call_details_map = self._get_call_details_by_ids(call_ids)
+        if set(call_ids) == set(call_details_map.keys()):
+            return call_details_map
+
+        for attempt in range(2, self.MAX_CALL_DETAILS_ATTEMPTS + 1):
+            missing_ids = list(set(call_ids) - set(call_details_map.keys()))
+            logger.warning(
+                f"_get_call_details_by_ids is missing call id's: current_attempt={attempt - 1} missing_call_ids={missing_ids}"
+            )
+
+            wait_seconds = self.CALL_DETAILS_DELAY * pow(2, attempt - 2)
+            logger.warning(
+                f"_get_call_details_by_ids waiting to retry: "
+                f"wait={wait_seconds}s "
+                f"current_attempt={attempt - 1} "
+                f"next_attempt={attempt} "
+                f"max_attempts={self.MAX_CALL_DETAILS_ATTEMPTS}"
+            )
+            time.sleep(wait_seconds)
+
+            # Only re-fetch the missing IDs, merge into existing results
+            new_details = self._get_call_details_by_ids(missing_ids)
+            call_details_map.update(new_details)
+
+            if set(call_ids) == set(call_details_map.keys()):
+                return call_details_map
+
+        missing_ids = list(set(call_ids) - set(call_details_map.keys()))
+        logger.error(
+            f"Giving up on missing call id's after "
+            f"{self.MAX_CALL_DETAILS_ATTEMPTS} attempts: "
+            f"missing_call_ids={missing_ids} — "
+            f"proceeding with {len(call_details_map)} of "
+            f"{len(call_ids)} calls"
+        )
+        return call_details_map
+
     @staticmethod
     def _parse_parties(parties: list[dict]) -> dict[str, str]:
         id_mapping = {}
@@ -244,6 +291,88 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         return start_time, end_time
 
+    def _process_transcripts(
+        self,
+        transcripts: list[dict[str, Any]],
+    ) -> Generator[Document | ConnectorFailure, None, None]:
+        """Process a batch of transcripts into Documents or ConnectorFailures."""
+        transcript_call_ids = cast(
+            list[str],
+            [t.get("callId") for t in transcripts if t.get("callId")],
+        )
+
+        call_details_map = self._fetch_call_details_with_retry(transcript_call_ids)
+
+        for transcript in transcripts:
+            call_id = transcript.get("callId")
+
+            if not call_id or call_id not in call_details_map:
+                logger.error(f"Couldn't get call information for Call ID: {call_id}")
+                if call_id:
+                    logger.error(
+                        f"Call debug info: call_id={call_id} "
+                        f"call_ids={transcript_call_ids} "
+                        f"call_details_map={call_details_map.keys()}"
+                    )
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=call_id or "unknown",
+                    ),
+                    failure_message=f"Couldn't get call information for Call ID: {call_id}",
+                )
+                continue
+
+            call_details = call_details_map[call_id]
+            call_metadata = call_details["metaData"]
+
+            call_time_str = call_metadata["started"]
+            call_title = call_metadata["title"]
+            logger.info(
+                f"Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
+            )
+
+            call_parties = cast(list[dict] | None, call_details.get("parties"))
+            if call_parties is None:
+                logger.error(f"Couldn't get parties for Call ID: {call_id}")
+                call_parties = []
+
+            id_to_name_map = self._parse_parties(call_parties)
+
+            speaker_to_name: dict[str, str] = {}
+
+            transcript_text = ""
+            call_purpose = call_metadata["purpose"]
+            if call_purpose:
+                transcript_text += f"Call Description: {call_purpose}\n\n"
+
+            contents = transcript["transcript"]
+            for segment in contents:
+                speaker_id = segment.get("speakerId", "")
+                if speaker_id not in speaker_to_name:
+                    if self.hide_user_info:
+                        speaker_to_name[speaker_id] = f"User {len(speaker_to_name) + 1}"
+                    else:
+                        speaker_to_name[speaker_id] = id_to_name_map.get(
+                            speaker_id, "Unknown"
+                        )
+
+                speaker_name = speaker_to_name[speaker_id]
+
+                sentences = segment.get("sentences", {})
+                monolog = " ".join([sentence.get("text", "") for sentence in sentences])
+                transcript_text += f"{speaker_name}: {monolog}\n\n"
+
+            yield Document(
+                id=call_id,
+                sections=[TextSection(link=call_metadata["url"], text=transcript_text)],
+                source=DocumentSource.GONG,
+                semantic_identifier=call_title or "Untitled",
+                doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
+                    timezone.utc
+                ),
+                metadata={"client": call_metadata.get("system")},
+            )
+
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         combined = (
             f"{credentials['gong_access_key']}:{credentials['gong_access_key_secret']}"
@@ -277,6 +406,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         # Step 1: Resolve workspace IDs on first call
         if checkpoint.workspace_ids is None:
             checkpoint.workspace_ids = self._resolve_workspace_ids()
+            checkpoint.time_range = self._compute_time_range(start, end)
             checkpoint.has_more = True
             return checkpoint
 
@@ -287,7 +417,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.has_more = False
             return checkpoint
 
-        start_time, end_time = self._compute_time_range(start, end)
+        # Use cached time range, falling back to computation if not cached
+        start_time, end_time = checkpoint.time_range or self._compute_time_range(
+            start, end
+        )
         logger.info(
             f"Fetching Gong calls between {start_time} and {end_time} "
             f"(workspace {checkpoint.workspace_index + 1}/{len(workspace_ids)})"
@@ -305,130 +438,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         # Step 3: Process transcripts into documents
         if transcripts:
-            transcript_call_ids = cast(
-                list[str],
-                [t.get("callId") for t in transcripts if t.get("callId")],
-            )
-
-            call_details_map: dict[str, Any] = {}
-
-            # There's a likely race condition in the API where a transcript will have a
-            # call id but the call to v2/calls/extensive will not return all of the id's
-            # retry with exponential backoff has been observed to mitigate this
-            # in ~2 minutes. After max attempts, proceed with whatever we have —
-            # the per-call loop below will yield failures for missing IDs.
-            current_attempt = 0
-            while True:
-                current_attempt += 1
-                call_details_map = self._get_call_details_by_ids(transcript_call_ids)
-                if set(transcript_call_ids) == set(call_details_map.keys()):
-                    break
-
-                missing_call_ids = set(transcript_call_ids) - set(
-                    call_details_map.keys()
-                )
-                logger.warning(
-                    f"_get_call_details_by_ids is missing call id's: "
-                    f"current_attempt={current_attempt} "
-                    f"missing_call_ids={missing_call_ids}"
-                )
-                if current_attempt >= self.MAX_CALL_DETAILS_ATTEMPTS:
-                    logger.error(
-                        f"Giving up on missing call id's after "
-                        f"{self.MAX_CALL_DETAILS_ATTEMPTS} attempts: "
-                        f"missing_call_ids={missing_call_ids} — "
-                        f"proceeding with {len(call_details_map)} of "
-                        f"{len(transcript_call_ids)} calls"
-                    )
-                    break
-
-                wait_seconds = self.CALL_DETAILS_DELAY * pow(2, current_attempt - 1)
-                logger.warning(
-                    f"_get_call_details_by_ids waiting to retry: "
-                    f"wait={wait_seconds}s "
-                    f"current_attempt={current_attempt} "
-                    f"next_attempt={current_attempt + 1} "
-                    f"max_attempts={self.MAX_CALL_DETAILS_ATTEMPTS}"
-                )
-                time.sleep(wait_seconds)
-
-            for transcript in transcripts:
-                call_id = transcript.get("callId")
-
-                if not call_id or call_id not in call_details_map:
-                    logger.error(
-                        f"Couldn't get call information for Call ID: {call_id}"
-                    )
-                    if call_id:
-                        logger.error(
-                            f"Call debug info: call_id={call_id} "
-                            f"call_ids={transcript_call_ids} "
-                            f"call_details_map={call_details_map.keys()}"
-                        )
-                    yield ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=call_id or "unknown",
-                        ),
-                        failure_message=f"Couldn't get call information for Call ID: {call_id}",
-                    )
-                    continue
-
-                call_details = call_details_map[call_id]
-                call_metadata = call_details["metaData"]
-
-                call_time_str = call_metadata["started"]
-                call_title = call_metadata["title"]
-                logger.info(
-                    f"Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
-                )
-
-                call_parties = cast(list[dict] | None, call_details.get("parties"))
-                if call_parties is None:
-                    logger.error(f"Couldn't get parties for Call ID: {call_id}")
-                    call_parties = []
-
-                id_to_name_map = self._parse_parties(call_parties)
-
-                speaker_to_name: dict[str, str] = {}
-
-                transcript_text = ""
-                call_purpose = call_metadata["purpose"]
-                if call_purpose:
-                    transcript_text += f"Call Description: {call_purpose}\n\n"
-
-                contents = transcript["transcript"]
-                for segment in contents:
-                    speaker_id = segment.get("speakerId", "")
-                    if speaker_id not in speaker_to_name:
-                        if self.hide_user_info:
-                            speaker_to_name[speaker_id] = (
-                                f"User {len(speaker_to_name) + 1}"
-                            )
-                        else:
-                            speaker_to_name[speaker_id] = id_to_name_map.get(
-                                speaker_id, "Unknown"
-                            )
-
-                    speaker_name = speaker_to_name[speaker_id]
-
-                    sentences = segment.get("sentences", {})
-                    monolog = " ".join(
-                        [sentence.get("text", "") for sentence in sentences]
-                    )
-                    transcript_text += f"{speaker_name}: {monolog}\n\n"
-
-                yield Document(
-                    id=call_id,
-                    sections=[
-                        TextSection(link=call_metadata["url"], text=transcript_text)
-                    ],
-                    source=DocumentSource.GONG,
-                    semantic_identifier=call_title or "Untitled",
-                    doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
-                        timezone.utc
-                    ),
-                    metadata={"client": call_metadata.get("system")},
-                )
+            yield from self._process_transcripts(transcripts)
 
         # Step 4: Update checkpoint state
         if next_cursor:

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -233,6 +233,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         Returns a list of workspace IDs. If no workspaces are configured,
         returns [None] to indicate "fetch all workspaces".
+
+        Raises ValueError if workspaces are configured but none resolve —
+        we never silently widen scope to "fetch all" on misconfiguration,
+        because that could ingest an entire Gong account by mistake.
         """
         if not self.workspaces:
             return [None]
@@ -246,12 +250,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
                 continue
             resolved.append(workspace_id)
 
-        # If all workspaces were invalid, fall back to fetching all
         if not resolved:
-            logger.warning(
-                "No valid workspaces found, falling back to fetching all workspaces"
+            raise ValueError(
+                f"No valid Gong workspaces found — check workspace names/IDs in connector config. Configured: {self.workspaces}"
             )
-            return [None]
 
         return resolved
 

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import cast
 
 import requests
+from pydantic import BaseModel
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
@@ -39,6 +40,24 @@ class GongConnectorCheckpoint(ConnectorCheckpoint):
     cursor: str | None = None
     # Cached time range — computed once, reused across checkpoint calls
     time_range: tuple[str, str] | None = None
+
+
+class _TranscriptPage(BaseModel):
+    """One page of transcripts from /v2/calls/transcript."""
+
+    transcripts: list[dict[str, Any]]
+    next_cursor: str | None = None
+
+
+class _CursorExpiredError(Exception):
+    """Raised when Gong rejects a pagination cursor as expired.
+
+    Gong pagination cursors TTL is ~1 hour from the first request in a
+    pagination sequence, not from the last cursor fetch. Since checkpointed
+    connector runs can pause between invocations, a resumed run may encounter
+    an expired cursor and must restart the current workspace from scratch.
+    See https://visioneers.gong.io/integrations-77/pagination-cursor-expires-after-1-hours-even-for-a-new-cursor-1382
+    """
 
 
 class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
@@ -113,10 +132,11 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         end_datetime: str | None,
         workspace_id: str | None,
         cursor: str | None,
-    ) -> tuple[list[dict[str, Any]], str | None]:
+    ) -> _TranscriptPage:
         """Fetch one page of transcripts from the Gong API.
 
-        Returns (transcripts, next_cursor). next_cursor is None when no more pages.
+        Raises _CursorExpiredError if Gong reports the pagination cursor
+        expired (TTL is ~1 hour from first request in the pagination sequence).
         """
         body: dict[str, Any] = {"filter": {}}
         if start_datetime:
@@ -133,18 +153,21 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         )
         # If no calls in the range, return empty
         if response.status_code == 404:
-            return [], None
+            return _TranscriptPage(transcripts=[])
 
-        try:
-            response.raise_for_status()
-        except Exception:
+        if not response.ok:
+            # Cursor expiration comes back as a 4xx with this error message —
+            # detect it before raise_for_status so callers can restart the workspace.
+            if cursor and "cursor has expired" in response.text.lower():
+                raise _CursorExpiredError(response.text)
             logger.error(f"Error fetching transcripts: {response.text}")
-            raise
+            response.raise_for_status()
 
         data = response.json()
-        transcripts = data.get("callTranscripts", [])
-        next_cursor = data.get("records", {}).get("cursor")
-        return transcripts, next_cursor
+        return _TranscriptPage(
+            transcripts=data.get("callTranscripts", []),
+            next_cursor=data.get("records", {}).get("cursor"),
+        )
 
     def _get_call_details_by_ids(self, call_ids: list[str]) -> dict[str, Any]:
         body = {
@@ -428,21 +451,36 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         workspace_id = workspace_ids[checkpoint.workspace_index]
 
         # Step 2: Fetch one page of transcripts
-        transcripts, next_cursor = self._fetch_transcript_page(
-            start_datetime=start_time,
-            end_datetime=end_time,
-            workspace_id=workspace_id,
-            cursor=checkpoint.cursor,
-        )
+        try:
+            page = self._fetch_transcript_page(
+                start_datetime=start_time,
+                end_datetime=end_time,
+                workspace_id=workspace_id,
+                cursor=checkpoint.cursor,
+            )
+        except _CursorExpiredError:
+            # Gong cursors TTL ~1h from first request in the sequence. If the
+            # checkpoint paused long enough for the cursor to expire, restart
+            # the current workspace from the beginning of the time range.
+            # Document upserts are idempotent (keyed by call_id) so
+            # reprocessing is safe.
+            logger.warning(
+                f"Gong pagination cursor expired for workspace "
+                f"{checkpoint.workspace_index + 1}/{len(workspace_ids)}; "
+                f"restarting workspace from beginning of time range."
+            )
+            checkpoint.cursor = None
+            checkpoint.has_more = True
+            return checkpoint
 
         # Step 3: Process transcripts into documents
-        if transcripts:
-            yield from self._process_transcripts(transcripts)
+        if page.transcripts:
+            yield from self._process_transcripts(page.transcripts)
 
         # Step 4: Update checkpoint state
-        if next_cursor:
+        if page.next_cursor:
             # More pages in this workspace
-            checkpoint.cursor = next_cursor
+            checkpoint.cursor = page.next_cursor
             checkpoint.has_more = True
         else:
             # This workspace is exhausted — advance to next

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -13,7 +13,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 from onyx.configs.app_configs import GONG_CONNECTOR_START_TIME
-from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CheckpointOutput
@@ -52,11 +51,9 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
     def __init__(
         self,
         workspaces: list[str] | None = None,
-        batch_size: int = INDEX_BATCH_SIZE,
         hide_user_info: bool = False,
     ) -> None:
         self.workspaces = workspaces
-        self.batch_size: int = batch_size
         self.auth_token_basic: str | None = None
         self.hide_user_info = hide_user_info
         self._last_request_time: float = 0.0

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -1,6 +1,6 @@
 import base64
+import copy
 import time
-from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -11,24 +11,35 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from onyx.configs.app_configs import CONTINUE_ON_CONNECTOR_FAILURE
 from onyx.configs.app_configs import GONG_CONNECTOR_START_TIME
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.interfaces import GenerateDocumentsOutput
-from onyx.connectors.interfaces import LoadConnector
-from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import CheckpointedConnector
+from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
-from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
-class GongConnector(LoadConnector, PollConnector):
+class GongConnectorCheckpoint(ConnectorCheckpoint):
+    # Resolved workspace IDs to iterate through.
+    # None means "not yet resolved" — first checkpoint call resolves them.
+    # Inner None means "no workspace filter" (fetch all).
+    workspace_ids: list[str | None] | None = None
+    # Index into workspace_ids for current workspace
+    workspace_index: int = 0
+    # Gong API cursor for current workspace's transcript pagination
+    cursor: str | None = None
+
+
+class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
     BASE_URL = "https://api.gong.io"
     MAX_CALL_DETAILS_ATTEMPTS = 6
     CALL_DETAILS_DELAY = 30  # in seconds
@@ -39,12 +50,10 @@ class GongConnector(LoadConnector, PollConnector):
         self,
         workspaces: list[str] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
-        continue_on_fail: bool = CONTINUE_ON_CONNECTOR_FAILURE,
         hide_user_info: bool = False,
     ) -> None:
         self.workspaces = workspaces
         self.batch_size: int = batch_size
-        self.continue_on_fail = continue_on_fail
         self.auth_token_basic: str | None = None
         self.hide_user_info = hide_user_info
         self._last_request_time: float = 0.0
@@ -98,65 +107,44 @@ class GongConnector(LoadConnector, PollConnector):
         # Then the user input is treated as the name
         return {**id_id_map, **name_id_map}
 
-    def _get_transcript_batches(
-        self, start_datetime: str | None = None, end_datetime: str | None = None
-    ) -> Generator[list[dict[str, Any]], None, None]:
-        body: dict[str, dict] = {"filter": {}}
+    def _fetch_transcript_page(
+        self,
+        start_datetime: str | None,
+        end_datetime: str | None,
+        workspace_id: str | None,
+        cursor: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Fetch one page of transcripts from the Gong API.
+
+        Returns (transcripts, next_cursor). next_cursor is None when no more pages.
+        """
+        body: dict[str, Any] = {"filter": {}}
         if start_datetime:
             body["filter"]["fromDateTime"] = start_datetime
         if end_datetime:
             body["filter"]["toDateTime"] = end_datetime
+        if workspace_id:
+            body["filter"]["workspaceId"] = workspace_id
+        if cursor:
+            body["cursor"] = cursor
 
-        # The batch_ids in the previous method appears to be batches of call_ids to process
-        # In this method, we will retrieve transcripts for them in batches.
-        transcripts: list[dict[str, Any]] = []
-        workspace_list = self.workspaces or [None]
-        workspace_map = self._get_workspace_id_map() if self.workspaces else {}
+        response = self._throttled_request(
+            "POST", GongConnector.make_url("/v2/calls/transcript"), json=body
+        )
+        # If no calls in the range, return empty
+        if response.status_code == 404:
+            return [], None
 
-        for workspace in workspace_list:
-            if workspace:
-                logger.info(f"Updating Gong workspace: {workspace}")
-                workspace_id = workspace_map.get(workspace)
-                if not workspace_id:
-                    logger.error(f"Invalid Gong workspace: {workspace}")
-                    if not self.continue_on_fail:
-                        raise ValueError(f"Invalid workspace: {workspace}")
-                    continue
-                body["filter"]["workspaceId"] = workspace_id
-            else:
-                if "workspaceId" in body["filter"]:
-                    del body["filter"]["workspaceId"]
+        try:
+            response.raise_for_status()
+        except Exception:
+            logger.error(f"Error fetching transcripts: {response.text}")
+            raise
 
-            while True:
-                response = self._throttled_request(
-                    "POST", GongConnector.make_url("/v2/calls/transcript"), json=body
-                )
-                # If no calls in the range, just break out
-                if response.status_code == 404:
-                    break
-
-                try:
-                    response.raise_for_status()
-                except Exception:
-                    logger.error(f"Error fetching transcripts: {response.text}")
-                    raise
-
-                data = response.json()
-                call_transcripts = data.get("callTranscripts", [])
-                transcripts.extend(call_transcripts)
-
-                while len(transcripts) >= self.batch_size:
-                    yield transcripts[: self.batch_size]
-                    transcripts = transcripts[self.batch_size :]
-
-                cursor = data.get("records", {}).get("cursor")
-                if cursor:
-                    body["cursor"] = cursor
-                else:
-                    break
-
-        if transcripts:
-            yield transcripts
+        data = response.json()
+        transcripts = data.get("callTranscripts", [])
+        next_cursor = data.get("records", {}).get("cursor")
+        return transcripts, next_cursor
 
     def _get_call_details_by_ids(self, call_ids: list[str]) -> dict:
         body = {
@@ -196,19 +184,128 @@ class GongConnector(LoadConnector, PollConnector):
 
         return id_mapping
 
-    def _fetch_calls(
-        self, start_datetime: str | None = None, end_datetime: str | None = None
-    ) -> GenerateDocumentsOutput:
-        num_calls = 0
+    def _resolve_workspace_ids(self) -> list[str | None]:
+        """Resolve configured workspace names/IDs to actual workspace IDs.
 
-        for transcript_batch in self._get_transcript_batches(
-            start_datetime, end_datetime
-        ):
-            doc_batch: list[Document | HierarchyNode] = []
+        Returns a list of workspace IDs. If no workspaces are configured,
+        returns [None] to indicate "fetch all workspaces".
+        """
+        if not self.workspaces:
+            return [None]
 
+        workspace_map = self._get_workspace_id_map()
+        resolved: list[str | None] = []
+        for workspace in self.workspaces:
+            workspace_id = workspace_map.get(workspace)
+            if not workspace_id:
+                logger.error(f"Invalid Gong workspace: {workspace}")
+                continue
+            resolved.append(workspace_id)
+
+        # If all workspaces were invalid, fall back to fetching all
+        if not resolved:
+            logger.warning(
+                "No valid workspaces found, falling back to fetching all workspaces"
+            )
+            return [None]
+
+        return resolved
+
+    @staticmethod
+    def _compute_time_range(
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> tuple[str, str]:
+        """Compute the start/end datetime strings for the Gong API filter,
+        applying GONG_CONNECTOR_START_TIME and the 1-day offset."""
+        end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
+
+        # if this env variable is set, don't start from a timestamp before the specified
+        # start time
+        if GONG_CONNECTOR_START_TIME:
+            special_start_datetime = datetime.fromisoformat(GONG_CONNECTOR_START_TIME)
+            special_start_datetime = special_start_datetime.replace(tzinfo=timezone.utc)
+        else:
+            special_start_datetime = datetime.fromtimestamp(0, tz=timezone.utc)
+
+        # don't let the special start dt be past the end time, this causes issues when
+        # the Gong API (`filter.fromDateTime: must be before toDateTime`)
+        special_start_datetime = min(special_start_datetime, end_datetime)
+
+        start_datetime = max(
+            datetime.fromtimestamp(start, tz=timezone.utc), special_start_datetime
+        )
+
+        # Because these are meeting start times, the meeting needs to end and be processed
+        # so adding a 1 day buffer and fetching by default till current time
+        start_one_day_offset = start_datetime - timedelta(days=1)
+        start_time = start_one_day_offset.isoformat()
+        end_time = end_datetime.isoformat()
+
+        return start_time, end_time
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        combined = (
+            f"{credentials['gong_access_key']}:{credentials['gong_access_key_secret']}"
+        )
+        self.auth_token_basic = base64.b64encode(combined.encode("utf-8")).decode(
+            "utf-8"
+        )
+
+        if self.auth_token_basic is None:
+            raise ConnectorMissingCredentialError("Gong")
+
+        self._session.headers.update(
+            {"Authorization": f"Basic {self.auth_token_basic}"}
+        )
+        return None
+
+    def build_dummy_checkpoint(self) -> GongConnectorCheckpoint:
+        return GongConnectorCheckpoint(has_more=True)
+
+    def validate_checkpoint_json(self, checkpoint_json: str) -> GongConnectorCheckpoint:
+        return GongConnectorCheckpoint.model_validate_json(checkpoint_json)
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: GongConnectorCheckpoint,
+    ) -> CheckpointOutput[GongConnectorCheckpoint]:
+        checkpoint = copy.deepcopy(checkpoint)
+
+        # Step 1: Resolve workspace IDs on first call
+        if checkpoint.workspace_ids is None:
+            checkpoint.workspace_ids = self._resolve_workspace_ids()
+            checkpoint.has_more = True
+            return checkpoint
+
+        # If we've exhausted all workspaces, we're done
+        if checkpoint.workspace_index >= len(checkpoint.workspace_ids):
+            checkpoint.has_more = False
+            return checkpoint
+
+        start_time, end_time = self._compute_time_range(start, end)
+        logger.info(
+            f"Fetching Gong calls between {start_time} and {end_time} "
+            f"(workspace {checkpoint.workspace_index + 1}/{len(checkpoint.workspace_ids)})"
+        )
+
+        workspace_id = checkpoint.workspace_ids[checkpoint.workspace_index]
+
+        # Step 2: Fetch one page of transcripts
+        transcripts, next_cursor = self._fetch_transcript_page(
+            start_datetime=start_time,
+            end_datetime=end_time,
+            workspace_id=workspace_id,
+            cursor=checkpoint.cursor,
+        )
+
+        # Step 3: Process transcripts into documents
+        if transcripts:
             transcript_call_ids = cast(
                 list[str],
-                [t.get("callId") for t in transcript_batch if t.get("callId")],
+                [t.get("callId") for t in transcripts if t.get("callId")],
             )
 
             call_details_map: dict[str, Any] = {}
@@ -217,16 +314,14 @@ class GongConnector(LoadConnector, PollConnector):
             # call id but the call to v2/calls/extensive will not return all of the id's
             # retry with exponential backoff has been observed to mitigate this
             # in ~2 minutes. After max attempts, proceed with whatever we have —
-            # the per-call loop below will skip missing IDs gracefully.
+            # the per-call loop below will yield failures for missing IDs.
             current_attempt = 0
             while True:
                 current_attempt += 1
                 call_details_map = self._get_call_details_by_ids(transcript_call_ids)
                 if set(transcript_call_ids) == set(call_details_map.keys()):
-                    # we got all the id's we were expecting ... break and continue
                     break
 
-                # we are missing some id's. Log and retry with exponential backoff
                 missing_call_ids = set(transcript_call_ids) - set(
                     call_details_map.keys()
                 )
@@ -255,13 +350,10 @@ class GongConnector(LoadConnector, PollConnector):
                 )
                 time.sleep(wait_seconds)
 
-            # now we can iterate per call/transcript
-            for transcript in transcript_batch:
+            for transcript in transcripts:
                 call_id = transcript.get("callId")
 
                 if not call_id or call_id not in call_details_map:
-                    # NOTE(rkuo): seeing odd behavior where call_ids from the transcript
-                    # don't have call details. adding error debugging logs to trace.
                     logger.error(
                         f"Couldn't get call information for Call ID: {call_id}"
                     )
@@ -271,10 +363,12 @@ class GongConnector(LoadConnector, PollConnector):
                             f"call_ids={transcript_call_ids} "
                             f"call_details_map={call_details_map.keys()}"
                         )
-                    if not self.continue_on_fail:
-                        raise RuntimeError(
-                            f"Couldn't get call information for Call ID: {call_id}"
-                        )
+                    yield ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=call_id or "unknown",
+                        ),
+                        failure_message=f"Couldn't get call information for Call ID: {call_id}",
+                    )
                     continue
 
                 call_details = call_details_map[call_id]
@@ -283,7 +377,7 @@ class GongConnector(LoadConnector, PollConnector):
                 call_time_str = call_metadata["started"]
                 call_title = call_metadata["title"]
                 logger.info(
-                    f"{num_calls + 1}: Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
+                    f"Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
                 )
 
                 call_parties = cast(list[dict] | None, call_details.get("parties"))
@@ -293,7 +387,6 @@ class GongConnector(LoadConnector, PollConnector):
 
                 id_to_name_map = self._parse_parties(call_parties)
 
-                # Keeping a separate dict here in case the parties info is incomplete
                 speaker_to_name: dict[str, str] = {}
 
                 transcript_text = ""
@@ -322,83 +415,33 @@ class GongConnector(LoadConnector, PollConnector):
                     )
                     transcript_text += f"{speaker_name}: {monolog}\n\n"
 
-                metadata = {}
-                if call_metadata.get("system"):
-                    metadata["client"] = call_metadata.get("system")
-                # TODO calls have a clientUniqueId field, can pull that in later
-
-                doc_batch.append(
-                    Document(
-                        id=call_id,
-                        sections=[
-                            TextSection(link=call_metadata["url"], text=transcript_text)
-                        ],
-                        source=DocumentSource.GONG,
-                        # Should not ever be Untitled as a call cannot be made without a Title
-                        semantic_identifier=call_title or "Untitled",
-                        doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
-                            timezone.utc
-                        ),
-                        metadata={"client": call_metadata.get("system")},
-                    )
+                yield Document(
+                    id=call_id,
+                    sections=[
+                        TextSection(link=call_metadata["url"], text=transcript_text)
+                    ],
+                    source=DocumentSource.GONG,
+                    semantic_identifier=call_title or "Untitled",
+                    doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
+                        timezone.utc
+                    ),
+                    metadata={"client": call_metadata.get("system")},
                 )
 
-                num_calls += 1
-
-            yield doc_batch
-
-        logger.info(f"_fetch_calls finished: num_calls={num_calls}")
-
-    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
-        combined = (
-            f"{credentials['gong_access_key']}:{credentials['gong_access_key_secret']}"
-        )
-        self.auth_token_basic = base64.b64encode(combined.encode("utf-8")).decode(
-            "utf-8"
-        )
-
-        if self.auth_token_basic is None:
-            raise ConnectorMissingCredentialError("Gong")
-
-        self._session.headers.update(
-            {"Authorization": f"Basic {self.auth_token_basic}"}
-        )
-        return None
-
-    def load_from_state(self) -> GenerateDocumentsOutput:
-        return self._fetch_calls()
-
-    def poll_source(
-        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
-    ) -> GenerateDocumentsOutput:
-        end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
-
-        # if this env variable is set, don't start from a timestamp before the specified
-        # start time
-        # TODO: remove this once this is globally available
-        if GONG_CONNECTOR_START_TIME:
-            special_start_datetime = datetime.fromisoformat(GONG_CONNECTOR_START_TIME)
-            special_start_datetime = special_start_datetime.replace(tzinfo=timezone.utc)
+        # Step 4: Update checkpoint state
+        if next_cursor:
+            # More pages in this workspace
+            checkpoint.cursor = next_cursor
+            checkpoint.has_more = True
         else:
-            special_start_datetime = datetime.fromtimestamp(0, tz=timezone.utc)
+            # This workspace is exhausted — advance to next
+            checkpoint.workspace_index += 1
+            checkpoint.cursor = None
+            checkpoint.has_more = checkpoint.workspace_index < len(
+                checkpoint.workspace_ids
+            )
 
-        # don't let the special start dt be past the end time, this causes issues when
-        # the Gong API (`filter.fromDateTime: must be before toDateTime`)
-        special_start_datetime = min(special_start_datetime, end_datetime)
-
-        start_datetime = max(
-            datetime.fromtimestamp(start, tz=timezone.utc), special_start_datetime
-        )
-
-        # Because these are meeting start times, the meeting needs to end and be processed
-        # so adding a 1 day buffer and fetching by default till current time
-        start_one_day_offset = start_datetime - timedelta(days=1)
-        start_time = start_one_day_offset.isoformat()
-
-        end_time = datetime.fromtimestamp(end, tz=timezone.utc).isoformat()
-
-        logger.info(f"Fetching Gong calls between {start_time} and {end_time}")
-        return self._fetch_calls(start_time, end_time)
+        return checkpoint
 
 
 if __name__ == "__main__":
@@ -412,5 +455,13 @@ if __name__ == "__main__":
         }
     )
 
-    latest_docs = connector.load_from_state()
-    print(next(latest_docs))
+    checkpoint = connector.build_dummy_checkpoint()
+    while checkpoint.has_more:
+        doc_generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(doc_generator)
+                print(item)
+        except StopIteration as e:
+            checkpoint = e.value
+            print(f"Checkpoint: {checkpoint}")

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -146,7 +146,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         next_cursor = data.get("records", {}).get("cursor")
         return transcripts, next_cursor
 
-    def _get_call_details_by_ids(self, call_ids: list[str]) -> dict:
+    def _get_call_details_by_ids(self, call_ids: list[str]) -> dict[str, Any]:
         body = {
             "filter": {"callIds": call_ids},
             "contentSelector": {"exposedFields": {"parties": True}},
@@ -280,18 +280,20 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.has_more = True
             return checkpoint
 
+        workspace_ids = checkpoint.workspace_ids
+
         # If we've exhausted all workspaces, we're done
-        if checkpoint.workspace_index >= len(checkpoint.workspace_ids):
+        if checkpoint.workspace_index >= len(workspace_ids):
             checkpoint.has_more = False
             return checkpoint
 
         start_time, end_time = self._compute_time_range(start, end)
         logger.info(
             f"Fetching Gong calls between {start_time} and {end_time} "
-            f"(workspace {checkpoint.workspace_index + 1}/{len(checkpoint.workspace_ids)})"
+            f"(workspace {checkpoint.workspace_index + 1}/{len(workspace_ids)})"
         )
 
-        workspace_id = checkpoint.workspace_ids[checkpoint.workspace_index]
+        workspace_id = workspace_ids[checkpoint.workspace_index]
 
         # Step 2: Fetch one page of transcripts
         transcripts, next_cursor = self._fetch_transcript_page(
@@ -437,9 +439,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             # This workspace is exhausted — advance to next
             checkpoint.workspace_index += 1
             checkpoint.cursor = None
-            checkpoint.has_more = checkpoint.workspace_index < len(
-                checkpoint.workspace_ids
-            )
+            checkpoint.has_more = checkpoint.workspace_index < len(workspace_ids)
 
         return checkpoint
 

--- a/backend/tests/daily/connectors/gong/test_gong.py
+++ b/backend/tests/daily/connectors/gong/test_gong.py
@@ -7,7 +7,6 @@ import pytest
 
 from onyx.connectors.gong.connector import GongConnector
 from onyx.connectors.models import Document
-from onyx.connectors.models import HierarchyNode
 
 
 @pytest.fixture
@@ -32,18 +31,20 @@ def test_gong_basic(
     mock_get_api_key: MagicMock,  # noqa: ARG001
     gong_connector: GongConnector,
 ) -> None:
-    doc_batch_generator = gong_connector.poll_source(0, time.time())
-
-    doc_batch = next(doc_batch_generator)
-    with pytest.raises(StopIteration):
-        next(doc_batch_generator)
-
-    assert len(doc_batch) == 2
+    checkpoint = gong_connector.build_dummy_checkpoint()
 
     docs: list[Document] = []
-    for doc in doc_batch:
-        if not isinstance(doc, HierarchyNode):
-            docs.append(doc)
+    while checkpoint.has_more:
+        generator = gong_connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+    assert len(docs) == 2
 
     assert docs[0].semantic_identifier == "test with chris"
     assert docs[1].semantic_identifier == "Testing Gong"

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -1,0 +1,385 @@
+import time
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.connectors.gong.connector import GongConnector
+from onyx.connectors.gong.connector import GongConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+
+
+def _make_transcript(call_id: str) -> dict[str, Any]:
+    return {
+        "callId": call_id,
+        "transcript": [
+            {
+                "speakerId": "speaker1",
+                "sentences": [{"text": "Hello world"}],
+            }
+        ],
+    }
+
+
+def _make_call_detail(call_id: str, title: str) -> dict[str, Any]:
+    return {
+        "metaData": {
+            "id": call_id,
+            "started": "2026-01-15T10:00:00Z",
+            "title": title,
+            "purpose": "Test call",
+            "url": f"https://app.gong.io/call?id={call_id}",
+            "system": "test-system",
+        },
+        "parties": [
+            {
+                "speakerId": "speaker1",
+                "name": "Alice",
+                "emailAddress": "alice@test.com",
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def connector() -> GongConnector:
+    connector = GongConnector()
+    connector.load_credentials(
+        {
+            "gong_access_key": "test-key",
+            "gong_access_key_secret": "test-secret",
+        }
+    )
+    return connector
+
+
+class TestGongConnectorCheckpoint:
+    def test_build_dummy_checkpoint(self, connector: GongConnector) -> None:
+        checkpoint = connector.build_dummy_checkpoint()
+        assert checkpoint.has_more is True
+        assert checkpoint.workspace_ids is None
+        assert checkpoint.workspace_index == 0
+        assert checkpoint.cursor is None
+
+    def test_validate_checkpoint_json(self, connector: GongConnector) -> None:
+        original = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=["ws1", None],
+            workspace_index=1,
+            cursor="abc123",
+        )
+        json_str = original.model_dump_json()
+        restored = connector.validate_checkpoint_json(json_str)
+        assert restored == original
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_first_call_resolves_workspaces(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """First checkpoint call should resolve workspaces and return without fetching."""
+        # No workspaces configured — should resolve to [None]
+        checkpoint = connector.build_dummy_checkpoint()
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+
+        # Should return immediately (no yields)
+        with pytest.raises(StopIteration) as exc_info:
+            next(generator)
+
+        new_checkpoint = exc_info.value.value
+        assert new_checkpoint.workspace_ids == [None]
+        assert new_checkpoint.has_more is True
+        assert new_checkpoint.workspace_index == 0
+
+        # No API calls should have been made for workspace resolution
+        # when no workspaces are configured
+        mock_request.assert_not_called()
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_single_page_no_cursor(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Single page of transcripts with no pagination cursor."""
+        transcript_response = MagicMock()
+        transcript_response.status_code = 200
+        transcript_response.json.return_value = {
+            "callTranscripts": [_make_transcript("call1")],
+            "records": {},
+        }
+
+        details_response = MagicMock()
+        details_response.status_code = 200
+        details_response.json.return_value = {
+            "calls": [_make_call_detail("call1", "Test Call")]
+        }
+
+        mock_request.side_effect = [transcript_response, details_response]
+
+        # Start from a checkpoint that already has workspaces resolved
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        docs: list[Document] = []
+        failures: list[ConnectorFailure] = []
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    docs.append(item)
+                elif isinstance(item, ConnectorFailure):
+                    failures.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(docs) == 1
+        assert docs[0].semantic_identifier == "Test Call"
+        assert len(failures) == 0
+        assert checkpoint.has_more is False
+        assert checkpoint.workspace_index == 1
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_multi_page_with_cursor(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Two pages of transcripts — cursor advances between checkpoint calls."""
+        # Page 1: returns cursor
+        page1_response = MagicMock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "callTranscripts": [_make_transcript("call1")],
+            "records": {"cursor": "page2cursor"},
+        }
+
+        details1_response = MagicMock()
+        details1_response.status_code = 200
+        details1_response.json.return_value = {
+            "calls": [_make_call_detail("call1", "Call One")]
+        }
+
+        # Page 2: no cursor (done)
+        page2_response = MagicMock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "callTranscripts": [_make_transcript("call2")],
+            "records": {},
+        }
+
+        details2_response = MagicMock()
+        details2_response.status_code = 200
+        details2_response.json.return_value = {
+            "calls": [_make_call_detail("call2", "Call Two")]
+        }
+
+        mock_request.side_effect = [
+            page1_response,
+            details1_response,
+            page2_response,
+            details2_response,
+        ]
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        all_docs: list[Document] = []
+
+        # First checkpoint call — page 1
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    all_docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(all_docs) == 1
+        assert checkpoint.cursor == "page2cursor"
+        assert checkpoint.has_more is True
+
+        # Second checkpoint call — page 2
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    all_docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(all_docs) == 2
+        assert all_docs[0].semantic_identifier == "Call One"
+        assert all_docs[1].semantic_identifier == "Call Two"
+        assert checkpoint.has_more is False
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_missing_call_details_yields_failure(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """When call details are missing after retries, yield ConnectorFailure."""
+        transcript_response = MagicMock()
+        transcript_response.status_code = 200
+        transcript_response.json.return_value = {
+            "callTranscripts": [_make_transcript("call1")],
+            "records": {},
+        }
+
+        # Return empty call details every time (simulating the race condition)
+        empty_details = MagicMock()
+        empty_details.status_code = 200
+        empty_details.json.return_value = {"calls": []}
+
+        mock_request.side_effect = [transcript_response] + [
+            empty_details
+        ] * GongConnector.MAX_CALL_DETAILS_ATTEMPTS
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        failures: list[ConnectorFailure] = []
+        docs: list[Document] = []
+
+        with patch("onyx.connectors.gong.connector.time.sleep"):
+            generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+            try:
+                while True:
+                    item = next(generator)
+                    if isinstance(item, ConnectorFailure):
+                        failures.append(item)
+                    elif isinstance(item, Document):
+                        docs.append(item)
+            except StopIteration as e:
+                checkpoint = e.value
+
+        assert len(docs) == 0
+        assert len(failures) == 1
+        assert failures[0].failed_document is not None
+        assert failures[0].failed_document.document_id == "call1"
+        assert checkpoint.has_more is False
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_multi_workspace_iteration(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Checkpoint iterates through multiple workspaces."""
+        # Workspace 1: one call
+        ws1_transcript = MagicMock()
+        ws1_transcript.status_code = 200
+        ws1_transcript.json.return_value = {
+            "callTranscripts": [_make_transcript("call_ws1")],
+            "records": {},
+        }
+        ws1_details = MagicMock()
+        ws1_details.status_code = 200
+        ws1_details.json.return_value = {
+            "calls": [_make_call_detail("call_ws1", "WS1 Call")]
+        }
+
+        # Workspace 2: one call
+        ws2_transcript = MagicMock()
+        ws2_transcript.status_code = 200
+        ws2_transcript.json.return_value = {
+            "callTranscripts": [_make_transcript("call_ws2")],
+            "records": {},
+        }
+        ws2_details = MagicMock()
+        ws2_details.status_code = 200
+        ws2_details.json.return_value = {
+            "calls": [_make_call_detail("call_ws2", "WS2 Call")]
+        }
+
+        mock_request.side_effect = [
+            ws1_transcript,
+            ws1_details,
+            ws2_transcript,
+            ws2_details,
+        ]
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=["ws1_id", "ws2_id"],
+            workspace_index=0,
+        )
+
+        all_docs: list[Document] = []
+
+        # Checkpoint call 1 — workspace 1
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    all_docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert checkpoint.workspace_index == 1
+        assert checkpoint.has_more is True
+
+        # Checkpoint call 2 — workspace 2
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    all_docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(all_docs) == 2
+        assert all_docs[0].semantic_identifier == "WS1 Call"
+        assert all_docs[1].semantic_identifier == "WS2 Call"
+        assert checkpoint.has_more is False
+        assert checkpoint.workspace_index == 2
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_empty_workspace_404(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """404 from transcript API means no calls — workspace exhausted."""
+        response_404 = MagicMock()
+        response_404.status_code = 404
+
+        mock_request.return_value = response_404
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        list(generator)
+        # generator.return value not accessible via list() — use the loop
+        # Re-run properly:
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                next(generator)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert checkpoint.has_more is False
+        assert checkpoint.workspace_index == 1

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -371,10 +371,6 @@ class TestGongConnectorCheckpoint:
         )
 
         generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
-        list(generator)
-        # generator.return value not accessible via list() — use the loop
-        # Re-run properly:
-        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
         try:
             while True:
                 next(generator)
@@ -383,3 +379,67 @@ class TestGongConnectorCheckpoint:
 
         assert checkpoint.has_more is False
         assert checkpoint.workspace_index == 1
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_retry_only_fetches_missing_ids(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Retry for missing call details should only re-request the missing IDs."""
+        transcript_response = MagicMock()
+        transcript_response.status_code = 200
+        transcript_response.json.return_value = {
+            "callTranscripts": [
+                _make_transcript("call1"),
+                _make_transcript("call2"),
+            ],
+            "records": {},
+        }
+
+        # First fetch: returns call1 but not call2
+        partial_details = MagicMock()
+        partial_details.status_code = 200
+        partial_details.json.return_value = {
+            "calls": [_make_call_detail("call1", "Call One")]
+        }
+
+        # Second fetch (retry): returns call2
+        missing_details = MagicMock()
+        missing_details.status_code = 200
+        missing_details.json.return_value = {
+            "calls": [_make_call_detail("call2", "Call Two")]
+        }
+
+        mock_request.side_effect = [
+            transcript_response,
+            partial_details,
+            missing_details,
+        ]
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        docs: list[Document] = []
+        with patch("onyx.connectors.gong.connector.time.sleep"):
+            generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+            try:
+                while True:
+                    item = next(generator)
+                    if isinstance(item, Document):
+                        docs.append(item)
+            except StopIteration:
+                pass
+
+        assert len(docs) == 2
+        assert docs[0].semantic_identifier == "Call One"
+        assert docs[1].semantic_identifier == "Call Two"
+
+        # Verify: 3 API calls total (1 transcript + 1 full details + 1 retry for missing only)
+        assert mock_request.call_count == 3
+        # The retry call should only request call2, not both
+        retry_call_body = mock_request.call_args_list[2][1]["json"]
+        assert retry_call_body["filter"]["callIds"] == ["call2"]

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -443,3 +443,41 @@ class TestGongConnectorCheckpoint:
         # The retry call should only request call2, not both
         retry_call_body = mock_request.call_args_list[2][1]["json"]
         assert retry_call_body["filter"]["callIds"] == ["call2"]
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_expired_cursor_restarts_workspace(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Expired pagination cursor resets checkpoint to restart the workspace."""
+        expired_response = MagicMock()
+        expired_response.status_code = 400
+        expired_response.ok = False
+        expired_response.text = '{"requestId":"abc","errors":["cursor has expired"]}'
+
+        mock_request.return_value = expired_response
+
+        # Checkpoint mid-pagination with a (now-expired) cursor
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+            cursor="stale-cursor",
+        )
+
+        docs: list[Document] = []
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(docs) == 0
+        # Cursor reset so next call restarts the workspace from scratch
+        assert checkpoint.cursor is None
+        assert checkpoint.workspace_index == 0
+        assert checkpoint.has_more is True


### PR DESCRIPTION
## Description

Convert the Gong connector from `PollConnector`/`LoadConnector` to `CheckpointedConnector` for resumable indexing on failure.

**Key changes:**
- `GongConnectorCheckpoint` model tracks workspace IDs, current workspace index, and Gong API pagination cursor
- `load_from_checkpoint` fetches one transcript page per invocation — if interrupted, resumes from the last checkpoint
- Workspace IDs resolved once on first call and stored in checkpoint state (not re-resolved per page)
- Errors now yield `ConnectorFailure` instead of being silently swallowed by `continue_on_fail`
- All existing behavior preserved: rate limiting, exponential backoff retry for missing call details, `GONG_CONNECTOR_START_TIME` env var, multi-workspace support

Closes https://linear.app/onyx-app/issue/CS-70/playlist-convert-gong-connector-from-poll-to-checkpointed

## How Has This Been Tested?

ran an index locally + unit tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check