### PR TITLE
feat(indexing): Total descriptor chunk emitted during Tabular Indexing

### DIFF
--- a/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
@@ -54,10 +54,10 @@ def analyze_sheet(headers: list[str], parsed_rows: list[ParsedRow]) -> SheetAnal
             continue
 
         # Date: every value parses as a date — fold into the sheet-wide range.
-        dates = [_try_date(v) for v in values]
-        if all(d is not None for d in dates):
-            dmin = min(filter(None, dates))
-            dmax = max(filter(None, dates))
+        dates = _try_all_dates(values)
+        if dates:
+            dmin = min(dates)
+            dmax = max(dates)
             a.date_min = dmin if a.date_min is None else min(a.date_min, dmin)
             a.date_max = dmax if a.date_max is None else max(a.date_max, dmax)
             continue
@@ -84,6 +84,16 @@ def _parse_num(value: str) -> float | None:
         return float(value.replace(",", ""))
     except ValueError:
         return None
+
+
+def _try_all_dates(values: list[str]) -> list[date] | None:
+    parsed: list[date] = []
+    for v in values:
+        d = _try_date(v)
+        if d is None:
+            return None
+        parsed.append(d)
+    return parsed
 
 
 def _try_date(value: str) -> date | None:

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
@@ -6,12 +6,13 @@ or categorical. Result is consumed by both ``sheet_descriptor`` and
 """
 
 from collections import Counter
-from dataclasses import dataclass
-from dataclasses import field
 from datetime import date
 from itertools import zip_longest
 
 from dateutil.parser import parse as parse_dt
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
 
 from onyx.utils.csv_utils import ParsedRow
 
@@ -20,14 +21,15 @@ CATEGORICAL_DISTINCT_THRESHOLD = 20
 ID_NAME_TOKENS = {"id", "uuid", "uid", "guid", "key"}
 
 
-@dataclass
-class SheetAnalysis:
+class SheetAnalysis(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     row_count: int
     num_cols: int
-    numeric_cols: list[int] = field(default_factory=list)
-    categorical_cols: list[int] = field(default_factory=list)
-    numeric_values: dict[int, list[float]] = field(default_factory=dict)
-    categorical_counts: dict[int, Counter[str]] = field(default_factory=dict)
+    numeric_cols: list[int] = Field(default_factory=list)
+    categorical_cols: list[int] = Field(default_factory=list)
+    numeric_values: dict[int, list[float]] = Field(default_factory=dict)
+    categorical_counts: dict[int, Counter[str]] = Field(default_factory=dict)
     id_col: int | None = None
     date_min: date | None = None
     date_max: date | None = None

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
@@ -1,0 +1,107 @@
+"""Shared per-sheet column type inference.
+
+Walks each column once and classifies it as numeric, date, identifier,
+or categorical. Result is consumed by both ``sheet_descriptor`` and
+``total_descriptor`` so the analysis only runs once per analysis call.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import date
+from itertools import zip_longest
+
+from dateutil.parser import parse as parse_dt
+
+from onyx.utils.csv_utils import ParsedRow
+
+
+CATEGORICAL_DISTINCT_THRESHOLD = 20
+ID_NAME_TOKENS = {"id", "uuid", "uid", "guid", "key"}
+
+
+@dataclass
+class SheetAnalysis:
+    row_count: int
+    num_cols: int
+    numeric_cols: list[int] = field(default_factory=list)
+    categorical_cols: list[int] = field(default_factory=list)
+    numeric_values: dict[int, list[float]] = field(default_factory=dict)
+    categorical_counts: dict[int, Counter[str]] = field(default_factory=dict)
+    id_col: int | None = None
+    date_min: date | None = None
+    date_max: date | None = None
+
+    @property
+    def categorical_values(self) -> dict[int, list[str]]:
+        return {ci: list(c.keys()) for ci, c in self.categorical_counts.items()}
+
+
+def analyze_sheet(headers: list[str], parsed_rows: list[ParsedRow]) -> SheetAnalysis:
+    a = SheetAnalysis(row_count=len(parsed_rows), num_cols=len(headers))
+    columns = zip_longest(*(pr.row for pr in parsed_rows), fillvalue="")
+    for idx, (header, raw_values) in enumerate(zip(headers, columns)):
+        values = [v.strip() for v in raw_values if v.strip()]
+        if not values:
+            continue
+
+        # Identifier: id-named column whose values are all unique. Detected
+        # before classification so a numeric `id` column still gets flagged.
+        distinct = set(values)
+        if a.id_col is None and len(distinct) == len(values) and _is_id_name(header):
+            a.id_col = idx
+
+        # Numeric: every value parses as a number.
+        nums = _try_all_numeric(values)
+        if nums is not None:
+            a.numeric_cols.append(idx)
+            a.numeric_values[idx] = nums
+            continue
+
+        # Date: every value parses as a date — fold into the sheet-wide range.
+        dates = [_try_date(v) for v in values]
+        if all(d is not None for d in dates):
+            dmin = min(filter(None, dates))
+            dmax = max(filter(None, dates))
+            a.date_min = dmin if a.date_min is None else min(a.date_min, dmin)
+            a.date_max = dmax if a.date_max is None else max(a.date_max, dmax)
+            continue
+
+        # Categorical: low-cardinality column — keep counts for samples + top values.
+        if len(distinct) <= max(CATEGORICAL_DISTINCT_THRESHOLD, len(values) // 2):
+            a.categorical_cols.append(idx)
+            a.categorical_counts[idx] = Counter(values)
+    return a
+
+
+def _try_all_numeric(values: list[str]) -> list[float] | None:
+    parsed: list[float] = []
+    for v in values:
+        n = _parse_num(v)
+        if n is None:
+            return None
+        parsed.append(n)
+    return parsed
+
+
+def _parse_num(value: str) -> float | None:
+    try:
+        return float(value.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _try_date(value: str) -> date | None:
+    if len(value) < 4 or not any(c in value for c in "-/T"):
+        return None
+    try:
+        return parse_dt(value).date()
+    except (ValueError, OverflowError, TypeError):
+        return None
+
+
+def _is_id_name(name: str) -> bool:
+    lowered = name.lower().strip().replace("-", "_")
+    return lowered in ID_NAME_TOKENS or any(
+        lowered.endswith(f"_{t}") for t in ID_NAME_TOKENS
+    )

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
@@ -1,10 +1,3 @@
-"""Shared per-sheet column type inference.
-
-Walks each column once and classifies it as numeric, date, identifier,
-or categorical. Result is consumed by both ``sheet_descriptor`` and
-``total_descriptor`` so the analysis only runs once per analysis call.
-"""
-
 from collections import Counter
 from datetime import date
 from itertools import zip_longest

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
@@ -1,17 +1,11 @@
 """Per-section sheet descriptor chunk builder."""
 
-from datetime import date
-from itertools import zip_longest
-
-from dateutil.parser import parse as parse_dt
-from pydantic import BaseModel
-from pydantic import Field
-
 from onyx.connectors.models import Section
+from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
+from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
+from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
 from onyx.natural_language_processing.utils import BaseTokenizer
-from onyx.natural_language_processing.utils import count_tokens
 from onyx.utils.csv_utils import parse_csv_string
-from onyx.utils.csv_utils import ParsedRow
 from onyx.utils.csv_utils import read_csv_header
 
 
@@ -19,19 +13,6 @@ MAX_NUMERIC_COLS = 12
 MAX_CATEGORICAL_COLS = 6
 MAX_CATEGORICAL_WITH_SAMPLES = 4
 MAX_DISTINCT_SAMPLES = 8
-CATEGORICAL_DISTINCT_THRESHOLD = 20
-ID_NAME_TOKENS = {"id", "uuid", "uid", "guid", "key"}
-
-
-class SheetAnalysis(BaseModel):
-    row_count: int
-    num_cols: int
-    numeric_cols: list[int] = Field(default_factory=list)
-    categorical_cols: list[int] = Field(default_factory=list)
-    categorical_values: dict[int, list[str]] = Field(default_factory=dict)
-    id_col: int | None = None
-    date_min: date | None = None
-    date_max: date | None = None
 
 
 def build_sheet_descriptor_chunks(
@@ -61,7 +42,7 @@ def build_sheet_descriptor_chunks(
     if not headers:
         return []
 
-    a = _analyze(headers, parsed_rows)
+    a = analyze_sheet(headers, parsed_rows)
     lines = [
         _overview_line(a),
         _columns_line(headers),
@@ -71,7 +52,7 @@ def build_sheet_descriptor_chunks(
         _id_col_line(headers, a),
         _values_seen_line(headers, a),
     ]
-    return _pack_lines(
+    return pack_lines(
         [line for line in lines if line],
         prefix=section.heading or "",
         tokenizer=tokenizer,
@@ -129,100 +110,3 @@ def _values_seen_line(headers: list[str], a: SheetAnalysis) -> str:
 
 def _label(name: str) -> str:
     return f"{name} ({name.replace('_', ' ')})" if "_" in name else name
-
-
-def _is_numeric(value: str) -> bool:
-    try:
-        float(value.replace(",", ""))
-        return True
-    except ValueError:
-        return False
-
-
-def _try_date(value: str) -> date | None:
-    if len(value) < 4 or not any(c in value for c in "-/T"):
-        return None
-    try:
-        return parse_dt(value).date()
-    except (ValueError, OverflowError, TypeError):
-        return None
-
-
-def _is_id_name(name: str) -> bool:
-    lowered = name.lower().strip().replace("-", "_")
-    return lowered in ID_NAME_TOKENS or any(
-        lowered.endswith(f"_{t}") for t in ID_NAME_TOKENS
-    )
-
-
-def _analyze(headers: list[str], parsed_rows: list[ParsedRow]) -> SheetAnalysis:
-    a = SheetAnalysis(row_count=len(parsed_rows), num_cols=len(headers))
-    columns = zip_longest(*(pr.row for pr in parsed_rows), fillvalue="")
-    for idx, (header, raw_values) in enumerate(zip(headers, columns)):
-        # Pull the column's non-empty values; skip if the column is blank.
-        values = [v.strip() for v in raw_values if v.strip()]
-        if not values:
-            continue
-
-        # Identifier: id-named column whose values are all unique. Detected
-        # before classification so a numeric `id` column still gets flagged.
-        distinct = set(values)
-        if a.id_col is None and len(distinct) == len(values) and _is_id_name(header):
-            a.id_col = idx
-
-        # Numeric: every value parses as a number.
-        if all(_is_numeric(v) for v in values):
-            a.numeric_cols.append(idx)
-            continue
-
-        # Date: every value parses as a date — fold into the sheet-wide range.
-        dates = [_try_date(v) for v in values]
-        if all(d is not None for d in dates):
-            dmin = min(filter(None, dates))
-            dmax = max(filter(None, dates))
-            a.date_min = dmin if a.date_min is None else min(a.date_min, dmin)
-            a.date_max = dmax if a.date_max is None else max(a.date_max, dmax)
-            continue
-
-        # Categorical: low-cardinality column — keep distinct values for samples.
-        if len(distinct) <= max(CATEGORICAL_DISTINCT_THRESHOLD, len(values) // 2):
-            a.categorical_cols.append(idx)
-            a.categorical_values[idx] = list(distinct)
-    return a
-
-
-def _pack_lines(
-    lines: list[str],
-    prefix: str,
-    tokenizer: BaseTokenizer,
-    max_tokens: int,
-) -> list[str]:
-    """Greedily pack lines into chunks ≤ max_tokens. Lines that on
-    their own exceed max_tokens (after accounting for the prefix) are
-    skipped. ``prefix`` is prepended to every emitted chunk."""
-    prefix_tokens = count_tokens(prefix, tokenizer) + 1 if prefix else 0
-    budget = max_tokens - prefix_tokens
-
-    chunks: list[str] = []
-    current: list[str] = []
-    current_tokens = 0
-    for line in lines:
-        line_tokens = count_tokens(line, tokenizer)
-        if line_tokens > budget:
-            continue
-        sep = 1 if current else 0
-        if current_tokens + sep + line_tokens > budget:
-            chunks.append(_join_with_prefix(current, prefix))
-            current = [line]
-            current_tokens = line_tokens
-        else:
-            current.append(line)
-            current_tokens += sep + line_tokens
-    if current:
-        chunks.append(_join_with_prefix(current, prefix))
-    return chunks
-
-
-def _join_with_prefix(lines: list[str], prefix: str) -> str:
-    body = "\n".join(lines)
-    return f"{prefix}\n{body}" if prefix else body

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
@@ -1,5 +1,3 @@
-"""Per-section sheet descriptor chunk builder."""
-
 from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
 from onyx.indexing.chunking.tabular_section_chunker.util import label
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
@@ -1,12 +1,8 @@
 """Per-section sheet descriptor chunk builder."""
 
-from onyx.connectors.models import Section
-from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
 from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
 from onyx.natural_language_processing.utils import BaseTokenizer
-from onyx.utils.csv_utils import parse_csv_string
-from onyx.utils.csv_utils import read_csv_header
 
 
 MAX_NUMERIC_COLS = 12
@@ -16,17 +12,19 @@ MAX_DISTINCT_SAMPLES = 8
 
 
 def build_sheet_descriptor_chunks(
-    section: Section,
+    headers: list[str],
+    analysis: SheetAnalysis,
+    heading: str,
     tokenizer: BaseTokenizer,
     max_tokens: int,
 ) -> list[str]:
-    """Build sheet descriptor chunk(s) from a parsed CSV section.
+    """Build sheet descriptor chunk(s) from a pre-parsed sheet.
 
     Output (lines joined by "\\n"; lines that overflow ``max_tokens`` on
-    their own are skipped; ``section.heading`` is prepended to every
-    emitted chunk so retrieval keeps sheet context after a split):
+    their own are skipped; ``heading`` is prepended to every emitted
+    chunk so retrieval keeps sheet context after a split):
 
-        {section.heading}                                                     # optional
+        {heading}                                                             # optional
         Sheet overview.
         This sheet has {N} rows and {M} columns.
         Columns: {col1}, {col2}, ...
@@ -36,25 +34,21 @@ def build_sheet_descriptor_chunks(
         Identifier column: {col}.                                             # optional
         Values seen in {col}: {v1}, {v2}, ...                                 # optional, repeated
     """
-    text = section.text or ""
-    parsed_rows = list(parse_csv_string(text))
-    headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
     if not headers:
         return []
 
-    a = analyze_sheet(headers, parsed_rows)
     lines = [
-        _overview_line(a),
+        _overview_line(analysis),
         _columns_line(headers),
-        _time_range_line(a),
-        _numeric_cols_line(headers, a),
-        _categorical_cols_line(headers, a),
-        _id_col_line(headers, a),
-        _values_seen_line(headers, a),
+        _time_range_line(analysis),
+        _numeric_cols_line(headers, analysis),
+        _categorical_cols_line(headers, analysis),
+        _id_col_line(headers, analysis),
+        _values_seen_line(headers, analysis),
     ]
     return pack_lines(
         [line for line in lines if line],
-        prefix=section.heading or "",
+        prefix=heading,
         tokenizer=tokenizer,
         max_tokens=max_tokens,
     )

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/sheet_descriptor.py
@@ -1,6 +1,7 @@
 """Per-section sheet descriptor chunk builder."""
 
 from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
+from onyx.indexing.chunking.tabular_section_chunker.util import label
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
 from onyx.natural_language_processing.utils import BaseTokenizer
 
@@ -62,7 +63,7 @@ def _overview_line(a: SheetAnalysis) -> str:
 
 
 def _columns_line(headers: list[str]) -> str:
-    return "Columns: " + ", ".join(_label(h) for h in headers)
+    return "Columns: " + ", ".join(label(h) for h in headers)
 
 
 def _time_range_line(a: SheetAnalysis) -> str:
@@ -74,7 +75,7 @@ def _time_range_line(a: SheetAnalysis) -> str:
 def _numeric_cols_line(headers: list[str], a: SheetAnalysis) -> str:
     if not a.numeric_cols:
         return ""
-    names = ", ".join(_label(headers[i]) for i in a.numeric_cols[:MAX_NUMERIC_COLS])
+    names = ", ".join(label(headers[i]) for i in a.numeric_cols[:MAX_NUMERIC_COLS])
     return f"Numeric columns (aggregatable by sum, average, min, max): {names}"
 
 
@@ -82,7 +83,7 @@ def _categorical_cols_line(headers: list[str], a: SheetAnalysis) -> str:
     if not a.categorical_cols:
         return ""
     names = ", ".join(
-        _label(headers[i]) for i in a.categorical_cols[:MAX_CATEGORICAL_COLS]
+        label(headers[i]) for i in a.categorical_cols[:MAX_CATEGORICAL_COLS]
     )
     return f"Categorical columns (groupable, can be counted by value): {names}"
 
@@ -90,7 +91,7 @@ def _categorical_cols_line(headers: list[str], a: SheetAnalysis) -> str:
 def _id_col_line(headers: list[str], a: SheetAnalysis) -> str:
     if a.id_col is None:
         return ""
-    return f"Identifier column: {_label(headers[a.id_col])}."
+    return f"Identifier column: {label(headers[a.id_col])}."
 
 
 def _values_seen_line(headers: list[str], a: SheetAnalysis) -> str:
@@ -98,9 +99,5 @@ def _values_seen_line(headers: list[str], a: SheetAnalysis) -> str:
     for ci in a.categorical_cols[:MAX_CATEGORICAL_WITH_SAMPLES]:
         sample = sorted(a.categorical_values.get(ci, []))[:MAX_DISTINCT_SAMPLES]
         if sample:
-            rows.append(f"Values seen in {_label(headers[ci])}: " + ", ".join(sample))
+            rows.append(f"Values seen in {label(headers[ci])}: " + ", ".join(sample))
     return "\n".join(rows)
-
-
-def _label(name: str) -> str:
-    return f"{name} ({name.replace('_', ' ')})" if "_" in name else name

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -10,6 +10,9 @@ from onyx.indexing.chunking.section_chunker import SectionChunkerOutput
 from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
+from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
+    build_total_descriptor_chunks,
+)
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
@@ -247,6 +250,13 @@ class TabularChunker(SectionChunker):
         if not self.ignore_metadata_chunks:
             chunk_texts.extend(
                 build_sheet_descriptor_chunks(
+                    section=section,
+                    tokenizer=self.tokenizer,
+                    max_tokens=content_token_limit,
+                )
+            )
+            chunk_texts.extend(
+                build_total_descriptor_chunks(
                     section=section,
                     tokenizer=self.tokenizer,
                     max_tokens=content_token_limit,

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -7,6 +7,7 @@ from onyx.indexing.chunking.section_chunker import AccumulatorState
 from onyx.indexing.chunking.section_chunker import ChunkPayload
 from onyx.indexing.chunking.section_chunker import SectionChunker
 from onyx.indexing.chunking.section_chunker import SectionChunkerOutput
+from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
 from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
@@ -18,6 +19,7 @@ from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
 from onyx.utils.csv_utils import parse_csv_string
 from onyx.utils.csv_utils import ParsedRow
+from onyx.utils.csv_utils import read_csv_header
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -233,31 +235,38 @@ class TabularChunker(SectionChunker):
     ) -> SectionChunkerOutput:
         payloads = accumulator.flush_to_list()
 
-        parsed_rows = list(parse_csv_string(section.text or ""))
-        sheet_header = section.heading or ""
+        text = section.text or ""
+        parsed_rows = list(parse_csv_string(text))
+        headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
+        heading = section.heading or ""
 
         chunk_texts: list[str] = []
         if parsed_rows:
             chunk_texts.extend(
                 parse_to_chunks(
                     rows=parsed_rows,
-                    sheet_header=sheet_header,
+                    sheet_header=heading,
                     tokenizer=self.tokenizer,
                     max_tokens=content_token_limit,
                 )
             )
 
-        if not self.ignore_metadata_chunks:
+        if not self.ignore_metadata_chunks and headers:
+            analysis = analyze_sheet(headers, parsed_rows)
             chunk_texts.extend(
                 build_sheet_descriptor_chunks(
-                    section=section,
+                    headers=headers,
+                    analysis=analysis,
+                    heading=heading,
                     tokenizer=self.tokenizer,
                     max_tokens=content_token_limit,
                 )
             )
             chunk_texts.extend(
                 build_total_descriptor_chunks(
-                    section=section,
+                    headers=headers,
+                    analysis=analysis,
+                    heading=heading,
                     tokenizer=self.tokenizer,
                     max_tokens=content_token_limit,
                 )

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
@@ -1,10 +1,8 @@
 from collections import Counter
 
-from onyx.connectors.models import Section
-from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
+from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
 from onyx.natural_language_processing.utils import BaseTokenizer
-from onyx.utils.csv_utils import parse_csv_string
 
 
 TOTALS_HEADER = (
@@ -15,30 +13,25 @@ TOTALS_HEADER = (
 
 
 def build_total_descriptor_chunks(
-    section: Section,
+    headers: list[str],
+    analysis: SheetAnalysis,
+    heading: str,
     tokenizer: BaseTokenizer,
     max_tokens: int,
 ) -> list[str]:
-    parsed_rows = list(parse_csv_string(section.text or ""))
-    if not parsed_rows:
+    if analysis.row_count == 0:
         return []
-    headers = parsed_rows[0].header
-
-    a = analyze_sheet(headers, parsed_rows)
 
     lines: list[str] = []
-    for idx in a.numeric_cols:
-        lines.append(_numeric_totals_line(headers[idx], a.numeric_values[idx]))
-    for idx in a.categorical_cols:
-        line = _categorical_top_line(headers[idx], a.categorical_counts[idx])
+    for idx in analysis.numeric_cols:
+        lines.append(_numeric_totals_line(headers[idx], analysis.numeric_values[idx]))
+    for idx in analysis.categorical_cols:
+        line = _categorical_top_line(headers[idx], analysis.categorical_counts[idx])
         if line:
             lines.append(line)
-    lines.append(f"Total row count: {a.row_count}.")
+    lines.append(f"Total row count: {analysis.row_count}.")
 
-    if not lines:
-        return []
-
-    prefix = (f"{section.heading}\n" if section.heading else "") + TOTALS_HEADER
+    prefix = (f"{heading}\n" if heading else "") + TOTALS_HEADER
     return pack_lines(
         lines=lines,
         prefix=prefix,

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
+from onyx.indexing.chunking.tabular_section_chunker.util import label
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
 from onyx.natural_language_processing.utils import BaseTokenizer
 
@@ -44,7 +45,7 @@ def _numeric_totals_line(name: str, values: list[float]) -> str:
     total = sum(values)
     avg = total / len(values)
     return (
-        f"Column {_label(name)}: total (sum across all rows) = {_fmt(total)}, "
+        f"Column {label(name)}: total (sum across all rows) = {_fmt(total)}, "
         f"average = {_fmt(avg)}, minimum = {_fmt(min(values))}, "
         f"maximum = {_fmt(max(values))}, count = {len(values)}."
     )
@@ -55,14 +56,10 @@ def _categorical_top_line(name: str, counts: Counter[str]) -> str:
     if not top:
         return ""
     val, n = top[0]
-    return f"Column {_label(name)} most frequent value: {val} ({n} occurrences)."
-
-
-def _label(name: str) -> str:
-    return f"{name} ({name.replace('_', ' ')})" if "_" in name else name
+    return f"Column {label(name)} most frequent value: {val} ({n} occurrences)."
 
 
 def _fmt(num: float) -> str:
-    if num == int(num) and abs(num) < 1e15:
+    if abs(num) < 1e15 and num == int(num):
         return str(int(num))
     return f"{num:.6g}"

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
@@ -1,0 +1,75 @@
+from collections import Counter
+
+from onyx.connectors.models import Section
+from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
+from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
+from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.utils.csv_utils import parse_csv_string
+
+
+TOTALS_HEADER = (
+    "Totals and overall aggregates across all rows. This sheet can answer "
+    "whole-dataset questions about total, overall, grand total, sum across "
+    "all, average, combined, mean, minimum, maximum, and count of values."
+)
+
+
+def build_total_descriptor_chunks(
+    section: Section,
+    tokenizer: BaseTokenizer,
+    max_tokens: int,
+) -> list[str]:
+    parsed_rows = list(parse_csv_string(section.text or ""))
+    if not parsed_rows:
+        return []
+    headers = parsed_rows[0].header
+
+    a = analyze_sheet(headers, parsed_rows)
+
+    lines: list[str] = []
+    for idx in a.numeric_cols:
+        lines.append(_numeric_totals_line(headers[idx], a.numeric_values[idx]))
+    for idx in a.categorical_cols:
+        line = _categorical_top_line(headers[idx], a.categorical_counts[idx])
+        if line:
+            lines.append(line)
+    lines.append(f"Total row count: {a.row_count}.")
+
+    if not lines:
+        return []
+
+    prefix = (f"{section.heading}\n" if section.heading else "") + TOTALS_HEADER
+    return pack_lines(
+        lines=lines,
+        prefix=prefix,
+        tokenizer=tokenizer,
+        max_tokens=max_tokens,
+    )
+
+
+def _numeric_totals_line(name: str, values: list[float]) -> str:
+    total = sum(values)
+    avg = total / len(values)
+    return (
+        f"Column {_label(name)}: total (sum across all rows) = {_fmt(total)}, "
+        f"average = {_fmt(avg)}, minimum = {_fmt(min(values))}, "
+        f"maximum = {_fmt(max(values))}, count = {len(values)}."
+    )
+
+
+def _categorical_top_line(name: str, counts: Counter[str]) -> str:
+    top = counts.most_common(1)
+    if not top:
+        return ""
+    val, n = top[0]
+    return f"Column {_label(name)} most frequent value: {val} ({n} occurrences)."
+
+
+def _label(name: str) -> str:
+    return f"{name} ({name.replace('_', ' ')})" if "_" in name else name
+
+
+def _fmt(num: float) -> str:
+    if num == int(num) and abs(num) < 1e15:
+        return str(int(num))
+    return f"{num:.6g}"

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
@@ -30,6 +30,11 @@ def build_total_descriptor_chunks(
         line = _categorical_top_line(headers[idx], analysis.categorical_counts[idx])
         if line:
             lines.append(line)
+
+    # No meaningful information - leave early
+    if not lines:
+        return []
+
     lines.append(f"Total row count: {analysis.row_count}.")
 
     prefix = (f"{heading}\n" if heading else "") + TOTALS_HEADER

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/util.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/util.py
@@ -1,0 +1,41 @@
+from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.natural_language_processing.utils import count_tokens
+
+
+def pack_lines(
+    lines: list[str],
+    prefix: str,
+    tokenizer: BaseTokenizer,
+    max_tokens: int,
+) -> list[str]:
+    """Greedily pack ``lines`` into chunks ≤ ``max_tokens``, prepending
+    ``prefix`` (verbatim) to every emitted chunk. Lines whose own token
+    count exceeds the post-prefix budget are skipped. Callers assemble
+    the full prefix (heading, header text, etc.) before calling.
+    """
+    prefix_tokens = count_tokens(prefix, tokenizer) + 1 if prefix else 0
+    budget = max_tokens - prefix_tokens
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_tokens = 0
+    for line in lines:
+        line_tokens = count_tokens(line, tokenizer)
+        if line_tokens > budget:
+            continue
+        sep = 1 if current else 0
+        if current_tokens + sep + line_tokens > budget:
+            chunks.append(_join_with_prefix(current, prefix))
+            current = [line]
+            current_tokens = line_tokens
+        else:
+            current.append(line)
+            current_tokens += sep + line_tokens
+    if current:
+        chunks.append(_join_with_prefix(current, prefix))
+    return chunks
+
+
+def _join_with_prefix(lines: list[str], prefix: str) -> str:
+    body = "\n".join(lines)
+    return f"{prefix}\n{body}" if prefix else body

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/util.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/util.py
@@ -2,6 +2,13 @@ from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 
 
+def label(name: str) -> str:
+    """Render a column name with a space-substituted friendly alias in
+    parens for underscored headers so retrieval matches either surface
+    form (e.g. ``MTTR_hours`` → ``MTTR_hours (MTTR hours)``)."""
+    return f"{name} ({name.replace('_', ' ')})" if "_" in name else name
+
+
 def pack_lines(
     lines: list[str],
     prefix: str,

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -12,14 +12,8 @@ class ParsedRow(BaseModel):
 
 def read_csv_header(csv_text: str) -> list[str]:
     """Return the first non-blank row (the header) of a CSV string, or
-<<<<<<< HEAD
     [] if the text has no usable header.
     """
-=======
-    [] if the text has no usable header. Useful when a caller needs the
-    header even though there are no data rows (where ``parse_csv_string``
-    would yield nothing)."""
->>>>>>> c55ab0cdf (Move csv parsing logic to util file)
     if not csv_text.strip():
         return []
     for row in csv.reader(io.StringIO(csv_text)):

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -12,8 +12,14 @@ class ParsedRow(BaseModel):
 
 def read_csv_header(csv_text: str) -> list[str]:
     """Return the first non-blank row (the header) of a CSV string, or
+<<<<<<< HEAD
     [] if the text has no usable header.
     """
+=======
+    [] if the text has no usable header. Useful when a caller needs the
+    header even though there are no data rows (where ``parse_csv_string``
+    would yield nothing)."""
+>>>>>>> c55ab0cdf (Move csv parsing logic to util file)
     if not csv_text.strip():
         return []
     for row in csv.reader(io.StringIO(csv_text)):

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -15,6 +15,7 @@ from onyx.connectors.models import Section
 from onyx.connectors.models import TabularSection
 from onyx.indexing.chunking.section_chunker import AccumulatorState
 from onyx.indexing.chunking.tabular_section_chunker import TabularChunker
+from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
 from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
@@ -25,6 +26,8 @@ from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
     TOTALS_HEADER,
 )
 from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.utils.csv_utils import parse_csv_string
+from onyx.utils.csv_utils import read_csv_header
 
 
 class CharTokenizer(BaseTokenizer):
@@ -643,9 +646,14 @@ class TestBuildSheetDescriptorChunks:
         heading: str | None = "sheet:T",
         max_tokens: int = 500,
     ) -> list[str]:
-        section = TabularSection(text=csv_text, link=_DEFAULT_LINK, heading=heading)
+        parsed_rows = list(parse_csv_string(csv_text))
+        headers = parsed_rows[0].header if parsed_rows else read_csv_header(csv_text)
+        if not headers:
+            return []
         return build_sheet_descriptor_chunks(
-            section=section,
+            headers=headers,
+            analysis=analyze_sheet(headers, parsed_rows),
+            heading=heading or "",
             tokenizer=CharTokenizer(),
             max_tokens=max_tokens,
         )
@@ -868,9 +876,14 @@ class TestBuildTotalDescriptorChunks:
         heading: str | None = "sheet:T",
         max_tokens: int = 1000,
     ) -> list[str]:
-        section = TabularSection(text=csv_text, link=_DEFAULT_LINK, heading=heading)
+        parsed_rows = list(parse_csv_string(csv_text))
+        headers = parsed_rows[0].header if parsed_rows else read_csv_header(csv_text)
+        if not headers:
+            return []
         return build_total_descriptor_chunks(
-            section=section,
+            headers=headers,
+            analysis=analyze_sheet(headers, parsed_rows),
+            heading=heading or "",
             tokenizer=CharTokenizer(),
             max_tokens=max_tokens,
         )

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -18,6 +18,12 @@ from onyx.indexing.chunking.tabular_section_chunker import TabularChunker
 from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
+from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
+    build_total_descriptor_chunks,
+)
+from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
+    TOTALS_HEADER,
+)
 from onyx.natural_language_processing.utils import BaseTokenizer
 
 
@@ -847,3 +853,169 @@ class TestBuildSheetDescriptorChunks:
 
         # --- ACT / ASSERT ---------------------------------------------
         assert self._build(csv_text, heading="", max_tokens=30) == expected
+
+
+class TestBuildTotalDescriptorChunks:
+    """Direct tests of `build_total_descriptor_chunks` — emits the totals
+    chunk that names aggregate vocabulary (total/sum/average/min/max/
+    count/most frequent) plus per-column aggregates so whole-dataset
+    questions retrieve a chunk whose text actually contains the answer.
+    """
+
+    @staticmethod
+    def _build(
+        csv_text: str,
+        heading: str | None = "sheet:T",
+        max_tokens: int = 1000,
+    ) -> list[str]:
+        section = TabularSection(text=csv_text, link=_DEFAULT_LINK, heading=heading)
+        return build_total_descriptor_chunks(
+            section=section,
+            tokenizer=CharTokenizer(),
+            max_tokens=max_tokens,
+        )
+
+    def test_numeric_and_categorical_columns_emit_every_line(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # amount → numeric (total=600, avg=200, min=100, max=300, count=3)
+        # region → categorical (US appears twice, EU once → top=US (2))
+        csv_text = "amount,region\n100,US\n200,EU\n300,US\n"
+
+        # --- EXPECTED --------------------------------------------------
+        expected = [
+            "sheet:T\n"
+            f"{TOTALS_HEADER}\n"
+            "Column amount: total (sum across all rows) = 600, average = 200, "
+            "minimum = 100, maximum = 300, count = 3.\n"
+            "Column region most frequent value: US (2 occurrences).\n"
+            "Total row count: 3."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text) == expected
+
+    def test_numeric_only_sheet_has_no_categorical_line(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # Both columns are all-numeric → no "most frequent value" lines.
+        csv_text = "x,y\n1,2\n3,4\n"
+
+        # --- EXPECTED --------------------------------------------------
+        expected = [
+            "sheet:T\n"
+            f"{TOTALS_HEADER}\n"
+            "Column x: total (sum across all rows) = 4, average = 2, "
+            "minimum = 1, maximum = 3, count = 2.\n"
+            "Column y: total (sum across all rows) = 6, average = 3, "
+            "minimum = 2, maximum = 4, count = 2.\n"
+            "Total row count: 2."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text) == expected
+
+    def test_categorical_only_sheet_has_no_numeric_line(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # Non-numeric low-cardinality column → categorical only. "red"
+        # wins over "blue" 2-to-1.
+        csv_text = "color\nred\nblue\nred\n"
+
+        # --- EXPECTED --------------------------------------------------
+        expected = [
+            "sheet:T\n"
+            f"{TOTALS_HEADER}\n"
+            "Column color most frequent value: red (2 occurrences).\n"
+            "Total row count: 3."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text) == expected
+
+    def test_underscored_column_names_get_friendly_alias(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # Underscored headers get the same `name (name with spaces)` alias
+        # used elsewhere so retrieval matches either surface form.
+        csv_text = "total_cost\n100\n200\n"
+
+        # --- EXPECTED --------------------------------------------------
+        expected = [
+            "sheet:T\n"
+            f"{TOTALS_HEADER}\n"
+            "Column total_cost (total cost): total (sum across all rows) = 300, "
+            "average = 150, minimum = 100, maximum = 200, count = 2.\n"
+            "Total row count: 2."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text) == expected
+
+    def test_non_integer_averages_format_with_decimals(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # Whole-number inputs but a fractional average. `_fmt` drops the
+        # ".0" when the value is integral and falls back to `:.6g` when
+        # it isn't — verify both surfaces on the same line.
+        csv_text = "rate\n1\n2\n"
+
+        # --- EXPECTED --------------------------------------------------
+        # total=3 (int), avg=1.5 (fractional), min=1, max=2, count=2.
+        expected = [
+            "sheet:T\n"
+            f"{TOTALS_HEADER}\n"
+            "Column rate: total (sum across all rows) = 3, average = 1.5, "
+            "minimum = 1, maximum = 2, count = 2.\n"
+            "Total row count: 2."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text) == expected
+
+    def test_empty_section_returns_no_chunks(self) -> None:
+        # No parsed rows → no totals to report; builder bails out early.
+        assert self._build("") == []
+
+    def test_header_only_csv_returns_no_chunks(self) -> None:
+        # Header-only CSV yields zero data rows → `parse_csv_string`
+        # returns nothing, so the builder returns an empty list.
+        assert self._build("col1,col2\n") == []
+
+    def test_no_heading_omits_prefix_line(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # heading=None → prefix is just TOTALS_HEADER, no leading heading
+        # line in the emitted chunk.
+        csv_text = "n\n5\n"
+
+        # --- EXPECTED --------------------------------------------------
+        expected = [
+            f"{TOTALS_HEADER}\n"
+            "Column n: total (sum across all rows) = 5, average = 5, "
+            "minimum = 5, maximum = 5, count = 1.\n"
+            "Total row count: 1."
+        ]
+
+        # --- ACT / ASSERT ---------------------------------------------
+        assert self._build(csv_text, heading=None) == expected
+
+    def test_tight_budget_splits_into_multiple_chunks_each_with_header(self) -> None:
+        # --- INPUT -----------------------------------------------------
+        # Three numeric columns under a tight budget force pack_lines to
+        # split across multiple chunks. Every emitted chunk must still
+        # start with `heading + TOTALS_HEADER` so retrieval keeps context
+        # on whichever chunk wins.
+        csv_text = "a,b,c\n1,2,3\n4,5,6\n"
+
+        # --- ACT -------------------------------------------------------
+        # Budget chosen so the three aggregate lines can't all fit under
+        # TOTALS_HEADER in a single chunk.
+        out = self._build(csv_text, heading="S", max_tokens=len(TOTALS_HEADER) + 120)
+
+        # --- ASSERT ----------------------------------------------------
+        # Split actually happened.
+        assert len(out) > 1
+        # Each chunk carries the full prefix (heading + totals header).
+        assert all(c.startswith(f"S\n{TOTALS_HEADER}\n") for c in out)
+        # Collectively, every per-column aggregate and the row count line
+        # must appear somewhere in the output.
+        body = "\n".join(out)
+        assert "Column a: total (sum across all rows) = 5" in body
+        assert "Column b: total (sum across all rows) = 7" in body
+        assert "Column c: total (sum across all rows) = 9" in body
+        assert "Total row count: 2." in body

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -587,7 +587,7 @@ class TestTabularChunkerChunkSection:
         content_chunk = (
             "sheet:T\n" "Columns: Name, Age\n" "Name=Alice, Age=30\n" "Name=Bob, Age=25"
         )
-        metadata_chunk = (
+        descriptor_chunk = (
             "sheet:T\n"
             "Sheet overview.\n"
             "This sheet has 2 rows and 2 columns.\n"
@@ -596,7 +596,17 @@ class TestTabularChunkerChunkSection:
             "Categorical columns (groupable, can be counted by value): Name\n"
             "Values seen in Name: Alice, Bob"
         )
-        expected_texts = [content_chunk, metadata_chunk]
+        totals_chunk = (
+            "sheet:T\n"
+            "Totals and overall aggregates across all rows. This sheet can answer "
+            "whole-dataset questions about total, overall, grand total, sum across "
+            "all, average, combined, mean, minimum, maximum, and count of values.\n"
+            "Column Age: total (sum across all rows) = 55, average = 27.5, "
+            "minimum = 25, maximum = 30, count = 2.\n"
+            "Column Name most frequent value: Alice (1 occurrences).\n"
+            "Total row count: 2."
+        )
+        expected_texts = [content_chunk, descriptor_chunk, totals_chunk]
 
         # --- ACT -------------------------------------------------------
         out = _make_chunker_with_metadata().chunk_section(
@@ -607,8 +617,8 @@ class TestTabularChunkerChunkSection:
 
         # --- ASSERT ----------------------------------------------------
         assert [p.text for p in out.payloads] == expected_texts
-        # Content first, metadata second — only the first chunk is fresh.
-        assert [p.is_continuation for p in out.payloads] == [False, True]
+        # Content first, metadata chunks follow as continuations.
+        assert [p.is_continuation for p in out.payloads] == [False, True, True]
 
 
 class TestBuildSheetDescriptorChunks:


### PR DESCRIPTION
## Description
This PR adds a chunk that answers questions about the total, average, sum, etc around a TabularSection.
This improves hits on common aggregate questions by putting them in more semantically meaningful sentences rather than just values.

In chunk should look like this:
```
Totals and overall aggregates across all rows. This sheet can answer
whole-dataset questions about total, overall, grand total, sum across
all, average, combined, mean, minimum, maximum, and count of values.
Column <name>: total (sum across all rows) = X, average = Y,
minimum = Z, maximum = W, count = N.
[repeat for each numeric column]
Column <cat_name> most frequent value: <val> (<count> occurrences).
[repeat for each categorical column]
```

## How Has This Been Tested?
Unit Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a totals descriptor to tabular indexing that writes whole‑sheet aggregates in plain sentences to improve retrieval for sum/avg/min/max/count and most‑frequent queries. Also derives headers for header‑only CSVs and appends totals after the sheet descriptor.

- **New Features**
  - Emits a totals chunk with per‑numeric‑column sum/avg/min/max/count, top categorical value, and a total row count; prefixed by the section heading plus a standard totals header (kept on split chunks).
  - Formats underscored headers with a friendly alias (e.g., MTTR_hours → “MTTR_hours (MTTR hours)”) and only emits totals when data rows exist.

- **Refactors**
  - Added `analysis.py` with `analyze_sheet`/`SheetAnalysis` to infer types and compute numeric values and categorical value counts for reuse.
  - Introduced `util.pack_lines` and `util.label`; `sheet_descriptor` now takes `headers`/`analysis`/`heading`. The chunker reads headers via `read_csv_header`, computes analysis once, and emits the sheet descriptor and totals as continuations after content. Expanded tests cover formatting, prefix behavior, split packing, continuation ordering, and header‑only CSV handling.

<sup>Written for commit 136094e72e9eb92f3497d988728897feace27a7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

