### PR TITLE
fix(openpyxl): Adding support for xlsm

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -41,7 +41,7 @@ def tabular_file_to_sections(
     """
     lowered = file_name.lower()
 
-    if lowered.endswith(".xlsx"):
+    if lowered.endswith((".xlsx", ".xlsm")):
         return [
             TabularSection(
                 link=link or file_name,

--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -41,7 +41,7 @@ def tabular_file_to_sections(
     """
     lowered = file_name.lower()
 
-    if lowered.endswith((".xlsx", ".xlsm")):
+    if lowered.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
         return [
             TabularSection(
                 link=link or file_name,

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -189,7 +189,7 @@ def _process_file(
     if is_tabular_file(file_name):
         # Produce TabularSections
         lowered_name = file_name.lower()
-        if lowered_name.endswith(".xlsx"):
+        if lowered_name.endswith((".xlsx", ".xlsm")):
             file.seek(0)
             tabular_source: IO[bytes] = file
         else:

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -189,7 +189,7 @@ def _process_file(
     if is_tabular_file(file_name):
         # Produce TabularSections
         lowered_name = file_name.lower()
-        if lowered_name.endswith((".xlsx", ".xlsm")):
+        if lowered_name.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
             file.seek(0)
             tabular_source: IO[bytes] = file
         else:

--- a/backend/onyx/file_processing/file_types.py
+++ b/backend/onyx/file_processing/file_types.py
@@ -53,12 +53,14 @@ class OnyxMimeTypes:
 
 
 class OnyxFileExtensions:
-    TABULAR_EXTENSIONS = {
-        ".csv",
-        ".tsv",
+    SPREADSHEET_EXTENSIONS = {
         ".xlsx",
         ".xlsm",
     }
+    TABULAR_EXTENSIONS = {
+        ".csv",
+        ".tsv",
+    } | SPREADSHEET_EXTENSIONS
     PLAIN_TEXT_EXTENSIONS = {
         ".txt",
         ".md",
@@ -77,11 +79,10 @@ class OnyxFileExtensions:
         ".pdf",
         ".docx",
         ".pptx",
-        ".xlsx",
         ".eml",
         ".epub",
         ".html",
-    }
+    } | SPREADSHEET_EXTENSIONS
     IMAGE_EXTENSIONS = {
         ".png",
         ".jpg",

--- a/backend/onyx/file_processing/file_types.py
+++ b/backend/onyx/file_processing/file_types.py
@@ -57,6 +57,7 @@ class OnyxFileExtensions:
         ".csv",
         ".tsv",
         ".xlsx",
+        ".xlsm",
     }
     PLAIN_TEXT_EXTENSIONS = {
         ".txt",

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
@@ -1,0 +1,69 @@
+import io
+from typing import cast
+
+import openpyxl
+import pytest
+from openpyxl.worksheet.worksheet import Worksheet
+
+from onyx.connectors.cross_connector_utils.tabular_section_utils import (
+    is_tabular_file,
+)
+from onyx.connectors.cross_connector_utils.tabular_section_utils import (
+    tabular_file_to_sections,
+)
+
+
+def _make_xlsx_bytes(sheets: dict[str, list[list[str]]]) -> io.BytesIO:
+    wb = openpyxl.Workbook()
+    if wb.active is not None:
+        wb.remove(cast(Worksheet, wb.active))
+    for sheet_name, rows in sheets.items():
+        ws = wb.create_sheet(title=sheet_name)
+        for row in rows:
+            ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+class TestIsTabularFile:
+    def test_recognizes_xlsm(self) -> None:
+        assert is_tabular_file("CWG_Cash_Flow_Analysis.(Telcon)_.xlsm")
+        assert is_tabular_file("FOO.XLSM")
+
+    def test_recognizes_existing_extensions(self) -> None:
+        assert is_tabular_file("data.xlsx")
+        assert is_tabular_file("data.csv")
+        assert is_tabular_file("data.tsv")
+
+    def test_rejects_non_tabular(self) -> None:
+        assert not is_tabular_file("report.pdf")
+        assert not is_tabular_file("note.txt")
+
+
+class TestTabularFileToSections:
+    def test_xlsm_file_parsed_like_xlsx(self) -> None:
+        """.xlsm uses the same OOXML container as .xlsx — openpyxl reads
+        both, so tabular_file_to_sections must not reject .xlsm by name."""
+        xlsm_bytes = _make_xlsx_bytes(
+            {
+                "Sheet1": [
+                    ["Name", "Age"],
+                    ["Alice", "30"],
+                    ["Bob", "25"],
+                ]
+            }
+        )
+
+        sections = tabular_file_to_sections(
+            xlsm_bytes,
+            file_name="budget.xlsm",
+        )
+        assert len(sections) == 1
+        assert "Alice" in sections[0].text
+        assert sections[0].heading == "budget.xlsm :: Sheet1"
+
+    def test_unknown_extension_raises(self) -> None:
+        with pytest.raises(ValueError):
+            tabular_file_to_sections(io.BytesIO(b""), file_name="notes.pdf")


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding support for xlsm

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Adding in tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `.xlsm` so macro‑enabled Excel files are parsed like `.xlsx` and produce tabular sections. Uses `openpyxl` with a shared spreadsheet extension list.

- **New Features**
  - Recognize `.xlsm` as a spreadsheet/tabular file in `OnyxFileExtensions` and parse it with `openpyxl` in the file connector and tabular utils.
  - Added tests for `.xlsm` detection and section parsing; unknown extensions still raise.

- **Refactors**
  - Introduced `SPREADSHEET_EXTENSIONS` (`.xlsx`, `.xlsm`) and updated checks to use it; `TABULAR_EXTENSIONS` and `DOCUMENT_EXTENSIONS` now include this set.

<sup>Written for commit f2cffccc818419551c8fdf2508dfd496a89fef8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

