### PR TITLE
chore(python): fix `ty` warnings

### DIFF
--- a/backend/alembic/versions/9aadf32dfeb4_add_user_files.py
+++ b/backend/alembic/versions/9aadf32dfeb4_add_user_files.py
@@ -52,7 +52,7 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             sa.DateTime(),
-            default=datetime.datetime.utcnow,
+            default=lambda: datetime.datetime.now(datetime.timezone.utc),
         ),
         sa.Column(
             "cc_pair_id",

--- a/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
+++ b/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 from sqlalchemy import text
-from typing import cast, Any
+from typing import cast
 
 from botocore.exceptions import ClientError
 
@@ -255,7 +255,7 @@ def _migrate_files_to_external_storage() -> None:
             continue
 
         lobj_id = cast(int, file_record.lobj_oid)
-        file_metadata = cast(Any, file_record.file_metadata)
+        file_metadata = file_record.file_metadata
 
         # Read file content from PostgreSQL
         try:

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from datetime import timezone
 
 import jwt
 from fastapi import Depends
@@ -58,7 +59,7 @@ def generate_anonymous_user_jwt_token(tenant_id: str) -> str:
     payload = {
         "tenant_id": tenant_id,
         # Token does not expire
-        "iat": datetime.utcnow(),  # Issued at time
+        "iat": datetime.now(timezone.utc),  # Issued at time
     }
 
     return jwt.encode(payload, USER_AUTH_SECRET, algorithm="HS256")

--- a/backend/ee/onyx/server/analytics/api.py
+++ b/backend/ee/onyx/server/analytics/api.py
@@ -46,9 +46,10 @@ def get_query_analytics(
     daily_query_usage_info = fetch_query_analytics(
         start=start
         or (
-            datetime.datetime.utcnow() - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
         ),  # default is 30d lookback
-        end=end or datetime.datetime.utcnow(),
+        end=end or datetime.datetime.now(tz=datetime.timezone.utc),
         db_session=db_session,
     )
     return [
@@ -77,9 +78,10 @@ def get_user_analytics(
     daily_query_usage_info_per_user = fetch_per_user_query_analytics(
         start=start
         or (
-            datetime.datetime.utcnow() - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
         ),  # default is 30d lookback
-        end=end or datetime.datetime.utcnow(),
+        end=end or datetime.datetime.now(tz=datetime.timezone.utc),
         db_session=db_session,
     )
 
@@ -111,9 +113,10 @@ def get_onyxbot_analytics(
     daily_onyxbot_info = fetch_onyxbot_analytics(
         start=start
         or (
-            datetime.datetime.utcnow() - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
         ),  # default is 30d lookback
-        end=end or datetime.datetime.utcnow(),
+        end=end or datetime.datetime.now(tz=datetime.timezone.utc),
         db_session=db_session,
     )
 
@@ -146,9 +149,10 @@ def get_persona_messages(
 ) -> list[PersonaMessageAnalyticsResponse]:
     """Fetch daily message counts for a single persona within the given time range."""
     start = start or (
-        datetime.datetime.utcnow() - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+        datetime.datetime.now(tz=datetime.timezone.utc)
+        - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
     )
-    end = end or datetime.datetime.utcnow()
+    end = end or datetime.datetime.now(tz=datetime.timezone.utc)
 
     persona_message_counts = []
     for count, date in fetch_persona_message_analytics(
@@ -226,9 +230,10 @@ def get_assistant_stats(
     along with the overall total messages and total distinct users.
     """
     start = start or (
-        datetime.datetime.utcnow() - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
+        datetime.datetime.now(tz=datetime.timezone.utc)
+        - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS)
     )
-    end = end or datetime.datetime.utcnow()
+    end = end or datetime.datetime.now(tz=datetime.timezone.utc)
 
     if not user_can_view_assistant_stats(db_session, user, assistant_id):
         raise HTTPException(

--- a/backend/ee/onyx/server/tenants/access.py
+++ b/backend/ee/onyx/server/tenants/access.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import jwt
 from fastapi import HTTPException
@@ -19,8 +20,8 @@ def generate_data_plane_token() -> str:
 
     payload = {
         "iss": "data_plane",
-        "exp": datetime.utcnow() + timedelta(minutes=5),
-        "iat": datetime.utcnow(),
+        "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+        "iat": datetime.now(tz=timezone.utc),
         "scope": "api_access",
     }
 

--- a/backend/onyx/connectors/axero/connector.py
+++ b/backend/onyx/connectors/axero/connector.py
@@ -290,8 +290,8 @@ class AxeroConnector(PollConnector):
         if not self.axero_key or not self.base_url:
             raise ConnectorMissingCredentialError("Axero")
 
-        start_datetime = datetime.utcfromtimestamp(start).replace(tzinfo=timezone.utc)
-        end_datetime = datetime.utcfromtimestamp(end).replace(tzinfo=timezone.utc)
+        start_datetime = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
 
         entity_types = []
         if self.include_article:

--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -2,6 +2,7 @@ import html
 import time
 from collections.abc import Callable
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -56,14 +57,14 @@ class BookstackConnector(LoadConnector, PollConnector):
         }
 
         if start:
-            params["filter[updated_at:gte]"] = datetime.utcfromtimestamp(
-                start
+            params["filter[updated_at:gte]"] = datetime.fromtimestamp(
+                start, tz=timezone.utc
             ).strftime("%Y-%m-%d")
 
         if end:
-            params["filter[updated_at:lte]"] = datetime.utcfromtimestamp(end).strftime(
-                "%Y-%m-%d"
-            )
+            params["filter[updated_at:lte]"] = datetime.fromtimestamp(
+                end, tz=timezone.utc
+            ).strftime("%Y-%m-%d")
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])
         doc_batch: list[Document | HierarchyNode] = [

--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -221,8 +221,8 @@ class DiscourseConnector(PollConnector):
         if self.permissions is None:
             raise ConnectorMissingCredentialError("Discourse")
 
-        start_datetime = datetime.utcfromtimestamp(start).replace(tzinfo=timezone.utc)
-        end_datetime = datetime.utcfromtimestamp(end).replace(tzinfo=timezone.utc)
+        start_datetime = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
 
         self._get_categories_map()
 

--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -159,7 +159,7 @@ def build_service_account_creds(
     service_account_key = get_service_account_key(source=source)
 
     credential_dict = {
-        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.json(),
+        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: service_account_key.model_dump_json(),
     }
     if primary_admin_email:
         credential_dict[DB_CREDENTIALS_PRIMARY_ADMIN_KEY] = primary_admin_email

--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -133,7 +133,7 @@ class ImapConnector(
         checkpoint: ImapCheckpoint,
         include_perm_sync: bool,
     ) -> CheckpointOutput[ImapCheckpoint]:
-        checkpoint = cast(ImapCheckpoint, copy.deepcopy(checkpoint))
+        checkpoint = copy.deepcopy(checkpoint)
         checkpoint.has_more = True
 
         mail_client = self._get_mail_client()
@@ -188,7 +188,7 @@ class ImapConnector(
         for email_id in current_todos:
             email_msg = _fetch_email(mail_client=mail_client, email_id=email_id)
             if not email_msg:
-                logger.warn(f"Failed to fetch message {email_id=}; skipping")
+                logger.warning(f"Failed to fetch message {email_id=}; skipping")
                 continue
 
             email_headers = EmailHeaders.from_email_msg(email_msg=email_msg)
@@ -260,7 +260,7 @@ def _fetch_all_mailboxes_for_email_account(mail_client: imaplib.IMAP4_SSL) -> li
         elif isinstance(mailboxes_raw, str):
             mailboxes_str = mailboxes_raw
         else:
-            logger.warn(
+            logger.warning(
                 f"Expected the mailbox data to be of type str, instead got {type(mailboxes_raw)=} {mailboxes_raw}; skipping"
             )
             continue
@@ -274,7 +274,7 @@ def _fetch_all_mailboxes_for_email_account(mail_client: imaplib.IMAP4_SSL) -> li
         # The below regex matches on that pattern; from there, we select the 3rd match (index 2), which is the mailbox-name.
         match = re.match(r'\([^)]*\)\s+"([^"]+)"\s+"?(.+?)"?$', mailboxes_str)
         if not match:
-            logger.warn(
+            logger.warning(
                 f"Invalid mailbox-data formatting structure: {mailboxes_str=}; skipping"
             )
             continue
@@ -391,7 +391,7 @@ def _parse_email_body(
         try:
             raw_payload = part.get_payload(decode=True)
             if not isinstance(raw_payload, bytes):
-                logger.warn(
+                logger.warning(
                     "Payload section from email was expected to be an array of bytes, instead got "
                     f"{type(raw_payload)=}, {raw_payload=}"
                 )
@@ -403,7 +403,7 @@ def _parse_email_body(
             continue
 
     if not body:
-        logger.warn(
+        logger.warning(
             f"Email with {email_headers.id=} has an empty body; returning an empty string"
         )
         return ""

--- a/backend/onyx/connectors/imap/models.py
+++ b/backend/onyx/connectors/imap/models.py
@@ -1,4 +1,5 @@
-import email
+import email.header
+import email.utils
 from datetime import datetime
 from email.message import Message
 from enum import Enum

--- a/backend/onyx/connectors/mediawiki/wiki.py
+++ b/backend/onyx/connectors/mediawiki/wiki.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import cast
 from typing import ClassVar
 
+import pywikibot.config
 import pywikibot.time
 from pywikibot import pagegenerators
 from pywikibot import textlib

--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from typing import cast
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.connectors.interfaces import GenerateDocumentsOutput
@@ -994,8 +993,6 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
             parent_to_relationship_queryable_fields[parent_type] = {}
 
             for child_type, child_relationship in child_types_working.items():
-                child_type = cast(str, child_type)
-
                 # onyx_sf_type = OnyxSalesforceType(child_type, sf_client)
 
                 # map parent name to child name

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -225,7 +225,7 @@ def thread_to_doc(
         ]
         valid_experts = [expert for expert in experts if expert]
 
-    first_message = slack_cleaner.index_clean(cast(str, thread[0]["text"]))
+    first_message = slack_cleaner.index_clean(thread[0]["text"])
     snippet = (
         first_message[:50].rstrip() + "..."
         if len(first_message) > 50
@@ -243,7 +243,7 @@ def thread_to_doc(
         sections=[
             TextSection(
                 link=get_message_link(event=m, client=client, channel_id=channel_id),
-                text=slack_cleaner.index_clean(cast(str, m["text"])),
+                text=slack_cleaner.index_clean(m["text"]),
             )
             for m in thread
         ],
@@ -893,7 +893,7 @@ class SlackConnector(
         if self.client is None or self.text_cleaner is None:
             raise ConnectorMissingCredentialError("Slack")
 
-        checkpoint = cast(SlackCheckpoint, copy.deepcopy(checkpoint))
+        checkpoint = copy.deepcopy(checkpoint)
 
         # if this is the very first time we've called this, need to
         # get all relevant channels and save them into the checkpoint
@@ -1299,7 +1299,7 @@ if __name__ == "__main__":
     gen = connector.load_from_checkpoint(
         one_day_ago,
         current,
-        cast(SlackCheckpoint, checkpoint),
+        checkpoint,
     )
     try:
         for document_or_failure in gen:

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
 from typing import Any
-from typing import cast
 
 import msal
 from office365.graph_client import GraphClient
@@ -205,7 +204,7 @@ class TeamsConnector(
         if self.graph_client is None:
             raise ConnectorMissingCredentialError("Teams")
 
-        checkpoint = cast(TeamsCheckpoint, copy.deepcopy(checkpoint))
+        checkpoint = copy.deepcopy(checkpoint)
 
         todos = checkpoint.todo_team_ids
 

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -94,14 +94,14 @@ def _get_or_fetch_email(
 
     user_id = member.properties.get("userId")
     if not user_id:
-        logger.warn(f"No user-id found for this member; {member=}")
+        logger.warning(f"No user-id found for this member; {member=}")
         return None
 
     json_data = _retry(graph_client=graph_client, request_url=f"users/{user_id}")
     email = json_data.get("userPrincipalName")
 
     if not isinstance(email, str):
-        logger.warn(f"Expected email to be of type str, instead got {email=}")
+        logger.warning(f"Expected email to be of type str, instead got {email=}")
         return None
 
     return email
@@ -172,12 +172,12 @@ def fetch_expert_infos(
     expert_infos = []
     for member in members:
         if not member.display_name:
-            logger.warn(f"Failed to grab the display-name of {member=}; skipping")
+            logger.warning(f"Failed to grab the display-name of {member=}; skipping")
             continue
 
         email = _get_or_fetch_email(graph_client=graph_client, member=member)
         if not email:
-            logger.warn(f"Failed to grab the email of {member=}; skipping")
+            logger.warning(f"Failed to grab the email of {member=}; skipping")
             continue
 
         expert_infos.append(

--- a/backend/onyx/connectors/xenforo/connector.py
+++ b/backend/onyx/connectors/xenforo/connector.py
@@ -18,7 +18,6 @@ from datetime import timezone
 from typing import Any
 from urllib.parse import urlparse
 
-import pytz
 import requests
 from bs4 import BeautifulSoup
 from bs4 import Tag
@@ -64,7 +63,7 @@ def get_pages(soup: BeautifulSoup, url: str) -> list[str]:
 def parse_post_date(post_element: BeautifulSoup) -> datetime:
     el = post_element.find("time")
     if not isinstance(el, Tag) or "datetime" not in el.attrs:
-        return datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
+        return datetime.fromtimestamp(0, tz=timezone.utc)
 
     date_value = el["datetime"]
 
@@ -130,7 +129,7 @@ class XenforoConnector(LoadConnector):
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url
         self.initial_run = not XenforoConnector.has_been_run_before
-        self.start = datetime.utcnow().replace(tzinfo=pytz.utc) - timedelta(days=1)
+        self.start = datetime.now(tz=timezone.utc) - timedelta(days=1)
         self.cookies: dict[str, str] = {}
         # mimic user browser to avoid being blocked by the website (see: https://www.useragents.me/)
         self.headers = {

--- a/backend/onyx/connectors/zulip/utils.py
+++ b/backend/onyx/connectors/zulip/utils.py
@@ -37,7 +37,7 @@ def __call_with_retry(fun: Callable, *args: Any, **kwargs: Any) -> Dict[str, Any
     if result.get("result") == "error":
         if result.get("code") == "RATE_LIMIT_HIT":
             retry_after = float(result["retry-after"]) + 1
-            logger.warn(f"Rate limit hit, retrying after {retry_after} seconds")
+            logger.warning(f"Rate limit hit, retrying after {retry_after} seconds")
             time.sleep(retry_after)
             return __call_with_retry(fun, *args)
     return result

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -384,7 +384,7 @@ def get_chat_sessions_older_than(
         A list of tuples, where each tuple contains the user_id (can be None) and the chat_session_id of an old chat session.
     """
 
-    cutoff_time = datetime.utcnow() - timedelta(days=days_old)
+    cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=days_old)
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
         select(ChatSession.user_id, ChatSession.id).where(
             ChatSession.time_created < cutoff_time

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from datetime import timezone
-from typing import cast
 
 from sqlalchemy import and_
 from sqlalchemy import exists
@@ -242,7 +241,7 @@ def fetch_latest_index_attempts_by_status(
         ),
     )
 
-    return cast(list[IndexAttempt], query.all())
+    return query.all()
 
 
 def fetch_unique_document_sources(db_session: Session) -> list[DocumentSource]:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4508,7 +4508,7 @@ class UserFile(Base):
     file_id: Mapped[str] = mapped_column(nullable=False)
     name: Mapped[str] = mapped_column(nullable=False)
     created_at: Mapped[datetime.datetime] = mapped_column(
-        default=datetime.datetime.utcnow
+        default=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
     user: Mapped["User"] = relationship(back_populates="files")
     token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/onyx/db/pydantic_type.py
+++ b/backend/onyx/db/pydantic_type.py
@@ -23,7 +23,7 @@ class PydanticType(TypeDecorator):
         dialect: Any,  # noqa: ARG002
     ) -> Optional[dict]:
         if value is not None:
-            return json.loads(value.json())
+            return json.loads(value.model_dump_json())
         return None
 
     def process_result_value(
@@ -32,7 +32,7 @@ class PydanticType(TypeDecorator):
         dialect: Any,  # noqa: ARG002
     ) -> Optional[BaseModel]:
         if value is not None:
-            return self.pydantic_model.parse_obj(value)
+            return self.pydantic_model.model_validate(value)
         return None
 
 

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -193,7 +193,7 @@ def update_search_settings(
     updated_settings: SavedSearchSettings,
     preserved_fields: list[str],
 ) -> None:
-    for field, value in updated_settings.dict().items():
+    for field, value in updated_settings.model_dump().items():
         if field not in preserved_fields:
             setattr(current_settings, field, value)
 

--- a/backend/onyx/db/seeding/chat_history_seeding.py
+++ b/backend/onyx/db/seeding/chat_history_seeding.py
@@ -1,6 +1,7 @@
 import random
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from logging import getLogger
 from uuid import UUID
 
@@ -43,7 +44,7 @@ def seed_chat_history(
                 logger.info(f"Seeded messages for {x} sessions so far.")
 
             row = rows[x]
-            row.time_created = datetime.utcnow() - timedelta(
+            row.time_created = datetime.now(tz=timezone.utc) - timedelta(
                 days=random.randint(0, days)
             )
             row.time_updated = row.time_created + timedelta(

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import time
-import urllib
+import urllib.parse
 import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass

--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -70,7 +70,7 @@ class RedisConnectorDelete:
             return None
 
         fence_str = fence_bytes.decode("utf-8")
-        payload = RedisConnectorDeletePayload.model_validate_json(cast(str, fence_str))
+        payload = RedisConnectorDeletePayload.model_validate_json(fence_str)
 
         return payload
 

--- a/backend/onyx/redis/redis_connector_ext_group_sync.py
+++ b/backend/onyx/redis/redis_connector_ext_group_sync.py
@@ -96,9 +96,7 @@ class RedisConnectorExternalGroupSync:
 
         fence_bytes = cast(bytes, fence_raw)
         fence_str = fence_bytes.decode("utf-8")
-        payload = RedisConnectorExternalGroupSyncPayload.model_validate_json(
-            cast(str, fence_str)
-        )
+        payload = RedisConnectorExternalGroupSyncPayload.model_validate_json(fence_str)
 
         return payload
 

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -104,7 +104,7 @@ class RedisConnectorPrune:
             return None
 
         fence_str = fence_bytes.decode("utf-8")
-        payload = RedisConnectorPrunePayload.model_validate_json(cast(str, fence_str))
+        payload = RedisConnectorPrunePayload.model_validate_json(fence_str)
 
         return payload
 

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -1621,7 +1621,7 @@ def create_connector_with_mock_credential(
         )
 
         # Store the created connector and credential IDs
-        connector_id = cast(int, connector_response.id)
+        connector_id = connector_response.id
         credential_id = credential.id
 
         validate_ccpair_for_user(

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -1,6 +1,7 @@
 """Database operations for Build Mode sessions."""
 
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 from uuid import UUID
 
@@ -139,7 +140,7 @@ def update_session_activity(
         .one_or_none()
     )
     if session:
-        session.last_activity_at = datetime.utcnow()
+        session.last_activity_at = datetime.now(tz=timezone.utc)
         db_session.commit()
 
 
@@ -217,7 +218,7 @@ def update_sandbox_status(
         sandbox.status = status
         if container_id is not None:
             sandbox.container_id = container_id
-        sandbox.last_heartbeat = datetime.utcnow()
+        sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
         db_session.commit()
         logger.info(f"Updated sandbox {sandbox_id} status to {status}")
 
@@ -229,7 +230,7 @@ def update_sandbox_heartbeat(
     """Update the heartbeat timestamp for a sandbox."""
     sandbox = db_session.query(Sandbox).filter(Sandbox.id == sandbox_id).one_or_none()
     if sandbox:
-        sandbox.last_heartbeat = datetime.utcnow()
+        sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
         db_session.commit()
 
 
@@ -284,7 +285,7 @@ def update_artifact(
             artifact.path = path
         if name is not None:
             artifact.name = name
-        artifact.updated_at = datetime.utcnow()
+        artifact.updated_at = datetime.now(tz=timezone.utc)
         db_session.commit()
         logger.info(f"Updated artifact {artifact_id}")
 

--- a/backend/onyx/server/features/input_prompt/api.py
+++ b/backend/onyx/server/features/input_prompt/api.py
@@ -96,7 +96,7 @@ def patch_input_prompt(
         )
     except ValueError as e:
         error_msg = "Error occurred while updated input prompt"
-        logger.warn(f"{error_msg}. Stack trace: {e}")
+        logger.warning(f"{error_msg}. Stack trace: {e}")
         raise HTTPException(status_code=404, detail=error_msg)
 
     return InputPromptSnapshot.from_model(updated_input_prompt)
@@ -116,7 +116,7 @@ def delete_input_prompt(
 
     except ValueError as e:
         error_msg = "Error occurred while deleting input prompt"
-        logger.warn(f"{error_msg}. Stack trace: {e}")
+        logger.warning(f"{error_msg}. Stack trace: {e}")
         raise HTTPException(status_code=404, detail=error_msg)
 
 
@@ -131,7 +131,7 @@ def delete_public_input_prompt(
 
     except ValueError as e:
         error_msg = "Error occurred while deleting input prompt"
-        logger.warn(f"{error_msg}. Stack trace: {e}")
+        logger.warning(f"{error_msg}. Stack trace: {e}")
         raise HTTPException(status_code=404, detail=error_msg)
 
 

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -486,5 +486,5 @@ class ImageGenerationTool(Tool[ImageGenerationToolOverrideKwargs | None]):
 
         return ToolResponse(
             rich_response=final_image_generation_response,
-            llm_facing_response=cast(str, llm_facing_response),
+            llm_facing_response=llm_facing_response,
         )

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -5,8 +5,8 @@ This module provides a proper MCP client that follows the JSON-RPC 2.0 specifica
 and handles connection initialization, session management, and protocol communication.
 """
 
-from collections.abc import Awaitable
 from collections.abc import Callable
+from collections.abc import Coroutine
 from enum import Enum
 from typing import Any
 from typing import Dict
@@ -31,7 +31,7 @@ logger = setup_logger()
 
 T = TypeVar("T", covariant=True)
 
-MCPClientFunction = Callable[[ClientSession], Awaitable[T]]
+MCPClientFunction = Callable[[ClientSession], Coroutine[Any, Any, T]]
 
 
 class MCPMessageType(str, Enum):
@@ -120,13 +120,13 @@ class MCPMessage(BaseModel):
 
 
 def _create_mcp_client_function_runner(
-    function: Callable[[ClientSession], Awaitable[T]],
+    function: Callable[[ClientSession], Coroutine[Any, Any, T]],
     server_url: str,
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,  # TODO: maybe used this for all auth types
     **kwargs: Any,
-) -> Callable[[], Awaitable[T]]:
+) -> Callable[[], Coroutine[Any, Any, T]]:
     auth_headers = connection_headers or {}
     # WARNING: httpx.Auth with requires_response_body=True (as in the MCP OAuth
     # provider) forces httpx to fully read the response body. That is incompatible
@@ -177,7 +177,7 @@ def log_exception_group(e: ExceptionGroup) -> Exception | None:
 
 
 def _call_mcp_client_function_sync(
-    function: Callable[[ClientSession], Awaitable[T]],
+    function: Callable[[ClientSession], Coroutine[Any, Any, T]],
     server_url: str,
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
@@ -201,7 +201,7 @@ def _call_mcp_client_function_sync(
 
 
 async def _call_mcp_client_function_async(
-    function: Callable[[ClientSession], Awaitable[T]],
+    function: Callable[[ClientSession], Coroutine[Any, Any, T]],
     server_url: str,
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -1,12 +1,12 @@
 import asyncio
 import collections.abc
-import concurrent
+import concurrent.futures
 import contextvars
 import copy
 import threading
 import uuid
-from collections.abc import Awaitable
 from collections.abc import Callable
+from collections.abc import Coroutine
 from collections.abc import Iterator
 from collections.abc import MutableMapping
 from collections.abc import Sequence
@@ -445,18 +445,18 @@ def run_functions_in_parallel(
     return results
 
 
-def run_async_sync_no_cancel(coro: Awaitable[T]) -> T:
+def run_async_sync_no_cancel(coro: Coroutine[Any, Any, T]) -> T:
     """
     async-to-sync converter. Basically just executes asyncio.run in a separate thread.
     Which is probably somehow inefficient or not ideal but fine for now.
     """
     context = contextvars.copy_context()
+
+    def _run() -> T:
+        return cast(T, context.run(asyncio.run, coro))
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future: concurrent.futures.Future[T] = executor.submit(
-            context.run,
-            asyncio.run,
-            coro,
-        )
+        future = executor.submit(_run)
         return future.result()
 
 

--- a/backend/scripts/tenant_cleanup/cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/cleanup_tenants.py
@@ -27,6 +27,7 @@ import signal
 import subprocess
 import sys
 from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 
 from scripts.tenant_cleanup.cleanup_utils import confirm_step
@@ -704,7 +705,7 @@ def main() -> None:
                     successful_tenants.append(tenant_id)
 
                     # Write to CSV immediately after successful cleanup
-                    timestamp = datetime.utcnow().isoformat()
+                    timestamp = datetime.now(timezone.utc).isoformat()
                     csv_writer.writerow([tenant_id, timestamp])
                     csv_file.flush()  # Ensure real-time write
                     print(f"✓ Recorded cleanup in {csv_output_path}")

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -20,6 +20,7 @@ import sys
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from threading import Lock
 
@@ -778,7 +779,7 @@ def main() -> None:
                         successful_tenants.append(tenant_id)
 
                         # Write to CSV immediately after successful cleanup
-                        timestamp = datetime.utcnow().isoformat()
+                        timestamp = datetime.now(timezone.utc).isoformat()
                         csv_writer.writerow([tenant_id, timestamp])
                         csv_file.flush()
                         print(f"✓ Recorded cleanup in {csv_output_path}")
@@ -843,7 +844,7 @@ def main() -> None:
                         failed_tenants.append((tenant_id, error))
                     elif was_cleaned:
                         with _csv_lock:
-                            timestamp = datetime.utcnow().isoformat()
+                            timestamp = datetime.now(timezone.utc).isoformat()
                             csv_writer.writerow([tenant_id, timestamp])
                             csv_file.flush()
                         successful_tenants.append(tenant_id)

--- a/backend/tests/external_dependency_unit/answer/stream_test_assertions.py
+++ b/backend/tests/external_dependency_unit/answer/stream_test_assertions.py
@@ -19,7 +19,7 @@ def assert_answer_stream_part_correct(
     assert isinstance(received, type(expected))
 
     if isinstance(received, Packet):
-        r_packet = cast(Packet, received)
+        r_packet = received
         e_packet = cast(Packet, expected)
 
         assert r_packet.placement == e_packet.placement

--- a/backend/tests/integration/common_utils/managers/tenant.py
+++ b/backend/tests/integration/common_utils/managers/tenant.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import jwt
 import requests
@@ -14,8 +15,8 @@ from tests.integration.common_utils.test_models import DATestUser
 def generate_auth_token() -> str:
     payload = {
         "iss": "control_plane",
-        "exp": datetime.utcnow() + timedelta(minutes=5),
-        "iat": datetime.utcnow(),
+        "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+        "iat": datetime.now(tz=timezone.utc),
         "scope": "tenant:create",
     }
     token = jwt.encode(payload, "", algorithm="HS256")

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -249,7 +249,7 @@ def test_update_model_configurations(
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
             "model_configurations": [
-                model_configuration.dict()
+                model_configuration.model_dump()
                 for model_configuration in model_configurations
             ],
             "is_public": True,
@@ -283,7 +283,7 @@ def test_update_model_configurations(
             "provider": created_provider["provider"],
             "api_key": "sk-000000000000000000000000000000000000000000000001",
             "model_configurations": [
-                model_configuration.dict()
+                model_configuration.model_dump()
                 for model_configuration in updated_model_configurations
             ],
             "is_public": True,
@@ -316,7 +316,7 @@ def test_update_model_configurations(
             "provider": created_provider["provider"],
             "api_key": "sk-000000000000000000000000000000000000000000000001",
             "model_configurations": [
-                model_configuration.dict()
+                model_configuration.model_dump()
                 for model_configuration in updated_model_configurations
             ],
             "is_public": True,
@@ -361,7 +361,7 @@ def test_delete_llm_provider(
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
             "model_configurations": [
-                model_configuration.dict()
+                model_configuration.model_dump()
                 for model_configuration in model_configurations
             ],
             "is_public": True,
@@ -773,7 +773,7 @@ def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG00
             "name": "test-visibility-provider",
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
-            "model_configurations": [config.dict() for config in model_configs],
+            "model_configurations": [config.model_dump() for config in model_configs],
             "is_public": True,
             "groups": [],
             "personas": [],
@@ -823,7 +823,7 @@ def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG00
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
             "model_configurations": [
-                config.dict() for config in edit_configs_all_visible
+                config.model_dump() for config in edit_configs_all_visible
             ],
             "is_public": True,
             "groups": [],
@@ -871,7 +871,7 @@ def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG00
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
             "model_configurations": [
-                config.dict() for config in edit_configs_one_visible
+                config.model_dump() for config in edit_configs_one_visible
             ],
             "is_public": True,
             "groups": [],
@@ -919,7 +919,7 @@ def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG00
             "provider": LlmProviderNames.OPENAI,
             "api_key": "sk-000000000000000000000000000000000000000000000000",
             "model_configurations": [
-                config.dict() for config in edit_configs_none_visible
+                config.model_dump() for config in edit_configs_none_visible
             ],
             "is_public": True,
             "groups": [],

--- a/backend/tests/integration/tests/users/test_seat_limit.py
+++ b/backend/tests/integration/tests/users/test_seat_limit.py
@@ -6,6 +6,7 @@ creation (registration, invite, reactivation) is blocked with HTTP 402.
 
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import redis
 import requests
@@ -28,7 +29,7 @@ _LICENSE_REDIS_KEY = "public:license:metadata"
 
 def _seed_license(r: redis.Redis, seats: int) -> None:
     """Write a LicenseMetadata entry into Redis with the given seat cap."""
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     metadata = LicenseMetadata(
         tenant_id="public",
         organization_name="Test Org",

--- a/backend/tests/integration/tests/users/test_slack_user_deactivation.py
+++ b/backend/tests/integration/tests/users/test_slack_user_deactivation.py
@@ -8,6 +8,7 @@ Verifies that:
 
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import redis
 import requests
@@ -28,7 +29,7 @@ _LICENSE_REDIS_KEY = "public:license:metadata"
 
 
 def _seed_license(r: redis.Redis, seats: int) -> None:
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     metadata = LicenseMetadata(
         tenant_id="public",
         organization_name="Test Org",

--- a/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
+++ b/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
@@ -5,7 +5,7 @@ import tempfile
 from collections.abc import Iterable
 
 import pytest
-import pywikibot
+import pywikibot.config
 from pytest_mock import MockFixture
 
 from onyx.connectors.mediawiki import wiki

--- a/backend/tests/unit/onyx/connectors/utils.py
+++ b/backend/tests/unit/onyx/connectors/utils.py
@@ -1,4 +1,3 @@
-from typing import cast
 from typing import Generic
 from typing import TypeVar
 
@@ -28,7 +27,7 @@ def load_everything_from_checkpoint_connector(
     end: SecondsSinceUnixEpoch,
 ) -> list[SingleConnectorCallOutput[CT]]:
 
-    checkpoint = cast(CT, connector.build_dummy_checkpoint())
+    checkpoint = connector.build_dummy_checkpoint()
     return load_everything_from_checkpoint_connector_from_checkpoint(
         connector, start, end, checkpoint
     )

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -248,7 +248,7 @@ def _make_doc(
         id=doc_id,
         title="Test Doc",
         semantic_identifier="test-doc",
-        sections=cast(list[TextSection | ImageSection], sections),
+        sections=sections,
         source=DocumentSource.FILE,
         metadata={},
     )
@@ -322,10 +322,7 @@ def test_document_ingestion_hook_preserves_image_section_order() -> None:
     """Hook receives all sections including images and controls final ordering."""
     image = ImageSection(image_file_id="img-1", link=None)
     doc = _make_doc(
-        sections=cast(
-            list[TextSection | ImageSection],
-            [TextSection(text="original", link=None), image],
-        )
+        sections=[TextSection(text="original", link=None), image],
     )
     # Hook moves the image before the text section
     with patch(

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest.mock
 import uuid
 from typing import Any
 from unittest.mock import patch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,17 +216,6 @@ exclude = [
 # fail CI.
 all = "error"
 
-# Track stale suppression comments as ty improves and false positives are resolved.
-unused-type-ignore-comment = "warn"
-
-# TODO: 28x datetime.utcnow() + 7x datetime.utcfromtimestamp() are real Python 3.12+
-# deprecations worth cleaning up. Set to "warn" so they show but don't block CI.
-deprecated = "warn"
-
-# Low-priority warnings -- show but don't block CI
-redundant-cast = "warn"
-possibly-missing-submodule = "warn"
-
 [tool.uv.workspace]
 members = ["tools/ods"]
 


### PR DESCRIPTION
## Description

Most of these seem like no-ops. There are some functional changes, but they look coherent. 

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes UTC-aware timestamps, updates to `pydantic` v2 APIs, and cleans up typing/depredations to resolve `ty` warnings across the backend. Behavior now consistently uses timezone-aware UTC for token/analytics timestamps and model defaults.

- **Refactors**
  - Replaced `datetime.utcnow`/`utcfromtimestamp` with `datetime.now(timezone.utc)`/`fromtimestamp(..., tz=timezone.utc)` across models, analytics, connectors, seeds, and scripts; removed `pytz` use.
  - Migrated to `pydantic` v2 (`.model_dump()`, `.model_dump_json()`, `.model_validate()`), including Redis payloads and DB type adapters.
  - Switched `logger.warn` to `logger.warning`; cleaned imports (`urllib.parse`, `email.header/utils`, `pywikibot.config`) and minor test/connector adjustments.
  - Tightened types by removing redundant `cast`, adopting `Coroutine` over `Awaitable`, using `concurrent.futures`, and correcting return types.

<sup>Written for commit b40f32f25231c427104cc5f272113d19d9b6f2ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

