### PR TITLE
chore(playwright): always hide the text under the onyx-logo

### DIFF
--- a/web/tests/e2e/chat/welcome_page.spec.ts
+++ b/web/tests/e2e/chat/welcome_page.spec.ts
@@ -35,7 +35,6 @@ for (const theme of THEMES) {
 
       await expectScreenshot(page, {
         name: `welcome-${theme}-full-page`,
-        hide: ['[data-testid="onyx-logo"]'], // greeting text is random, hide to prevent size variation
       });
     });
 

--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -31,6 +31,7 @@ const DEFAULT_MASK_SELECTORS: string[] = [
  */
 const DEFAULT_HIDE_SELECTORS: string[] = [
   '[data-testid="toast-container"]',
+  '[data-testid="onyx-logo"] p', // greeting text is random, hide to prevent size variation
   // TODO: Remove once it loads consistently.
   '[data-testid="actions-container"]',
 ];


### PR DESCRIPTION
## Description

Now that this text is left-aligned on this page, it protrudes outside of modals which causes inconsistencies with the playwright visual regression tests, so just always hide it.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always hide the greeting text under `[data-testid="onyx-logo"]` in Playwright visual regression to prevent flakey diffs from random text and left-aligned overflow. Moved the selector (`[data-testid="onyx-logo"] p`) to `DEFAULT_HIDE_SELECTORS` so it applies across tests and removed the per-test override.

<sup>Written for commit 7575134e89905ff6728451a2a44ab33a9cd50b7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

