### PR TITLE
fix(mt): Tighten tenant work-gating writer hooks (2.5/3)

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -166,16 +166,21 @@ def check_for_connector_deletion_task(self: Task, *, tenant_id: str) -> bool | N
 
             r.set(OnyxRedisSignals.BLOCK_VALIDATE_CONNECTOR_DELETION_FENCES, 1, ex=300)
 
-        # collect cc_pair_ids
+        # collect cc_pair_ids and note whether any are in DELETING status
         cc_pair_ids: list[int] = []
+        has_deleting_cc_pair = False
         with get_session_with_current_tenant() as db_session:
             cc_pairs = get_connector_credential_pairs(db_session)
             for cc_pair in cc_pairs:
                 cc_pair_ids.append(cc_pair.id)
+                if cc_pair.status == ConnectorCredentialPairStatus.DELETING:
+                    has_deleting_cc_pair = True
 
-        # Tenant-work-gating hook: any cc_pair means deletion could have
-        # cleanup work to do for this tenant on some cycle.
-        if cc_pair_ids:
+        # Tenant-work-gating hook: mark only when at least one cc_pair is in
+        # DELETING status. Marking on bare cc_pair existence would keep
+        # nearly every tenant in the active set since most have cc_pairs
+        # but almost none are actively being deleted on any given cycle.
+        if has_deleting_cc_pair:
             maybe_mark_tenant_active(tenant_id)
 
         # try running cleanup on the cc_pair_ids

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -897,11 +897,6 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
 
                 secondary_cc_pair_ids = standard_cc_pair_ids
 
-        # Tenant-work-gating hook: refresh this tenant's active-set membership
-        # whenever indexing actually has work to dispatch.
-        if primary_cc_pair_ids or secondary_cc_pair_ids:
-            maybe_mark_tenant_active(tenant_id)
-
         # Flag CC pairs in repeated error state for primary/current search settings
         with get_session_with_current_tenant() as db_session:
             for cc_pair_id in primary_cc_pair_ids:
@@ -1018,6 +1013,14 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                 task_logger.info(
                     f"Skipping secondary indexing: switchover_type=INSTANT for search_settings={secondary_search_settings.id}"
                 )
+
+        # Tenant-work-gating hook: refresh membership only when indexing
+        # actually dispatched at least one docfetching task. `_kickoff_indexing_tasks`
+        # internally calls `should_index()` to decide per-cc_pair; using
+        # `tasks_created > 0` here gives us a "real work was done" signal
+        # rather than just "tenant has a cc_pair somewhere."
+        if tasks_created > 0:
+            maybe_mark_tenant_active(tenant_id)
 
         # 2/3: VALIDATE
         # Check for inconsistent index attempts - active attempts without task IDs

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -229,11 +229,7 @@ def check_for_pruning(self: Task, *, tenant_id: str) -> bool | None:
                 for cc_pair_entry in cc_pairs:
                     cc_pair_ids.append(cc_pair_entry.id)
 
-            # Tenant-work-gating hook: any cc_pair means pruning could have
-            # work to do for this tenant on some cycle.
-            if cc_pair_ids:
-                maybe_mark_tenant_active(tenant_id)
-
+            prune_dispatched = False
             for cc_pair_id in cc_pair_ids:
                 lock_beat.reacquire()
                 with get_session_with_current_tenant() as db_session:
@@ -256,9 +252,18 @@ def check_for_pruning(self: Task, *, tenant_id: str) -> bool | None:
                         logger.info(f"Pruning not created: {cc_pair_id}")
                         continue
 
+                    prune_dispatched = True
                     task_logger.info(
                         f"Pruning queued: cc_pair={cc_pair.id} id={payload_id}"
                     )
+
+            # Tenant-work-gating hook: mark only when at least one cc_pair
+            # was actually due for pruning AND a prune task was dispatched.
+            # Marking on bare cc_pair existence over-counts the population
+            # since most tenants have cc_pairs but almost none are due on
+            # any given cycle.
+            if prune_dispatched:
+                maybe_mark_tenant_active(tenant_id)
             r.set(OnyxRedisSignals.BLOCK_PRUNING, 1, ex=_get_pruning_block_expiration())
 
         # we want to run this less frequently than the overall task

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -126,6 +126,8 @@ class TenantRedis(redis.Redis):
             "srem",
             "scard",
             "zadd",
+            "zrange",
+            "zrevrange",
             "zrangebyscore",
             "zremrangebyscore",
             "zscore",


### PR DESCRIPTION
## Description

Follow-up to #10246 after live validation on managed_services.

After flipping ` runtime:tenant_work_gating:enabled=true`, the set populated to 22,865 tenants within 5 minutes — out of 24,571 total, 11,481 non-gated. Only ~979 non-gated tenants (8.5%) would have been skipped by the gate, far short of the 60–80% target.

Root cause: three of the seven consumer hooks fired on bare \"tenant has any cc_pair\" instead of \"tenant has due work right now\". Since nearly all non-gated tenants have cc_pairs (they got past product-gating precisely because they're active), the gate would barely filter anything.

This PR tightens the three offending hooks so the write happens only when real work actually dispatches, and fixes a small  `zrange`/`zrevrange` wrapping bug discovered along the way.

### Hook changes

| Task | Before | After |
|---|---|---|
| `check_for_indexing` | mark if `primary_cc_pair_ids or secondary_cc_pair_ids` | mark if `tasks_created > 0` from `_kickoff_indexing_tasks` (reflects `should_index()`) |
| `check_for_pruning` | mark if `cc_pair_ids` non-empty | mark only when `try_creating_prune_generator_task` returns a payload (implies `_is_pruning_due`) |
| `check_for_connector_deletion` | mark if `cc_pair_ids` non-empty | mark only when at least one cc_pair has `status == DELETING` |

The other four hooks ( vespa sync, doc permissions sync, external group sync, cleanup idle sandboxes) already fired on real due work and are untouched.

### Also

- Add `zrange` and `zrevrange` to `TenantRedis.methods_to_wrap`. These weren't prefixed, so any unqualified call silently missed the `cloud:` namespace. PR 3's gate uses `zrangebyscore` (already wrapped) so this wasn't blocking, but it's a real bug.

## How Has This Been Tested?

- Existing external-dependency unit tests for helpers still pass (13/13).
- After this merges, I'll redeploy and repeat the same flip/ZCARD-over-time validation on `managed_services`. The previous run's ~22k set size should drop substantially.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens tenant work-gating so we only mark tenants active when real work is dispatched, not just when they have `cc_pair`s. Also fixes missing Redis method wrapping to ensure proper `cloud:` namespacing.

- **Bug Fixes**
  - Indexing: mark only when `_kickoff_indexing_tasks` creates tasks (`tasks_created > 0`).
  - Pruning: mark only when `try_creating_prune_generator_task` dispatches a task.
  - Connector deletion: mark only if any `cc_pair` has status `DELETING`.
  - Redis: wrap `zrange` and `zrevrange` in `TenantRedis.methods_to_wrap` to apply the `cloud:` prefix.

<sup>Written for commit bb59a5d1c58efdc22b1f146830d91d466aec1e84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

