### PR TITLE
fix(logos): github logo displays correctly in dark mode

### DIFF
--- a/web/src/components/WebResultIcon.tsx
+++ b/web/src/components/WebResultIcon.tsx
@@ -3,7 +3,7 @@
 import { ValidSources } from "@/lib/types";
 import { SourceIcon } from "./SourceIcon";
 import { useState } from "react";
-import { OnyxIcon } from "./icons/icons";
+import { GithubIcon, OnyxIcon } from "./icons/icons";
 
 export function WebResultIcon({
   url,
@@ -23,6 +23,8 @@ export function WebResultIcon({
     <>
       {hostname.includes("onyx.app") ? (
         <OnyxIcon size={size} className="dark:text-[#fff] text-[#000]" />
+      ) : hostname === "github.com" || hostname.endsWith(".github.com") ? (
+        <GithubIcon size={size} />
       ) : !error ? (
         <img
           className="my-0 rounded-full py-0"

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -46,6 +46,7 @@ import freshdeskIcon from "@public/Freshdesk.png";
 import geminiSVG from "@public/Gemini.svg";
 import gitbookDarkIcon from "@public/GitBookDark.png";
 import gitbookLightIcon from "@public/GitBookLight.png";
+import githubDarkIcon from "@public/GithubDarkMode.png";
 import githubLightIcon from "@public/Github.png";
 import gongIcon from "@public/Gong.png";
 import googleIcon from "@public/Google.png";
@@ -855,7 +856,7 @@ export const GitbookIcon = createLogoIcon(gitbookDarkIcon, {
   darkSrc: gitbookLightIcon,
 });
 export const GithubIcon = createLogoIcon(githubLightIcon, {
-  monochromatic: true,
+  darkSrc: githubDarkIcon,
 });
 export const GitlabIcon = createLogoIcon(gitlabIcon);
 export const GmailIcon = createLogoIcon(gmailIcon);


### PR DESCRIPTION
## Description

Trying to fix the flaky rendering in playwright visual regression tests, but this should have a separate icon for dark mode, so add.

## How Has This Been Tested?

Will check the visual regression report

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub logo in dark mode with a dedicated dark asset and uses `GithubIcon` for GitHub URLs. Improves contrast and stabilizes visual regression tests.

- **Bug Fixes**
  - Added `GithubDarkMode.png` and set `darkSrc` for `GithubIcon` in `web/src/components/icons/icons.tsx` (replaces monochrome).
  - Updated `web/src/components/WebResultIcon.tsx` to render `GithubIcon` for `github.com` and subdomains.

<sup>Written for commit 364d7d8a8f105752e67766d5c18224466cd70d62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

