### PR TITLE
feat(opal): add SvgVector icon

### DIFF
--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -184,6 +184,7 @@ export { default as SvgUserSpeaker } from "@opal/icons/user-speaker";
 export { default as SvgUserSync } from "@opal/icons/user-sync";
 export { default as SvgUserX } from "@opal/icons/user-x";
 export { default as SvgUsers } from "@opal/icons/users";
+export { default as SvgVector } from "@opal/icons/vector";
 export { default as SvgVolume } from "@opal/icons/volume";
 export { default as SvgVolumeOff } from "@opal/icons/volume-off";
 export { default as SvgWallet } from "@opal/icons/wallet";

--- a/web/lib/opal/src/icons/vector.tsx
+++ b/web/lib/opal/src/icons/vector.tsx
@@ -1,0 +1,20 @@
+import type { IconProps } from "@opal/types";
+const SvgVector = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      d="M8 2L6 4M8 2L8 9M8 2L10 4M8 9L14.0622 12.5M8 9L1.93782 12.5M14.0622 12.5L11.3301 13.232M14.0622 12.5L13.3301 9.76794M1.93782 12.5L4.66987 13.2321M1.93782 12.5L2.66987 9.76795"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default SvgVector;


### PR DESCRIPTION
## Screenshots + Videos

<img width="148" height="141" alt="image" src="https://github.com/user-attachments/assets/9898f96b-9fe3-4856-8b32-72803b179c8b" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `SvgVector` icon to `@opal/icons` and exports it from the icons barrel. Consumers can now import it as `import { SvgVector } from "@opal/icons"`, and it will be used in the Index Settings reskin.

<sup>Written for commit ecd88a001e3100cdfb2e71f72ee6a210941800cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->