### PR TITLE
feat(opal): add LinkButton component

### DIFF
--- a/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { LinkButton } from "@opal/components";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+const meta: Meta<typeof LinkButton> = {
+  title: "opal/components/LinkButton",
+  component: LinkButton,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <TooltipPrimitive.Provider>
+        <Story />
+      </TooltipPrimitive.Provider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LinkButton>;
+
+// ─── Anchor mode ────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  render: () => <LinkButton href="/">Home</LinkButton>,
+};
+
+export const ExternalLink: Story = {
+  render: () => (
+    <LinkButton href="https://onyx.app" target="_blank">
+      Onyx
+    </LinkButton>
+  ),
+};
+
+export const LongLabel: Story = {
+  render: () => (
+    <LinkButton href="https://docs.onyx.app" target="_blank">
+      Go read the full Onyx documentation site
+    </LinkButton>
+  ),
+};
+
+// ─── Button mode ────────────────────────────────────────────────────────────
+
+export const AsButton: Story = {
+  render: () => (
+    <LinkButton onClick={() => alert("clicked")}>Click me</LinkButton>
+  ),
+};
+
+// ─── Disabled ───────────────────────────────────────────────────────────────
+
+export const DisabledLink: Story = {
+  render: () => (
+    <LinkButton href="/" disabled>
+      Disabled link
+    </LinkButton>
+  ),
+};
+
+export const DisabledButton: Story = {
+  render: () => (
+    <LinkButton onClick={() => alert("should not fire")} disabled>
+      Disabled button
+    </LinkButton>
+  ),
+};
+
+// ─── Tooltip ────────────────────────────────────────────────────────────────
+
+export const Tooltip: Story = {
+  render: () => (
+    <LinkButton href="/" tooltip="This is a tooltip">
+      Hover me
+    </LinkButton>
+  ),
+};
+
+export const TooltipSides: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8 p-16">
+      <LinkButton href="/" tooltip="Tooltip on top" tooltipSide="top">
+        top
+      </LinkButton>
+      <LinkButton href="/" tooltip="Tooltip on right" tooltipSide="right">
+        right
+      </LinkButton>
+      <LinkButton href="/" tooltip="Tooltip on bottom" tooltipSide="bottom">
+        bottom
+      </LinkButton>
+      <LinkButton href="/" tooltip="Tooltip on left" tooltipSide="left">
+        left
+      </LinkButton>
+    </div>
+  ),
+};
+
+// ─── Inline in prose ────────────────────────────────────────────────────────
+
+export const InlineInProse: Story = {
+  render: () => (
+    <p style={{ maxWidth: "36rem", lineHeight: 1.7 }}>
+      Modifying embedding settings requires a full re-index of all documents and
+      may take hours or days depending on corpus size.{" "}
+      <LinkButton href="https://docs.onyx.app" target="_blank">
+        Learn more
+      </LinkButton>
+      .
+    </p>
+  ),
+};

--- a/web/lib/opal/src/components/buttons/link-button/README.md
+++ b/web/lib/opal/src/components/buttons/link-button/README.md
@@ -23,7 +23,7 @@ The component renders a plain `<a>` (when given `href`) or `<button>` (when give
 | `target` | `string` | — | Anchor target (e.g. `"_blank"`). Adds `rel="noopener noreferrer"` automatically when `"_blank"`. |
 | `onClick` | `() => void` | — | Click handler. Without `href`, renders the component as `<button>`. |
 | `disabled` | `boolean` | `false` | Applies disabled styling + suppresses navigation / clicks |
-| `tooltip` | `string` | — | Hover tooltip text |
+| `tooltip` | `string \| RichStr` | — | Hover tooltip text. Pass `markdown(...)` for inline markdown. |
 | `tooltipSide` | `TooltipSide` | `"top"` | Tooltip placement |
 
 Exactly one of `href` / `onClick` is expected. Passing both is allowed but only `href` takes effect (renders as an anchor).

--- a/web/lib/opal/src/components/buttons/link-button/README.md
+++ b/web/lib/opal/src/components/buttons/link-button/README.md
@@ -1,0 +1,60 @@
+# LinkButton
+
+**Import:** `import { LinkButton, type LinkButtonProps } from "@opal/components";`
+
+A compact, anchor-styled link with an underlined label and a trailing external-link glyph. Intended for **inline references** — "Pricing", "Docs", "Learn more" — not for interactive surfaces that need hover backgrounds or prominence tiers. Use [`Button`](../button/README.md) for those.
+
+## Architecture
+
+Deliberately **does not** use `Interactive.Stateless` / `Interactive.Container`. Those primitives come with height, rounding, padding, and a colour matrix designed for clickable surfaces — all wrong for an inline text link.
+
+The component renders a plain `<a>` (when given `href`) or `<button>` (when given `onClick`) with:
+- `inline-flex` so the label + icon track naturally next to surrounding prose
+- `text-text-03` that shifts to `text-text-05` on hover
+- `underline` on the label only (the icon stays non-underlined)
+- `data-disabled` driven opacity + `cursor-not-allowed` for the disabled state
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `string` | — | Visible label (required) |
+| `href` | `string` | — | Destination URL. Renders the component as `<a>`. |
+| `target` | `string` | — | Anchor target (e.g. `"_blank"`). Adds `rel="noopener noreferrer"` automatically when `"_blank"`. |
+| `onClick` | `() => void` | — | Click handler. Without `href`, renders the component as `<button>`. |
+| `disabled` | `boolean` | `false` | Applies disabled styling + suppresses navigation / clicks |
+| `tooltip` | `string` | — | Hover tooltip text |
+| `tooltipSide` | `TooltipSide` | `"top"` | Tooltip placement |
+
+Exactly one of `href` / `onClick` is expected. Passing both is allowed but only `href` takes effect (renders as an anchor).
+
+## Usage
+
+```tsx
+import { LinkButton } from "@opal/components";
+
+// External link — automatic rel="noopener noreferrer"
+<LinkButton href="https://docs.onyx.app" target="_blank">
+  Read the docs
+</LinkButton>
+
+// Internal link
+<LinkButton href="/admin/settings">Settings</LinkButton>
+
+// Button-mode (no href)
+<LinkButton onClick={openModal}>Learn more</LinkButton>
+
+// Disabled
+<LinkButton href="/" disabled>
+  Not available
+</LinkButton>
+
+// With a tooltip
+<LinkButton
+  href="/docs/pricing"
+  tooltip="See plan details"
+  tooltipSide="bottom"
+>
+  Pricing
+</LinkButton>
+```

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -1,0 +1,85 @@
+import { Interactive, type InteractiveStatelessProps } from "@opal/core";
+import { Text, Tooltip, type TooltipSide } from "@opal/components";
+import SvgExternalLink from "@opal/icons/external-link";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type LinkButtonProps = Pick<
+  InteractiveStatelessProps,
+  "onClick" | "href" | "target" | "ref" | "group" | "disabled"
+> & {
+  /** Visible label rendered as underlined link text. */
+  children: string;
+
+  /** Tooltip text shown on hover. */
+  tooltip?: string;
+
+  /** Which side the tooltip appears on. @default "top" */
+  tooltipSide?: TooltipSide;
+};
+
+// ---------------------------------------------------------------------------
+// LinkButton
+// ---------------------------------------------------------------------------
+
+/**
+ * A compact, link-style button with an external-link icon.
+ *
+ * Renders as `text` + external-link icon, both in `text-03`. The text is
+ * always underlined. Backed by `Interactive.Stateless` (`internal` prominence)
+ * so it picks up the standard hover/active background tints.
+ *
+ * Use `href` (with optional `target="_blank"`) to render as a link, or
+ * `onClick` for a button.
+ */
+function LinkButton({
+  children,
+  onClick,
+  href,
+  target,
+  ref,
+  group,
+  disabled,
+  tooltip,
+  tooltipSide = "top",
+}: LinkButtonProps) {
+  const button = (
+    <Interactive.Stateless
+      prominence="internal"
+      onClick={onClick}
+      href={href}
+      target={target}
+      ref={ref}
+      group={group}
+      disabled={disabled}
+      type={href ? undefined : "button"}
+    >
+      <Interactive.Container
+        type={href ? undefined : "button"}
+        heightVariant="fit"
+        roundingVariant="xs"
+      >
+        <div className="flex flex-row items-center gap-0.5">
+          <span className="underline">
+            <Text font="secondary-body" color="text-03">
+              {children}
+            </Text>
+          </span>
+          <div className="p-0.5">
+            <SvgExternalLink size={12} className="text-text-03" />
+          </div>
+        </div>
+      </Interactive.Container>
+    </Interactive.Stateless>
+  );
+
+  return (
+    <Tooltip tooltip={tooltip} side={tooltipSide}>
+      {button}
+    </Tooltip>
+  );
+}
+
+export { LinkButton, type LinkButtonProps };

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -1,83 +1,93 @@
-import { Interactive, type InteractiveStatelessProps } from "@opal/core";
-import { Text, Tooltip, type TooltipSide } from "@opal/components";
+import "@opal/components/buttons/link-button/styles.css";
+import { Tooltip, type TooltipSide } from "@opal/components";
 import SvgExternalLink from "@opal/icons/external-link";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type LinkButtonProps = Pick<
-  InteractiveStatelessProps,
-  "onClick" | "href" | "target" | "ref" | "group" | "disabled"
-> & {
-  /** Visible label rendered as underlined link text. */
+interface LinkButtonProps {
+  /** Visible label. Always rendered as underlined link text. */
   children: string;
+
+  /** Destination URL. When provided, the component renders as an `<a>`. */
+  href?: string;
+
+  /** Anchor `target` attribute (e.g. `"_blank"`). Only meaningful with `href`. */
+  target?: string;
+
+  /** Click handler. When provided without `href`, the component renders as a `<button>`. */
+  onClick?: () => void;
+
+  /** Applies disabled styling + suppresses navigation/clicks. */
+  disabled?: boolean;
 
   /** Tooltip text shown on hover. */
   tooltip?: string;
 
   /** Which side the tooltip appears on. @default "top" */
   tooltipSide?: TooltipSide;
-};
+}
 
 // ---------------------------------------------------------------------------
 // LinkButton
 // ---------------------------------------------------------------------------
 
 /**
- * A compact, link-style button with an external-link icon.
+ * A bare, anchor-styled link with a trailing external-link glyph. Renders
+ * as `<a>` when given `href`, or `<button>` when given `onClick`. Intended
+ * for inline references — "Pricing", "Docs", etc. — not for interactive
+ * surfaces that need hover backgrounds or prominence tiers (use `Button`
+ * for those).
  *
- * Renders as `text` + external-link icon, both in `text-03`. The text is
- * always underlined. Backed by `Interactive.Stateless` (`internal` prominence)
- * so it picks up the standard hover/active background tints.
- *
- * Use `href` (with optional `target="_blank"`) to render as a link, or
- * `onClick` for a button.
+ * Deliberately does NOT use `Interactive.Stateless` / `Interactive.Container`
+ * — those come with height/rounding/padding and a colour matrix that are
+ * wrong for an inline text link. Styling is kept to: underlined label,
+ * small external-link icon, a subtle color shift on hover, and disabled
+ * opacity.
  */
 function LinkButton({
   children,
-  onClick,
   href,
   target,
-  ref,
-  group,
+  onClick,
   disabled,
   tooltip,
   tooltipSide = "top",
 }: LinkButtonProps) {
-  const button = (
-    <Interactive.Stateless
-      prominence="internal"
-      onClick={onClick}
-      href={href}
+  const inner = (
+    <>
+      <span className="opal-link-button-label">{children}</span>
+      <SvgExternalLink size={12} />
+    </>
+  );
+
+  const element = href ? (
+    <a
+      className="opal-link-button"
+      href={disabled ? undefined : href}
       target={target}
-      ref={ref}
-      group={group}
-      disabled={disabled}
-      type={href ? undefined : "button"}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled || undefined}
     >
-      <Interactive.Container
-        type={href ? undefined : "button"}
-        heightVariant="fit"
-        roundingVariant="xs"
-      >
-        <div className="flex flex-row items-center gap-0.5">
-          <span className="underline">
-            <Text font="secondary-body" color="text-03">
-              {children}
-            </Text>
-          </span>
-          <div className="p-0.5">
-            <SvgExternalLink size={12} className="text-text-03" />
-          </div>
-        </div>
-      </Interactive.Container>
-    </Interactive.Stateless>
+      {inner}
+    </a>
+  ) : (
+    <button
+      type="button"
+      className="opal-link-button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      data-disabled={disabled || undefined}
+    >
+      {inner}
+    </button>
   );
 
   return (
     <Tooltip tooltip={tooltip} side={tooltipSide}>
-      {button}
+      {element}
     </Tooltip>
   );
 }

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -1,5 +1,10 @@
 import "@opal/components/buttons/link-button/styles.css";
-import { Tooltip, type TooltipSide } from "@opal/components";
+import type { RichStr } from "@opal/types";
+import type { TooltipSide } from "@opal/components/tooltip/components";
+
+// Direct file imports to avoid circular resolution through the @opal/components
+// and @opal/icons barrels, which break CJS-based test runners (jest).
+import { Tooltip } from "@opal/components/tooltip/components";
 import SvgExternalLink from "@opal/icons/external-link";
 
 // ---------------------------------------------------------------------------
@@ -22,8 +27,8 @@ interface LinkButtonProps {
   /** Applies disabled styling + suppresses navigation/clicks. */
   disabled?: boolean;
 
-  /** Tooltip text shown on hover. */
-  tooltip?: string;
+  /** Tooltip text shown on hover. Pass `markdown(...)` for inline markdown. */
+  tooltip?: string | RichStr;
 
   /** Which side the tooltip appears on. @default "top" */
   tooltipSide?: TooltipSide;
@@ -57,10 +62,26 @@ function LinkButton({
 }: LinkButtonProps) {
   const inner = (
     <>
-      <span className="opal-link-button-label">{children}</span>
+      <span className="opal-link-button-label font-secondary-body">
+        {children}
+      </span>
       <SvgExternalLink size={12} />
     </>
   );
+
+  // Always stop propagation so clicks don't bubble to interactive ancestors
+  // (cards, list rows, etc. that commonly wrap a LinkButton). If disabled,
+  // also preventDefault on anchors so the browser doesn't navigate.
+  const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.stopPropagation();
+    if (disabled) e.preventDefault();
+  };
+
+  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (disabled) return;
+    onClick?.();
+  };
 
   const element = href ? (
     <a
@@ -70,6 +91,7 @@ function LinkButton({
       rel={target === "_blank" ? "noopener noreferrer" : undefined}
       aria-disabled={disabled || undefined}
       data-disabled={disabled || undefined}
+      onClick={handleAnchorClick}
     >
       {inner}
     </a>
@@ -77,7 +99,7 @@ function LinkButton({
     <button
       type="button"
       className="opal-link-button"
-      onClick={disabled ? undefined : onClick}
+      onClick={handleButtonClick}
       disabled={disabled}
       data-disabled={disabled || undefined}
     >

--- a/web/lib/opal/src/components/buttons/link-button/styles.css
+++ b/web/lib/opal/src/components/buttons/link-button/styles.css
@@ -23,6 +23,9 @@
   @apply opacity-50 cursor-not-allowed;
 }
 
+/* `font-secondary-body` is a plain CSS class defined in globals.css (not a
+   Tailwind utility), so `@apply` can't consume it — other Opal components
+   attach it via `className` on the JSX element, and we do the same here. */
 .opal-link-button-label {
-  @apply font-secondary-body underline;
+  @apply underline;
 }

--- a/web/lib/opal/src/components/buttons/link-button/styles.css
+++ b/web/lib/opal/src/components/buttons/link-button/styles.css
@@ -1,0 +1,28 @@
+/* ============================================================================
+   LinkButton — a bare anchor-style link with a trailing external-link icon.
+
+   Intentionally does NOT use `Interactive.Stateless` / `Interactive.Container`.
+   Styling is minimal: inline-flex, underlined label, subtle color shift on
+   hover, disabled opacity. The icon inherits the parent's text color via
+   `currentColor` so `text-text-03` on the root cascades through.
+============================================================================ */
+
+.opal-link-button {
+  @apply inline-flex flex-row items-center gap-0.5 text-text-03;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  transition: color 150ms ease-out;
+}
+
+.opal-link-button:hover:not([data-disabled]) {
+  @apply text-text-05;
+}
+
+.opal-link-button[data-disabled] {
+  @apply opacity-50 cursor-not-allowed;
+}
+
+.opal-link-button-label {
+  @apply font-secondary-body underline;
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -42,6 +42,12 @@ export {
   type SidebarTabProps,
 } from "@opal/components/buttons/sidebar-tab/components";
 
+/* LinkButton */
+export {
+  LinkButton,
+  type LinkButtonProps,
+} from "@opal/components/buttons/link-button/components";
+
 /* Text */
 export {
   Text,

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -5,7 +5,6 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { mutate } from "swr";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
-import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import { SvgArrowUpCircle, SvgWallet } from "@opal/icons";
 import type { IconProps } from "@opal/types";
@@ -19,7 +18,7 @@ import {
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { useUser } from "@/providers/UserProvider";
-import { MessageCard } from "@opal/components";
+import { LinkButton, MessageCard } from "@opal/components";
 
 import PlansView from "./PlansView";
 import CheckoutView from "./CheckoutView";
@@ -72,25 +71,10 @@ function FooterLinks({
           <Text secondaryBody text03>
             Have a license key?
           </Text>
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <Button action tertiary onClick={onActivateLicense}>
-            <Text secondaryBody text05 className="underline">
-              {licenseText}
-            </Text>
-          </Button>
+          <LinkButton onClick={onActivateLicense}>{licenseText}</LinkButton>
         </>
       )}
-      {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-      <Button
-        action
-        tertiary
-        href={billingHelpHref}
-        className="billing-text-link"
-      >
-        <Text secondaryBody text03 className="underline">
-          Billing Help
-        </Text>
-      </Button>
+      <LinkButton href={billingHelpHref}>Billing Help</LinkButton>
     </Section>
   );
 }

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Formik, Form, useFormikContext } from "formik";
 import * as Yup from "yup";
-import { Button, Text } from "@opal/components";
+import { Button, LinkButton, Text } from "@opal/components";
 import {
   SvgCheckCircle,
   SvgShareWebhook,
@@ -286,16 +286,9 @@ export default function HookFormModal({
                           widthVariant="fit"
                         />
                         {docsUrl && (
-                          <a
-                            href={docsUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline leading-none"
-                          >
-                            <Text font="secondary-body" color="text-03">
-                              Documentation
-                            </Text>
-                          </a>
+                          <LinkButton href={docsUrl} target="_blank">
+                            Documentation
+                          </LinkButton>
                         )}
                       </div>
                     }

--- a/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
@@ -15,7 +15,7 @@ import {
   useModalClose,
 } from "@/refresh-components/contexts/ModalContext";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-import { Button, SelectCard, Text } from "@opal/components";
+import { Button, LinkButton, SelectCard, Text } from "@opal/components";
 import { Disabled, Hoverable } from "@opal/core";
 import { markdown } from "@opal/utils";
 import { Content, IllustrationContent } from "@opal/layouts";
@@ -23,7 +23,6 @@ import Modal from "@/refresh-components/Modal";
 import {
   SvgArrowExchange,
   SvgBubbleText,
-  SvgExternalLink,
   SvgFileBroadcast,
   SvgShareWebhook,
   SvgPlug,
@@ -190,17 +189,11 @@ function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
           />
 
           {spec.docs_url && (
-            <a
-              href={spec.docs_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-6 flex items-center gap-1 w-min"
-            >
-              <span className="underline font-secondary-body text-text-03">
+            <div className="ml-6">
+              <LinkButton href={spec.docs_url} target="_blank">
                 Documentation
-              </span>
-              <SvgExternalLink size={12} className="shrink-0" />
-            </a>
+              </LinkButton>
+            </div>
           )}
         </div>
 
@@ -369,17 +362,11 @@ function ConnectedHookCard({
               />
 
               {spec?.docs_url && (
-                <a
-                  href={spec.docs_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ml-6 flex items-center gap-1 w-min"
-                >
-                  <span className="underline font-secondary-body text-text-03">
+                <div className="ml-6">
+                  <LinkButton href={spec.docs_url} target="_blank">
                     Documentation
-                  </span>
-                  <SvgExternalLink size={12} className="shrink-0" />
-                </a>
+                  </LinkButton>
+                </div>
               )}
             </div>
 


### PR DESCRIPTION
## Description

Adds `LinkButton` — an Opal Button variant specialized for external links. Wraps `Interactive.Stateless` + `Interactive.Container` and renders as an `<a>` when given an `href`, with standard `target` / `rel` passthrough.

```tsx
import { LinkButton } from "@opal/components";

<LinkButton href="https://docs.onyx.app" target="_blank">
  Docs
</LinkButton>
```

Same size / prominence / width / tooltip API as `Button`. Split out from the Index Settings reskin work on `feat/index-settings-reskin` as a self-contained, additive change — used by the upcoming embedding-model card (Pricing / Docs links).

## Screenshots + Videos

### General Appearance

https://github.com/user-attachments/assets/30bc835b-82f4-4868-8d80-1d48c5fa8139

### Active Usage (in the `/admin/hooks` page, for example)

https://github.com/user-attachments/assets/9da4204f-073b-4322-be18-d86b6fd86674

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `LinkButton`, a compact text-style link with a trailing external-link icon for inline references, and migrated five inline links to use it. Exported from `@opal/components` with optional tooltips.

- **New Features**
  - Renders as `<a>` with `href` or as `<button>` with `onClick`.
  - Supports `href`, `target`, `onClick`, `disabled`, `tooltip` (`string | RichStr`), and `tooltipSide`; auto-adds `rel="noopener noreferrer"` when `target="_blank"`.
  - Minimal styles (no `Interactive` primitives): underlined label, small icon, subtle hover color.
  - Stops click propagation; disabled anchors prevent navigation.
  - Adopted in admin billing footer links and Hooks pages (“Documentation” links), replacing hand-rolled anchors.

<sup>Written for commit c035966c4727de42f83eba6b00b340d80d750f6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

