### PR TITLE
feat(opal): opalify `ExpandableCard`

### DIFF
--- a/web/lib/opal/src/components/cards/card/Card.stories.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card } from "@opal/components";
+import { useState } from "react";
+import { Button, Card } from "@opal/components";
 
 const BACKGROUND_VARIANTS = ["none", "light", "heavy"] as const;
 const BORDER_VARIANTS = ["none", "dashed", "solid"] as const;
@@ -99,4 +100,84 @@ export const AllCombinations: Story = {
       ))}
     </div>
   ),
+};
+
+// ─── Expandable mode ─────────────────────────────────────────────────────────
+
+export const Expandable: Story = {
+  render: function ExpandableStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <div className="w-96">
+        <Card
+          expandable
+          expanded={open}
+          border="solid"
+          expandedContent={
+            <div className="flex flex-col gap-2">
+              <p>First model</p>
+              <p>Second model</p>
+              <p>Third model</p>
+            </div>
+          }
+        >
+          <Button
+            prominence="tertiary"
+            width="full"
+            onClick={() => setOpen((v) => !v)}
+          >
+            Toggle (expanded={String(open)})
+          </Button>
+        </Card>
+      </div>
+    );
+  },
+};
+
+export const ExpandableNoContent: Story = {
+  render: function ExpandableNoContentStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <div className="w-96">
+        <Card expandable expanded={open} border="solid">
+          <Button
+            prominence="tertiary"
+            width="full"
+            onClick={() => setOpen((v) => !v)}
+          >
+            Toggle (no content — renders like a plain card)
+          </Button>
+        </Card>
+      </div>
+    );
+  },
+};
+
+export const ExpandableRoundingVariants: Story = {
+  render: function ExpandableRoundingStory() {
+    const [openKey, setOpenKey] =
+      useState<(typeof ROUNDING_VARIANTS)[number]>("md");
+    return (
+      <div className="flex flex-col gap-4 w-96">
+        {ROUNDING_VARIANTS.map((rounding) => (
+          <Card
+            key={rounding}
+            expandable
+            expanded={openKey === rounding}
+            rounding={rounding}
+            border="solid"
+            expandedContent={<p>content for rounding={rounding}</p>}
+          >
+            <Button
+              prominence="tertiary"
+              width="full"
+              onClick={() => setOpenKey(rounding)}
+            >
+              rounding={rounding} (click to expand)
+            </Button>
+          </Card>
+        ))}
+      </div>
+    );
+  },
 };

--- a/web/lib/opal/src/components/cards/card/README.md
+++ b/web/lib/opal/src/components/cards/card/README.md
@@ -2,11 +2,36 @@
 
 **Import:** `import { Card, type CardProps } from "@opal/components";`
 
-A plain container component with configurable background, border, padding, and rounding. Uses a simple `<div>` internally with `overflow-clip`.
+A container component with configurable background, border, padding, and rounding. Has two mutually-exclusive modes:
 
-## Architecture
+- **Plain** (default) — renders children inside a single styled `<div>`.
+- **Expandable** (`expandable: true`) — renders children as an always-visible header plus an `expandedContent` prop that animates open/closed.
 
-Padding and rounding are controlled independently:
+## Plain mode
+
+Default behavior — a plain container.
+
+```tsx
+import { Card } from "@opal/components";
+
+<Card padding="md" border="solid">
+  <p>Hello</p>
+</Card>
+```
+
+### Plain mode props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `padding` | `PaddingVariants` | `"md"` | Padding preset |
+| `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
+| `background` | `"none" \| "light" \| "heavy"` | `"light"` | Background fill intensity |
+| `border` | `"none" \| "dashed" \| "solid"` | `"none"` | Border style |
+| `borderColor` | `StatusVariants` | `"default"` | Status-palette border color (needs `border` ≠ `"none"`) |
+| `ref` | `React.Ref<HTMLDivElement>` | — | Ref forwarded to the root div |
+| `children` | `React.ReactNode` | — | Card content |
+
+### Padding scale
 
 | `padding` | Class   |
 |-----------|---------|
@@ -17,6 +42,8 @@ Padding and rounding are controlled independently:
 | `"2xs"`   | `p-0.5` |
 | `"fit"`   | `p-0`   |
 
+### Rounding scale
+
 | `rounding` | Class        |
 |------------|--------------|
 | `"xs"`     | `rounded-04` |
@@ -24,40 +51,92 @@ Padding and rounding are controlled independently:
 | `"md"`     | `rounded-12` |
 | `"lg"`     | `rounded-16` |
 
-## Props
+## Expandable mode
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `padding` | `PaddingVariants` | `"sm"` | Padding preset |
-| `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
-| `background` | `"none" \| "light" \| "heavy"` | `"light"` | Background fill intensity |
-| `border` | `"none" \| "dashed" \| "solid"` | `"none"` | Border style |
-| `ref` | `React.Ref<HTMLDivElement>` | — | Ref forwarded to the root div |
-| `children` | `React.ReactNode` | — | Card content |
-
-## Usage
+Enabled by passing `expandable: true`. The type is a discriminated union — `expanded` and `expandedContent` are only available (and type-checked) when `expandable: true`.
 
 ```tsx
 import { Card } from "@opal/components";
+import { useState } from "react";
 
-// Default card (light background, no border, sm padding, md rounding)
-<Card>
-  <h2>Card Title</h2>
-  <p>Card content</p>
-</Card>
+function ProviderCard() {
+  const [open, setOpen] = useState(false);
 
-// Large padding + rounding with solid border
-<Card padding="lg" rounding="lg" border="solid">
-  <p>Spacious card</p>
-</Card>
+  return (
+    <Card
+      expandable
+      expanded={open}
+      expandedContent={<ModelList />}
+      border="solid"
+      rounding="lg"
+    >
+      {/* always visible — the header region */}
+      <div
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center justify-between cursor-pointer"
+      >
+        <ProviderInfo />
+        <SvgChevronDown
+          className={cn("transition-transform", open && "rotate-180")}
+        />
+      </div>
+    </Card>
+  );
+}
+```
 
-// Compact card with solid border
-<Card padding="xs" rounding="sm" border="solid">
-  <p>Compact card</p>
-</Card>
+### Expandable mode props
 
-// Empty state card
-<Card background="none" border="dashed">
-  <p>No items yet</p>
-</Card>
+Everything from plain mode, **plus**:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `expandable` | `true` | — | Required to enable the expandable variant |
+| `expanded` | `boolean` | `false` | Controlled expanded state. Card never mutates this. |
+| `expandedContent` | `React.ReactNode` | — | The body that animates open/closed below the header |
+
+### Behavior
+
+- **No trigger baked in.** Card does not attach any click handlers. Callers wire their own `onClick` / keyboard / button / etc. to toggle state. This keeps `padding` semantics consistent across modes and avoids surprises with interactive children.
+- **Always controlled.** `expanded` is a pure one-way visual prop. There is no `defaultExpanded` or `onExpandChange` — the caller owns state entirely (`useState` at the call site).
+- **No React context.** The component renders a flat tree; there are no compound sub-components (`Card.Header` / `Card.Content`) and no exported context hooks.
+- **Rounding adapts automatically.** When `expanded && expandedContent !== undefined`, the header's bottom corners flatten and the content's top corners flatten so they meet seamlessly. When collapsed (or when `expandedContent` is undefined), the header is fully rounded.
+- **Content background is always transparent.** The `background` prop applies to the header only; the content slot never fills its own background so the page shows through and keeps the two regions visually distinct.
+- **Content has no intrinsic padding.** The `padding` prop applies to the header only. Callers own any padding inside whatever they pass to `expandedContent` — wrap it in a `<div className="p-4">` (or whatever) if you want spacing.
+- **Animation.** Content uses a pure CSS grid `0fr ↔ 1fr` animation with an opacity fade (~200ms ease-out). No `@radix-ui/react-collapsible` dependency.
+
+### Accessibility
+
+Because Card doesn't own the trigger, it also doesn't generate IDs or ARIA attributes. Consumers are responsible for wiring `aria-expanded`, `aria-controls`, `aria-labelledby`, etc. on their trigger element.
+
+## Complete prop reference
+
+```ts
+type CardBaseProps = {
+  padding?: PaddingVariants;
+  rounding?: RoundingVariants;
+  background?: "none" | "light" | "heavy";
+  border?: "none" | "dashed" | "solid";
+  borderColor?: StatusVariants;
+  ref?: React.Ref<HTMLDivElement>;
+  children?: React.ReactNode;
+};
+
+type CardPlainProps = CardBaseProps & { expandable?: false };
+
+type CardExpandableProps = CardBaseProps & {
+  expandable: true;
+  expanded?: boolean;
+  expandedContent?: React.ReactNode;
+};
+
+type CardProps = CardPlainProps | CardExpandableProps;
+```
+
+The discriminated union enforces:
+
+```tsx
+<Card expanded>…</Card>                   // ❌ TS error — `expanded` not in plain mode
+<Card expandable expandedContent={…}>…</Card>     // ✅ expandable mode
+<Card border="solid">…</Card>             // ✅ plain mode
 ```

--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -3,6 +3,7 @@ import "@opal/components/cards/card/styles.css";
 import type {
   PaddingVariants,
   RoundingVariants,
+  SizeVariants,
   StatusVariants,
 } from "@opal/types";
 import {
@@ -132,6 +133,15 @@ type CardExpandableProps = CardBaseProps & {
    * a plain card (no divider, no bottom slot).
    */
   expandedContent?: React.ReactNode;
+
+  /**
+   * Max-height constraint on the expandable content area.
+   * - `"md"` (default): caps at 20rem with vertical scroll.
+   * - `"fit"`: no max-height — content takes its natural height.
+   *
+   * @default "md"
+   */
+  expandableContentHeight?: Extract<SizeVariants, "md" | "fit">;
 };
 
 type CardProps = CardPlainProps | CardExpandableProps;
@@ -204,7 +214,11 @@ function Card(props: CardProps) {
   }
 
   // Expandable mode
-  const { expanded = false, expandedContent } = props;
+  const {
+    expanded = false,
+    expandedContent,
+    expandableContentHeight = "md",
+  } = props;
   const showContent = expanded && expandedContent !== undefined;
   const headerRounding = showContent
     ? cardTopRoundingVariants[roundingProp]
@@ -233,6 +247,7 @@ function Card(props: CardProps) {
               )}
               data-border={border}
               data-opal-status-border={borderColor}
+              data-content-height={expandableContentHeight}
             >
               {expandedContent}
             </div>

--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -1,6 +1,16 @@
+import "@opal/components/cards/shared.css";
 import "@opal/components/cards/card/styles.css";
-import type { PaddingVariants, RoundingVariants } from "@opal/types";
-import { paddingVariants, cardRoundingVariants } from "@opal/shared";
+import type {
+  PaddingVariants,
+  RoundingVariants,
+  StatusVariants,
+} from "@opal/types";
+import {
+  paddingVariants,
+  cardRoundingVariants,
+  cardTopRoundingVariants,
+  cardBottomRoundingVariants,
+} from "@opal/shared";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -10,7 +20,10 @@ import { cn } from "@opal/utils";
 type BackgroundVariant = "none" | "light" | "heavy";
 type BorderVariant = "none" | "dashed" | "solid";
 
-type CardProps = {
+/**
+ * Props shared by both plain and expandable Card modes.
+ */
+type CardBaseProps = {
   /**
    * Padding preset.
    *
@@ -22,6 +35,10 @@ type CardProps = {
    * | `"xs"`  | `p-1`   |
    * | `"2xs"` | `p-0.5` |
    * | `"fit"` | `p-0`   |
+   *
+   * In expandable mode, applied **only** to the header region. The
+   * `expandedContent` slot has no intrinsic padding — callers own any padding
+   * inside the content they pass in.
    *
    * @default "md"
    */
@@ -36,6 +53,10 @@ type CardProps = {
    * | `"sm"` | `rounded-08` |
    * | `"md"` | `rounded-12` |
    * | `"lg"` | `rounded-16` |
+   *
+   * In expandable mode when expanded, rounding applies only to the header's
+   * top corners and the expandedContent's bottom corners so the two join seamlessly.
+   * When collapsed, rounding applies to all four corners of the header.
    *
    * @default "md"
    */
@@ -61,35 +82,163 @@ type CardProps = {
    */
   border?: BorderVariant;
 
+  /**
+   * Border color, drawn from the same status palette as {@link MessageCard}.
+   * Has no visual effect when `border="none"`.
+   *
+   * @default "default"
+   */
+  borderColor?: StatusVariants;
+
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 
+  /**
+   * In plain mode, the card body. In expandable mode, the always-visible
+   * header region (the part that stays put whether expanded or collapsed).
+   */
   children?: React.ReactNode;
 };
+
+type CardPlainProps = CardBaseProps & {
+  /**
+   * When `false` (or omitted), renders a plain card — same behavior as before
+   * this prop existed. No fold behavior, no `expandedContent` slot.
+   *
+   * @default false
+   */
+  expandable?: false;
+};
+
+type CardExpandableProps = CardBaseProps & {
+  /**
+   * Enables the expandable variant. Renders `children` as the always-visible
+   * header and `expandedContent` as the body that animates open/closed based on
+   * `expanded`.
+   */
+  expandable: true;
+
+  /**
+   * Controlled expanded state. The caller owns the state and any trigger
+   * (click-to-toggle) — Card is purely visual and never mutates this value.
+   *
+   * @default false
+   */
+  expanded?: boolean;
+
+  /**
+   * The expandable body. Rendered below the header, animating open/closed
+   * when `expanded` changes. If `undefined`, the card behaves visually like
+   * a plain card (no divider, no bottom slot).
+   */
+  expandedContent?: React.ReactNode;
+};
+
+type CardProps = CardPlainProps | CardExpandableProps;
 
 // ---------------------------------------------------------------------------
 // Card
 // ---------------------------------------------------------------------------
 
-function Card({
-  padding: paddingProp = "md",
-  rounding: roundingProp = "md",
-  background = "light",
-  border = "none",
-  ref,
-  children,
-}: CardProps) {
+/**
+ * A container with configurable background, border, padding, and rounding.
+ *
+ * Has two mutually-exclusive modes:
+ *
+ * - **Plain** (default): renders `children` inside a single styled `<div>`.
+ *   Same shape as the original Card.
+ *
+ * - **Expandable** (`expandable: true`): renders `children` as the header
+ *   region and the `expandedContent` prop as an animating body below. Fold state is
+ *   fully controlled via the `expanded` prop — Card does not own state and
+ *   does not wire a click trigger. Callers attach their own
+ *   `onClick={() => setExpanded(v => !v)}` to whatever element they want to
+ *   act as the toggle.
+ *
+ * @example Plain
+ * ```tsx
+ * <Card padding="md" border="solid">
+ *   <p>Hello</p>
+ * </Card>
+ * ```
+ *
+ * @example Expandable, controlled
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ * <Card
+ *   expandable
+ *   expanded={open}
+ *   expandedContent={<ModelList />}
+ *   border="solid"
+ * >
+ *   <button onClick={() => setOpen(v => !v)}>Toggle</button>
+ * </Card>
+ * ```
+ */
+function Card(props: CardProps) {
+  const {
+    padding: paddingProp = "md",
+    rounding: roundingProp = "md",
+    background = "light",
+    border = "none",
+    borderColor = "default",
+    ref,
+    children,
+  } = props;
+
   const padding = paddingVariants[paddingProp];
-  const rounding = cardRoundingVariants[roundingProp];
+
+  // Plain mode — unchanged behavior
+  if (!props.expandable) {
+    return (
+      <div
+        ref={ref}
+        className={cn("opal-card", padding, cardRoundingVariants[roundingProp])}
+        data-background={background}
+        data-border={border}
+        data-opal-status-border={borderColor}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  // Expandable mode
+  const { expanded = false, expandedContent } = props;
+  const showContent = expanded && expandedContent !== undefined;
+  const headerRounding = showContent
+    ? cardTopRoundingVariants[roundingProp]
+    : cardRoundingVariants[roundingProp];
 
   return (
-    <div
-      ref={ref}
-      className={cn("opal-card", padding, rounding)}
-      data-background={background}
-      data-border={border}
-    >
-      {children}
+    <div ref={ref} className="opal-card-expandable">
+      <div
+        className={cn("opal-card-expandable-header", padding, headerRounding)}
+        data-background={background}
+        data-border={border}
+        data-opal-status-border={borderColor}
+      >
+        {children}
+      </div>
+      {expandedContent !== undefined && (
+        <div
+          className="opal-card-expandable-wrapper"
+          data-expanded={showContent ? "true" : "false"}
+        >
+          <div className="opal-card-expandable-inner">
+            <div
+              className={cn(
+                "opal-card-expandable-body",
+                cardBottomRoundingVariants[roundingProp]
+              )}
+              data-border={border}
+              data-opal-status-border={borderColor}
+            >
+              {expandedContent}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/lib/opal/src/components/cards/card/styles.css
+++ b/web/lib/opal/src/components/cards/card/styles.css
@@ -110,8 +110,14 @@
       keeping it visually distinct from the header. ─ */
 
 .opal-card-expandable-body {
-  @apply w-full overflow-clip bg-transparent;
+  @apply w-full bg-transparent;
 }
+
+.opal-card-expandable-body[data-content-height="md"] {
+  @apply max-h-[20rem] overflow-y-auto;
+}
+
+/* "fit" = no constraint; natural height, no scroll. */
 
 .opal-card-expandable-body[data-border="none"] {
   border: none;

--- a/web/lib/opal/src/components/cards/card/styles.css
+++ b/web/lib/opal/src/components/cards/card/styles.css
@@ -1,3 +1,7 @@
+/* ============================================================================
+   Plain Card
+============================================================================ */
+
 .opal-card {
   @apply w-full overflow-clip;
 }
@@ -15,7 +19,8 @@
   @apply bg-background-tint-01;
 }
 
-/* Border variants */
+/* Border variants. Border *color* lives in `cards/shared.css` and is keyed
+   off the `data-opal-status-border` attribute. */
 .opal-card[data-border="none"] {
   border: none;
 }
@@ -26,4 +31,96 @@
 
 .opal-card[data-border="solid"] {
   @apply border;
+}
+
+/* ============================================================================
+   Expandable Card
+
+   Structure:
+     .opal-card-expandable                 (flex-col wrapper, no styling)
+       .opal-card-expandable-header        (bg + border + padding + rounding)
+       .opal-card-expandable-wrapper       (grid animation, overflow clip)
+         .opal-card-expandable-inner       (min-h:0, overflow clip for grid)
+           .opal-card-expandable-body      (bg + border-minus-top + padding)
+
+   Animation: pure CSS grid `0fr ↔ 1fr` with opacity fade on the wrapper.
+   No JS state machine, no Radix.
+============================================================================ */
+
+.opal-card-expandable {
+  @apply w-full flex flex-col;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.opal-card-expandable-header {
+  @apply w-full overflow-clip transition-[border-radius] duration-200 ease-out;
+}
+
+.opal-card-expandable-header[data-background="none"] {
+  @apply bg-transparent;
+}
+
+.opal-card-expandable-header[data-background="light"] {
+  @apply bg-background-tint-00;
+}
+
+.opal-card-expandable-header[data-background="heavy"] {
+  @apply bg-background-tint-01;
+}
+
+.opal-card-expandable-header[data-border="none"] {
+  border: none;
+}
+
+.opal-card-expandable-header[data-border="dashed"] {
+  @apply border border-dashed;
+}
+
+.opal-card-expandable-header[data-border="solid"] {
+  @apply border;
+}
+
+/* ── Content wrapper: grid 0fr↔1fr animation ─────────────────────────── */
+
+.opal-card-expandable-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    grid-template-rows 200ms ease-out,
+    opacity 200ms ease-out;
+}
+
+.opal-card-expandable-wrapper[data-expanded="true"] {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+/* ── Content inner: clips the grid child so it collapses to 0 cleanly ── */
+
+.opal-card-expandable-inner {
+  @apply overflow-hidden;
+  min-height: 0;
+}
+
+/* ── Content body: carries border + padding. Background is always
+      transparent so the page background shows through the content slot,
+      keeping it visually distinct from the header. ─ */
+
+.opal-card-expandable-body {
+  @apply w-full overflow-clip bg-transparent;
+}
+
+.opal-card-expandable-body[data-border="none"] {
+  border: none;
+}
+
+.opal-card-expandable-body[data-border="dashed"] {
+  @apply border border-t-0 border-dashed;
+}
+
+.opal-card-expandable-body[data-border="solid"] {
+  @apply border border-t-0;
 }

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -1,6 +1,11 @@
+import "@opal/components/cards/shared.css";
 import "@opal/components/cards/message-card/styles.css";
 import { cn } from "@opal/utils";
-import type { RichStr, IconFunctionComponent } from "@opal/types";
+import type {
+  IconFunctionComponent,
+  RichStr,
+  StatusVariants,
+} from "@opal/types";
 import { ContentAction } from "@opal/layouts";
 import { Button, Divider } from "@opal/components";
 import {
@@ -15,11 +20,9 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-type MessageCardVariant = "default" | "info" | "success" | "warning" | "error";
-
 interface MessageCardBaseProps {
   /** Visual variant controlling background, border, and icon. @default "default" */
-  variant?: MessageCardVariant;
+  variant?: StatusVariants;
 
   /** Override the default variant icon. */
   icon?: IconFunctionComponent;
@@ -59,7 +62,7 @@ type MessageCardProps = MessageCardBaseProps &
 // ---------------------------------------------------------------------------
 
 const VARIANT_CONFIG: Record<
-  MessageCardVariant,
+  StatusVariants,
   { icon: IconFunctionComponent; iconClass: string }
 > = {
   default: { icon: SvgAlertCircle, iconClass: "stroke-text-03" },
@@ -157,4 +160,4 @@ function MessageCard({
   );
 }
 
-export { MessageCard, type MessageCardProps, type MessageCardVariant };
+export { MessageCard, type MessageCardProps };

--- a/web/lib/opal/src/components/cards/shared.css
+++ b/web/lib/opal/src/components/cards/shared.css
@@ -1,0 +1,32 @@
+/* ============================================================================
+   Shared status-border palette for card components.
+
+   Sets the `border-color` per `StatusVariants` value. Components opt in by
+   setting the `data-opal-status-border` attribute on their root element
+   (and, separately, declaring an actual border via Tailwind's `border` /
+   `border-dashed` utility).
+
+   Used by:
+     - Card           (`borderColor` prop)
+     - MessageCard    (`variant` prop, in addition to its own background)
+============================================================================ */
+
+[data-opal-status-border="default"] {
+  @apply border-border-01;
+}
+
+[data-opal-status-border="info"] {
+  @apply border-status-info-02;
+}
+
+[data-opal-status-border="success"] {
+  @apply border-status-success-02;
+}
+
+[data-opal-status-border="warning"] {
+  @apply border-status-warning-02;
+}
+
+[data-opal-status-border="error"] {
+  @apply border-status-error-02;
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -93,7 +93,6 @@ export {
 export {
   MessageCard,
   type MessageCardProps,
-  type MessageCardVariant,
 } from "@opal/components/cards/message-card/components";
 
 /* Pagination */

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -72,7 +72,8 @@ function Header({
   bottomRightChildren,
   bottomChildren,
 }: CardHeaderProps) {
-  const hasRight = topRightChildren || bottomRightChildren;
+  const hasRight =
+    topRightChildren !== undefined || bottomRightChildren !== undefined;
 
   return (
     <div className="flex flex-col w-full">

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -1,48 +1,62 @@
-import { Content, type ContentProps } from "@opal/layouts/content/components";
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type CardHeaderProps = ContentProps & {
-  /** Content rendered to the right of the Content block. */
-  rightChildren?: React.ReactNode;
+interface CardHeaderProps {
+  /** Content rendered in the top-left header slot — typically a {@link Content} block. */
+  headerChildren?: React.ReactNode;
 
-  /** Content rendered below `rightChildren` in the same column. */
+  /** Content rendered to the right of `headerChildren` (top of right column). */
+  topRightChildren?: React.ReactNode;
+
+  /** Content rendered below `topRightChildren`, in the same column. */
   bottomRightChildren?: React.ReactNode;
 
   /**
-   * Content rendered below the header row, full-width.
-   * Use for expandable sections, search bars, or any content
-   * that should appear beneath the icon/title/actions row.
+   * Content rendered below the entire header (left + right columns),
+   * spanning the full width. Use for expandable sections, search bars, or
+   * any content that should appear beneath the icon/title/actions row.
    */
-  children?: React.ReactNode;
-};
+  bottomChildren?: React.ReactNode;
+}
 
 // ---------------------------------------------------------------------------
 // Card.Header
 // ---------------------------------------------------------------------------
 
 /**
- * A card header layout that pairs a {@link Content} block (with `p-2`)
- * with a right-side column.
+ * A card header layout with three optional slots arranged in two independent
+ * columns, plus a full-width `bottomChildren` slot below.
  *
- * The right column contains two vertically stacked slots —
- * `rightChildren` on top, `bottomRightChildren` below — with no
- * padding or gap between them.
+ * ```
+ * +------------------+----------------+
+ * | headerChildren   | topRight       |
+ * +                  +----------------+
+ * |                  | bottomRight    |
+ * +------------------+----------------+
+ * | bottomChildren (full width)       |
+ * +-----------------------------------+
+ * ```
  *
- * The optional `children` slot renders below the full header row,
- * spanning the entire width.
+ * The left column grows to fill available space; the right column shrinks
+ * to fit its content. The two columns are independent in height.
+ *
+ * For the typical icon/title/description pattern, pass a {@link Content}
+ * (or {@link ContentAction}) into `headerChildren`.
  *
  * @example
  * ```tsx
  * <Card.Header
- *   icon={SvgGlobe}
- *   title="Google"
- *   description="Search engine"
- *   sizePreset="main-ui"
- *   variant="section"
- *   rightChildren={<Button>Connect</Button>}
+ *   headerChildren={
+ *     <Content
+ *       icon={SvgGlobe}
+ *       title="Google"
+ *       description="Search engine"
+ *       sizePreset="main-ui"
+ *       variant="section"
+ *     />
+ *   }
+ *   topRightChildren={<Button>Connect</Button>}
  *   bottomRightChildren={
  *     <>
  *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
@@ -53,29 +67,29 @@ type CardHeaderProps = ContentProps & {
  * ```
  */
 function Header({
-  rightChildren,
+  headerChildren,
+  topRightChildren,
   bottomRightChildren,
-  children,
-  ...contentProps
+  bottomChildren,
 }: CardHeaderProps) {
-  const hasRight = rightChildren || bottomRightChildren;
+  const hasRight = topRightChildren || bottomRightChildren;
 
   return (
     <div className="flex flex-col w-full">
-      <div className="flex flex-row items-stretch w-full">
-        <div className="flex-1 min-w-0 self-start p-2">
-          <Content {...contentProps} />
-        </div>
+      <div className="flex flex-row items-start w-full">
+        {headerChildren && (
+          <div className="self-start p-2 grow min-w-0">{headerChildren}</div>
+        )}
         {hasRight && (
           <div className="flex flex-col items-end shrink-0">
-            {rightChildren && <div className="flex-1">{rightChildren}</div>}
+            {topRightChildren && <div>{topRightChildren}</div>}
             {bottomRightChildren && (
               <div className="flex flex-row">{bottomRightChildren}</div>
             )}
           </div>
         )}
       </div>
-      {children && <div className="w-full">{children}</div>}
+      {bottomChildren && <div className="w-full">{bottomChildren}</div>}
     </div>
   );
 }

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -72,25 +72,24 @@ function Header({
   bottomRightChildren,
   bottomChildren,
 }: CardHeaderProps) {
-  const hasRight =
-    topRightChildren !== undefined || bottomRightChildren !== undefined;
+  const hasRight = topRightChildren != null || bottomRightChildren != null;
 
   return (
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
-        {headerChildren && (
+        {headerChildren != null && (
           <div className="self-start p-2 grow min-w-0">{headerChildren}</div>
         )}
         {hasRight && (
           <div className="flex flex-col items-end shrink-0">
-            {topRightChildren && <div>{topRightChildren}</div>}
-            {bottomRightChildren && (
+            {topRightChildren != null && <div>{topRightChildren}</div>}
+            {bottomRightChildren != null && (
               <div className="flex flex-row">{bottomRightChildren}</div>
             )}
           </div>
         )}
       </div>
-      {bottomChildren && <div className="w-full">{bottomChildren}</div>}
+      {bottomChildren != null && <div className="w-full">{bottomChildren}</div>}
     </div>
   );
 }

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -134,6 +134,20 @@ const cardRoundingVariants: Record<RoundingVariants, string> = {
   xs: "rounded-04",
 };
 
+const cardTopRoundingVariants: Record<RoundingVariants, string> = {
+  lg: "rounded-t-16",
+  md: "rounded-t-12",
+  sm: "rounded-t-08",
+  xs: "rounded-t-04",
+};
+
+const cardBottomRoundingVariants: Record<RoundingVariants, string> = {
+  lg: "rounded-b-16",
+  md: "rounded-b-12",
+  sm: "rounded-b-08",
+  xs: "rounded-b-04",
+};
+
 export {
   type ExtremaSizeVariants,
   type ContainerSizeVariants,
@@ -144,6 +158,8 @@ export {
   paddingXVariants,
   paddingYVariants,
   cardRoundingVariants,
+  cardTopRoundingVariants,
+  cardBottomRoundingVariants,
   widthVariants,
   heightVariants,
 };

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -82,6 +82,22 @@ export type ExtremaSizeVariants = Extract<SizeVariants, "fit" | "full">;
 export type OverridableExtremaSizeVariants = ExtremaSizeVariants | number;
 
 // ---------------------------------------------------------------------------
+// Status Variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Severity / status variants used by alert-style components (e.g. {@link
+ * MessageCard}, {@link Card}'s `borderColor`). Each variant maps to a
+ * dedicated background/border/icon palette in the design system.
+ */
+export type StatusVariants =
+  | "default"
+  | "info"
+  | "success"
+  | "warning"
+  | "error";
+
+// ---------------------------------------------------------------------------
 // Icon Props
 // ---------------------------------------------------------------------------
 

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 import { cn } from "@/lib/utils";
-import { MessageCard, type MessageCardVariant } from "@opal/components";
+import { MessageCard } from "@opal/components";
+import type { StatusVariants } from "@opal/types";
 import { NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK } from "@/lib/constants";
 import { toast, toastStore, MAX_VISIBLE_TOASTS } from "@/hooks/useToast";
 import type { Toast, ToastLevel } from "@/hooks/useToast";
@@ -10,7 +11,7 @@ import type { Toast, ToastLevel } from "@/hooks/useToast";
 const ANIMATION_DURATION = 200; // matches tailwind fade-out-scale (0.2s)
 const MAX_TOAST_MESSAGE_LENGTH = 150;
 
-const LEVEL_TO_VARIANT: Record<ToastLevel, MessageCardVariant> = {
+const LEVEL_TO_VARIANT: Record<ToastLevel, StatusVariants> = {
   success: "success",
   error: "error",
   warning: "warning",

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -77,7 +77,6 @@ import {
 import useMcpServersForAgentEditor from "@/hooks/useMcpServersForAgentEditor";
 import useOpenApiTools from "@/hooks/useOpenApiTools";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
-import * as ActionsLayouts from "@/layouts/actions-layouts";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { MCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/interfaces";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
@@ -331,35 +330,45 @@ function MCPServerCard({
   let cardContent: React.ReactNode | undefined;
   if (isLoading) {
     cardContent = (
-      <ActionsLayouts.Content>
+      <div className="flex flex-col gap-2 p-2">
         <GeneralLayouts.Section padding={1}>
           <SimpleLoader />
         </GeneralLayouts.Section>
-      </ActionsLayouts.Content>
+      </div>
     );
   } else if (hasTools) {
     cardContent = (
-      <ActionsLayouts.Content>
-        {filteredTools.map((tool) => (
-          <ActionsLayouts.Tool
-            key={tool.id}
-            name={`${serverFieldName}.tool_${tool.id}`}
-            title={tool.name}
-            description={tool.description}
-            icon={tool.icon ?? SvgSliders}
-            disabled={
-              !tool.isAvailable ||
-              !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value
-            }
-            rightChildren={
-              <SwitchField
-                name={`${serverFieldName}.tool_${tool.id}`}
-                disabled={!isServerEnabled}
-              />
-            }
-          />
-        ))}
-      </ActionsLayouts.Content>
+      <div className="flex flex-col gap-2 p-2">
+        {filteredTools.map((tool) => {
+          const toolDisabled =
+            !tool.isAvailable ||
+            !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value;
+          return (
+            <Disabled key={tool.id} disabled={toolDisabled}>
+              <Card border="solid" rounding="lg" padding="sm">
+                <CardLayout.Header
+                  headerChildren={
+                    <ContentAction
+                      icon={tool.icon ?? SvgSliders}
+                      title={tool.name}
+                      description={tool.description}
+                      sizePreset="main-ui"
+                      variant="section"
+                      paddingVariant="fit"
+                    />
+                  }
+                  topRightChildren={
+                    <SwitchField
+                      name={`${serverFieldName}.tool_${tool.id}`}
+                      disabled={!isServerEnabled}
+                    />
+                  }
+                />
+              </Card>
+            </Disabled>
+          );
+        })}
+      </div>
     );
   }
 

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -4,8 +4,8 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
-import { Button, Divider, MessageCard } from "@opal/components";
-import { Hoverable } from "@opal/core";
+import { Button, Card, Divider, MessageCard } from "@opal/components";
+import { Hoverable, Disabled } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Formik, Form, FieldArray } from "formik";
@@ -14,7 +14,12 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import InputTypeInElementField from "@/refresh-components/form/InputTypeInElementField";
 import InputDatePickerField from "@/refresh-components/form/InputDatePickerField";
-import { InputHorizontal, InputVertical } from "@opal/layouts";
+import {
+  Card as CardLayout,
+  ContentAction,
+  InputHorizontal,
+  InputVertical,
+} from "@opal/layouts";
 import { useFormikContext } from "formik";
 import LLMSelector from "@/components/llm/LLMSelector";
 import { parseLlmDescriptor, structureValue } from "@/lib/llmConfig/utils";
@@ -32,7 +37,7 @@ import {
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
 import Text from "@/refresh-components/texts/Text";
-import { Card } from "@/refresh-components/cards";
+
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import { Tooltip } from "@opal/components";
@@ -73,7 +78,6 @@ import useMcpServersForAgentEditor from "@/hooks/useMcpServersForAgentEditor";
 import useOpenApiTools from "@/hooks/useOpenApiTools";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import * as ActionsLayouts from "@/layouts/actions-layouts";
-import * as ExpandableCard from "@/layouts/expandable-card-layouts";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { MCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/interfaces";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
@@ -221,7 +225,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
               {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
               <div className="absolute bottom-0 left-1/2 -translate-x-1/2 mb-2">
                 <Hoverable.Item group="inputAvatar" variant="opacity-on-hover">
-                  <Button size="md" prominence="secondary">
+                  <Button prominence="secondary" size="md">
                     Edit
                   </Button>
                 </Hoverable.Item>
@@ -277,14 +281,21 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
   const toolFieldName = `openapi_tool_${tool.id}`;
 
   return (
-    <ExpandableCard.Root defaultFolded>
-      <ActionsLayouts.Header
-        title={tool.display_name || tool.name}
-        description={tool.description}
-        icon={SvgActions}
-        rightChildren={<SwitchField name={toolFieldName} />}
+    <Card border="solid" rounding="lg" padding="sm">
+      <CardLayout.Header
+        headerChildren={
+          <ContentAction
+            icon={SvgActions}
+            title={tool.display_name || tool.name}
+            description={tool.description}
+            sizePreset="main-ui"
+            variant="section"
+            paddingVariant="fit"
+          />
+        }
+        topRightChildren={<SwitchField name={toolFieldName} />}
       />
-    </ExpandableCard.Root>
+    </Card>
   );
 }
 
@@ -315,87 +326,110 @@ function MCPServerCard({
     return toolFieldValue === true;
   }).length;
 
+  const hasTools = enabledTools.length > 0 && filteredTools.length > 0;
+
+  let cardContent: React.ReactNode | undefined;
+  if (isLoading) {
+    cardContent = (
+      <ActionsLayouts.Content>
+        <GeneralLayouts.Section padding={1}>
+          <SimpleLoader />
+        </GeneralLayouts.Section>
+      </ActionsLayouts.Content>
+    );
+  } else if (hasTools) {
+    cardContent = (
+      <ActionsLayouts.Content>
+        {filteredTools.map((tool) => (
+          <ActionsLayouts.Tool
+            key={tool.id}
+            name={`${serverFieldName}.tool_${tool.id}`}
+            title={tool.name}
+            description={tool.description}
+            icon={tool.icon ?? SvgSliders}
+            disabled={
+              !tool.isAvailable ||
+              !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value
+            }
+            rightChildren={
+              <SwitchField
+                name={`${serverFieldName}.tool_${tool.id}`}
+                disabled={!isServerEnabled}
+              />
+            }
+          />
+        ))}
+      </ActionsLayouts.Content>
+    );
+  }
+
   return (
-    <ExpandableCard.Root isFolded={isFolded} onFoldedChange={setIsFolded}>
-      <ActionsLayouts.Header
-        title={server.name}
-        description={server.description}
-        icon={getActionIcon(server.server_url, server.name)}
-        rightChildren={
-          <GeneralLayouts.Section
-            flexDirection="row"
-            gap={0.5}
-            alignItems="start"
-          >
-            <EnabledCount
-              enabledCount={enabledCount}
-              totalCount={enabledTools.length}
+    <Card
+      expandable
+      expanded={!isFolded}
+      border="solid"
+      rounding="lg"
+      padding="sm"
+      expandedContent={cardContent}
+    >
+      <CardLayout.Header
+        headerChildren={
+          <ContentAction
+            icon={getActionIcon(server.server_url, server.name)}
+            title={server.name}
+            description={server.description}
+            sizePreset="main-ui"
+            variant="section"
+            paddingVariant="fit"
+            rightChildren={
+              <GeneralLayouts.Section
+                flexDirection="row"
+                gap={0.5}
+                alignItems="start"
+              >
+                <EnabledCount
+                  enabledCount={enabledCount}
+                  totalCount={enabledTools.length}
+                />
+                <SwitchField
+                  name={`${serverFieldName}.enabled`}
+                  onCheckedChange={(checked) => {
+                    enabledTools.forEach((tool) => {
+                      setFieldValue(
+                        `${serverFieldName}.tool_${tool.id}`,
+                        checked
+                      );
+                    });
+                    if (!checked) return;
+                    setIsFolded(false);
+                  }}
+                />
+              </GeneralLayouts.Section>
+            }
+          />
+        }
+        bottomChildren={
+          <GeneralLayouts.Section flexDirection="row" gap={0.5}>
+            <InputTypeIn
+              placeholder="Search tools..."
+              variant="internal"
+              leftSearchIcon
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
             />
-            <SwitchField
-              name={`${serverFieldName}.enabled`}
-              onCheckedChange={(checked) => {
-                enabledTools.forEach((tool) => {
-                  setFieldValue(`${serverFieldName}.tool_${tool.id}`, checked);
-                });
-                if (!checked) return;
-                setIsFolded(false);
-              }}
-            />
+            {enabledTools.length > 0 && (
+              <Button
+                prominence="internal"
+                rightIcon={isFolded ? SvgExpand : SvgFold}
+                onClick={() => setIsFolded((prev) => !prev)}
+              >
+                {isFolded ? "Expand" : "Fold"}
+              </Button>
+            )}
           </GeneralLayouts.Section>
         }
-      >
-        <GeneralLayouts.Section flexDirection="row" gap={0.5}>
-          <InputTypeIn
-            placeholder="Search tools..."
-            variant="internal"
-            leftSearchIcon
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-          {enabledTools.length > 0 && (
-            <Button
-              prominence="internal"
-              rightIcon={isFolded ? SvgExpand : SvgFold}
-              onClick={() => setIsFolded((prev) => !prev)}
-            >
-              {isFolded ? "Expand" : "Fold"}
-            </Button>
-          )}
-        </GeneralLayouts.Section>
-      </ActionsLayouts.Header>
-      {isLoading ? (
-        <ActionsLayouts.Content>
-          <GeneralLayouts.Section padding={1}>
-            <SimpleLoader />
-          </GeneralLayouts.Section>
-        </ActionsLayouts.Content>
-      ) : (
-        enabledTools.length > 0 &&
-        filteredTools.length > 0 && (
-          <ActionsLayouts.Content>
-            {filteredTools.map((tool) => (
-              <ActionsLayouts.Tool
-                key={tool.id}
-                name={`${serverFieldName}.tool_${tool.id}`}
-                title={tool.name}
-                description={tool.description}
-                icon={tool.icon ?? SvgSliders}
-                disabled={
-                  !tool.isAvailable ||
-                  !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value
-                }
-                rightChildren={
-                  <SwitchField
-                    name={`${serverFieldName}.tool_${tool.id}`}
-                    disabled={!isServerEnabled}
-                  />
-                }
-              />
-            ))}
-          </ActionsLayouts.Content>
-        )
-      )}
-    </ExpandableCard.Root>
+      />
+    </Card>
   );
 }
 
@@ -1376,17 +1410,11 @@ export default function AgentEditorPage({
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section gap={0.5}>
-                            <Tooltip
+                            <Disabled
+                              disabled={!isImageGenerationAvailable}
                               tooltip={imageGenerationDisabledTooltip}
-                              side="top"
                             >
-                              <Card
-                                variant={
-                                  isImageGenerationAvailable
-                                    ? undefined
-                                    : "disabled"
-                                }
-                              >
+                              <Card border="solid" rounding="lg">
                                 <InputHorizontal
                                   withLabel="image_generation"
                                   title="Image Generation"
@@ -1399,57 +1427,55 @@ export default function AgentEditorPage({
                                   />
                                 </InputHorizontal>
                               </Card>
-                            </Tooltip>
+                            </Disabled>
 
-                            <Card
-                              variant={!!webSearchTool ? undefined : "disabled"}
-                            >
-                              <InputHorizontal
-                                withLabel="web_search"
-                                title="Web Search"
-                                description="Search the web for real-time information and up-to-date results."
-                                disabled={!webSearchTool}
-                              >
-                                <SwitchField
-                                  name="web_search"
+                            <Disabled disabled={!webSearchTool}>
+                              <Card border="solid" rounding="lg">
+                                <InputHorizontal
+                                  withLabel="web_search"
+                                  title="Web Search"
+                                  description="Search the web for real-time information and up-to-date results."
                                   disabled={!webSearchTool}
-                                />
-                              </InputHorizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="web_search"
+                                    disabled={!webSearchTool}
+                                  />
+                                </InputHorizontal>
+                              </Card>
+                            </Disabled>
 
-                            <Card
-                              variant={!!openURLTool ? undefined : "disabled"}
-                            >
-                              <InputHorizontal
-                                withLabel="open_url"
-                                title="Open URL"
-                                description="Fetch and read content from web URLs."
-                                disabled={!openURLTool}
-                              >
-                                <SwitchField
-                                  name="open_url"
+                            <Disabled disabled={!openURLTool}>
+                              <Card border="solid" rounding="lg">
+                                <InputHorizontal
+                                  withLabel="open_url"
+                                  title="Open URL"
+                                  description="Fetch and read content from web URLs."
                                   disabled={!openURLTool}
-                                />
-                              </InputHorizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="open_url"
+                                    disabled={!openURLTool}
+                                  />
+                                </InputHorizontal>
+                              </Card>
+                            </Disabled>
 
-                            <Card
-                              variant={
-                                !!codeInterpreterTool ? undefined : "disabled"
-                              }
-                            >
-                              <InputHorizontal
-                                withLabel="code_interpreter"
-                                title="Code Interpreter"
-                                description="Generate and run code."
-                                disabled={!codeInterpreterTool}
-                              >
-                                <SwitchField
-                                  name="code_interpreter"
+                            <Disabled disabled={!codeInterpreterTool}>
+                              <Card border="solid" rounding="lg">
+                                <InputHorizontal
+                                  withLabel="code_interpreter"
+                                  title="Code Interpreter"
+                                  description="Generate and run code."
                                   disabled={!codeInterpreterTool}
-                                />
-                              </InputHorizontal>
-                            </Card>
+                                >
+                                  <SwitchField
+                                    name="code_interpreter"
+                                    disabled={!codeInterpreterTool}
+                                  />
+                                </InputHorizontal>
+                              </Card>
+                            </Disabled>
 
                             {/* Tools */}
                             <>
@@ -1506,73 +1532,77 @@ export default function AgentEditorPage({
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section>
-                            <Card>
-                              <InputHorizontal
-                                title="Share This Agent"
-                                description="with other users, groups, or everyone in your organization."
-                                center
-                              >
-                                <Button
-                                  prominence="secondary"
-                                  icon={isShared ? SvgUsers : SvgLock}
-                                  onClick={() => shareAgentModal.toggle(true)}
+                            <Card border="solid" rounding="lg">
+                              <GeneralLayouts.Section>
+                                <InputHorizontal
+                                  title="Share This Agent"
+                                  description="with other users, groups, or everyone in your organization."
+                                  center
                                 >
-                                  Share
-                                </Button>
-                              </InputHorizontal>
-                              {canUpdateFeaturedStatus && (
-                                <>
-                                  <InputHorizontal
-                                    withLabel="is_featured"
-                                    title="Feature This Agent"
-                                    description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                  <Button
+                                    prominence="secondary"
+                                    icon={isShared ? SvgUsers : SvgLock}
+                                    onClick={() => shareAgentModal.toggle(true)}
                                   >
-                                    <SwitchField name="is_featured" />
-                                  </InputHorizontal>
-                                  {values.is_featured && !isShared && (
-                                    <MessageCard title="This agent is private to you and will only be featured for yourself." />
-                                  )}
-                                </>
-                              )}
+                                    Share
+                                  </Button>
+                                </InputHorizontal>
+                                {canUpdateFeaturedStatus && (
+                                  <>
+                                    <InputHorizontal
+                                      withLabel="is_featured"
+                                      title="Feature This Agent"
+                                      description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                    >
+                                      <SwitchField name="is_featured" />
+                                    </InputHorizontal>
+                                    {values.is_featured && !isShared && (
+                                      <MessageCard title="This agent is private to you and will only be featured for yourself." />
+                                    )}
+                                  </>
+                                )}
+                              </GeneralLayouts.Section>
                             </Card>
 
-                            <Card>
-                              <InputHorizontal
-                                withLabel="llm_model"
-                                title="Default Model"
-                                description="This model will be used by Onyx by default in your chats."
-                              >
-                                <LLMSelector
-                                  name="llm_model"
-                                  llmProviders={llmProviders ?? []}
-                                  currentLlm={getCurrentLlm(
-                                    values,
-                                    llmProviders
-                                  )}
-                                  onSelect={(selected) =>
-                                    onLlmSelect(selected, setFieldValue)
-                                  }
-                                />
-                              </InputHorizontal>
-                              <InputHorizontal
-                                withLabel="knowledge_cutoff_date"
-                                title="Knowledge Cutoff Date"
-                                suffix="optional"
-                                description="Documents with a last-updated date prior to this will be ignored."
-                              >
-                                <InputDatePickerField
-                                  name="knowledge_cutoff_date"
-                                  maxDate={new Date()}
-                                />
-                              </InputHorizontal>
-                              <InputHorizontal
-                                withLabel="replace_base_system_prompt"
-                                title="Overwrite System Prompt"
-                                suffix="(Not Recommended)"
-                                description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
-                              >
-                                <SwitchField name="replace_base_system_prompt" />
-                              </InputHorizontal>
+                            <Card border="solid" rounding="lg">
+                              <GeneralLayouts.Section>
+                                <InputHorizontal
+                                  withLabel="llm_model"
+                                  title="Default Model"
+                                  description="This model will be used by Onyx by default in your chats."
+                                >
+                                  <LLMSelector
+                                    name="llm_model"
+                                    llmProviders={llmProviders ?? []}
+                                    currentLlm={getCurrentLlm(
+                                      values,
+                                      llmProviders
+                                    )}
+                                    onSelect={(selected) =>
+                                      onLlmSelect(selected, setFieldValue)
+                                    }
+                                  />
+                                </InputHorizontal>
+                                <InputHorizontal
+                                  withLabel="knowledge_cutoff_date"
+                                  title="Knowledge Cutoff Date"
+                                  suffix="optional"
+                                  description="Documents with a last-updated date prior to this will be ignored."
+                                >
+                                  <InputDatePickerField
+                                    name="knowledge_cutoff_date"
+                                    maxDate={new Date()}
+                                  />
+                                </InputHorizontal>
+                                <InputHorizontal
+                                  withLabel="replace_base_system_prompt"
+                                  title="Overwrite System Prompt"
+                                  suffix="(Not Recommended)"
+                                  description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
+                                >
+                                  <SwitchField name="replace_base_system_prompt" />
+                                </InputHorizontal>
+                              </GeneralLayouts.Section>
                             </Card>
 
                             <GeneralLayouts.Section gap={0.25}>
@@ -1605,7 +1635,7 @@ export default function AgentEditorPage({
                             paddingPerpendicular="fit"
                           />
 
-                          <Card>
+                          <Card border="solid" rounding="lg">
                             <InputHorizontal
                               title="Delete This Agent"
                               description="Anyone using this agent will no longer be able to access it."

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -13,7 +13,7 @@ import {
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Section } from "@/layouts/general-layouts";
 import { Button, SelectCard } from "@opal/components";
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Disabled, Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
@@ -114,12 +114,16 @@ export default function CodeInterpreterPage() {
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header
-                sizePreset="main-ui"
-                variant="section"
-                icon={SvgTerminal}
-                title="Code Interpreter"
-                description="Built-in Python runtime"
-                rightChildren={
+                headerChildren={
+                  <Content
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={SvgTerminal}
+                    title="Code Interpreter"
+                    description="Built-in Python runtime"
+                  />
+                }
+                topRightChildren={
                   <ConnectionStatus healthy={isHealthy} isLoading={isLoading} />
                 }
                 bottomRightChildren={
@@ -162,12 +166,16 @@ export default function CodeInterpreterPage() {
             onClick={() => handleToggle(true)}
           >
             <Card.Header
-              sizePreset="main-ui"
-              variant="section"
-              icon={SvgTerminal}
-              title="Code Interpreter (Disconnected)"
-              description="Built-in Python runtime"
-              rightChildren={
+              headerChildren={
+                <Content
+                  sizePreset="main-ui"
+                  variant="section"
+                  icon={SvgTerminal}
+                  title="Code Interpreter (Disconnected)"
+                  description="Built-in Python runtime"
+                />
+              }
+              topRightChildren={
                 <Section flexDirection="row" alignItems="center" padding={0.5}>
                   {isReconnecting ? (
                     <CheckingStatus />

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -256,17 +256,21 @@ export default function ImageGenerationContent() {
                     }
                   >
                     <Card.Header
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={() => (
-                        <ModelIcon
-                          provider={provider.provider_name}
-                          size={16}
+                      headerChildren={
+                        <Content
+                          sizePreset="main-ui"
+                          variant="section"
+                          icon={() => (
+                            <ModelIcon
+                              provider={provider.provider_name}
+                              size={16}
+                            />
+                          )}
+                          title={provider.title}
+                          description={provider.description}
                         />
-                      )}
-                      title={provider.title}
-                      description={provider.description}
-                      rightChildren={
+                      }
+                      topRightChildren={
                         isDisconnected ? (
                           <Button
                             prominence="tertiary"

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -141,13 +141,19 @@ function ExistingProviderCard({
           onClick={() => setIsOpen(true)}
         >
           <CardLayout.Header
-            icon={icon}
-            title={provider.name}
-            description={companyName}
-            sizePreset="main-ui"
-            variant="section"
-            tag={isDefault ? { title: "Default", color: "blue" } : undefined}
-            rightChildren={
+            headerChildren={
+              <Content
+                icon={icon}
+                title={provider.name}
+                description={companyName}
+                sizePreset="main-ui"
+                variant="section"
+                tag={
+                  isDefault ? { title: "Default", color: "blue" } : undefined
+                }
+              />
+            }
+            topRightChildren={
               <div className="flex flex-row">
                 <Hoverable.Item
                   group="ExistingProviderCard"
@@ -205,12 +211,16 @@ function NewProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        icon={icon}
-        title={productName}
-        description={companyName}
-        sizePreset="main-ui"
-        variant="section"
-        rightChildren={
+        headerChildren={
+          <Content
+            icon={icon}
+            title={productName}
+            description={companyName}
+            sizePreset="main-ui"
+            variant="section"
+          />
+        }
+        topRightChildren={
           <Button
             rightIcon={SvgArrowExchange}
             prominence="tertiary"
@@ -252,12 +262,16 @@ function NewCustomProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        icon={icon}
-        title={productName}
-        description={companyName}
-        sizePreset="main-ui"
-        variant="section"
-        rightChildren={
+        headerChildren={
+          <Content
+            icon={icon}
+            title={productName}
+            description={companyName}
+            sizePreset="main-ui"
+            variant="section"
+          />
+        }
+        topRightChildren={
           <Button
             rightIcon={SvgArrowExchange}
             prominence="tertiary"

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -277,12 +277,16 @@ function ProviderCard({
         }
       >
         <Card.Header
-          sizePreset="main-ui"
-          variant="section"
-          icon={icon}
-          title={title}
-          description={description}
-          rightChildren={
+          headerChildren={
+            <Content
+              sizePreset="main-ui"
+              variant="section"
+              icon={icon}
+              title={title}
+              description={description}
+            />
+          }
+          topRightChildren={
             isDisconnected && onConnect ? (
               <Button
                 prominence="tertiary"

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -93,12 +93,16 @@ export default function ProviderCard({
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={icon}
-        title={title}
-        description={description}
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={icon}
+            title={title}
+            description={description}
+          />
+        }
+        topRightChildren={
           isDisconnected && onConnect ? (
             <Button
               prominence="tertiary"

--- a/web/tests/e2e/admin/oauth_config/test_tool_oauth.spec.ts
+++ b/web/tests/e2e/admin/oauth_config/test_tool_oauth.spec.ts
@@ -226,14 +226,14 @@ test("Tool OAuth Configuration: Creation, Selection, and Assistant Integration",
   await expect(actionsHeading).toBeVisible({ timeout: 10000 });
   await actionsHeading.scrollIntoViewIfNeeded();
 
-  // Look for our tool in the list
-  // The tool display_name is the tool name we created
-  const toolLabel = page.locator(`label:has-text("${toolName}")`);
-  await expect(toolLabel).toBeVisible({ timeout: 10000 });
-  await toolLabel.scrollIntoViewIfNeeded();
-
-  // Turn it on
-  await toolLabel.click();
+  // Look for our tool's card and toggle it on
+  const toolCard = page
+    .locator(".opal-card")
+    .filter({ hasText: toolName })
+    .first();
+  await expect(toolCard).toBeVisible({ timeout: 10000 });
+  await toolCard.scrollIntoViewIfNeeded();
+  await toolCard.getByRole("switch").click();
 
   // Submit the assistant creation form
   const createButton = page.locator('button[type="submit"]:has-text("Create")');


### PR DESCRIPTION
## Description

Adds an opt-in expandable mode to Opal `Card` and the supporting design-system primitives.

**`Card` — expandable variant**
- Discriminated-union props: when `expandable: true`, the `content` prop is rendered below `children` (= the header region) and animates open/closed based on `expanded`.
- **Always controlled** — no `defaultExpanded`, no `onExpandChange`, no internal state. Caller owns state + whatever element acts as the trigger.
- **No baked-in trigger** — Card doesn't touch clicks. Caller wires up their own.
- **No internal context** and no exported hook — end consumers only ever write `<Card expandable expanded={…} content={…}>…</Card>`.
- **Animation**: pure CSS `grid-template-rows: 0fr ↔ 1fr` with an opacity fade (~200ms ease-out). No Radix dependency.
- **Rounding adapts** automatically — header's bottom corners flatten and content's top corners flatten when expanded so they meet seamlessly; when collapsed, header is fully rounded.
- **Content is padding-free and transparent** — `padding` and `background` apply to the header only. Caller owns any padding inside whatever they pass to `content`, and the content slot stays transparent so the page shows through.

Plain-mode Card is unchanged behaviourally.

**Supporting additions**
- `StatusVariants` in `@opal/types` — shared severity palette (`"default" | "info" | "success" | "warning" | "error"`). Used by `Card`'s new `borderColor` prop; reusable by `MessageCard` etc.
- `cards/shared.css` — `[data-opal-status-border=…]` palette. Components opt in by setting the attribute on their root element.
- `cardTopRoundingVariants` / `cardBottomRoundingVariants` in `@opal/shared` — used by the expandable Card's split-corner rounding.

**Usage**

```tsx
const [open, setOpen] = useState(false);

<Card
  expandable
  expanded={open}
  border="solid"
  rounding="lg"
  content={
    // Whatever you want to render here.
    // It will be rendered inside of a transparent "subbody", matching to what the mocks depict.
    <InternalContent />
  }
>
  <div onClick={() => setOpen((v) => !v)}>
    <MainHeaderContent />
  </div>
</Card>
```

## Screenshots + Videos

### Demo Usage

https://github.com/user-attachments/assets/d417d934-3fc3-48da-b041-4ee2b8f63db2

### Practical Usage in the `Agent Editor Page`

https://github.com/user-attachments/assets/c0753a9e-b662-431b-93f1-54ab1c512fd3

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

\

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in expandable `Card` with controlled open/close, status‑border colors, and an optional height cap, plus a slot-based `CardLayout.Header`; call sites and the OAuth tool e2e test were updated.

- **New Features**
  - Expandable mode via `expandable`, `expanded`, and `expandedContent`. No built‑in trigger; pure CSS open/close (`grid-template-rows` + fade). Header keeps `padding`/background; content is transparent with no padding. Rounding adapts so header/content meet cleanly; without `expandedContent` it renders like a plain card.
  - `expandableContentHeight`: `"md"` (default, 20rem with scroll) or `"fit"` (no cap).
  - `borderColor` on `Card` using shared `StatusVariants` (`"default" | "info" | "success" | "warning" | "error"`). Shared CSS palette in `cards/shared.css` (`data-opal-status-border=…`). New `cardTopRoundingVariants`/`cardBottomRoundingVariants` in `@opal/shared` and `StatusVariants` in `@opal/types`.

- **Migration**
  - Card: no breaking changes. To use expandable mode, pass `expandable`, control `expanded`, provide `expandedContent`, and optionally `expandableContentHeight`. Add your own trigger and ARIA; apply padding inside `expandedContent` if needed.
  - Layouts: `CardLayout.Header` now uses slots — `headerChildren`, `topRightChildren`, `bottomRightChildren`, `bottomChildren` — with null‑checks so falsy‑but‑valid nodes render correctly. Consumers in admin pages were migrated.
  - MessageCard: now uses shared `StatusVariants`; the `MessageCardVariant` type is removed. Import `StatusVariants` from `@opal/types` if you need the type.

<sup>Written for commit 498a0563a71670c2bf57c5c351d237a318dcfa25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

