### PR TITLE
refactor(opal): restructure Card.Header around explicit layout slots

### DIFF
--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Button } from "@opal/components";
 import {
   SvgArrowExchange,
@@ -39,12 +39,16 @@ export const Default: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Google Search"
-        description="Web search provider"
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Google Search"
+            description="Web search provider"
+          />
+        }
+        topRightChildren={
           <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
             Connect
           </Button>
@@ -58,12 +62,16 @@ export const WithBothSlots: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Google Search"
-        description="Currently the default provider."
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Google Search"
+            description="Currently the default provider."
+          />
+        }
+        topRightChildren={
           <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
             Current Default
           </Button>
@@ -93,12 +101,16 @@ export const RightChildrenOnly: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="OpenAI"
-        description="Not configured"
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="OpenAI"
+            description="Not configured"
+          />
+        }
+        topRightChildren={
           <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
             Connect
           </Button>
@@ -112,11 +124,15 @@ export const NoRightChildren: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Section Header"
-        description="No actions on the right."
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Section Header"
+            description="No actions on the right."
+          />
+        }
       />
     </div>
   ),
@@ -126,12 +142,16 @@ export const LongContent: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Very Long Provider Name That Should Truncate"
-        description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Very Long Provider Name That Should Truncate"
+            description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
+          />
+        }
+        topRightChildren={
           <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
             Current Default
           </Button>

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -6,56 +6,61 @@ A namespace of card layout primitives. Each sub-component handles a specific reg
 
 ## Card.Header
 
-A card header layout that pairs a [`Content`](../content/README.md) block with a right-side column and an optional full-width children slot.
+A flexible card header with one slot for the main header content, two stacked slots in a right-side column, and a full-width slot below.
 
 ### Why Card.Header?
 
-[`ContentAction`](../content-action/README.md) provides a single `rightChildren` slot. Card headers typically need two distinct right-side regions — a primary action on top and secondary actions on the bottom. `Card.Header` provides this with `rightChildren` and `bottomRightChildren` slots, plus a `children` slot for full-width content below the header row (e.g., search bars, expandable tool lists).
+[`ContentAction`](../content-action/README.md) provides a single right-side slot. Card headers typically need more — a primary action on top, secondary actions on the bottom, and sometimes a full-width region beneath the entire row (e.g. expandable details, search bars, secondary info).
+
+`Card.Header` is layout-only — it intentionally doesn't bake in `Content` props. Pass a `<Content />` (or any other element) into `headerChildren` for the icon/title/description region.
 
 ### Props
 
-Inherits **all** props from [`Content`](../content/README.md) (icon, title, description, sizePreset, variant, editable, onTitleChange, suffix, etc.) plus:
-
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `rightChildren` | `ReactNode` | `undefined` | Content rendered to the right of the Content block (top of right column). |
-| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `rightChildren` in the same column. Laid out as `flex flex-row`. |
-| `children` | `ReactNode` | `undefined` | Content rendered below the full header row, spanning the entire width. |
+| `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
+| `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
+| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
+| `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
 
 ### Layout Structure
 
 ```
-+---------------------------------------------------------+
-| [Content (p-2, self-start)]    [rightChildren]          |
-|  icon + title + description    [bottomRightChildren]    |
-+---------------------------------------------------------+
-| [children — full width]                                 |
-+---------------------------------------------------------+
++------------------+----------------+
+| headerChildren   | topRight       |
++                  +----------------+
+|                  | bottomRight    |
++------------------+----------------+
+| bottomChildren (full width)       |
++-----------------------------------+
 ```
 
 - Outer wrapper: `flex flex-col w-full`
-- Header row: `flex flex-row items-stretch w-full`
-- Content area: `flex-1 min-w-0 self-start p-2` — top-aligned with fixed padding
-- Right column: `flex flex-col items-end shrink-0` — no padding, no gap
-- `bottomRightChildren` wrapper: `flex flex-row` — lays children out horizontally
-- `children` wrapper: `w-full` — only rendered when children are provided
+- Header row: `flex flex-row items-start w-full` — columns are independent in height
+- Left column (headerChildren wrapper): `self-start p-2 grow min-w-0` — grows to fill available space
+- Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
+- `bottomChildren` wrapper: `w-full` — only rendered when provided
 
 ### Usage
 
 #### Card with primary and secondary actions
 
 ```tsx
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Button } from "@opal/components";
 import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 <Card.Header
-  icon={SvgGlobe}
-  title="Google Search"
-  description="Web search provider"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={
+  headerChildren={
+    <Content
+      icon={SvgGlobe}
+      title="Google Search"
+      description="Web search provider"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={
     <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
       Current Default
     </Button>
@@ -73,12 +78,16 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
-  icon={SvgCloud}
-  title="OpenAI"
-  description="Not configured"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={
+  headerChildren={
+    <Content
+      icon={SvgCloud}
+      title="OpenAI"
+      description="Not configured"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={
     <Button rightIcon={SvgArrowExchange} prominence="tertiary">
       Connect
     </Button>
@@ -86,31 +95,36 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 />
 ```
 
-#### Card with expandable children
+#### Card with extra info beneath the header
 
 ```tsx
 <Card.Header
-  icon={SvgServer}
-  title="MCP Server"
-  description="12 tools available"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
->
-  <SearchBar placeholder="Search tools..." />
-</Card.Header>
-```
-
-#### No right children
-
-```tsx
-<Card.Header
-  icon={SvgInfo}
-  title="Section Header"
-  description="Description text"
-  sizePreset="main-content"
-  variant="section"
+  headerChildren={
+    <Content
+      icon={SvgServer}
+      title="MCP Server"
+      description="12 tools available"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
+  bottomChildren={<SearchBar placeholder="Search tools..." />}
 />
 ```
 
-When both `rightChildren` and `bottomRightChildren` are omitted and no `children` are provided, the component renders only the padded `Content`.
+#### No slots
+
+```tsx
+<Card.Header
+  headerChildren={
+    <Content
+      icon={SvgInfo}
+      title="Section Header"
+      description="Description text"
+      sizePreset="main-content"
+      variant="section"
+    />
+  }
+/>
+```

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -1,48 +1,62 @@
-import { Content, type ContentProps } from "@opal/layouts/content/components";
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type CardHeaderProps = ContentProps & {
-  /** Content rendered to the right of the Content block. */
-  rightChildren?: React.ReactNode;
+interface CardHeaderProps {
+  /** Content rendered in the top-left header slot — typically a {@link Content} block. */
+  headerChildren?: React.ReactNode;
 
-  /** Content rendered below `rightChildren` in the same column. */
+  /** Content rendered to the right of `headerChildren` (top of right column). */
+  topRightChildren?: React.ReactNode;
+
+  /** Content rendered below `topRightChildren`, in the same column. */
   bottomRightChildren?: React.ReactNode;
 
   /**
-   * Content rendered below the header row, full-width.
-   * Use for expandable sections, search bars, or any content
-   * that should appear beneath the icon/title/actions row.
+   * Content rendered below the entire header (left + right columns),
+   * spanning the full width. Use for expandable sections, search bars, or
+   * any content that should appear beneath the icon/title/actions row.
    */
-  children?: React.ReactNode;
-};
+  bottomChildren?: React.ReactNode;
+}
 
 // ---------------------------------------------------------------------------
 // Card.Header
 // ---------------------------------------------------------------------------
 
 /**
- * A card header layout that pairs a {@link Content} block (with `p-2`)
- * with a right-side column.
+ * A card header layout with three optional slots arranged in two independent
+ * columns, plus a full-width `bottomChildren` slot below.
  *
- * The right column contains two vertically stacked slots —
- * `rightChildren` on top, `bottomRightChildren` below — with no
- * padding or gap between them.
+ * ```
+ * +------------------+----------------+
+ * | headerChildren   | topRight       |
+ * +                  +----------------+
+ * |                  | bottomRight    |
+ * +------------------+----------------+
+ * | bottomChildren (full width)       |
+ * +-----------------------------------+
+ * ```
  *
- * The optional `children` slot renders below the full header row,
- * spanning the entire width.
+ * The left column grows to fill available space; the right column shrinks
+ * to fit its content. The two columns are independent in height.
+ *
+ * For the typical icon/title/description pattern, pass a {@link Content}
+ * (or {@link ContentAction}) into `headerChildren`.
  *
  * @example
  * ```tsx
  * <Card.Header
- *   icon={SvgGlobe}
- *   title="Google"
- *   description="Search engine"
- *   sizePreset="main-ui"
- *   variant="section"
- *   rightChildren={<Button>Connect</Button>}
+ *   headerChildren={
+ *     <Content
+ *       icon={SvgGlobe}
+ *       title="Google"
+ *       description="Search engine"
+ *       sizePreset="main-ui"
+ *       variant="section"
+ *     />
+ *   }
+ *   topRightChildren={<Button>Connect</Button>}
  *   bottomRightChildren={
  *     <>
  *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
@@ -53,29 +67,29 @@ type CardHeaderProps = ContentProps & {
  * ```
  */
 function Header({
-  rightChildren,
+  headerChildren,
+  topRightChildren,
   bottomRightChildren,
-  children,
-  ...contentProps
+  bottomChildren,
 }: CardHeaderProps) {
-  const hasRight = rightChildren || bottomRightChildren;
+  const hasRight = topRightChildren || bottomRightChildren;
 
   return (
     <div className="flex flex-col w-full">
-      <div className="flex flex-row items-stretch w-full">
-        <div className="flex-1 min-w-0 self-start p-2">
-          <Content {...contentProps} />
-        </div>
+      <div className="flex flex-row items-start w-full">
+        {headerChildren && (
+          <div className="self-start p-2 grow min-w-0">{headerChildren}</div>
+        )}
         {hasRight && (
           <div className="flex flex-col items-end shrink-0">
-            {rightChildren && <div className="flex-1">{rightChildren}</div>}
+            {topRightChildren && <div>{topRightChildren}</div>}
             {bottomRightChildren && (
               <div className="flex flex-row">{bottomRightChildren}</div>
             )}
           </div>
         )}
       </div>
-      {children && <div className="w-full">{children}</div>}
+      {bottomChildren && <div className="w-full">{bottomChildren}</div>}
     </div>
   );
 }

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -13,7 +13,7 @@ import {
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Section } from "@/layouts/general-layouts";
 import { Button, SelectCard } from "@opal/components";
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Disabled, Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
@@ -114,12 +114,16 @@ export default function CodeInterpreterPage() {
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header
-                sizePreset="main-ui"
-                variant="section"
-                icon={SvgTerminal}
-                title="Code Interpreter"
-                description="Built-in Python runtime"
-                rightChildren={
+                headerChildren={
+                  <Content
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={SvgTerminal}
+                    title="Code Interpreter"
+                    description="Built-in Python runtime"
+                  />
+                }
+                topRightChildren={
                   <ConnectionStatus healthy={isHealthy} isLoading={isLoading} />
                 }
                 bottomRightChildren={
@@ -162,12 +166,16 @@ export default function CodeInterpreterPage() {
             onClick={() => handleToggle(true)}
           >
             <Card.Header
-              sizePreset="main-ui"
-              variant="section"
-              icon={SvgTerminal}
-              title="Code Interpreter (Disconnected)"
-              description="Built-in Python runtime"
-              rightChildren={
+              headerChildren={
+                <Content
+                  sizePreset="main-ui"
+                  variant="section"
+                  icon={SvgTerminal}
+                  title="Code Interpreter (Disconnected)"
+                  description="Built-in Python runtime"
+                />
+              }
+              topRightChildren={
                 <Section flexDirection="row" alignItems="center" padding={0.5}>
                   {isReconnecting ? (
                     <CheckingStatus />

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -256,17 +256,21 @@ export default function ImageGenerationContent() {
                     }
                   >
                     <Card.Header
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={() => (
-                        <ModelIcon
-                          provider={provider.provider_name}
-                          size={16}
+                      headerChildren={
+                        <Content
+                          sizePreset="main-ui"
+                          variant="section"
+                          icon={() => (
+                            <ModelIcon
+                              provider={provider.provider_name}
+                              size={16}
+                            />
+                          )}
+                          title={provider.title}
+                          description={provider.description}
                         />
-                      )}
-                      title={provider.title}
-                      description={provider.description}
-                      rightChildren={
+                      }
+                      topRightChildren={
                         isDisconnected ? (
                           <Button
                             prominence="tertiary"

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -141,13 +141,19 @@ function ExistingProviderCard({
           onClick={() => setIsOpen(true)}
         >
           <CardLayout.Header
-            icon={icon}
-            title={provider.name}
-            description={companyName}
-            sizePreset="main-ui"
-            variant="section"
-            tag={isDefault ? { title: "Default", color: "blue" } : undefined}
-            rightChildren={
+            headerChildren={
+              <Content
+                icon={icon}
+                title={provider.name}
+                description={companyName}
+                sizePreset="main-ui"
+                variant="section"
+                tag={
+                  isDefault ? { title: "Default", color: "blue" } : undefined
+                }
+              />
+            }
+            topRightChildren={
               <div className="flex flex-row">
                 <Hoverable.Item
                   group="ExistingProviderCard"
@@ -205,12 +211,16 @@ function NewProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        icon={icon}
-        title={productName}
-        description={companyName}
-        sizePreset="main-ui"
-        variant="section"
-        rightChildren={
+        headerChildren={
+          <Content
+            icon={icon}
+            title={productName}
+            description={companyName}
+            sizePreset="main-ui"
+            variant="section"
+          />
+        }
+        topRightChildren={
           <Button
             rightIcon={SvgArrowExchange}
             prominence="tertiary"
@@ -252,12 +262,16 @@ function NewCustomProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        icon={icon}
-        title={productName}
-        description={companyName}
-        sizePreset="main-ui"
-        variant="section"
-        rightChildren={
+        headerChildren={
+          <Content
+            icon={icon}
+            title={productName}
+            description={companyName}
+            sizePreset="main-ui"
+            variant="section"
+          />
+        }
+        topRightChildren={
           <Button
             rightIcon={SvgArrowExchange}
             prominence="tertiary"

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -277,12 +277,16 @@ function ProviderCard({
         }
       >
         <Card.Header
-          sizePreset="main-ui"
-          variant="section"
-          icon={icon}
-          title={title}
-          description={description}
-          rightChildren={
+          headerChildren={
+            <Content
+              sizePreset="main-ui"
+              variant="section"
+              icon={icon}
+              title={title}
+              description={description}
+            />
+          }
+          topRightChildren={
             isDisconnected && onConnect ? (
               <Button
                 prominence="tertiary"

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -93,12 +93,16 @@ export default function ProviderCard({
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={icon}
-        title={title}
-        description={description}
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={icon}
+            title={title}
+            description={description}
+          />
+        }
+        topRightChildren={
           isDisconnected && onConnect ? (
             <Button
               prominence="tertiary"


### PR DESCRIPTION
## Description

Swaps `Card.Header`'s old Content-prop-spread API for an explicit slot-based API.

**Before:**
```tsx
<CardLayout.Header
  icon={icon}
  title={provider.name}
  description={companyName}
  sizePreset="main-ui"
  variant="section"
  tag={...}
  rightChildren={<Button>Connect</Button>}
  bottomRightChildren={<Button icon={SvgSettings} />}
/>
```

**After:**
```tsx
<CardLayout.Header
  headerChildren={
    <Content
      icon={icon}
      title={provider.name}
      description={companyName}
      sizePreset="main-ui"
      variant="section"
      tag={...}
    />
  }
  topRightChildren={<Button>Connect</Button>}
  bottomRightChildren={<Button icon={SvgSettings} />}
/>
```

Four explicit layout slots:

```
+------------------+----------------+
| headerChildren   | topRight       |
+                  +----------------+
|                  | bottomRight    |
+------------------+----------------+
| bottomChildren (full width)       |
+-----------------------------------+
```

The new API is slot-based and composition-first — callers decide what to render in each slot (`Content`, `ContentAction`, `Button`, arbitrary JSX) instead of the header baking in `icon` / `title` / `description` props that only fit one shape. It also makes the slots *independent*: a caller can now render a tag + bottom subtitle + right-action trio that the old API couldn't express cleanly.

**All 5 in-tree consumers** migrated:
- `LLMConfigurationPage.tsx` (3 call-sites)
- `CodeInterpreterPage/index.tsx` (2 call-sites)
- `ImageGenerationPage/ImageGenerationContent.tsx`
- `WebSearchPage/index.tsx`
- `sections/admin/ProviderCard.tsx`

Stories and README updated.

Split out from the Index Settings reskin work on `feat/index-settings-reskin`.

## How Has This Been Tested?

- `bun run types:check` passes.
- Manual smoke on each migrated page (LLM configuration, code interpreter, image generation, web search, provider cards) — cards render the same as before the refactor; this is a pure-API reshape.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `Card.Header` in `@opal/layouts` to a slot-based API with four explicit layout slots for more flexible compositions, with no visual changes. All in-tree consumers, stories, and README are updated.

- **Refactors**
  - Replaced content-prop API with slots: `headerChildren`, `topRightChildren`, `bottomRightChildren`, `bottomChildren`.
  - Removed `icon`/`title`/`description`/`sizePreset`/`variant`/`tag`/`rightChildren` props from `Card.Header`.
  - Updated Storybook stories and documentation to use `<Content />` within `headerChildren`.

- **Migration**
  - Replace previous prop spread with `headerChildren={<Content ... />}`.
  - Move actions to `topRightChildren` and `bottomRightChildren`; use `bottomChildren` for full-width content below the header.

<sup>Written for commit 1e8446a62acd533b3ca72f753ff3f5477e859718. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

