### PR TITLE
feat(mt): Tenant work-gating gate + metrics (3/3)

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
@@ -1,8 +1,10 @@
 import time
+from typing import cast
 
 from celery import shared_task
 from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
+from redis.client import Redis
 from redis.lock import Lock as RedisLock
 
 from ee.onyx.server.tenants.product_gating import get_gated_tenants
@@ -16,7 +18,54 @@ from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
+from onyx.redis.redis_tenant_work_gating import cleanup_expired
+from onyx.redis.redis_tenant_work_gating import get_active_tenants
+from onyx.redis.redis_tenant_work_gating import observe_active_set_size
+from onyx.redis.redis_tenant_work_gating import record_full_fanout_cycle
+from onyx.redis.redis_tenant_work_gating import record_gate_decision
+from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from shared_configs.configs import IGNORED_SYNCING_TENANT_LIST
+
+
+_FULL_FANOUT_TIMESTAMP_KEY_PREFIX = "tenant_work_gating_last_full_fanout_ms"
+
+
+def _should_bypass_gate_for_full_fanout(
+    redis_client: Redis, task_name: str, interval_seconds: int
+) -> bool:
+    """True if at least `interval_seconds` have elapsed since the last
+    full-fanout bypass for this task. On True, updates the stored timestamp
+    atomically-enough (it's a best-effort counter, not a lock)."""
+    key = f"{_FULL_FANOUT_TIMESTAMP_KEY_PREFIX}:{task_name}"
+    now_ms = int(time.time() * 1000)
+    threshold_ms = now_ms - (interval_seconds * 1000)
+
+    try:
+        raw = cast(bytes | None, redis_client.get(key))
+    except Exception:
+        task_logger.exception(f"full-fanout timestamp read failed: task={task_name}")
+        # Fail open: treat as "interval elapsed" so we don't skip every
+        # tenant during a Redis hiccup.
+        return True
+
+    if raw is None:
+        # First invocation — bypass so the set seeds cleanly.
+        elapsed = True
+    else:
+        try:
+            last_ms = int(raw.decode())
+            elapsed = last_ms <= threshold_ms
+        except ValueError:
+            elapsed = True
+
+    if elapsed:
+        try:
+            redis_client.set(key, str(now_ms))
+        except Exception:
+            task_logger.exception(
+                f"full-fanout timestamp write failed: task={task_name}"
+            )
+    return elapsed
 
 
 @shared_task(
@@ -32,6 +81,7 @@ def cloud_beat_task_generator(
     priority: int = OnyxCeleryPriority.MEDIUM,
     expires: int = BEAT_EXPIRES_DEFAULT,
     skip_gated: bool = True,
+    work_gated: bool = False,
 ) -> bool | None:
     """a lightweight task used to kick off individual beat tasks per tenant."""
     time_start = time.monotonic()
@@ -51,6 +101,48 @@ def cloud_beat_task_generator(
     tenant_ids: list[str] = []
     num_processed_tenants = 0
     num_skipped_gated = 0
+    num_would_skip_work_gate = 0
+    num_skipped_work_gate = 0
+
+    # Tenant-work-gating read path. Resolve once per invocation.
+    gate_enabled = False
+    gate_enforce = False
+    full_fanout_cycle = False
+    active_tenants: set[str] | None = None
+    if work_gated:
+        try:
+            gate_enabled = OnyxRuntime.get_tenant_work_gating_enabled()
+            gate_enforce = OnyxRuntime.get_tenant_work_gating_enforce()
+        except Exception:
+            task_logger.exception("tenant work gating: runtime flag read failed")
+            gate_enabled = False
+
+        if gate_enabled:
+            interval_s = (
+                OnyxRuntime.get_tenant_work_gating_full_fanout_interval_seconds()
+            )
+            full_fanout_cycle = _should_bypass_gate_for_full_fanout(
+                redis_client, task_name, interval_s
+            )
+            if full_fanout_cycle:
+                record_full_fanout_cycle(task_name)
+                # Piggyback memory hygiene on the full-fanout invocation.
+                try:
+                    ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
+                    cleanup_expired(ttl_s)
+                except Exception:
+                    task_logger.exception("tenant work gating: cleanup_expired failed")
+            else:
+                ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
+                active_tenants = get_active_tenants(ttl_s)
+                if active_tenants is None:
+                    # Redis error or single-tenant mode — fail open for this
+                    # invocation (treat as full-fanout so no tenant is skipped).
+                    full_fanout_cycle = True
+                    record_full_fanout_cycle(task_name)
+
+            # Refresh the size gauge whenever the gate runs.
+            observe_active_set_size()
 
     try:
         tenant_ids = get_all_tenant_ids()
@@ -75,6 +167,21 @@ def cloud_beat_task_generator(
             # needed in the cloud
             if IGNORED_SYNCING_TENANT_LIST and tenant_id in IGNORED_SYNCING_TENANT_LIST:
                 continue
+
+            # Tenant work gate: if the feature is on, check membership. Skip
+            # unmarked tenants when enforce=True AND we're not in a full-
+            # fanout cycle. Always log/emit the shadow counter.
+            if work_gated and gate_enabled and not full_fanout_cycle:
+                would_skip = (
+                    active_tenants is not None and tenant_id not in active_tenants
+                )
+                if would_skip:
+                    num_would_skip_work_gate += 1
+                    if gate_enforce:
+                        num_skipped_work_gate += 1
+                        record_gate_decision(task_name, would_skip=True, skipped=True)
+                        continue
+                    record_gate_decision(task_name, would_skip=True, skipped=False)
 
             self.app.send_task(
                 task_name,
@@ -109,6 +216,12 @@ def cloud_beat_task_generator(
         f"task={task_name} "
         f"num_processed_tenants={num_processed_tenants} "
         f"num_skipped_gated={num_skipped_gated} "
+        f"num_would_skip_work_gate={num_would_skip_work_gate} "
+        f"num_skipped_work_gate={num_skipped_work_gate} "
+        f"full_fanout_cycle={full_fanout_cycle} "
+        f"work_gated={work_gated} "
+        f"gate_enabled={gate_enabled} "
+        f"gate_enforce={gate_enforce} "
         f"num_tenants={len(tenant_ids)} "
         f"elapsed={time_elapsed:.2f}"
     )

--- a/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
@@ -109,42 +109,48 @@ def cloud_beat_task_generator(
     gate_enforce = False
     full_fanout_cycle = False
     active_tenants: set[str] | None = None
-    if work_gated:
-        try:
-            gate_enabled = OnyxRuntime.get_tenant_work_gating_enabled()
-            gate_enforce = OnyxRuntime.get_tenant_work_gating_enforce()
-        except Exception:
-            task_logger.exception("tenant work gating: runtime flag read failed")
-            gate_enabled = False
-
-        if gate_enabled:
-            interval_s = (
-                OnyxRuntime.get_tenant_work_gating_full_fanout_interval_seconds()
-            )
-            full_fanout_cycle = _should_bypass_gate_for_full_fanout(
-                redis_client, task_name, interval_s
-            )
-            if full_fanout_cycle:
-                record_full_fanout_cycle(task_name)
-                # Piggyback memory hygiene on the full-fanout invocation.
-                try:
-                    ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
-                    cleanup_expired(ttl_s)
-                except Exception:
-                    task_logger.exception("tenant work gating: cleanup_expired failed")
-            else:
-                ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
-                active_tenants = get_active_tenants(ttl_s)
-                if active_tenants is None:
-                    # Redis error or single-tenant mode — fail open for this
-                    # invocation (treat as full-fanout so no tenant is skipped).
-                    full_fanout_cycle = True
-                    record_full_fanout_cycle(task_name)
-
-            # Refresh the size gauge whenever the gate runs.
-            observe_active_set_size()
 
     try:
+        # Gating setup is inside the try block so any exception still
+        # reaches the finally that releases the beat lock.
+        if work_gated:
+            try:
+                gate_enabled = OnyxRuntime.get_tenant_work_gating_enabled()
+                gate_enforce = OnyxRuntime.get_tenant_work_gating_enforce()
+            except Exception:
+                task_logger.exception("tenant work gating: runtime flag read failed")
+                gate_enabled = False
+
+            if gate_enabled:
+                redis_failed = False
+                interval_s = (
+                    OnyxRuntime.get_tenant_work_gating_full_fanout_interval_seconds()
+                )
+                full_fanout_cycle = _should_bypass_gate_for_full_fanout(
+                    redis_client, task_name, interval_s
+                )
+                if full_fanout_cycle:
+                    record_full_fanout_cycle(task_name)
+                    try:
+                        ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
+                        cleanup_expired(ttl_s)
+                    except Exception:
+                        task_logger.exception(
+                            "tenant work gating: cleanup_expired failed"
+                        )
+                else:
+                    ttl_s = OnyxRuntime.get_tenant_work_gating_ttl_seconds()
+                    active_tenants = get_active_tenants(ttl_s)
+                    if active_tenants is None:
+                        full_fanout_cycle = True
+                        record_full_fanout_cycle(task_name)
+                        redis_failed = True
+
+                # Only refresh the gauge when Redis is known-reachable —
+                # skip the ZCARD if we just failed open due to a Redis error.
+                if not redis_failed:
+                    observe_active_set_size()
+
         tenant_ids = get_all_tenant_ids()
 
         # Per-task control over whether gated tenants are included. Most periodic tasks
@@ -179,9 +185,9 @@ def cloud_beat_task_generator(
                     num_would_skip_work_gate += 1
                     if gate_enforce:
                         num_skipped_work_gate += 1
-                        record_gate_decision(task_name, would_skip=True, skipped=True)
+                        record_gate_decision(task_name, skipped=True)
                         continue
-                    record_gate_decision(task_name, would_skip=True, skipped=False)
+                    record_gate_decision(task_name, skipped=False)
 
             self.app.send_task(
                 task_name,

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -67,6 +67,7 @@ beat_task_templates: list[dict] = [
         "options": {
             "priority": OnyxCeleryPriority.MEDIUM,
             "expires": BEAT_EXPIRES_DEFAULT,
+            "work_gated": True,
         },
     },
     {
@@ -100,6 +101,7 @@ beat_task_templates: list[dict] = [
             "expires": BEAT_EXPIRES_DEFAULT,
             # Gated tenants may still have connectors awaiting deletion.
             "skip_gated": False,
+            "work_gated": True,
         },
     },
     {
@@ -109,6 +111,7 @@ beat_task_templates: list[dict] = [
         "options": {
             "priority": OnyxCeleryPriority.MEDIUM,
             "expires": BEAT_EXPIRES_DEFAULT,
+            "work_gated": True,
         },
     },
     {
@@ -118,6 +121,7 @@ beat_task_templates: list[dict] = [
         "options": {
             "priority": OnyxCeleryPriority.MEDIUM,
             "expires": BEAT_EXPIRES_DEFAULT,
+            "work_gated": True,
         },
     },
     {
@@ -155,6 +159,7 @@ beat_task_templates: list[dict] = [
             "priority": OnyxCeleryPriority.LOW,
             "expires": BEAT_EXPIRES_DEFAULT,
             "queue": OnyxCeleryQueues.SANDBOX,
+            "work_gated": True,
         },
     },
     {
@@ -179,6 +184,7 @@ if ENTERPRISE_EDITION_ENABLED:
                 "options": {
                     "priority": OnyxCeleryPriority.MEDIUM,
                     "expires": BEAT_EXPIRES_DEFAULT,
+                    "work_gated": True,
                 },
             },
             {
@@ -188,6 +194,7 @@ if ENTERPRISE_EDITION_ENABLED:
                 "options": {
                     "priority": OnyxCeleryPriority.MEDIUM,
                     "expires": BEAT_EXPIRES_DEFAULT,
+                    "work_gated": True,
                 },
             },
         ]
@@ -280,7 +287,7 @@ def make_cloud_generator_task(task: dict[str, Any]) -> dict[str, Any]:
     cloud_task["kwargs"] = {}
     cloud_task["kwargs"]["task_name"] = task["task"]
 
-    optional_fields = ["queue", "priority", "expires", "skip_gated"]
+    optional_fields = ["queue", "priority", "expires", "skip_gated", "work_gated"]
     for field in optional_fields:
         if field in task["options"]:
             cloud_task["kwargs"][field] = task["options"][field]
@@ -373,12 +380,14 @@ if not MULTI_TENANT:
         ]
     )
 
-    # `skip_gated` is a cloud-only hint consumed by `cloud_beat_task_generator`. Strip
-    # it before extending the self-hosted schedule so it doesn't leak into apply_async
-    # as an unrecognised option on every fired task message.
+    # `skip_gated` and `work_gated` are cloud-only hints consumed by
+    # `cloud_beat_task_generator`. Strip them before extending the self-hosted
+    # schedule so they don't leak into apply_async as unrecognised options on
+    # every fired task message.
     for _template in beat_task_templates:
         _self_hosted_template = copy.deepcopy(_template)
         _self_hosted_template["options"].pop("skip_gated", None)
+        _self_hosted_template["options"].pop("work_gated", None)
         tasks_to_schedule.append(_self_hosted_template)
 
 

--- a/backend/onyx/redis/redis_tenant_work_gating.py
+++ b/backend/onyx/redis/redis_tenant_work_gating.py
@@ -130,16 +130,11 @@ def observe_active_set_size() -> int | None:
         return None
 
 
-def record_gate_decision(task_name: str, would_skip: bool, skipped: bool) -> None:
-    """Increment shadow / enforced skip counters from the gate generator.
-
-    `would_skip`: the tenant was missing from the set, i.e. the gate would
-    skip them if enforcing.
-    `skipped`: the tenant was actually skipped (would_skip AND enforce=True
-    AND not a full-fanout cycle).
-    """
-    if would_skip:
-        _would_skip_total.labels(task=task_name).inc()
+def record_gate_decision(task_name: str, skipped: bool) -> None:
+    """Increment skip counters from the gate generator. Called once per
+    tenant that the gate would skip. Always increments the shadow counter;
+    increments the enforced counter only when `skipped=True`."""
+    _would_skip_total.labels(task=task_name).inc()
     if skipped:
         _skipped_total.labels(task=task_name).inc()
 

--- a/backend/onyx/redis/redis_tenant_work_gating.py
+++ b/backend/onyx/redis/redis_tenant_work_gating.py
@@ -11,6 +11,8 @@ All public functions no-op in single-tenant mode (`MULTI_TENANT=False`).
 import time
 from typing import cast
 
+from prometheus_client import Counter
+from prometheus_client import Gauge
 from redis.client import Redis
 
 from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
@@ -24,6 +26,40 @@ logger = setup_logger()
 # Unprefixed key. `TenantRedis._prefixed` prepends `cloud:` at call time so
 # the full rendered key is `cloud:active_tenants`.
 _SET_KEY = "active_tenants"
+
+
+# --- Prometheus metrics ---
+
+_active_set_size = Gauge(
+    "onyx_tenant_work_gating_active_set_size",
+    "Current cardinality of the active_tenants sorted set (updated once per "
+    "generator invocation when the gate reads it).",
+)
+
+_marked_total = Counter(
+    "onyx_tenant_work_gating_marked_total",
+    "Writes into active_tenants, labelled by caller.",
+    ["caller"],
+)
+
+_skipped_total = Counter(
+    "onyx_tenant_work_gating_skipped_total",
+    "Per-tenant fanouts skipped by the gate (enforce mode only), by task.",
+    ["task"],
+)
+
+_would_skip_total = Counter(
+    "onyx_tenant_work_gating_would_skip_total",
+    "Per-tenant fanouts that would have been skipped if enforce were on "
+    "(shadow counter), by task.",
+    ["task"],
+)
+
+_full_fanout_total = Counter(
+    "onyx_tenant_work_gating_full_fanout_total",
+    "Generator invocations that bypassed the gate for a full fanout cycle, by task.",
+    ["task"],
+)
 
 
 def _now_ms() -> int:
@@ -54,10 +90,14 @@ def mark_tenant_active(tenant_id: str) -> None:
         logger.exception(f"mark_tenant_active failed: tenant_id={tenant_id}")
 
 
-def maybe_mark_tenant_active(tenant_id: str) -> None:
+def maybe_mark_tenant_active(tenant_id: str, caller: str = "unknown") -> None:
     """Convenience wrapper for writer call sites: records the tenant only
     when the feature flag is on. Fully defensive — never raises, so a Redis
-    outage or flag-read failure can't abort the calling task."""
+    outage or flag-read failure can't abort the calling task.
+
+    `caller` labels the Prometheus counter so a dashboard can show which
+    consumer is firing the hook most.
+    """
     try:
         # Local import to avoid a module-load cycle: OnyxRuntime imports
         # onyx.redis.redis_pool, so a top-level import here would wedge on
@@ -67,8 +107,47 @@ def maybe_mark_tenant_active(tenant_id: str) -> None:
         if not OnyxRuntime.get_tenant_work_gating_enabled():
             return
         mark_tenant_active(tenant_id)
+        _marked_total.labels(caller=caller).inc()
     except Exception:
         logger.exception(f"maybe_mark_tenant_active failed: tenant_id={tenant_id}")
+
+
+def observe_active_set_size() -> int | None:
+    """Return `ZCARD active_tenants` and update the Prometheus gauge. Call
+    from the gate generator once per invocation so the dashboard has a
+    live reading.
+
+    Returns `None` on Redis error or in single-tenant mode; callers can
+    tolerate that (gauge simply doesn't update)."""
+    if not MULTI_TENANT:
+        return None
+    try:
+        size = cast(int, _client().zcard(_SET_KEY))
+        _active_set_size.set(size)
+        return size
+    except Exception:
+        logger.exception("observe_active_set_size failed")
+        return None
+
+
+def record_gate_decision(task_name: str, would_skip: bool, skipped: bool) -> None:
+    """Increment shadow / enforced skip counters from the gate generator.
+
+    `would_skip`: the tenant was missing from the set, i.e. the gate would
+    skip them if enforcing.
+    `skipped`: the tenant was actually skipped (would_skip AND enforce=True
+    AND not a full-fanout cycle).
+    """
+    if would_skip:
+        _would_skip_total.labels(task=task_name).inc()
+    if skipped:
+        _skipped_total.labels(task=task_name).inc()
+
+
+def record_full_fanout_cycle(task_name: str) -> None:
+    """Increment the full-fanout counter. Called once per generator
+    invocation where the gate is bypassed (interval elapsed OR fail-open)."""
+    _full_fanout_total.labels(task=task_name).inc()
 
 
 def get_active_tenants(ttl_seconds: int) -> set[str] | None:

--- a/backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py
+++ b/backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py
@@ -28,7 +28,7 @@ _TENANT_A = "tenant_aaaa0000-0000-0000-0000-000000000001"
 _TENANT_B = "tenant_bbbb0000-0000-0000-0000-000000000002"
 _TENANT_C = "tenant_cccc0000-0000-0000-0000-000000000003"
 _ALL_TEST_TENANTS = [_TENANT_A, _TENANT_B, _TENANT_C]
-_FANOUT_KEY_PREFIX = "tenant_work_gating_last_full_fanout_ms"
+_FANOUT_KEY_PREFIX = cloud_tasks._FULL_FANOUT_TIMESTAMP_KEY_PREFIX
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py
+++ b/backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py
@@ -1,0 +1,210 @@
+"""Tests for `cloud_beat_task_generator`'s tenant work-gating logic.
+
+Exercises the gate-read path end-to-end against real Redis. The Celery
+`.app.send_task` is mocked so we can count dispatches without actually
+sending messages.
+
+Requires a running Redis instance. Run with::
+
+    python -m dotenv -f .vscode/.env run -- pytest \
+        backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ee.onyx.background.celery.tasks.cloud import tasks as cloud_tasks
+from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
+from onyx.redis import redis_tenant_work_gating as twg
+from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.redis_tenant_work_gating import _SET_KEY
+from onyx.redis.redis_tenant_work_gating import mark_tenant_active
+
+
+_TENANT_A = "tenant_aaaa0000-0000-0000-0000-000000000001"
+_TENANT_B = "tenant_bbbb0000-0000-0000-0000-000000000002"
+_TENANT_C = "tenant_cccc0000-0000-0000-0000-000000000003"
+_ALL_TEST_TENANTS = [_TENANT_A, _TENANT_B, _TENANT_C]
+_FANOUT_KEY_PREFIX = "tenant_work_gating_last_full_fanout_ms"
+
+
+@pytest.fixture(autouse=True)
+def _multi_tenant_true() -> Generator[None, None, None]:
+    with patch.object(twg, "MULTI_TENANT", True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_redis() -> Generator[None, None, None]:
+    """Clear the active set AND the per-task full-fanout timestamp so each
+    test starts fresh."""
+    r = get_redis_client(tenant_id=ONYX_CLOUD_TENANT_ID)
+    r.delete(_SET_KEY)
+    r.delete(f"{_FANOUT_KEY_PREFIX}:test_task")
+    r.delete("runtime:tenant_work_gating:enabled")
+    r.delete("runtime:tenant_work_gating:enforce")
+    yield
+    r.delete(_SET_KEY)
+    r.delete(f"{_FANOUT_KEY_PREFIX}:test_task")
+    r.delete("runtime:tenant_work_gating:enabled")
+    r.delete("runtime:tenant_work_gating:enforce")
+
+
+def _invoke_generator(
+    *,
+    work_gated: bool,
+    enabled: bool,
+    enforce: bool,
+    tenant_ids: list[str],
+    full_fanout_interval_seconds: int = 1200,
+    ttl_seconds: int = 1800,
+) -> MagicMock:
+    """Helper: call the generator with runtime flags fixed and the Celery
+    app mocked. Returns the mock so callers can assert on send_task calls."""
+    mock_app = MagicMock()
+    # The task binds `self` = the task itself when invoked via `.run()`;
+    # patch its `.app` so `self.app.send_task` routes to our mock.
+    with (
+        patch.object(cloud_tasks.cloud_beat_task_generator, "app", mock_app),
+        patch.object(cloud_tasks, "get_all_tenant_ids", return_value=list(tenant_ids)),
+        patch.object(cloud_tasks, "get_gated_tenants", return_value=set()),
+        patch(
+            "onyx.server.runtime.onyx_runtime.OnyxRuntime.get_tenant_work_gating_enabled",
+            return_value=enabled,
+        ),
+        patch(
+            "onyx.server.runtime.onyx_runtime.OnyxRuntime.get_tenant_work_gating_enforce",
+            return_value=enforce,
+        ),
+        patch(
+            "onyx.server.runtime.onyx_runtime.OnyxRuntime.get_tenant_work_gating_full_fanout_interval_seconds",
+            return_value=full_fanout_interval_seconds,
+        ),
+        patch(
+            "onyx.server.runtime.onyx_runtime.OnyxRuntime.get_tenant_work_gating_ttl_seconds",
+            return_value=ttl_seconds,
+        ),
+    ):
+        cloud_tasks.cloud_beat_task_generator.run(
+            task_name="test_task",
+            work_gated=work_gated,
+        )
+    return mock_app
+
+
+def _dispatched_tenants(mock_app: MagicMock) -> list[str]:
+    """Pull tenant_ids out of each send_task call for assertion."""
+    return [c.kwargs["kwargs"]["tenant_id"] for c in mock_app.send_task.call_args_list]
+
+
+def _seed_recent_full_fanout_timestamp() -> None:
+    """Pre-seed the per-task timestamp so the interval-elapsed branch
+    reports False, i.e. the gate enforces normally instead of going into
+    full-fanout on first invocation."""
+    import time as _t
+
+    r = get_redis_client(tenant_id=ONYX_CLOUD_TENANT_ID)
+    r.set(f"{_FANOUT_KEY_PREFIX}:test_task", str(int(_t.time() * 1000)))
+
+
+def test_enforce_skips_unmarked_tenants() -> None:
+    """With enable+enforce on (interval NOT elapsed), only tenants in the
+    active set get dispatched."""
+    mark_tenant_active(_TENANT_A)
+    _seed_recent_full_fanout_timestamp()
+
+    mock_app = _invoke_generator(
+        work_gated=True,
+        enabled=True,
+        enforce=True,
+        tenant_ids=_ALL_TEST_TENANTS,
+        full_fanout_interval_seconds=3600,
+    )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert dispatched == [_TENANT_A]
+
+
+def test_shadow_mode_dispatches_all_tenants() -> None:
+    """enabled=True, enforce=False: gate computes skip but still dispatches."""
+    mark_tenant_active(_TENANT_A)
+    _seed_recent_full_fanout_timestamp()
+
+    mock_app = _invoke_generator(
+        work_gated=True,
+        enabled=True,
+        enforce=False,
+        tenant_ids=_ALL_TEST_TENANTS,
+        full_fanout_interval_seconds=3600,
+    )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert set(dispatched) == set(_ALL_TEST_TENANTS)
+
+
+def test_full_fanout_cycle_dispatches_all_tenants() -> None:
+    """First invocation (no prior timestamp → interval considered elapsed)
+    counts as full-fanout; every tenant gets dispatched even under enforce."""
+    mark_tenant_active(_TENANT_A)
+
+    mock_app = _invoke_generator(
+        work_gated=True,
+        enabled=True,
+        enforce=True,
+        tenant_ids=_ALL_TEST_TENANTS,
+    )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert set(dispatched) == set(_ALL_TEST_TENANTS)
+
+
+def test_redis_unavailable_fails_open() -> None:
+    """When `get_active_tenants` returns None (simulated Redis outage) the
+    gate treats the invocation as full-fanout and dispatches everyone —
+    even when the interval hasn't elapsed and enforce is on."""
+    mark_tenant_active(_TENANT_A)
+    _seed_recent_full_fanout_timestamp()
+
+    with patch.object(cloud_tasks, "get_active_tenants", return_value=None):
+        mock_app = _invoke_generator(
+            work_gated=True,
+            enabled=True,
+            enforce=True,
+            tenant_ids=_ALL_TEST_TENANTS,
+            full_fanout_interval_seconds=3600,
+        )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert set(dispatched) == set(_ALL_TEST_TENANTS)
+
+
+def test_work_gated_false_bypasses_gate_entirely() -> None:
+    """Beat templates that don't opt in (`work_gated=False`) never consult
+    the set — no matter the flag state."""
+    # Even with enforce on and nothing in the set, all tenants dispatch.
+    mock_app = _invoke_generator(
+        work_gated=False,
+        enabled=True,
+        enforce=True,
+        tenant_ids=_ALL_TEST_TENANTS,
+    )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert set(dispatched) == set(_ALL_TEST_TENANTS)
+
+
+def test_gate_disabled_dispatches_everyone_regardless_of_enforce() -> None:
+    """enabled=False means the gate isn't computed — dispatch is unchanged."""
+    # Intentionally don't add anyone to the set.
+    mock_app = _invoke_generator(
+        work_gated=True,
+        enabled=False,
+        enforce=True,
+        tenant_ids=_ALL_TEST_TENANTS,
+    )
+
+    dispatched = _dispatched_tenants(mock_app)
+    assert set(dispatched) == set(_ALL_TEST_TENANTS)


### PR DESCRIPTION
## Description

Final PR in the tenant work-gating stack (follows #10209, #10246, #10268).

Adds the gate plumbing that reads `cloud:active_tenants` and skips per-tenant fanouts for tenants not currently doing work. Ships dark: with default config (`enforce=false`) nothing is actually skipped. Rollout is a two-Redis-flag config step.

**Live validation on managed_services with PR 2.5's tightened writer hooks measured 99.1% of non-gated fanouts (11,343 of 11,462) as skippable at steady state, with zero writer errors across a 30-min window.** At default settings the gate is expected to eliminate ~11.3k per-tenant task dispatches per beat cycle across the 7 gated task types.

## What ships

### Gate logic

`cloud_beat_task_generator` gets `work_gated: bool = False`. When True AND `OnyxRuntime.get_tenant_work_gating_enabled()`:

- Check per-task Redis timestamp (`cloud:tenant_work_gating_last_full_fanout_ms:{task}`); if the configured interval has elapsed (or the key is absent), bypass the gate — \"full fanout cycle\" — and update the timestamp. Also bypass when `get_active_tenants` returns `None` (Redis error / single-tenant — fail open).
- Otherwise read `active_tenants = get_active_tenants(ttl_seconds)` and skip unmarked tenants when `enforce=true`.
- Always log `num_would_skip_work_gate`, `num_skipped_work_gate`, `full_fanout_cycle`, `gate_enabled`, `gate_enforce`.
- Full-fanout cycles also call `cleanup_expired(ttl)` for memory hygiene.

### Beat template plumbing

- `make_cloud_generator_task` threads `work_gated` through `optional_fields` alongside `skip_gated`.
- Self-hosted loop strips `work_gated` like `skip_gated` so it doesn't leak into `apply_async` options.
- `work_gated: True` on 7 templates: `check-for-indexing`, `check-for-pruning`, `check-for-doc-permissions-sync`, `check-for-external-group-sync`, `check-for-connector-deletion`, `check-for-vespa-sync`, `cleanup-idle-sandboxes`.

### Prometheus metrics

New metrics on `redis_tenant_work_gating` so ops has first-class visibility:

- `onyx_tenant_work_gating_active_set_size` (Gauge) — updated every generator invocation
- `onyx_tenant_work_gating_marked_total{caller}` (Counter)
- `onyx_tenant_work_gating_would_skip_total{task}` (Counter — shadow)
- `onyx_tenant_work_gating_skipped_total{task}` (Counter — enforced)
- `onyx_tenant_work_gating_full_fanout_total{task}` (Counter)

A matching Grafana dashboard ConfigMap is in the companion `cloud-deployment-yamls` PR.

## How Has This Been Tested?

6 new integration tests in `backend/tests/external_dependency_unit/tenant_work_gating/test_gate_generator.py`:

- `test_enforce_skips_unmarked_tenants` — A in set / B not → only A dispatched
- `test_shadow_mode_dispatches_all_tenants` — enabled=true, enforce=false still dispatches all
- `test_full_fanout_cycle_dispatches_all_tenants` — fresh state = bypass
- `test_redis_unavailable_fails_open` — `get_active_tenants` returns None → dispatches all
- `test_work_gated_false_bypasses_gate_entirely` — non-opted-in templates unaffected
- `test_gate_disabled_dispatches_everyone_regardless_of_enforce` — enabled=false is a hard pass-through

Full gating suite: 19 tests, all green.

Plus the live-prod validation above.

## Rollout plan (no code changes after merge)

1. Deploy. `enabled=true` is already set in Redis from PR 2's validation; `enforce` stays at the code default (False).
2. Wait 30 min; verify shadow counters on the dashboard match the expected ~99% skip ratio and there are zero writer errors.
3. Set `runtime:tenant_work_gating:enforce=true` in managed_services Redis. Watch Aurora PI for the primary-worker AAS drop.
4. Rollback is a single Redis DEL on the enforce key — shadow keeps reporting so we can root-cause anything unexpected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant work-gating to Celery beat to skip per-tenant fanouts for inactive tenants and adds Prometheus metrics for visibility. Ships dark by default (`enforce=false`) with no behavior change until we flip the flag.

- **New Features**
  - Gate in `cloud_beat_task_generator`: checks per-task full-fanout interval (`tenant_work_gating_last_full_fanout_ms:{task}`), reads `cloud:active_tenants`, fails open on Redis/single-tenant, logs skip stats, and runs `cleanup_expired` on full fanout.
  - Beat plumbing: threads `work_gated` via `make_cloud_generator_task` (stripped for self-hosted); enabled on 7 templates (indexing, pruning, doc-permissions sync, external-group sync, connector deletion, Vespa sync, idle-sandbox cleanup).
  - Metrics: gauge `onyx_tenant_work_gating_active_set_size`; counters `onyx_tenant_work_gating_marked_total`, `onyx_tenant_work_gating_would_skip_total`, `onyx_tenant_work_gating_skipped_total`, `onyx_tenant_work_gating_full_fanout_total`.

- **Bug Fixes**
  - Avoid beat lock leaks by moving gating setup inside the try/finally path.
  - Simplified `record_gate_decision`: always increments shadow; only increments enforced when a tenant is skipped.
  - Skip `observe_active_set_size` when Redis is unreachable to prevent redundant `ZCARD` and extra error logs.
  - Tests: import `_FULL_FANOUT_TIMESTAMP_KEY_PREFIX` from source and fix minor drift.

<sup>Written for commit 1faf845a0096d4e09f5d2a8d39fbd4080468fc03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

