### PR TITLE
fix(fe): LineItem can disable icon stroke

### DIFF
--- a/web/src/app/css/line-item.css
+++ b/web/src/app/css/line-item.css
@@ -207,37 +207,37 @@
 
 /* LineItem Icon Variants */
 .line-item-icon-main {
-  @apply stroke-text-03;
+  @apply fill-text-03;
 
   .group\/LineItem[data-selected="true"] & {
-    @apply stroke-action-link-05;
+    @apply fill-action-link-05;
   }
 }
 
 .line-item-icon-strikethrough {
-  @apply stroke-text-03;
+  @apply fill-text-03;
 }
 
 .line-item-icon-disabled {
-  @apply stroke-text-01;
+  @apply fill-text-01;
 }
 
 .line-item-icon-danger {
-  @apply stroke-status-error-05;
+  @apply fill-status-error-05;
 }
 
 .line-item-icon-action {
-  @apply stroke-text-03;
+  @apply fill-text-03;
 }
 
 .line-item-icon-muted {
-  @apply stroke-text-02;
+  @apply fill-text-02;
 
   .group\/LineItem[data-selected="true"] & {
-    @apply stroke-text-02;
+    @apply fill-text-02;
   }
 }
 
 .line-item-icon-skeleton {
-  @apply stroke-text-02;
+  @apply fill-text-02;
 }

--- a/web/src/app/css/line-item.css
+++ b/web/src/app/css/line-item.css
@@ -207,37 +207,37 @@
 
 /* LineItem Icon Variants */
 .line-item-icon-main {
-  @apply fill-text-03;
+  @apply stroke-text-03;
 
   .group\/LineItem[data-selected="true"] & {
-    @apply fill-action-link-05;
+    @apply stroke-action-link-05;
   }
 }
 
 .line-item-icon-strikethrough {
-  @apply fill-text-03;
+  @apply stroke-text-03;
 }
 
 .line-item-icon-disabled {
-  @apply fill-text-01;
+  @apply stroke-text-01;
 }
 
 .line-item-icon-danger {
-  @apply fill-status-error-05;
+  @apply stroke-status-error-05;
 }
 
 .line-item-icon-action {
-  @apply fill-text-03;
+  @apply stroke-text-03;
 }
 
 .line-item-icon-muted {
-  @apply fill-text-02;
+  @apply stroke-text-02;
 
   .group\/LineItem[data-selected="true"] & {
-    @apply fill-text-02;
+    @apply stroke-text-02;
   }
 }
 
 .line-item-icon-skeleton {
-  @apply fill-text-02;
+  @apply stroke-text-02;
 }

--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -82,6 +82,7 @@ export interface LineItemProps
 
   selected?: boolean;
   icon?: React.FunctionComponent<IconProps>;
+  strokeIcon?: boolean;
   description?: string;
   rightChildren?: React.ReactNode;
   href?: string;
@@ -154,6 +155,7 @@ export default function LineItem({
   skeleton,
   emphasized,
   icon: Icon,
+  strokeIcon = true,
   description,
   children,
   rightChildren,
@@ -245,7 +247,12 @@ export default function LineItem({
             !!(children && description) && "mt-0.5"
           )}
         >
-          <Icon className={cn("h-[1rem] w-[1rem]", iconClassNames[variant])} />
+          <Icon
+            className={cn(
+              "h-[1rem] w-[1rem]",
+              strokeIcon && iconClassNames[variant]
+            )}
+          />
         </div>
       )}
       <Section alignItems="start" gap={0}>

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -99,6 +99,7 @@ export default function SwitchList({
                         item.leading) as React.FunctionComponent<IconProps>)
                     : undefined
                 }
+                strokeIcon={false}
                 rightChildren={
                   <Switch
                     checked={item.isEnabled}

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -172,6 +172,7 @@ export default function ModelListContent({
                         <LineItem
                           muted
                           icon={group.Icon}
+                          strokeIcon={false}
                           rightChildren={
                             open ? (
                               <SvgChevronDown className="h-4 w-4 stroke-text-04 shrink-0" />

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -146,6 +146,7 @@ function SharedGroupResources({
               interactive={!dimmed}
               muted={dimmed}
               icon={getSourceMetadata(p.connector.source).icon}
+              strokeIcon={false}
               rightChildren={
                 p.groups.length > 0 || dimmed ? <SharedBadge /> : undefined
               }

--- a/web/src/refresh-pages/admin/UsersPage/UserFilters.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserFilters.tsx
@@ -186,6 +186,7 @@ export default function UserFilters({
                 <LineItem
                   key={role}
                   icon={isSelected ? SvgCheck : roleIcon}
+                  strokeIcon={isSelected || role !== UserRole.SLACK_USER}
                   selected={isSelected}
                   emphasized={isSelected}
                   onClick={() => toggleRole(role)}

--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -129,6 +129,7 @@ function KnowledgeSidebar({
               <LineItem
                 key={connectedSource.source}
                 icon={sourceMetadata.icon}
+                strokeIcon={false}
                 onClick={() => onNavigateToSource(connectedSource.source)}
                 selected={isActive}
                 emphasized={isActive || isSelected || selectionCount > 0}
@@ -718,6 +719,7 @@ const KnowledgeAddView = memo(function KnowledgeAddView({
               <LineItem
                 key={connectedSource.source}
                 icon={sourceMetadata.icon}
+                strokeIcon={false}
                 onClick={() => onNavigateToSource(connectedSource.source)}
                 emphasized={isSelected || selectionCount > 0}
                 aria-label={`knowledge-add-source-${connectedSource.source}`}


### PR DESCRIPTION
## Description

Updates the `LineItem` to allow disabling the icon stroke and disables it in places where filled, third-party icons are used with `LineItem` (like the ModelListContent).

Closes https://onyx-company.slack.com/archives/C0832RVRVG8/p1776372199544339

## How Has This Been Tested?

<img width="1420" height="2085" alt="20260416_16h13m16s_grim" src="https://github.com/user-attachments/assets/525e36bb-febc-4425-be6c-cf5ffca5c598" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `LineItem` icons render correctly with filled SVGs by adding a `strokeIcon` toggle and updating call sites. Fixes inconsistent colors, especially in selected and muted states.

- **Bug Fixes**
  - Added `strokeIcon` prop (default true) to control stroke color classes on icons.
  - Set `strokeIcon={false}` where icons are filled (`SwitchList`, `ModelListContent`, `SharedGroupResources`, `AgentKnowledgePane`); dynamic in `UserFilters`.
  - Ensures correct colors for default, selected, muted, disabled, danger, and skeleton states.

<sup>Written for commit 844a86f81d9589b5ac6c729832af92fcdc270317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

