### PR TITLE
fix(llm-selector): show each provider instance as its own group

### DIFF
--- a/web/src/components/llm/LLMSelector.tsx
+++ b/web/src/components/llm/LLMSelector.tsx
@@ -12,6 +12,7 @@ interface LLMOption {
   value: string;
   icon: ReturnType<typeof getModelIcon>;
   modelName: string;
+  providerId: number;
   providerName: string;
   provider: string;
   providerDisplayName: string;
@@ -64,7 +65,7 @@ export default function LLMSelector({
           return;
         }
 
-        const key = `${provider.provider}:${modelConfiguration.name}`;
+        const key = `${provider.id}:${modelConfiguration.name}`;
         if (seenKeys.has(key)) {
           return; // Skip exact duplicate
         }
@@ -87,6 +88,7 @@ export default function LLMSelector({
           ),
           icon: getModelIcon(provider.provider, modelConfiguration.name),
           modelName: modelConfiguration.name,
+          providerId: provider.id,
           providerName: provider.name,
           provider: provider.provider,
           providerDisplayName:
@@ -108,33 +110,34 @@ export default function LLMSelector({
     requiresImageGeneration,
   ]);
 
-  // Group options by provider using backend-provided display names
+  // Group options by configured provider instance so multiple instances of the
+  // same provider type (e.g., two Anthropic API keys) appear as separate groups
+  // labeled with their user-given names.
   const groupedOptions = useMemo(() => {
     const groups = new Map<
-      string,
+      number,
       { displayName: string; options: LLMOption[] }
     >();
 
     llmOptions.forEach((option) => {
-      const provider = option.provider.toLowerCase();
-      if (!groups.has(provider)) {
-        groups.set(provider, {
-          displayName: option.providerDisplayName,
+      if (!groups.has(option.providerId)) {
+        groups.set(option.providerId, {
+          displayName: option.providerName,
           options: [],
         });
       }
-      groups.get(provider)!.options.push(option);
+      groups.get(option.providerId)!.options.push(option);
     });
 
     // Sort groups alphabetically by display name
-    const sortedProviders = Array.from(groups.keys()).sort((a, b) =>
+    const sortedProviderIds = Array.from(groups.keys()).sort((a, b) =>
       groups.get(a)!.displayName.localeCompare(groups.get(b)!.displayName)
     );
 
-    return sortedProviders.map((provider) => {
-      const group = groups.get(provider)!;
+    return sortedProviderIds.map((providerId) => {
+      const group = groups.get(providerId)!;
       return {
-        provider,
+        providerId,
         displayName: group.displayName,
         options: group.options,
       };
@@ -179,7 +182,7 @@ export default function LLMSelector({
         )}
         {showGrouped
           ? groupedOptions.map((group) => (
-              <InputSelect.Group key={group.provider}>
+              <InputSelect.Group key={group.providerId}>
                 <InputSelect.Label>{group.displayName}</InputSelect.Label>
                 {group.options.map((option) => (
                   <InputSelect.Item

--- a/web/src/components/llm/LLMSelector.tsx
+++ b/web/src/components/llm/LLMSelector.tsx
@@ -15,7 +15,6 @@ interface LLMOption {
   providerId: number;
   providerName: string;
   provider: string;
-  providerDisplayName: string;
   supportsImageInput: boolean;
   vendor: string | null;
 }
@@ -91,8 +90,6 @@ export default function LLMSelector({
           providerId: provider.id,
           providerName: provider.name,
           provider: provider.provider,
-          providerDisplayName:
-            provider.provider_display_name || provider.provider,
           supportsImageInput,
           vendor: modelConfiguration.vendor || null,
         };


### PR DESCRIPTION

## Description

Per Claude:

> The dedup and group keys used `provider.provider` (provider type), collapsing multiple configured instances of the same provider type (e.g. multiple Anthropic API keys) into a single generic group and silently dropping the second instance's models as duplicates. Key on `provider.id` and label groups with `provider.name` so each instance appears separately in the Agents Default Model dropdown.

Closes https://discord.com/channels/1119886360506023946/1213362679629090827/threads/1494241447665336330

## How Has This Been Tested?

**before**
<img width="1420" height="2085" alt="20260416_16h29m20s_grim" src="https://github.com/user-attachments/assets/fe8b29a9-ee21-4967-8ca5-72369730a320" />



**after**
<img width="1420" height="2085" alt="20260416_16h28m42s_grim" src="https://github.com/user-attachments/assets/22eb0931-601f-4009-a9cc-27da65166151" />



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LLM selector so each configured provider instance (e.g., two Anthropic keys) shows as its own group in the Agents Default Model dropdown. Prevents models from being dropped when multiple instances share the same provider type.

- **Bug Fixes**
  - Deduplicate using `${provider.id}:${modelName}` to avoid cross-instance collisions.
  - Group options by provider instance and label with `provider.name` (sorted alphabetically).
  - Added `providerId` to option data and used as the group key.

<sup>Written for commit 7025676b4166640d985b0eb88e3dd433cab090d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



