### PR TITLE
fix(image): Cap Uploaded File Image Count

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -848,8 +848,22 @@ MAX_FILE_SIZE_BYTES = int(
 # because every image is decoded with PIL and then sent to the vision LLM.
 # Enforced both at upload time (rejects the file) and during extraction
 # (defense-in-depth: caps the number of images materialized).
-MAX_EMBEDDED_IMAGES_PER_FILE = int(
-    os.environ.get("MAX_EMBEDDED_IMAGES_PER_FILE") or 500
+#
+# Clamped to >= 0; a negative env value would turn upload validation into
+# always-fail and extraction into always-stop, which is never desired. 0
+# disables image extraction entirely, which is a valid (if aggressive) setting.
+MAX_EMBEDDED_IMAGES_PER_FILE = max(
+    0, int(os.environ.get("MAX_EMBEDDED_IMAGES_PER_FILE") or 500)
+)
+
+# Maximum embedded images allowed across all files in a single upload batch.
+# Protects against the scenario where a user uploads many files that each
+# fall under MAX_EMBEDDED_IMAGES_PER_FILE but aggregate to enough work
+# (serial-ish celery fan-out plus per-image vision-LLM calls) to OOM the
+# worker under concurrency or run up surprise latency/cost. Also clamped
+# to >= 0.
+MAX_EMBEDDED_IMAGES_PER_UPLOAD = max(
+    0, int(os.environ.get("MAX_EMBEDDED_IMAGES_PER_UPLOAD") or 1000)
 )
 
 # Use document summary for contextual rag

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -843,6 +843,15 @@ MAX_FILE_SIZE_BYTES = int(
     os.environ.get("MAX_FILE_SIZE_BYTES") or 2 * 1024 * 1024 * 1024
 )  # 2GB in bytes
 
+# Maximum embedded images allowed in a single file. PDFs (and other formats)
+# with thousands of embedded images can OOM the user-file-processing worker
+# because every image is decoded with PIL and then sent to the vision LLM.
+# Enforced both at upload time (rejects the file) and during extraction
+# (defense-in-depth: caps the number of images materialized).
+MAX_EMBEDDED_IMAGES_PER_FILE = int(
+    os.environ.get("MAX_EMBEDDED_IMAGES_PER_FILE") or 500
+)
+
 # Use document summary for contextual rag
 USE_DOCUMENT_SUMMARY = os.environ.get("USE_DOCUMENT_SUMMARY", "true").lower() == "true"
 # Use chunk summary for contextual rag

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -23,6 +23,7 @@ import openpyxl
 from openpyxl.worksheet.worksheet import Worksheet
 from PIL import Image
 
+from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -254,8 +255,27 @@ def read_pdf_file(
         )
 
         if extract_images:
+            image_cap = MAX_EMBEDDED_IMAGES_PER_FILE
+            images_processed = 0
+            cap_reached = False
             for page_num, page in enumerate(pdf_reader.pages):
+                if cap_reached:
+                    break
                 for image_file_object in page.images:
+                    if images_processed >= image_cap:
+                        # Defense-in-depth backstop. Upload-time validation
+                        # should have rejected files exceeding the cap, but
+                        # we also break here so a single oversized file can
+                        # never pin a worker.
+                        logger.warning(
+                            "PDF embedded image cap reached (%d). "
+                            "Skipping remaining images on page %d and beyond.",
+                            image_cap,
+                            page_num + 1,
+                        )
+                        cap_reached = True
+                        break
+
                     image = Image.open(io.BytesIO(image_file_object.data))
                     img_byte_arr = io.BytesIO()
                     image.save(img_byte_arr, format=image.format)
@@ -268,6 +288,7 @@ def read_pdf_file(
                         image_callback(img_bytes, image_name)
                     else:
                         extracted_images.append((img_bytes, image_name))
+                    images_processed += 1
 
         return text, metadata, extracted_images
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -192,6 +192,56 @@ def read_text_file(
     return file_content_raw, metadata
 
 
+def count_pdf_embedded_images(file: IO[Any], cap: int) -> int:
+    """Return the number of embedded images in a PDF, short-circuiting at cap+1.
+
+    Used to reject PDFs whose image count would OOM the user-file-processing
+    worker during indexing. Returns a value > cap as a sentinel once the count
+    exceeds the cap, so callers do not iterate thousands of image objects just
+    to report a number. Returns 0 if the PDF cannot be parsed.
+
+    Owner-password-only PDFs (permission restrictions but no open password) are
+    counted normally — they decrypt with an empty string. Truly password-locked
+    PDFs are skipped (return 0) since we can't inspect them; the caller should
+    ensure the password-protected check runs first.
+
+    Always restores the file pointer to its original position before returning.
+    """
+    from pypdf import PdfReader
+
+    try:
+        start_pos = file.tell()
+    except Exception:
+        start_pos = None
+    try:
+        if start_pos is not None:
+            file.seek(0)
+        reader = PdfReader(file)
+        if reader.is_encrypted:
+            # Try empty password first (owner-password-only PDFs); give up if that fails.
+            try:
+                if reader.decrypt("") == 0:
+                    return 0
+            except Exception:
+                return 0
+        count = 0
+        for page in reader.pages:
+            for _ in page.images:
+                count += 1
+                if count > cap:
+                    return count
+        return count
+    except Exception:
+        logger.warning("Failed to count embedded images in PDF", exc_info=True)
+        return 0
+    finally:
+        if start_pos is not None:
+            try:
+                file.seek(start_pos)
+            except Exception:
+                pass
+
+
 def pdf_to_text(file: IO[Any], pdf_pass: str | None = None) -> str:
     """
     Extract text from a PDF. For embedded images, a more complex approach is needed.

--- a/backend/onyx/server/features/build/api/user_library.py
+++ b/backend/onyx/server/features/build/api/user_library.py
@@ -55,6 +55,7 @@ from onyx.db.models import User
 from onyx.document_index.interfaces import DocumentMetadata
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_FILE_SIZE_BYTES
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_FILES_PER_UPLOAD
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_TOTAL_SIZE_BYTES
@@ -132,34 +133,17 @@ class DeleteFileResponse(BaseModel):
 # =============================================================================
 
 
-def _count_pdf_embedded_images(content: bytes, cap: int) -> int:
-    """Return the number of embedded images in a PDF, short-circuiting at cap+1.
+def _looks_like_pdf(filename: str, content_type: str | None) -> bool:
+    """True if either the filename or the content-type indicates a PDF.
 
-    Used to reject PDFs whose image count would OOM the user-file-processing
-    worker during indexing. Returns ``cap + 1`` as a sentinel if the count
-    exceeds the cap, so callers do not iterate thousands of image objects just
-    to report a number. Returns 0 if the PDF cannot be parsed — the downstream
-    indexing pipeline handles malformed PDFs separately.
+    Client-supplied ``content_type`` can be spoofed (e.g. a PDF uploaded with
+    ``Content-Type: application/octet-stream``), so we also fall back to
+    extension-based detection via ``mimetypes.guess_type`` on the filename.
     """
-    try:
-        from pypdf import PdfReader
-
-        reader = PdfReader(BytesIO(content))
-        if reader.is_encrypted:
-            # Encrypted PDFs cannot be inspected without the password. Let the
-            # indexing pipeline handle them (it has decrypt-with-empty-password
-            # fallback) and rely on the extraction-time cap as the backstop.
-            return 0
-        count = 0
-        for page in reader.pages:
-            for _ in page.images:
-                count += 1
-                if count > cap:
-                    return count
-        return count
-    except Exception:
-        logger.exception("Failed to count embedded images in PDF")
-        return 0
+    if content_type == "application/pdf":
+        return True
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed == "application/pdf"
 
 
 def _check_pdf_image_caps(
@@ -171,12 +155,12 @@ def _check_pdf_image_caps(
     callers can update their running batch total. Raises OnyxError(INVALID_INPUT)
     if either cap is exceeded.
     """
-    if content_type != "application/pdf":
+    if not _looks_like_pdf(filename, content_type):
         return 0
     file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
     batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
     # Short-circuit at the larger cap so we get a useful count for both checks.
-    count = _count_pdf_embedded_images(content, max(file_cap, batch_cap))
+    count = count_pdf_embedded_images(BytesIO(content), max(file_cap, batch_cap))
     if count > file_cap:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
@@ -592,8 +576,8 @@ async def upload_zip(
                 zip_file_name = zip_info.filename.split("/")[-1]
                 zip_content_type, _ = mimetypes.guess_type(zip_file_name)
                 if zip_content_type == "application/pdf":
-                    image_count = _count_pdf_embedded_images(
-                        file_content,
+                    image_count = count_pdf_embedded_images(
+                        BytesIO(file_content),
                         max(
                             MAX_EMBEDDED_IMAGES_PER_FILE,
                             MAX_EMBEDDED_IMAGES_PER_UPLOAD,

--- a/backend/onyx/server/features/build/api/user_library.py
+++ b/backend/onyx/server/features/build/api/user_library.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as celery_app
+from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -126,6 +127,54 @@ class DeleteFileResponse(BaseModel):
 # =============================================================================
 # Helper Functions
 # =============================================================================
+
+
+def _count_pdf_embedded_images(content: bytes, cap: int) -> int:
+    """Return the number of embedded images in a PDF, short-circuiting at cap+1.
+
+    Used to reject PDFs whose image count would OOM the user-file-processing
+    worker during indexing. Returns ``cap + 1`` as a sentinel if the count
+    exceeds the cap, so callers do not iterate thousands of image objects just
+    to report a number. Returns 0 if the PDF cannot be parsed — the downstream
+    indexing pipeline handles malformed PDFs separately.
+    """
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(BytesIO(content))
+        if reader.is_encrypted:
+            # Encrypted PDFs cannot be inspected without the password. Let the
+            # indexing pipeline handle them (it has decrypt-with-empty-password
+            # fallback) and rely on the extraction-time cap as the backstop.
+            return 0
+        count = 0
+        for page in reader.pages:
+            for _ in page.images:
+                count += 1
+                if count > cap:
+                    return count
+        return count
+    except Exception:
+        logger.exception("Failed to count embedded images in PDF")
+        return 0
+
+
+def _reject_if_too_many_embedded_images(
+    filename: str, content: bytes, content_type: str | None
+) -> None:
+    """Raise HTTPException(400) if the PDF has more embedded images than the cap."""
+    if content_type != "application/pdf":
+        return
+    cap = MAX_EMBEDDED_IMAGES_PER_FILE
+    count = _count_pdf_embedded_images(content, cap)
+    if count > cap:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"PDF '{filename}' contains too many embedded images "
+                f"(more than {cap}). Consider splitting or compressing the file."
+            ),
+        )
 
 
 def _sanitize_path(path: str) -> str:
@@ -375,6 +424,13 @@ async def upload_files(
                 detail=f"File '{file.filename}' exceeds maximum size of {USER_LIBRARY_MAX_FILE_SIZE_BYTES // (1024 * 1024)}MB",
             )
 
+        # Reject PDFs with an unreasonable number of embedded images
+        _reject_if_too_many_embedded_images(
+            filename=file.filename or "unnamed",
+            content=content,
+            content_type=file.content_type,
+        )
+
         # Validate cumulative storage (existing + this upload batch)
         total_size += file_size
         if existing_usage + total_size > USER_LIBRARY_MAX_TOTAL_SIZE_BYTES:
@@ -510,6 +566,26 @@ async def upload_zip(
                 if file_size > USER_LIBRARY_MAX_FILE_SIZE_BYTES:
                     logger.warning(f"Skipping '{zip_info.filename}' - exceeds max size")
                     continue
+
+                # Skip PDFs with an unreasonable number of embedded images (would
+                # OOM the user-file-processing worker). Matches /upload behavior
+                # but uses skip-and-warn to stay consistent with the zip path's
+                # handling of oversized files.
+                zip_file_name = zip_info.filename.split("/")[-1]
+                zip_content_type, _ = mimetypes.guess_type(zip_file_name)
+                if zip_content_type == "application/pdf":
+                    if (
+                        _count_pdf_embedded_images(
+                            file_content, MAX_EMBEDDED_IMAGES_PER_FILE
+                        )
+                        > MAX_EMBEDDED_IMAGES_PER_FILE
+                    ):
+                        logger.warning(
+                            "Skipping '%s' - exceeds %d embedded-image cap",
+                            zip_info.filename,
+                            MAX_EMBEDDED_IMAGES_PER_FILE,
+                        )
+                        continue
 
                 total_size += file_size
 

--- a/backend/onyx/server/features/build/api/user_library.py
+++ b/backend/onyx/server/features/build/api/user_library.py
@@ -41,6 +41,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as celery_app
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
+from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_UPLOAD
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -52,6 +53,8 @@ from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.document_index.interfaces import DocumentMetadata
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_FILE_SIZE_BYTES
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_FILES_PER_UPLOAD
 from onyx.server.features.build.configs import USER_LIBRARY_MAX_TOTAL_SIZE_BYTES
@@ -159,22 +162,34 @@ def _count_pdf_embedded_images(content: bytes, cap: int) -> int:
         return 0
 
 
-def _reject_if_too_many_embedded_images(
-    filename: str, content: bytes, content_type: str | None
-) -> None:
-    """Raise HTTPException(400) if the PDF has more embedded images than the cap."""
+def _check_pdf_image_caps(
+    filename: str, content: bytes, content_type: str | None, batch_total: int
+) -> int:
+    """Enforce per-file and per-batch embedded-image caps for PDFs.
+
+    Returns the number of embedded images in this file (0 for non-PDFs) so
+    callers can update their running batch total. Raises OnyxError(INVALID_INPUT)
+    if either cap is exceeded.
+    """
     if content_type != "application/pdf":
-        return
-    cap = MAX_EMBEDDED_IMAGES_PER_FILE
-    count = _count_pdf_embedded_images(content, cap)
-    if count > cap:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"PDF '{filename}' contains too many embedded images "
-                f"(more than {cap}). Consider splitting or compressing the file."
-            ),
+        return 0
+    file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
+    batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
+    # Short-circuit at the larger cap so we get a useful count for both checks.
+    count = _count_pdf_embedded_images(content, max(file_cap, batch_cap))
+    if count > file_cap:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"PDF '{filename}' contains too many embedded images "
+            f"(more than {file_cap}). Try splitting the document into smaller files.",
         )
+    if batch_total + count > batch_cap:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Upload would exceed the {batch_cap}-image limit across all "
+            f"files in this batch. Try uploading fewer image-heavy files at once.",
+        )
+    return count
 
 
 def _sanitize_path(path: str) -> str:
@@ -405,6 +420,7 @@ async def upload_files(
 
     uploaded_entries: list[LibraryEntryResponse] = []
     total_size = 0
+    batch_image_total = 0
     now = datetime.now(timezone.utc)
 
     # Sanitize the base path
@@ -424,11 +440,12 @@ async def upload_files(
                 detail=f"File '{file.filename}' exceeds maximum size of {USER_LIBRARY_MAX_FILE_SIZE_BYTES // (1024 * 1024)}MB",
             )
 
-        # Reject PDFs with an unreasonable number of embedded images
-        _reject_if_too_many_embedded_images(
+        # Reject PDFs with an unreasonable per-file or per-batch image count
+        batch_image_total += _check_pdf_image_caps(
             filename=file.filename or "unnamed",
             content=content,
             content_type=file.content_type,
+            batch_total=batch_image_total,
         )
 
         # Validate cumulative storage (existing + this upload batch)
@@ -529,6 +546,7 @@ async def upload_zip(
 
     uploaded_entries: list[LibraryEntryResponse] = []
     total_size = 0
+    batch_image_total = 0
 
     # Extract zip contents into a subfolder named after the zip file
     zip_name = api_sanitize_filename(file.filename or "upload")
@@ -567,25 +585,35 @@ async def upload_zip(
                     logger.warning(f"Skipping '{zip_info.filename}' - exceeds max size")
                     continue
 
-                # Skip PDFs with an unreasonable number of embedded images (would
-                # OOM the user-file-processing worker). Matches /upload behavior
-                # but uses skip-and-warn to stay consistent with the zip path's
-                # handling of oversized files.
+                # Skip PDFs that would trip the per-file or per-batch image
+                # cap (would OOM the user-file-processing worker). Matches
+                # /upload behavior but uses skip-and-warn to stay consistent
+                # with the zip path's handling of oversized files.
                 zip_file_name = zip_info.filename.split("/")[-1]
                 zip_content_type, _ = mimetypes.guess_type(zip_file_name)
                 if zip_content_type == "application/pdf":
-                    if (
-                        _count_pdf_embedded_images(
-                            file_content, MAX_EMBEDDED_IMAGES_PER_FILE
-                        )
-                        > MAX_EMBEDDED_IMAGES_PER_FILE
-                    ):
+                    image_count = _count_pdf_embedded_images(
+                        file_content,
+                        max(
+                            MAX_EMBEDDED_IMAGES_PER_FILE,
+                            MAX_EMBEDDED_IMAGES_PER_UPLOAD,
+                        ),
+                    )
+                    if image_count > MAX_EMBEDDED_IMAGES_PER_FILE:
                         logger.warning(
-                            "Skipping '%s' - exceeds %d embedded-image cap",
+                            "Skipping '%s' - exceeds %d per-file embedded-image cap",
                             zip_info.filename,
                             MAX_EMBEDDED_IMAGES_PER_FILE,
                         )
                         continue
+                    if batch_image_total + image_count > MAX_EMBEDDED_IMAGES_PER_UPLOAD:
+                        logger.warning(
+                            "Skipping '%s' - would exceed %d per-batch embedded-image cap",
+                            zip_info.filename,
+                            MAX_EMBEDDED_IMAGES_PER_UPLOAD,
+                        )
+                        continue
+                    batch_image_total += image_count
 
                 total_size += file_size
 

--- a/backend/onyx/server/features/projects/projects_file_utils.py
+++ b/backend/onyx/server/features/projects/projects_file_utils.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_UPLOAD
 from onyx.db.llm import fetch_default_llm_model
+from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -52,48 +53,6 @@ def get_upload_size_bytes(upload: UploadFile) -> int | None:
             f"error_type={type(e).__name__}, error={e})"
         )
         return None
-
-
-def count_pdf_embedded_images(upload: UploadFile, cap: int) -> int:
-    """Count embedded images in a PDF, short-circuiting at cap+1.
-
-    Used to reject PDFs whose image count would OOM the user-file-processing
-    worker during indexing. Returns ``cap + 1`` (or whatever the running count
-    is at the point we exceed) as a sentinel if the count exceeds the cap, so
-    callers do not iterate thousands of image objects just to report a number.
-    Returns 0 if the PDF cannot be parsed — the upstream extractor will raise
-    a clearer error in that case.
-
-    Always resets the file pointer before returning.
-    """
-    try:
-        from pypdf import PdfReader
-
-        upload.file.seek(0)
-        reader = PdfReader(upload.file)
-        if reader.is_encrypted:
-            # Encrypted PDFs cannot be inspected without the password. Let the
-            # password-protected check (which runs before this one) handle them
-            # and rely on the extraction-time cap as the backstop.
-            return 0
-        count = 0
-        for page in reader.pages:
-            for _ in page.images:
-                count += 1
-                if count > cap:
-                    return count
-        return count
-    except Exception as e:
-        logger.warning(
-            f"Failed to count embedded images in PDF "
-            f"'{get_safe_filename(upload)}': {type(e).__name__}: {e}"
-        )
-        return 0
-    finally:
-        try:
-            upload.file.seek(0)
-        except Exception:
-            pass
 
 
 def is_upload_too_large(upload: UploadFile, max_bytes: int) -> bool:
@@ -311,7 +270,10 @@ def categorize_uploaded_files(
                     batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
                     # Use the larger of the two caps as the short-circuit
                     # threshold so we get a useful count for both checks.
-                    count = count_pdf_embedded_images(upload, max(file_cap, batch_cap))
+                    # count_pdf_embedded_images restores the stream position.
+                    count = count_pdf_embedded_images(
+                        upload.file, max(file_cap, batch_cap)
+                    )
                     if count > file_cap:
                         results.rejected.append(
                             RejectedFile(

--- a/backend/onyx/server/features/projects/projects_file_utils.py
+++ b/backend/onyx/server/features/projects/projects_file_utils.py
@@ -9,6 +9,8 @@ from pydantic import ConfigDict
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
+from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_UPLOAD
 from onyx.db.llm import fetch_default_llm_model
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
@@ -50,6 +52,48 @@ def get_upload_size_bytes(upload: UploadFile) -> int | None:
             f"error_type={type(e).__name__}, error={e})"
         )
         return None
+
+
+def count_pdf_embedded_images(upload: UploadFile, cap: int) -> int:
+    """Count embedded images in a PDF, short-circuiting at cap+1.
+
+    Used to reject PDFs whose image count would OOM the user-file-processing
+    worker during indexing. Returns ``cap + 1`` (or whatever the running count
+    is at the point we exceed) as a sentinel if the count exceeds the cap, so
+    callers do not iterate thousands of image objects just to report a number.
+    Returns 0 if the PDF cannot be parsed — the upstream extractor will raise
+    a clearer error in that case.
+
+    Always resets the file pointer before returning.
+    """
+    try:
+        from pypdf import PdfReader
+
+        upload.file.seek(0)
+        reader = PdfReader(upload.file)
+        if reader.is_encrypted:
+            # Encrypted PDFs cannot be inspected without the password. Let the
+            # password-protected check (which runs before this one) handle them
+            # and rely on the extraction-time cap as the backstop.
+            return 0
+        count = 0
+        for page in reader.pages:
+            for _ in page.images:
+                count += 1
+                if count > cap:
+                    return count
+        return count
+    except Exception as e:
+        logger.warning(
+            f"Failed to count embedded images in PDF "
+            f"'{get_safe_filename(upload)}': {type(e).__name__}: {e}"
+        )
+        return 0
+    finally:
+        try:
+            upload.file.seek(0)
+        except Exception:
+            pass
 
 
 def is_upload_too_large(upload: UploadFile, max_bytes: int) -> bool:
@@ -190,6 +234,11 @@ def categorize_uploaded_files(
         token_threshold_k * 1000 if token_threshold_k else None
     )  # 0 → None = no limit
 
+    # Running total of embedded images across PDFs in this batch. Once the
+    # aggregate cap is reached, subsequent PDFs in the same upload are
+    # rejected even if they'd individually fit under MAX_EMBEDDED_IMAGES_PER_FILE.
+    batch_image_total = 0
+
     for upload in files:
         try:
             filename = get_safe_filename(upload)
@@ -251,6 +300,44 @@ def categorize_uploaded_files(
                         )
                     )
                     continue
+
+                # Reject PDFs with an unreasonable number of embedded images
+                # (either per-file or accumulated across this upload batch).
+                # A PDF with thousands of embedded images can OOM the
+                # user-file-processing celery worker because every image is
+                # decoded with PIL and then sent to the vision LLM.
+                if extension == ".pdf":
+                    file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
+                    batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
+                    # Use the larger of the two caps as the short-circuit
+                    # threshold so we get a useful count for both checks.
+                    count = count_pdf_embedded_images(upload, max(file_cap, batch_cap))
+                    if count > file_cap:
+                        results.rejected.append(
+                            RejectedFile(
+                                filename=filename,
+                                reason=(
+                                    f"PDF contains too many embedded images "
+                                    f"(more than {file_cap}). Try splitting "
+                                    f"the document into smaller files."
+                                ),
+                            )
+                        )
+                        continue
+                    if batch_image_total + count > batch_cap:
+                        results.rejected.append(
+                            RejectedFile(
+                                filename=filename,
+                                reason=(
+                                    f"Upload would exceed the "
+                                    f"{batch_cap}-image limit across all "
+                                    f"files in this batch. Try uploading "
+                                    f"fewer image-heavy files at once."
+                                ),
+                            )
+                        )
+                        continue
+                    batch_image_total += count
 
                 text_content = extract_file_text(
                     file=upload.file,

--- a/backend/tests/unit/onyx/file_processing/test_pdf.py
+++ b/backend/tests/unit/onyx/file_processing/test_pdf.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from onyx.file_processing import extract_file_text
+from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.file_processing.extract_file_text import pdf_to_text
 from onyx.file_processing.extract_file_text import read_pdf_file
 from onyx.file_processing.password_validation import is_pdf_protected
@@ -134,6 +135,44 @@ class TestReadPdfFile:
             _load("with_image.pdf"), extract_images=True, image_callback=callback
         )
         assert collected == []
+
+
+# ── count_pdf_embedded_images ────────────────────────────────────────────
+
+
+class TestCountPdfEmbeddedImages:
+    def test_returns_count_for_normal_pdf(self) -> None:
+        assert count_pdf_embedded_images(_load("with_image.pdf"), cap=10) == 1
+
+    def test_short_circuits_above_cap(self) -> None:
+        # with_image.pdf has 1 image. cap=0 means "anything > 0 is over cap" —
+        # function returns on first increment as the over-cap sentinel.
+        assert count_pdf_embedded_images(_load("with_image.pdf"), cap=0) == 1
+
+    def test_returns_zero_for_pdf_without_images(self) -> None:
+        assert count_pdf_embedded_images(_load("simple.pdf"), cap=10) == 0
+
+    def test_returns_zero_for_invalid_pdf(self) -> None:
+        assert count_pdf_embedded_images(BytesIO(b"not a pdf"), cap=10) == 0
+
+    def test_returns_zero_for_password_locked_pdf(self) -> None:
+        # encrypted.pdf has an open password; we can't inspect without it, so
+        # the helper returns 0 — callers rely on the password-protected check
+        # that runs earlier in the upload pipeline.
+        assert count_pdf_embedded_images(_load("encrypted.pdf"), cap=10) == 0
+
+    def test_inspects_owner_password_only_pdf(self) -> None:
+        # owner_protected.pdf is encrypted but has no open password. It should
+        # decrypt with an empty string and count images normally. The fixture
+        # has zero images, so 0 is a real count (not the "bail on encrypted"
+        # path).
+        assert count_pdf_embedded_images(_load("owner_protected.pdf"), cap=10) == 0
+
+    def test_preserves_file_position(self) -> None:
+        pdf = _load("with_image.pdf")
+        pdf.seek(42)
+        count_pdf_embedded_images(pdf, cap=10)
+        assert pdf.tell() == 42
 
 
 # ── pdf_to_text ──────────────────────────────────────────────────────────

--- a/backend/tests/unit/onyx/file_processing/test_pdf.py
+++ b/backend/tests/unit/onyx/file_processing/test_pdf.py
@@ -12,6 +12,9 @@ dependency on pypdf internals (pypdf.generic).
 from io import BytesIO
 from pathlib import Path
 
+import pytest
+
+from onyx.file_processing import extract_file_text
 from onyx.file_processing.extract_file_text import pdf_to_text
 from onyx.file_processing.extract_file_text import read_pdf_file
 from onyx.file_processing.password_validation import is_pdf_protected
@@ -95,6 +98,42 @@ class TestReadPdfFile:
         assert len(collected[0][0]) > 0
         # Returned list is empty when callback is used
         assert images == []
+
+    def test_image_cap_skips_images_above_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the embedded-image cap is exceeded, remaining images are skipped.
+
+        The cap protects the user-file-processing worker from OOMing on PDFs
+        with thousands of embedded images. Setting the cap to 0 should yield
+        zero extracted images even though the fixture has one.
+        """
+        monkeypatch.setattr(extract_file_text, "MAX_EMBEDDED_IMAGES_PER_FILE", 0)
+        _, _, images = read_pdf_file(_load("with_image.pdf"), extract_images=True)
+        assert images == []
+
+    def test_image_cap_at_limit_extracts_up_to_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cap >= image count behaves identically to the uncapped path."""
+        monkeypatch.setattr(extract_file_text, "MAX_EMBEDDED_IMAGES_PER_FILE", 100)
+        _, _, images = read_pdf_file(_load("with_image.pdf"), extract_images=True)
+        assert len(images) == 1
+
+    def test_image_cap_with_callback_stops_streaming_at_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap also short-circuits the streaming callback path."""
+        monkeypatch.setattr(extract_file_text, "MAX_EMBEDDED_IMAGES_PER_FILE", 0)
+        collected: list[tuple[bytes, str]] = []
+
+        def callback(data: bytes, name: str) -> None:
+            collected.append((data, name))
+
+        read_pdf_file(
+            _load("with_image.pdf"), extract_images=True, image_callback=callback
+        )
+        assert collected == []
 
 
 # ── pdf_to_text ──────────────────────────────────────────────────────────

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -271,6 +271,11 @@ export default function UserLibraryModal({
                   />
                 </Section>
 
+                {/* The exact cap is controlled by the backend env var
+                    MAX_EMBEDDED_IMAGES_PER_FILE (default 500). This copy is
+                    deliberately vague so it doesn't drift if the limit is
+                    tuned per-deployment; the precise number is surfaced in
+                    the rejection error the server returns. */}
                 <Section
                   flexDirection="row"
                   justifyContent="end"
@@ -278,7 +283,7 @@ export default function UserLibraryModal({
                   height="fit"
                 >
                   <Text secondaryBody text03>
-                    PDFs with more than 500 embedded images are not supported.
+                    PDFs with many embedded images may be rejected.
                   </Text>
                 </Section>
 

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -271,6 +271,17 @@ export default function UserLibraryModal({
                   />
                 </Section>
 
+                <Section
+                  flexDirection="row"
+                  justifyContent="end"
+                  padding={0.5}
+                  height="fit"
+                >
+                  <Text secondaryBody text03>
+                    PDFs with more than 500 embedded images are not supported.
+                  </Text>
+                </Section>
+
                 {isLoading ? (
                   <Section padding={2} height="fit">
                     <Text secondaryBody text03>


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently hitting an issue where we are seeing files that are uploaded be much smaller than the size threshold but are causing issues due to the number of images that are in the file.

We are introducing a per file limit of images which is set to 500 and a total combined limit of 1000 images in a chat in order to prevent any over loading the chat with too many images.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added tests and tested locally.

Image of what the error looks like:
<img width="961" height="92" alt="Screenshot 2026-04-16 at 6 12 22 PM" src="https://github.com/user-attachments/assets/29cbce0d-d330-48aa-bdc7-f0bb9bb0c808" />


## Additional Options
Need to add to v3.0 v3.1 v3.2

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hard caps on embedded images per PDF and per upload batch to prevent worker OOMs. Enforced during uploads (single and ZIP) and in extraction, with clearer UI copy.

- **Bug Fixes**
  - Introduced `MAX_EMBEDDED_IMAGES_PER_FILE` (default 500) and `MAX_EMBEDDED_IMAGES_PER_UPLOAD` (default 1000); read from env and clamped to >= 0.
  - Added fast preflight PDF image counting to enforce caps early: single-file uploads reject over-cap PDFs/batches; ZIP uploads skip offending PDFs with warnings; project uploads reject with clear reasons while tracking batch totals.
  - PDF extraction short-circuits when the cap is reached (defense-in-depth).
  - Updated modal copy (“PDFs with many embedded images may be rejected.”) and added unit tests for caps (including the streaming callback) and the counting helper.

<sup>Written for commit aed41cf1747fbd13f41669849adb38f0a33e2d4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



