### PR TITLE
fix(web): Sentry Token Check

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -82,7 +82,10 @@ ARG NODE_OPTIONS
 # SENTRY_AUTH_TOKEN is injected via BuildKit secret mount so it is never written
 # to any image layer, build cache, or registry manifest.
 # Use NODE_OPTIONS in the build command
-RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+RUN --mount=type=secret,id=sentry_auth_token \
+    if [ -f /run/secrets/sentry_auth_token ]; then \
+        export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"; \
+    fi && \
     NODE_OPTIONS="${NODE_OPTIONS}" npx next build
 
 # Step 2. Production image, copy all the files and run next


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Check for the auth token before trying to set it to avoid issues when deploying with docker compose.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested it live on the instance

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only export `SENTRY_AUTH_TOKEN` during the Next.js build if the BuildKit secret file exists, preventing build errors when the token isn’t provided (e.g., docker-compose).

<sup>Written for commit 0bfddb0d21d1af647220476410c6a66d706fb906. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

