### PR TITLE
Fix: mcp langfuse tracing and Jira adf parsing

### DIFF
--- a/backend/onyx/connectors/jira/utils.py
+++ b/backend/onyx/connectors/jira/utils.py
@@ -62,17 +62,19 @@ def best_effort_get_field_from_issue(jira_issue: Issue, field: str) -> Any:
 def extract_text_from_adf(adf: dict | None) -> str:
     """Extracts plain text from Atlassian Document Format:
     https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
-
-    WARNING: This function is incomplete and will e.g. skip lists!
     """
-    # TODO: complete this function
-    texts = []
-    if adf is not None and "content" in adf:
-        for block in adf["content"]:
-            if "content" in block:
-                for item in block["content"]:
-                    if item["type"] == "text":
-                        texts.append(item["text"])
+    texts: list[str] = []
+
+    def _extract(node: dict) -> None:
+        if node.get("type") == "text":
+            text = node.get("text", "")
+            if text:
+                texts.append(text)
+        for child in node.get("content", []):
+            _extract(child)
+
+    if adf is not None:
+        _extract(adf)
     return " ".join(texts)
 
 

--- a/backend/onyx/mcp_server_main.py
+++ b/backend/onyx/mcp_server_main.py
@@ -5,6 +5,7 @@ import uvicorn
 from onyx.configs.app_configs import MCP_SERVER_ENABLED
 from onyx.configs.app_configs import MCP_SERVER_HOST
 from onyx.configs.app_configs import MCP_SERVER_PORT
+from onyx.tracing.setup import setup_tracing
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
 
@@ -18,6 +19,7 @@ def main() -> None:
         return
 
     set_is_ee_based_on_env_variable()
+    setup_tracing()
     logger.info(f"Starting MCP server on {MCP_SERVER_HOST}:{MCP_SERVER_PORT}")
 
     from onyx.mcp_server.api import mcp_app


### PR DESCRIPTION
## Description

The MCP server runs as a separate process and never called setup_tracing() on startup, so no trace processors (e.g. Langfuse) were registered and all MCP query traces were silently dropped. Fix mirrors what main.py already does for the API server.

## How Has This Been Tested?

Manually verified, questions asked via mcp now appear in Langfuse.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize tracing at MCP server startup so Langfuse captures MCP query traces, matching the API server. Also improve ADF text parsing to extract all nested text.

- **Bug Fixes**
  - Call setup_tracing() in MCP server main to register trace processors (e.g., Langfuse).
  - Make extract_text_from_adf recursive to collect all text from nested ADF nodes.

<sup>Written for commit 8f5e685704eb0395d3a2da5ccc33659fcab656c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

