### PR TITLE
refactor: Update toast notifications look and feel

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -3,9 +3,11 @@ import "@opal/components/cards/message-card/styles.css";
 import { cn } from "@opal/utils";
 import type {
   IconFunctionComponent,
+  PaddingVariants,
   RichStr,
   StatusVariants,
 } from "@opal/types";
+import { paddingVariants } from "@opal/shared";
 import { ContentAction } from "@opal/layouts";
 import { Button, Divider } from "@opal/components";
 import {
@@ -32,6 +34,9 @@ interface MessageCardBaseProps {
 
   /** Optional description below the title. */
   description?: string | RichStr;
+
+  /** Padding preset. @default "sm" */
+  padding?: Extract<PaddingVariants, "sm" | "xs">;
 
   /**
    * Content rendered below a divider, under the main content area.
@@ -116,6 +121,7 @@ function MessageCard({
   icon: iconOverride,
   title,
   description,
+  padding = "sm",
   bottomChildren,
   rightChildren,
   onClose,
@@ -137,7 +143,11 @@ function MessageCard({
   );
 
   return (
-    <div className="opal-message-card" data-variant={variant} ref={ref}>
+    <div
+      className={cn("opal-message-card", paddingVariants[padding])}
+      data-variant={variant}
+      ref={ref}
+    >
       <ContentAction
         icon={(props) => (
           <Icon {...props} className={cn(props.className, iconClass)} />
@@ -146,7 +156,7 @@ function MessageCard({
         description={description}
         sizePreset="main-ui"
         variant="section"
-        paddingVariant="lg"
+        paddingVariant="md"
         rightChildren={right}
       />
 

--- a/web/lib/opal/src/components/cards/message-card/styles.css
+++ b/web/lib/opal/src/components/cards/message-card/styles.css
@@ -1,5 +1,5 @@
 .opal-message-card {
-  @apply flex flex-col self-stretch rounded-16 border p-2;
+  @apply flex flex-col w-full self-stretch rounded-16 border;
 }
 
 /* Variant colors */

--- a/web/src/app/css/sizes.css
+++ b/web/src/app/css/sizes.css
@@ -7,4 +7,6 @@
   --container-md: 54.5rem;
   --container-lg: 62rem;
   --container-full: 100%;
+
+  --toast-width: 420px;
 }

--- a/web/src/app/css/sizes.css
+++ b/web/src/app/css/sizes.css
@@ -8,5 +8,5 @@
   --container-lg: 62rem;
   --container-full: 100%;
 
-  --toast-width: 420px;
+  --toast-width: 25rem;
 }

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -51,11 +51,7 @@ function ToastContainer() {
   return (
     <div
       data-testid="toast-container"
-      className={cn(
-        "fixed bottom-4 right-4 z-[10000]",
-        "flex flex-col gap-2 items-end",
-        "w-[var(--toast-width)]"
-      )}
+      className="fixed bottom-4 right-4 z-[var(--z-toast)] flex flex-col gap-2 items-end max-w-[var(--toast-width)] w-full"
     >
       {visible.map((t) => {
         const text =
@@ -74,6 +70,7 @@ function ToastContainer() {
               variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
               title={text}
               description={buildDescription(t)}
+              padding="xs"
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
             />
           </div>

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -54,7 +54,7 @@ function ToastContainer() {
       className={cn(
         "fixed bottom-4 right-4 z-[10000]",
         "flex flex-col gap-2 items-end",
-        "max-w-[420px]"
+        "w-[420px]"
       )}
     >
       {visible.map((t) => {
@@ -66,7 +66,7 @@ function ToastContainer() {
           <div
             key={t.id}
             className={cn(
-              "shadow-02 rounded-12",
+              "w-full",
               t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale"
             )}
           >

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -54,7 +54,7 @@ function ToastContainer() {
       className={cn(
         "fixed bottom-4 right-4 z-[10000]",
         "flex flex-col gap-2 items-end",
-        "w-[420px]"
+        "w-[var(--toast-width)]"
       )}
     >
       {visible.map((t) => {


### PR DESCRIPTION
## Description

- Remove background shadow and rounding.
- Move the hardcoded `420px` toast container width to a `--toast-width` CSS variable in `sizes.css`, referenced via `var(--toast-width)` in `ToastProvider.tsx`.

## Screenshots + Videos

### Before

https://github.com/user-attachments/assets/87353a07-285b-4a70-a042-33a597ac19f9

### After

https://github.com/user-attachments/assets/7b0ace4f-e7b4-47f2-8095-fbbb7961a234

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized toast sizing and padding. Toasts now fill a configurable `--toast-width` container, use `--z-toast` for layering, and drop the wrapper shadow and rounding.

- **Refactors**
  - Moved the 420px width to `--toast-width` in `sizes.css`; container uses `max-w-[var(--toast-width)] w-full`, items are `w-full`, and z-index uses `--z-toast`.
  - Added a `padding` prop to `MessageCard` (via `paddingVariants`); default is "sm", toasts use "xs". Removed hardcoded card padding and set content padding to "md".

<sup>Written for commit dfc7d0dfcf755502523a76159cdf8757ceb9210d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

