### PR TITLE
feat: add document sets to mcp server options

### DIFF
--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -244,13 +244,21 @@ def fetch_latest_index_attempts_by_status(
     return query.all()
 
 
+_INTERNAL_ONLY_SOURCES = {
+    # Used by the ingestion API, not a user-created connector.
+    DocumentSource.INGESTION_API,
+    # Backs the user library / build feature, not a connector users filter by.
+    DocumentSource.CRAFT_FILE,
+}
+
+
 def fetch_unique_document_sources(db_session: Session) -> list[DocumentSource]:
     distinct_sources = db_session.query(Connector.source).distinct().all()
 
     sources = [
         source[0]
         for source in distinct_sources
-        if source[0] != DocumentSource.INGESTION_API
+        if source[0] not in _INTERNAL_ONLY_SOURCES
     ]
 
     return sources

--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -19,8 +19,13 @@ from onyx.configs.app_configs import MCP_SERVER_CORS_ORIGINS
 from onyx.mcp_server.auth import OnyxTokenVerifier
 from onyx.mcp_server.utils import shutdown_http_client
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
 
 logger = setup_logger()
+
+# Initialize EE flag at module import so it's set regardless of the entry point
+# (python -m onyx.mcp_server_main, uvicorn onyx.mcp_server.api:mcp_app, etc.).
+set_is_ee_based_on_env_variable()
 
 logger.info("Creating Onyx MCP Server...")
 

--- a/backend/onyx/mcp_server/resources/__init__.py
+++ b/backend/onyx/mcp_server/resources/__init__.py
@@ -1,4 +1,5 @@
 """Resource registrations for the Onyx MCP server."""
 
 # Import resource modules so decorators execute when the package loads.
+from onyx.mcp_server.resources import document_sets  # noqa: F401
 from onyx.mcp_server.resources import indexed_sources  # noqa: F401

--- a/backend/onyx/mcp_server/resources/document_sets.py
+++ b/backend/onyx/mcp_server/resources/document_sets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
 
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import get_accessible_document_sets
@@ -22,7 +22,7 @@ logger = setup_logger()
     ),
     mime_type="application/json",
 )
-async def document_sets_resource() -> dict[str, Any]:
+async def document_sets_resource() -> str:
     """Return the list of document sets the user can filter searches by."""
 
     access_token = require_access_token()
@@ -36,6 +36,6 @@ async def document_sets_resource() -> dict[str, Any]:
         len(document_sets),
     )
 
-    return {
-        "document_sets": [entry.model_dump(mode="json") for entry in document_sets],
-    }
+    # FastMCP 3.2+ requires str/bytes/list[ResourceContent] — it no longer
+    # auto-serializes; serialize to JSON ourselves.
+    return json.dumps([entry.model_dump(mode="json") for entry in document_sets])

--- a/backend/onyx/mcp_server/resources/document_sets.py
+++ b/backend/onyx/mcp_server/resources/document_sets.py
@@ -1,0 +1,41 @@
+"""Resource exposing document sets available to the current user."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from onyx.mcp_server.api import mcp_server
+from onyx.mcp_server.utils import get_accessible_document_sets
+from onyx.mcp_server.utils import require_access_token
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+@mcp_server.resource(
+    "resource://document_sets",
+    name="document_sets",
+    description=(
+        "Enumerate the Document Sets accessible to the current user. Use the "
+        "returned `name` values with the `document_set_names` filter of the "
+        "`search_indexed_documents` tool to scope searches to a specific set."
+    ),
+    mime_type="application/json",
+)
+async def document_sets_resource() -> dict[str, Any]:
+    """Return the list of document sets the user can filter searches by."""
+
+    access_token = require_access_token()
+
+    document_sets = sorted(
+        await get_accessible_document_sets(access_token), key=lambda entry: entry.name
+    )
+
+    logger.info(
+        "Onyx MCP Server: document_sets resource returning %s entries",
+        len(document_sets),
+    )
+
+    return {
+        "document_sets": [entry.model_dump(mode="json") for entry in document_sets],
+    }

--- a/backend/onyx/mcp_server/resources/indexed_sources.py
+++ b/backend/onyx/mcp_server/resources/indexed_sources.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
 
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import get_indexed_sources
@@ -21,7 +21,7 @@ logger = setup_logger()
     ),
     mime_type="application/json",
 )
-async def indexed_sources_resource() -> dict[str, Any]:
+async def indexed_sources_resource() -> str:
     """Return the list of indexed source types for search filtering."""
 
     access_token = require_access_token()
@@ -33,6 +33,6 @@ async def indexed_sources_resource() -> dict[str, Any]:
         len(sources),
     )
 
-    return {
-        "indexed_sources": sorted(sources),
-    }
+    # FastMCP 3.2+ requires str/bytes/list[ResourceContent] — it no longer
+    # auto-serializes; serialize to JSON ourselves.
+    return json.dumps(sorted(sources))

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -31,8 +31,16 @@ from onyx.utils.variable_functionality import global_version
 logger = setup_logger()
 
 
+# CE search falls through to the chat endpoint, which invokes an LLM — the
+# default 60s client timeout is not enough for a real RAG-backed response.
+_CE_SEARCH_TIMEOUT_SECONDS = 300.0
+
+
 async def _post_model(
-    url: str, body: BaseModel, access_token: AccessToken
+    url: str,
+    body: BaseModel,
+    access_token: AccessToken,
+    timeout: float | None = None,
 ) -> httpx.Response:
     """POST a Pydantic model as JSON to the Onyx backend."""
     return await get_http_client().post(
@@ -42,6 +50,7 @@ async def _post_model(
             "Authorization": f"Bearer {access_token.token}",
             "Content-Type": "application/json",
         },
+        timeout=timeout if timeout is not None else httpx.USE_CLIENT_DEFAULT,
     )
 
 
@@ -213,7 +222,12 @@ async def search_indexed_documents(
         endpoint = f"{base_url}/chat/send-chat-message"
 
     try:
-        response = await _post_model(endpoint, request, access_token)
+        response = await _post_model(
+            endpoint,
+            request,
+            access_token,
+            timeout=None if is_ee else _CE_SEARCH_TIMEOUT_SECONDS,
+        )
         if not response.is_success:
             return {
                 "documents": [],

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -7,9 +7,6 @@ import httpx
 from fastmcp.server.auth.auth import AccessToken
 from pydantic import BaseModel
 
-from ee.onyx.server.query_and_chat.models import SearchDocWithContent
-from ee.onyx.server.query_and_chat.models import SearchFullResponse
-from ee.onyx.server.query_and_chat.models import SendSearchQueryRequest
 from onyx.chat.models import ChatFullResponse
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import BaseFilters
@@ -54,10 +51,11 @@ async def _post_model(
     )
 
 
-def _project_doc(
-    doc: SearchDocWithContent | SearchDoc, content: str | None
-) -> dict[str, Any]:
-    """Project a backend search doc into the MCP wire shape."""
+def _project_doc(doc: SearchDoc, content: str | None) -> dict[str, Any]:
+    """Project a backend search doc into the MCP wire shape.
+
+    Accepts SearchDocWithContent (EE) too since it extends SearchDoc.
+    """
     return {
         "semantic_identifier": doc.semantic_identifier,
         "content": content,
@@ -199,9 +197,12 @@ async def search_indexed_documents(
     base_url = build_api_server_url_for_http_requests(respect_env_override_if_set=True)
     is_ee = global_version.is_ee_version()
 
-    request: SendSearchQueryRequest | SendMessageRequest
+    request: BaseModel
     if is_ee:
-        # EE: use the dedicated search endpoint (no LLM invocation)
+        # EE: use the dedicated search endpoint (no LLM invocation).
+        # Lazy import so CE deployments that strip ee/ never load this module.
+        from ee.onyx.server.query_and_chat.models import SendSearchQueryRequest
+
         request = SendSearchQueryRequest(
             search_query=query,
             filters=filters,
@@ -237,6 +238,8 @@ async def search_indexed_documents(
             }
 
         if is_ee:
+            from ee.onyx.server.query_and_chat.models import SearchFullResponse
+
             ee_payload = SearchFullResponse.model_validate_json(response.content)
             if ee_payload.error:
                 return {

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -4,17 +4,58 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+from fastmcp.server.auth.auth import AccessToken
+from pydantic import BaseModel
 
+from ee.onyx.server.query_and_chat.models import SearchDocWithContent
+from ee.onyx.server.query_and_chat.models import SearchFullResponse
+from ee.onyx.server.query_and_chat.models import SendSearchQueryRequest
+from onyx.chat.models import ChatFullResponse
 from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import SearchDoc
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import get_http_client
 from onyx.mcp_server.utils import get_indexed_sources
 from onyx.mcp_server.utils import require_access_token
+from onyx.server.features.web_search.models import OpenUrlsToolRequest
+from onyx.server.features.web_search.models import OpenUrlsToolResponse
+from onyx.server.features.web_search.models import WebSearchToolRequest
+from onyx.server.features.web_search.models import WebSearchToolResponse
+from onyx.server.query_and_chat.models import ChatSessionCreationRequest
+from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 from onyx.utils.variable_functionality import global_version
 
 logger = setup_logger()
+
+
+async def _post_model(
+    url: str, body: BaseModel, access_token: AccessToken
+) -> httpx.Response:
+    """POST a Pydantic model as JSON to the Onyx backend."""
+    return await get_http_client().post(
+        url,
+        content=body.model_dump_json(exclude_unset=True),
+        headers={
+            "Authorization": f"Bearer {access_token.token}",
+            "Content-Type": "application/json",
+        },
+    )
+
+
+def _project_doc(
+    doc: SearchDocWithContent | SearchDoc, content: str | None
+) -> dict[str, Any]:
+    """Project a backend search doc into the MCP wire shape."""
+    return {
+        "semantic_identifier": doc.semantic_identifier,
+        "content": content,
+        "source_type": doc.source_type.value,
+        "link": doc.link,
+        "score": doc.score,
+    }
 
 
 def _extract_error_detail(response: httpx.Response) -> str:
@@ -36,6 +77,7 @@ def _extract_error_detail(response: httpx.Response) -> str:
 async def search_indexed_documents(
     query: str,
     source_types: list[str] | None = None,
+    document_set_names: list[str] | None = None,
     time_cutoff: str | None = None,
     limit: int = 10,
 ) -> dict[str, Any]:
@@ -53,6 +95,10 @@ async def search_indexed_documents(
     In EE mode, the dedicated search endpoint is used instead.
 
     To find a list of available sources, use the `indexed_sources` resource.
+    `document_set_names` restricts results to documents belonging to the named
+    Document Sets — useful for scoping queries to a curated subset of the
+    knowledge base (e.g. to isolate knowledge between agents). Use the
+    `document_sets` resource to discover accessible set names.
     Returns chunks of text as search results with snippets, scores, and metadata.
 
     Example usage:
@@ -60,14 +106,22 @@ async def search_indexed_documents(
     {
         "query": "What is the latest status of PROJ-1234 and what is the next development item?",
         "source_types": ["jira", "google_drive", "github"],
+        "document_set_names": ["Engineering Wiki"],
         "time_cutoff": "2025-11-24T00:00:00Z",
         "limit": 10,
     }
     ```
     """
     logger.info(
-        f"Onyx MCP Server: document search: query='{query}', sources={source_types}, limit={limit}"
+        f"Onyx MCP Server: document search: query='{query}', sources={source_types}, "
+        f"document_sets={document_set_names}, limit={limit}"
     )
+
+    # Normalize empty list inputs to None so downstream filter construction is
+    # consistent — BaseFilters treats [] as "match zero" which differs from
+    # "no filter" (None).
+    source_types = source_types or None
+    document_set_names = document_set_names or None
 
     # Parse time_cutoff string to datetime if provided
     time_cutoff_dt: datetime | None = None
@@ -80,9 +134,6 @@ async def search_indexed_documents(
             )
             # Continue with no time_cutoff instead of returning an error
             time_cutoff_dt = None
-
-    # Initialize source_type_enums early to avoid UnboundLocalError
-    source_type_enums: list[DocumentSource] | None = None
 
     # Get authenticated user from FastMCP's access token
     access_token = require_access_token()
@@ -117,6 +168,7 @@ async def search_indexed_documents(
 
     # Convert source_types strings to DocumentSource enums if provided
     # Invalid values will be handled by the API server
+    source_type_enums: list[DocumentSource] | None = None
     if source_types is not None:
         source_type_enums = []
         for src in source_types:
@@ -127,83 +179,73 @@ async def search_indexed_documents(
                     f"Onyx MCP Server: Invalid source type '{src}' - will be ignored by server"
                 )
 
-    # Build filters dict only with non-None values
-    filters: dict[str, Any] | None = None
-    if source_type_enums or time_cutoff_dt:
-        filters = {}
-        if source_type_enums:
-            filters["source_type"] = [src.value for src in source_type_enums]
-        if time_cutoff_dt:
-            filters["time_cutoff"] = time_cutoff_dt.isoformat()
+    filters: BaseFilters | None = None
+    if source_type_enums or document_set_names or time_cutoff_dt:
+        filters = BaseFilters(
+            source_type=source_type_enums,
+            document_set=document_set_names,
+            time_cutoff=time_cutoff_dt,
+        )
 
-    is_ee = global_version.is_ee_version()
     base_url = build_api_server_url_for_http_requests(respect_env_override_if_set=True)
-    auth_headers = {"Authorization": f"Bearer {access_token.token}"}
+    is_ee = global_version.is_ee_version()
 
-    search_request: dict[str, Any]
+    request: SendSearchQueryRequest | SendMessageRequest
     if is_ee:
         # EE: use the dedicated search endpoint (no LLM invocation)
-        search_request = {
-            "search_query": query,
-            "filters": filters,
-            "num_docs_fed_to_llm_selection": limit,
-            "run_query_expansion": False,
-            "include_content": True,
-            "stream": False,
-        }
+        request = SendSearchQueryRequest(
+            search_query=query,
+            filters=filters,
+            num_docs_fed_to_llm_selection=limit,
+            run_query_expansion=False,
+            include_content=True,
+            stream=False,
+        )
         endpoint = f"{base_url}/search/send-search-message"
-        error_key = "error"
-        docs_key = "search_docs"
-        content_field = "content"
     else:
         # CE: fall back to the chat endpoint (invokes LLM, consumes tokens)
-        search_request = {
-            "message": query,
-            "stream": False,
-            "chat_session_info": {},
-        }
-        if filters:
-            search_request["internal_search_filters"] = filters
+        request = SendMessageRequest(
+            message=query,
+            stream=False,
+            chat_session_info=ChatSessionCreationRequest(),
+            internal_search_filters=filters,
+        )
         endpoint = f"{base_url}/chat/send-chat-message"
-        error_key = "error_msg"
-        docs_key = "top_documents"
-        content_field = "blurb"
 
     try:
-        response = await get_http_client().post(
-            endpoint,
-            json=search_request,
-            headers=auth_headers,
-        )
+        response = await _post_model(endpoint, request, access_token)
         if not response.is_success:
-            error_detail = _extract_error_detail(response)
             return {
                 "documents": [],
                 "total_results": 0,
                 "query": query,
-                "error": error_detail,
-            }
-        result = response.json()
-
-        # Check for error in response
-        if result.get(error_key):
-            return {
-                "documents": [],
-                "total_results": 0,
-                "query": query,
-                "error": result.get(error_key),
+                "error": _extract_error_detail(response),
             }
 
-        documents = [
-            {
-                "semantic_identifier": doc.get("semantic_identifier"),
-                "content": doc.get(content_field),
-                "source_type": doc.get("source_type"),
-                "link": doc.get("link"),
-                "score": doc.get("score"),
-            }
-            for doc in result.get(docs_key, [])
-        ]
+        if is_ee:
+            ee_payload = SearchFullResponse.model_validate_json(response.content)
+            if ee_payload.error:
+                return {
+                    "documents": [],
+                    "total_results": 0,
+                    "query": query,
+                    "error": ee_payload.error,
+                }
+            documents = [
+                _project_doc(doc, doc.content) for doc in ee_payload.search_docs
+            ]
+        else:
+            ce_payload = ChatFullResponse.model_validate_json(response.content)
+            if ce_payload.error_msg:
+                return {
+                    "documents": [],
+                    "total_results": 0,
+                    "query": query,
+                    "error": ce_payload.error_msg,
+                }
+            documents = [
+                _project_doc(doc, doc.blurb) for doc in ce_payload.top_documents
+            ]
 
         # NOTE: search depth is controlled by the backend persona defaults, not `limit`.
         # `limit` only caps the returned list; fewer results may be returned if the
@@ -252,23 +294,20 @@ async def search_web(
     access_token = require_access_token()
 
     try:
-        request_payload = {"queries": [query], "max_results": limit}
-        response = await get_http_client().post(
+        response = await _post_model(
             f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/web-search/search-lite",
-            json=request_payload,
-            headers={"Authorization": f"Bearer {access_token.token}"},
+            WebSearchToolRequest(queries=[query], max_results=limit),
+            access_token,
         )
         if not response.is_success:
-            error_detail = _extract_error_detail(response)
             return {
-                "error": error_detail,
+                "error": _extract_error_detail(response),
                 "results": [],
                 "query": query,
             }
-        response_payload = response.json()
-        results = response_payload.get("results", [])
+        payload = WebSearchToolResponse.model_validate_json(response.content)
         return {
-            "results": results,
+            "results": [result.model_dump(mode="json") for result in payload.results],
             "query": query,
         }
     except Exception as e:
@@ -305,21 +344,19 @@ async def open_urls(
     access_token = require_access_token()
 
     try:
-        response = await get_http_client().post(
+        response = await _post_model(
             f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/web-search/open-urls",
-            json={"urls": urls},
-            headers={"Authorization": f"Bearer {access_token.token}"},
+            OpenUrlsToolRequest(urls=urls),
+            access_token,
         )
         if not response.is_success:
-            error_detail = _extract_error_detail(response)
             return {
-                "error": error_detail,
+                "error": _extract_error_detail(response),
                 "results": [],
             }
-        response_payload = response.json()
-        results = response_payload.get("results", [])
+        payload = OpenUrlsToolResponse.model_validate_json(response.content)
         return {
-            "results": results,
+            "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as e:
         logger.error(f"Onyx MCP Server: URL fetch error: {e}", exc_info=True)

--- a/backend/onyx/mcp_server/utils.py
+++ b/backend/onyx/mcp_server/utils.py
@@ -5,9 +5,23 @@ from __future__ import annotations
 import httpx
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.dependencies import get_access_token
+from pydantic import BaseModel
+from pydantic import TypeAdapter
 
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
+
+
+class DocumentSetEntry(BaseModel):
+    """Minimal document-set shape surfaced to MCP clients.
+
+    Projected from the backend's DocumentSetSummary to avoid coupling MCP to
+    admin-only fields (cc-pair summaries, federated connectors, etc.).
+    """
+
+    name: str
+    description: str | None = None
+
 
 logger = setup_logger()
 
@@ -84,3 +98,32 @@ async def get_indexed_sources(
             exc_info=True,
         )
         raise RuntimeError(f"Failed to fetch indexed sources: {exc}") from exc
+
+
+_DOCUMENT_SET_ENTRIES_ADAPTER = TypeAdapter(list[DocumentSetEntry])
+
+
+async def get_accessible_document_sets(
+    access_token: AccessToken,
+) -> list[DocumentSetEntry]:
+    """Fetch document sets accessible to the current user."""
+    headers = {"Authorization": f"Bearer {access_token.token}"}
+    try:
+        response = await get_http_client().get(
+            f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/manage/document-set",
+            headers=headers,
+        )
+        response.raise_for_status()
+        return _DOCUMENT_SET_ENTRIES_ADAPTER.validate_json(response.content)
+    except (httpx.HTTPStatusError, httpx.RequestError, ValueError):
+        logger.error(
+            "Onyx MCP Server: Failed to fetch document sets",
+            exc_info=True,
+        )
+        raise
+    except Exception as exc:
+        logger.error(
+            "Onyx MCP Server: Unexpected error fetching document sets",
+            exc_info=True,
+        )
+        raise RuntimeError(f"Failed to fetch document sets: {exc}") from exc

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -303,7 +303,7 @@ def test_mcp_search_filters_by_document_set(
     resource_uris = {str(resource.uri) for resource in resources_result.resources}
     assert DOCUMENT_SETS_RESOURCE_URI in resource_uris
     doc_sets_payload = json.loads(doc_sets_contents.contents[0].text)
-    exposed_names = {entry["name"] for entry in doc_sets_payload["document_sets"]}
+    exposed_names = {entry["name"] for entry in doc_sets_payload}
     assert doc_set.name in exposed_names
 
     # Without the filter both documents are visible.

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -16,12 +16,14 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import CallToolResult
 from mcp.types import TextContent
+from pydantic import AnyUrl
 
 from onyx.db.enums import AccessType
 from tests.integration.common_utils.constants import MCP_SERVER_URL
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document_set import DocumentSetManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.managers.user import UserManager
@@ -34,6 +36,7 @@ from tests.integration.common_utils.test_models import DATestUser
 # Constants
 MCP_SEARCH_TOOL = "search_indexed_documents"
 INDEXED_SOURCES_RESOURCE_URI = "resource://indexed_sources"
+DOCUMENT_SETS_RESOURCE_URI = "resource://document_sets"
 DEFAULT_SEARCH_LIMIT = 5
 STREAMABLE_HTTP_URL = f"{MCP_SERVER_URL.rstrip('/')}/?transportType=streamable-http"
 
@@ -73,19 +76,22 @@ def _extract_tool_payload(result: CallToolResult) -> dict[str, Any]:
 
 
 def _call_search_tool(
-    headers: dict[str, str], query: str, limit: int = DEFAULT_SEARCH_LIMIT
+    headers: dict[str, str],
+    query: str,
+    limit: int = DEFAULT_SEARCH_LIMIT,
+    document_set_names: list[str] | None = None,
 ) -> CallToolResult:
     """Call the search_indexed_documents tool via MCP."""
 
     async def _action(session: ClientSession) -> CallToolResult:
         await session.initialize()
-        return await session.call_tool(
-            MCP_SEARCH_TOOL,
-            {
-                "query": query,
-                "limit": limit,
-            },
-        )
+        arguments: dict[str, Any] = {
+            "query": query,
+            "limit": limit,
+        }
+        if document_set_names is not None:
+            arguments["document_set_names"] = document_set_names
+        return await session.call_tool(MCP_SEARCH_TOOL, arguments)
 
     return _run_with_mcp_session(headers, _action)
 
@@ -238,3 +244,106 @@ def test_mcp_search_respects_acl_filters(
     blocked_payload = _extract_tool_payload(blocked_result)
     assert blocked_payload["total_results"] == 0
     assert blocked_payload["documents"] == []
+
+
+def test_mcp_search_filters_by_document_set(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+) -> None:
+    """Passing document_set_names should scope results to the named set."""
+    LLMProviderManager.create(user_performing_action=admin_user)
+
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    cc_pair_in_set = CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+    )
+    cc_pair_out_of_set = CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+    )
+
+    shared_phrase = "document-set-filter-shared-phrase"
+    in_set_content = f"{shared_phrase} inside curated set"
+    out_of_set_content = f"{shared_phrase} outside curated set"
+
+    _seed_document_and_wait_for_indexing(
+        cc_pair=cc_pair_in_set,
+        content=in_set_content,
+        api_key=api_key,
+        user_performing_action=admin_user,
+    )
+    _seed_document_and_wait_for_indexing(
+        cc_pair=cc_pair_out_of_set,
+        content=out_of_set_content,
+        api_key=api_key,
+        user_performing_action=admin_user,
+    )
+
+    doc_set = DocumentSetManager.create(
+        cc_pair_ids=[cc_pair_in_set.id],
+        user_performing_action=admin_user,
+    )
+    DocumentSetManager.wait_for_sync(
+        user_performing_action=admin_user,
+        document_sets_to_check=[doc_set],
+    )
+
+    headers = _auth_headers(admin_user, name="mcp-doc-set-filter")
+
+    # The document_sets resource should surface the newly created set so MCP
+    # clients can discover which values to pass to document_set_names.
+    async def _list_resources(session: ClientSession) -> Any:
+        await session.initialize()
+        resources = await session.list_resources()
+        contents = await session.read_resource(AnyUrl(DOCUMENT_SETS_RESOURCE_URI))
+        return resources, contents
+
+    resources_result, doc_sets_contents = _run_with_mcp_session(
+        headers, _list_resources
+    )
+    resource_uris = {str(resource.uri) for resource in resources_result.resources}
+    assert DOCUMENT_SETS_RESOURCE_URI in resource_uris
+    doc_sets_payload = json.loads(doc_sets_contents.contents[0].text)
+    exposed_names = {entry["name"] for entry in doc_sets_payload["document_sets"]}
+    assert doc_set.name in exposed_names
+
+    # Without the filter both documents are visible.
+    unfiltered_payload = _extract_tool_payload(
+        _call_search_tool(headers, shared_phrase, limit=10)
+    )
+    unfiltered_contents = [
+        doc.get("content") or "" for doc in unfiltered_payload["documents"]
+    ]
+    assert any(in_set_content in content for content in unfiltered_contents)
+    assert any(out_of_set_content in content for content in unfiltered_contents)
+
+    # With the document set filter only the in-set document is returned.
+    filtered_payload = _extract_tool_payload(
+        _call_search_tool(
+            headers,
+            shared_phrase,
+            limit=10,
+            document_set_names=[doc_set.name],
+        )
+    )
+    filtered_contents = [
+        doc.get("content") or "" for doc in filtered_payload["documents"]
+    ]
+    assert filtered_payload["total_results"] >= 1
+    assert any(in_set_content in content for content in filtered_contents)
+    assert all(out_of_set_content not in content for content in filtered_contents)
+
+    # An empty document_set_names should behave like "no filter" (normalized
+    # to None), not "match zero sets".
+    empty_list_payload = _extract_tool_payload(
+        _call_search_tool(
+            headers,
+            shared_phrase,
+            limit=10,
+            document_set_names=[],
+        )
+    )
+    empty_list_contents = [
+        doc.get("content") or "" for doc in empty_list_payload["documents"]
+    ]
+    assert any(in_set_content in content for content in empty_list_contents)
+    assert any(out_of_set_content in content for content in empty_list_contents)


### PR DESCRIPTION
## Description

Adds Document Set filtering to the MCP search tool and cleans up the MCP server's request/response plumbing along the way.

### New

- **`document_set_names` filter** on `search_indexed_documents` — scopes
  searches to named Document Sets, useful for multi-agent knowledge isolation.
- **`resource://document_sets`** — MCP resource clients read to discover
  accessible set names. Mirrors the existing `indexed_sources` pattern.

### Refactors

- **Typed requests/responses.** Replaced `dict[str, Any]` request bodies with
  the actual backend Pydantic models (`SendSearchQueryRequest`,
  `SendMessageRequest`, `BaseFilters`, `WebSearchToolRequest`,
  `OpenUrlsToolRequest`). Uses `_post_model` helper with
  `model_dump_json(exclude_unset=True)` +
  `Model.model_validate_json(response.content)` — no dict round-trips. Schema
  drift against the backend now fails loud at import/validation time.
- **CE/EE module boundary preserved.** EE model imports are function-local in the `if is_ee:` branch; no
  top-level `ee.*` imports in CE code.

### Fixes

- **`is_ee` always False under `uvicorn onyx.mcp_server.api:mcp_app`.**
  `set_is_ee_based_on_env_variable()` lived in `mcp_server_main.main()`, which
  uvicorn bypasses. Moved to module-import time in `mcp_server/api.py`.
- **Resources broken since fastmcp 3.0.2 → 3.2.0 bump (#9814).** 3.2+ rejects
  dict returns; resources now `json.dumps` an array. Fixes both the new
  `document_sets` and the silently-broken `indexed_sources`.
- **CE search ReadTimeout.** Shared httpx client defaults to 60s; CE hits the
  LLM-backed chat endpoint. Per-call 300s override on CE only.
- **`CRAFT_FILE` leaking into indexed sources.** Added to
  `_INTERNAL_ONLY_SOURCES` in `fetch_unique_document_sources` alongside
  `INGESTION_API`. Also cleans it out of KG entity-type grounding.
- **`document_set_names=[]` inconsistent semantics.** Normalized `[] → None` at
  tool entry (same for `source_types`).

### Tests

- Extended `test_mcp_server_search.py` with `test_mcp_search_filters_by_document_set`:
  seeds two cc-pairs sharing a phrase, puts one in a doc set, verifies (a) the
  `document_sets` resource surfaces the set, (b) filtering returns only the
  in-set doc, (c) `document_set_names=[]` behaves like "no filter".


Fixes https://github.com/onyx-dot-app/onyx/issues/10104

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add document set scoping to the MCP server so searches can be limited to named sets. Adds `resource://document_sets` and extends `search_indexed_documents` with a `document_set_names` filter to scope results to curated sets.

- **New Features**
  - Added `resource://document_sets` to list Document Sets accessible to the user; use returned `name` values with `document_set_names`.
  - Extended `search_indexed_documents` to accept `document_set_names`; empty lists are normalized to no filter.
  - Unified EE/CE handling and document projection; EE uses `SendSearchQueryRequest` with content included, CE passes `internal_search_filters`.
  - Integration tests cover resource discovery, set-based filtering, and empty-list behavior.

- **Bug Fixes**
  - Returned resource payloads as JSON strings for FastMCP 3.2 compatibility; `resource://indexed_sources` now returns a JSON array.
  - Initialized EE/CE mode at import so dev entry points behave correctly; increased CE search timeout to 300s.
  - Excluded internal-only connector sources (`INGESTION_API`, `CRAFT_FILE`) from source listings.
  - Lazy-loaded EE imports in tools to avoid CE import errors when EE code is not present.

<sup>Written for commit 3ee0db70eb071f70f5fcb6ad339f83767705f32d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

