### PR TITLE
fix: zuplip temp dir init

### DIFF
--- a/backend/onyx/connectors/zulip/connector.py
+++ b/backend/onyx/connectors/zulip/connector.py
@@ -81,9 +81,7 @@ class ZulipConnector(LoadConnector, PollConnector):
         # zuliprc file. This reverts them back to newlines.
         contents_spaces_to_newlines = contents.replace(" ", "\n")
         # create a temporary zuliprc file
-        tempdir = tempfile.tempdir
-        if tempdir is None:
-            raise Exception("Could not determine tempfile directory")
+        tempdir = tempfile.gettempdir()
         config_file = os.path.join(tempdir, f"zuliprc-{self.realm_name}")
         with open(config_file, "w") as f:
             f.write(contents_spaces_to_newlines)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Zulip connector temp directory resolution by using `tempfile.gettempdir()` instead of `tempfile.tempdir`. This reliably creates the temporary `zuliprc` file and prevents credential loading from failing when the global tempdir is unset.

<sup>Written for commit ee0d645129bbf0a218c373caaa79e648c3fc0e06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

