### PR TITLE
fix(pruning): Fix SharePoint sp_tenant_domain not resolved for client secret auth with site pages

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1958,8 +1958,7 @@ class SharepointConnector(
         self._graph_client = GraphClient(
             _acquire_token_for_graph, environment=self._azure_environment
         )
-        if self.include_site_pages:
-            self.sp_tenant_domain = self._resolve_tenant_domain()
+        self.sp_tenant_domain = self._resolve_tenant_domain()
         return None
 
     def _get_drive_names_for_site(self, site_url: str) -> list[str]:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1958,7 +1958,7 @@ class SharepointConnector(
         self._graph_client = GraphClient(
             _acquire_token_for_graph, environment=self._azure_environment
         )
-        if auth_method == SharepointAuthMethod.CERTIFICATE.value:
+        if self.include_site_pages:
             self.sp_tenant_domain = self._resolve_tenant_domain()
         return None
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
@@ -33,13 +33,11 @@ def _make_mock_msal() -> MagicMock:
     return mock_app
 
 
-@patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
 @patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
 @patch("onyx.connectors.sharepoint.connector.GraphClient")
 def test_client_secret_with_site_pages_sets_tenant_domain(
     _mock_graph_client: MagicMock,
     mock_msal_cls: MagicMock,
-    _mock_load_cert: MagicMock,
 ) -> None:
     """client_secret auth + include_site_pages=True must resolve sp_tenant_domain."""
     mock_msal_cls.return_value = _make_mock_msal()
@@ -52,17 +50,18 @@ def test_client_secret_with_site_pages_sets_tenant_domain(
 
 @patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
 @patch("onyx.connectors.sharepoint.connector.GraphClient")
-def test_client_secret_without_site_pages_leaves_tenant_domain_none(
+def test_client_secret_without_site_pages_still_sets_tenant_domain(
     _mock_graph_client: MagicMock,
     mock_msal_cls: MagicMock,
 ) -> None:
-    """client_secret auth + include_site_pages=False must leave sp_tenant_domain as None."""
+    """client_secret auth + include_site_pages=False must still resolve sp_tenant_domain
+    because _create_rest_client_context is also called for drive items."""
     mock_msal_cls.return_value = _make_mock_msal()
     connector = SharepointConnector(sites=[SITE_URL], include_site_pages=False)
 
     connector.load_credentials(CLIENT_SECRET_CREDS)
 
-    assert connector.sp_tenant_domain is None
+    assert connector.sp_tenant_domain == EXPECTED_TENANT_DOMAIN
 
 
 @patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
@@ -73,10 +72,29 @@ def test_certificate_with_site_pages_sets_tenant_domain(
     mock_msal_cls: MagicMock,
     mock_load_cert: MagicMock,
 ) -> None:
-    """certificate auth + include_site_pages=True must still resolve sp_tenant_domain."""
+    """certificate auth + include_site_pages=True must resolve sp_tenant_domain."""
     mock_msal_cls.return_value = _make_mock_msal()
     mock_load_cert.return_value = MagicMock()
     connector = SharepointConnector(sites=[SITE_URL], include_site_pages=True)
+
+    connector.load_credentials(CERTIFICATE_CREDS)
+
+    assert connector.sp_tenant_domain == EXPECTED_TENANT_DOMAIN
+
+
+@patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+def test_certificate_without_site_pages_sets_tenant_domain(
+    _mock_graph_client: MagicMock,
+    mock_msal_cls: MagicMock,
+    mock_load_cert: MagicMock,
+) -> None:
+    """certificate auth + include_site_pages=False must still resolve sp_tenant_domain
+    because _create_rest_client_context is also called for drive items."""
+    mock_msal_cls.return_value = _make_mock_msal()
+    mock_load_cert.return_value = MagicMock()
+    connector = SharepointConnector(sites=[SITE_URL], include_site_pages=False)
 
     connector.load_credentials(CERTIFICATE_CREDS)
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_load_credentials.py
@@ -1,0 +1,83 @@
+"""Unit tests for SharepointConnector.load_credentials sp_tenant_domain resolution."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.sharepoint.connector import SharepointConnector
+
+SITE_URL = "https://mytenant.sharepoint.com/sites/MySite"
+EXPECTED_TENANT_DOMAIN = "mytenant"
+
+CLIENT_SECRET_CREDS = {
+    "authentication_method": "client_secret",
+    "sp_client_id": "fake-client-id",
+    "sp_client_secret": "fake-client-secret",
+    "sp_directory_id": "fake-directory-id",
+}
+
+CERTIFICATE_CREDS = {
+    "authentication_method": "certificate",
+    "sp_client_id": "fake-client-id",
+    "sp_directory_id": "fake-directory-id",
+    "sp_private_key": base64.b64encode(b"fake-pfx-data").decode(),
+    "sp_certificate_password": "fake-password",
+}
+
+
+def _make_mock_msal() -> MagicMock:
+    mock_app = MagicMock()
+    mock_app.acquire_token_for_client.return_value = {"access_token": "fake-token"}
+    return mock_app
+
+
+@patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+def test_client_secret_with_site_pages_sets_tenant_domain(
+    _mock_graph_client: MagicMock,
+    mock_msal_cls: MagicMock,
+    _mock_load_cert: MagicMock,
+) -> None:
+    """client_secret auth + include_site_pages=True must resolve sp_tenant_domain."""
+    mock_msal_cls.return_value = _make_mock_msal()
+    connector = SharepointConnector(sites=[SITE_URL], include_site_pages=True)
+
+    connector.load_credentials(CLIENT_SECRET_CREDS)
+
+    assert connector.sp_tenant_domain == EXPECTED_TENANT_DOMAIN
+
+
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+def test_client_secret_without_site_pages_leaves_tenant_domain_none(
+    _mock_graph_client: MagicMock,
+    mock_msal_cls: MagicMock,
+) -> None:
+    """client_secret auth + include_site_pages=False must leave sp_tenant_domain as None."""
+    mock_msal_cls.return_value = _make_mock_msal()
+    connector = SharepointConnector(sites=[SITE_URL], include_site_pages=False)
+
+    connector.load_credentials(CLIENT_SECRET_CREDS)
+
+    assert connector.sp_tenant_domain is None
+
+
+@patch("onyx.connectors.sharepoint.connector.load_certificate_from_pfx")
+@patch("onyx.connectors.sharepoint.connector.msal.ConfidentialClientApplication")
+@patch("onyx.connectors.sharepoint.connector.GraphClient")
+def test_certificate_with_site_pages_sets_tenant_domain(
+    _mock_graph_client: MagicMock,
+    mock_msal_cls: MagicMock,
+    mock_load_cert: MagicMock,
+) -> None:
+    """certificate auth + include_site_pages=True must still resolve sp_tenant_domain."""
+    mock_msal_cls.return_value = _make_mock_msal()
+    mock_load_cert.return_value = MagicMock()
+    connector = SharepointConnector(sites=[SITE_URL], include_site_pages=True)
+
+    connector.load_credentials(CERTIFICATE_CREDS)
+
+    assert connector.sp_tenant_domain == EXPECTED_TENANT_DOMAIN


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
Summary ([more details](https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.w8kbivofmn8y#heading=h.28shhc53ta9z))
SharePoint connectors using client_secret authentication with include_site_pages: True were failing continuously with RuntimeError: MSAL app or tenant domain is not set. Three production connectors were affected.

sp_tenant_domain is required by the SharePoint REST API to construct the OAuth scope for site page indexing. In load_credentials(), the call to _resolve_tenant_domain() was gated behind if auth_method == CERTIFICATE, so it was never executed for client_secret connectors.

Fix
Replace the auth-method guard with an include_site_pages check — sp_tenant_domain is only needed when site pages are enabled, regardless of auth method:

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
<!--- Describe the tests you ran to verify your changes --->
No regression on existing tests,
Added test_load_credentials.py covering:

- client_secret + include_site_pages=True → domain resolved
- client_secret + include_site_pages=False → domain stays None
- certificate + include_site_pages=True → domain still resolved (regression)

no integration tests needed, the fix is a single conditional in load_credentials() and is fully covered by the unit tests.
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint connectors crashing with “MSAL app or tenant domain is not set” by always resolving the tenant domain in `load_credentials()`. Client secret and certificate auth now work for site pages and drive items (ENG-3954).

- **Bug Fixes**
  - In `load_credentials()`, always resolve `sp_tenant_domain` (no longer gated by auth method or `include_site_pages`).
  - Added unit tests for client_secret and certificate with/without site pages; indexing works again.

<sup>Written for commit e9270c81163cd6537aa7d86709c5885fc7cc8b5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



