### PR TITLE
fix(xlsx): Additional fixes for mime types

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -379,10 +379,20 @@ def _download_and_extract_sections_basic(
         mime_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         or is_tabular_file(file_name)
     ):
+        # Google Drive doesn't enforce file extensions, so the filename may not
+        # end in .xlsx even when the mime type says it's one. Synthesize the
+        # extension so tabular_file_to_sections dispatches correctly.
+        tabular_file_name = file_name
+        if (
+            mime_type
+            == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            and not is_tabular_file(file_name)
+        ):
+            tabular_file_name = f"{file_name}.xlsx"
         return list(
             tabular_file_to_sections(
                 io.BytesIO(response_call()),
-                file_name=file_name,
+                file_name=tabular_file_name,
                 link=link,
             )
         )

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -48,6 +48,7 @@ KNOWN_OPENPYXL_BUGS = [
     "File contains no valid workbook part",
     "Unable to read workbook: could not read stylesheet from None",
     "Colors must be aRGB hex values",
+    "Max value is",
 ]
 
 

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -1,6 +1,7 @@
 import io
 from typing import cast
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import openpyxl
 from openpyxl.worksheet.worksheet import Worksheet
@@ -319,6 +320,17 @@ class TestXlsxSheetExtraction:
         at debug (not warning) and still return []."""
         bad_file = io.BytesIO(b"not a zip file")
         sheets = xlsx_sheet_extraction(bad_file, file_name="~$temp.xlsx")
+        assert sheets == []
+
+    def test_known_openpyxl_bug_max_value_returns_empty(self) -> None:
+        """openpyxl's strict descriptor validation rejects font family
+        values >14 with 'Max value is 14'. Treat as a known openpyxl bug
+        and skip the file rather than fail the whole connector batch."""
+        with patch(
+            "onyx.file_processing.extract_file_text.openpyxl.load_workbook",
+            side_effect=ValueError("Max value is 14"),
+        ):
+            sheets = xlsx_sheet_extraction(io.BytesIO(b""), file_name="bad_font.xlsx")
         assert sheets == []
 
     def test_csv_content_matches_xlsx_to_text_per_sheet(self) -> None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Addressing some issues seen on the cloud. This happens when the mime type is xlsx but the file name does not contain the .xlsx extension. There is also another issue with openpyxl which is also captured with the string match

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added some new tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XLSX handling from Google Drive when the MIME type is XLSX but the file name lacks a `.xlsx` extension, and prevents connector failures on a known `openpyxl` validation error.

- **Bug Fixes**
  - Google Drive: when MIME is XLSX but the name lacks `.xlsx`, synthesize the extension before parsing so `tabular_file_to_sections` dispatches correctly.
  - Treat `openpyxl` “Max value is …” errors as known issues and skip the file (return empty) instead of failing the batch; added a unit test for “Max value is 14”.

<sup>Written for commit c6847446a4b647fdccaf9d5817b36846fce6be83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

