### PR TITLE
chore(gha): skip `ty` pre-commit in CI

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -39,6 +39,8 @@ jobs:
         working-directory: ./web
         run: npm ci
       - uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3
+        env:
+          SKIP: ty
         with:
           prek-version: '0.3.4'
           extra-args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || github.event_name == 'merge_group' && format('--from-ref {0} --to-ref {1}', github.event.merge_group.base_sha, github.event.merge_group.head_sha) || github.ref_name == 'main' && '--all-files' || '' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$
       - id: uv-run
+        alias: ty
         name: ty
         args: ["ty", "check"]
         pass_filenames: true


### PR DESCRIPTION
## Description

This is making the pre-commit job take a long time because it requires fetching all python packages which is made even worse since caching is not configured with this step. Therefore skip the test since it is sufficiently covered by the `pr-python-checks.yml` job.

## How Has This Been Tested?

Will confirm it is skipped on this presubmit

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the `ty` pre-commit hook in CI to speed up the pre-commit job. The Python type check still runs in `pr-python-checks.yml`, so coverage is unchanged.

- **Refactors**
  - Set `SKIP: ty` for `j178/prek-action` in `pr-quality-checks.yml`.
  - Added `alias: ty` to the `uv-run` pre-commit hook to allow skipping.

<sup>Written for commit 22e49fbc67117e63d48533ce0d94170b4adb59d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

