### PR TITLE
refactor: replace raw `Card`+`Content` message patterns with `@opal/components.MessageCard`

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1091,7 +1091,6 @@ export default function ChatPreferencesPage() {
                     </Text>
                   </Section>
                   <MessageCard
-                    variant="warning"
                     title="Modify with caution."
                     description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
                   />

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -21,7 +21,6 @@ import {
   SvgExpand,
   SvgFold,
   SvgExternalLink,
-  SvgAlertCircle,
   SvgRefreshCw,
 } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -49,7 +48,7 @@ import {
   PYTHON_TOOL_ID,
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
-import { Button, Divider, Text, Card } from "@opal/components";
+import { Button, Divider, Text, Card, MessageCard } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
 import Switch from "@/refresh-components/inputs/Switch";
 import useMcpServersForAgentEditor from "@/hooks/useMcpServersForAgentEditor";
@@ -1091,14 +1090,11 @@ export default function ChatPreferencesPage() {
                       )}
                     </Text>
                   </Section>
-                  <Card background="none" border="solid" padding="sm">
-                    <Content
-                      sizePreset="main-ui"
-                      icon={SvgAlertCircle}
-                      title="Modify with caution."
-                      description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
-                    />
-                  </Card>
+                  <MessageCard
+                    variant="warning"
+                    title="Modify with caution."
+                    description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
+                  />
                 </Modal.Body>
                 <Modal.Footer>
                   <Button

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1093,6 +1093,7 @@ export default function ChatPreferencesPage() {
                   <MessageCard
                     title="Modify with caution."
                     description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
+                    padding="xs"
                   />
                 </Modal.Body>
                 <Modal.Footer>

--- a/web/src/sections/modals/llmConfig/BedrockModal.tsx
+++ b/web/src/sections/modals/llmConfig/BedrockModal.tsx
@@ -28,15 +28,9 @@ import {
   ModalWrapper,
 } from "@/sections/modals/llmConfig/shared";
 import { fetchBedrockModels } from "@/lib/llmConfig/svc";
-import { Card } from "@opal/components";
+import { Card, MessageCard } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
-import { SvgAlertCircle } from "@opal/icons";
-import {
-  Content,
-  InputDivider,
-  InputPadder,
-  InputVertical,
-} from "@opal/layouts";
+import { InputDivider, InputPadder, InputVertical } from "@opal/layouts";
 import { toast } from "@/hooks/useToast";
 import { refreshLlmProviderCaches } from "@/lib/llmConfig/cache";
 
@@ -218,14 +212,10 @@ function BedrockModalInternals({
 
       {authMethod === AUTH_METHOD_IAM && (
         <InputPadder>
-          <Card background="none" border="solid" padding="sm">
-            <Content
-              icon={SvgAlertCircle}
-              title="Onyx will use the IAM role attached to the environment it’s running in to authenticate."
-              variant="body"
-              sizePreset="main-ui"
-            />
-          </Card>
+          <MessageCard
+            variant="info"
+            title="Onyx will use the IAM role attached to the environment it’s running in to authenticate."
+          />
         </InputPadder>
       )}
 


### PR DESCRIPTION
## Description

Migrate two instances where `Card` wraps a bare `Content` (icon + title + description, no interactivity) to use the semantic `MessageCard` component instead:

- **ChatPreferencesPage** (system prompt modal): "Modify with caution." → `MessageCard variant="warning"`
- **BedrockModal** (IAM auth info): IAM role message → `MessageCard variant="info"`

Cleaned up unused `SvgAlertCircle` imports from both files.

## Screenshots + Videos

### Bedrock Modal

<img width="892" height="849" alt="image" src="https://github.com/user-attachments/assets/e30708ae-951f-4f45-a3a0-af5d51ebd9a8" />

### Chat Preferences Page

<img width="1020" height="877" alt="image" src="https://github.com/user-attachments/assets/f981797f-5551-4228-9bf7-d4772a09c83d" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw `Card` + `Content` blocks with `@opal/components.MessageCard` to standardize UI and simplify markup. ChatPreferencesPage now uses the default MessageCard (no warning variant) with tighter padding (`padding="xs"`) for the system prompt notice, and BedrockModal uses an info MessageCard for IAM auth; removed unused icon imports.

<sup>Written for commit 4e4d3724543af3b0e20766515ab08e123b03ea5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

