### PR TITLE
fix(redis): update_sync_record_status cleanup

### DIFF
--- a/backend/onyx/db/sync_record.py
+++ b/backend/onyx/db/sync_record.py
@@ -129,9 +129,13 @@ def update_sync_record_status(
     """
     sync_record = fetch_latest_sync_record(db_session, entity_id, sync_type)
     if sync_record is None:
-        raise ValueError(
-            f"No sync record found for entity_id={entity_id} sync_type={sync_type}"
+        logger.warning(
+            f"No sync record found for entity_id={entity_id} "
+            f"sync_type={sync_type} — skipping status update. "
+            f"This typically means the record was never created "
+            f"(insert_sync_record failed silently) or was cleaned up."
         )
+        return
 
     sync_record.sync_status = sync_status
     if num_docs_synced is not None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Currently we are getting into a crash-loop pattern in which we:

1. `insert_sync_record` fails silently 
2. Tasks complete
3. `monitor_*_taskset` calls `update_sync_record_status` which crashes
4. Fence never gets cleaned up
5. Repeats forever

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Had to manually fix on the cloud to unblock one of the tenants

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash loops in `monitor_*_taskset` by making `update_sync_record_status` log a warning and return when no sync record exists. This avoids raising, unblocks fence cleanup, and keeps task monitoring running even if `insert_sync_record` failed or the record was cleaned up.

<sup>Written for commit 29a23c6ac2619b291bb9edb0435830e983c2343f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

