### PR TITLE
feat(opal): Update API for `LineItemButton`

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -5,8 +5,7 @@ import {
 } from "@opal/core";
 import type { ExtremaSizeVariants, DistributiveOmit } from "@opal/types";
 import { Tooltip, type TooltipSide } from "@opal/components";
-import type { ContentActionProps } from "@opal/layouts/content-action/components";
-import { ContentAction } from "@opal/layouts";
+import { type ContentActionProps, ContentAction } from "@opal/layouts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,13 +84,15 @@ function LineItemButton({
       <Interactive.Container
         type={type}
         widthVariant={width}
-        heightVariant="lg"
+        heightVariant="fit"
         roundingVariant={roundingVariant}
       >
-        <ContentAction
-          {...(contentActionProps as ContentActionProps)}
-          paddingVariant="fit"
-        />
+        <div className="w-full p-2">
+          <ContentAction
+            {...(contentActionProps as ContentActionProps)}
+            paddingVariant="fit"
+          />
+        </div>
       </Interactive.Container>
     </Interactive.Stateful>
   );

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -62,6 +62,17 @@ interface ContentBaseProps {
    */
   widthVariant?: ExtremaSizeVariants;
 
+  /**
+   * Opt out of the automatic interactive color override.
+   *
+   * When `Content` is nested inside an `.interactive` element, its title and
+   * icon colors are normally overridden by the interactive foreground palette.
+   * Set this to `true` to keep Content's own colors regardless of context.
+   *
+   * @default false
+   */
+  nonInteractive?: boolean;
+
   /** Ref forwarded to the root `<div>` of the resolved layout. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -127,6 +138,7 @@ function Content(props: ContentProps) {
     sizePreset = "headline",
     variant = "heading",
     widthVariant = "full",
+    nonInteractive,
     ref,
     ...rest
   } = props;
@@ -186,7 +198,14 @@ function Content(props: ContentProps) {
       `Content: no layout matched for sizePreset="${sizePreset}" variant="${variant}"`
     );
 
-  return <div className={widthVariants[widthVariant]}>{layout}</div>;
+  return (
+    <div
+      className={widthVariants[widthVariant]}
+      data-opal-non-interactive={nonInteractive || undefined}
+    >
+      {layout}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -352,36 +352,52 @@
    the title inherits color from the Interactive's `--interactive-foreground`
    and icons switch to `--interactive-foreground-icon`. This is automatic —
    no opt-in prop is required.
+
+   Opt-out: set `nonInteractive` on <Content> to add
+   `data-opal-non-interactive` to the wrapper div, which excludes
+   the element from these overrides via the `:not(…) >` selector.
    =========================================================================== */
 
-.interactive .opal-content-xl {
+.interactive :not([data-opal-non-interactive]) > .opal-content-xl {
   color: inherit;
 }
 
-.interactive .opal-content-xl .opal-content-xl-icon {
+.interactive
+  :not([data-opal-non-interactive])
+  > .opal-content-xl
+  .opal-content-xl-icon {
   color: var(--interactive-foreground-icon);
 }
 
-.interactive .opal-content-lg {
+.interactive :not([data-opal-non-interactive]) > .opal-content-lg {
   color: inherit;
 }
 
-.interactive .opal-content-lg .opal-content-lg-icon {
+.interactive
+  :not([data-opal-non-interactive])
+  > .opal-content-lg
+  .opal-content-lg-icon {
   color: var(--interactive-foreground-icon);
 }
 
-.interactive .opal-content-md {
+.interactive :not([data-opal-non-interactive]) > .opal-content-md {
   color: inherit;
 }
 
-.interactive .opal-content-md .opal-content-md-icon {
+.interactive
+  :not([data-opal-non-interactive])
+  > .opal-content-md
+  .opal-content-md-icon {
   color: var(--interactive-foreground-icon);
 }
 
-.interactive .opal-content-sm {
+.interactive :not([data-opal-non-interactive]) > .opal-content-sm {
   color: inherit;
 }
 
-.interactive .opal-content-sm .opal-content-sm-icon {
+.interactive
+  :not([data-opal-non-interactive])
+  > .opal-content-sm
+  .opal-content-sm-icon {
   color: var(--interactive-foreground-icon);
 }


### PR DESCRIPTION
## Description

- **Content**: Add `nonInteractive` boolean prop. When set, adds `data-opal-non-interactive` to the wrapper div, opting out of the automatic `.interactive` color overrides (title inheriting foreground, icon switching to foreground-icon).
- **Content CSS**: Update all `.interactive .opal-content-*` selectors to use `:not([data-opal-non-interactive]) >` child combinator so attributed elements keep their own colors.
- **LineItemButton**: Propagate `nonInteractive` to the internal Content component.
- **LineItemButton**: Update the internal padding to allow for better height adjustments.

## Screenshots + Videos

https://github.com/user-attachments/assets/1e42a715-5887-4ce5-9d94-5de6cdcba1f1

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `nonInteractive` prop to `Content` to opt out of interactive color overrides, and adjusts `LineItemButton` layout for correct padding and height in interactive states.

- **New Features**
  - `Content`: new `nonInteractive` prop adds `data-opal-non-interactive` to keep original title/icon colors inside `.interactive` parents.
  - CSS: `.interactive` selectors now use `:not([data-opal-non-interactive]) >` to avoid overriding opted-out elements.

- **Bug Fixes**
  - `LineItemButton`: set container height to `fit` and wrap `ContentAction` with `w-full p-2` for consistent spacing; forwards `nonInteractive` via `ContentAction`.

<sup>Written for commit a069adc0a5791c6aca338170b7c5572276c3fa2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->