### PR TITLE
refactor: update `ModelListContent` to use `LineItemButton`

### DIFF
--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -6,7 +6,6 @@ import { LlmDescriptor, LlmManager } from "@/lib/hooks";
 import { structureValue } from "@/lib/llmConfig/utils";
 import { getModelIcon } from "@/lib/llmConfig";
 import { AGGREGATOR_PROVIDERS } from "@/lib/llmConfig/svc";
-
 import { Slider } from "@/components/ui/slider";
 import { useUser } from "@/providers/UserProvider";
 import Text from "@/refresh-components/texts/Text";

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -187,21 +187,22 @@ export default function ModelListContent({
                                 title={group.displayName}
                                 padding="fit"
                                 rightChildren={
-                                  <div className="flex flex-col h-full justify-center">
+                                  <Section>
                                     <Button
                                       icon={(props) => (
                                         <SvgChevronRight
                                           {...props}
                                           className={cn(
-                                            "text-text-03 transition-all",
-                                            open && "rotate-90"
+                                            "transition-all",
+                                            open && "rotate-90",
+                                            props.className
                                           )}
                                         />
                                       )}
                                       prominence="tertiary"
                                       size="sm"
                                     />
-                                  </div>
+                                  </Section>
                                 }
                               />
                             </div>

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -3,8 +3,8 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import { PopoverMenu } from "@/refresh-components/Popover";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import { Text } from "@opal/components";
-import { SvgCheck, SvgChevronDown, SvgChevronRight } from "@opal/icons";
+import { LineItemButton, Text } from "@opal/components";
+import { SvgCheck, SvgChevronRight } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { LLMOption } from "./interfaces";
 import { buildLlmOptions, groupLlmOptions } from "./LLMPopover";
@@ -15,6 +15,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
+import { cn } from "@opal/utils";
 
 export interface ModelListContentProps {
   llmProviders: LLMProviderDescriptor[] | undefined;
@@ -114,20 +115,20 @@ export default function ModelListContent({
       capabilities.length > 0 ? capabilities.join(", ") : undefined;
 
     return (
-      <LineItem
+      <LineItemButton
         key={`${option.provider}:${option.modelName}`}
-        selected={selected}
-        disabled={disabled}
+        state={selected ? "selected" : "empty"}
+        title={option.displayName}
         description={description}
         onClick={() => onSelect(option)}
         rightChildren={
           selected ? (
-            <SvgCheck className="h-4 w-4 stroke-action-link-05 shrink-0" />
+            <SvgCheck className="text-action-link-05" size={16} />
           ) : null
         }
-      >
-        {option.displayName}
-      </LineItem>
+        sizePreset="main-ui"
+        roundingVariant="sm"
+      />
     );
   };
 
@@ -169,20 +170,26 @@ export default function ModelListContent({
                       onOpenChange={() => toggleGroup(group.key)}
                     >
                       <CollapsibleTrigger asChild>
-                        <LineItem
-                          muted
+                        <LineItemButton
+                          sizePreset="secondary"
+                          variant="body"
+                          prominence="muted"
                           icon={group.Icon}
-                          strokeIcon={false}
+                          title={group.displayName}
                           rightChildren={
-                            open ? (
-                              <SvgChevronDown className="h-4 w-4 stroke-text-04 shrink-0" />
-                            ) : (
-                              <SvgChevronRight className="h-4 w-4 stroke-text-04 shrink-0" />
-                            )
+                            <div className="flex flex-col h-full justify-center">
+                              <SvgChevronRight
+                                className={cn(
+                                  "text-text-04 transition-all",
+                                  open && "rotate-90"
+                                )}
+                                size={16}
+                              />
+                            </div>
                           }
-                        >
-                          {group.displayName}
-                        </LineItem>
+                          roundingVariant="sm"
+                          nonInteractive
+                        />
                       </CollapsibleTrigger>
 
                       <CollapsibleContent>

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -118,6 +118,7 @@ export default function ModelListContent({
     return (
       <LineItemButton
         key={`${option.provider}:${option.modelName}`}
+        selectVariant="select-heavy"
         state={selected ? "selected" : "empty"}
         icon={(props) => <div {...(props as any)} />}
         title={option.displayName}
@@ -159,7 +160,7 @@ export default function ModelListContent({
               ]
             : groupedOptions.length === 1
               ? [
-                  <Section key="single-provider" gap={0.25}>
+                  <Section key="single-provider" gap={1}>
                     {groupedOptions[0]!.options.map(renderModelItem)}
                   </Section>,
                 ]
@@ -170,6 +171,7 @@ export default function ModelListContent({
                       key={group.key}
                       open={open}
                       onOpenChange={() => toggleGroup(group.key)}
+                      className="flex flex-col gap-1"
                     >
                       <CollapsibleTrigger asChild>
                         <Interactive.Stateless prominence="tertiary">

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import { PopoverMenu } from "@/refresh-components/Popover";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import { LineItemButton, Text } from "@opal/components";
+import { Button, LineItemButton, Text } from "@opal/components";
 import { SvgCheck, SvgChevronRight } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { LLMOption } from "./interfaces";
@@ -15,6 +15,8 @@ import {
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
 import { cn } from "@opal/utils";
+import { Interactive } from "@opal/core";
+import { ContentAction } from "@opal/layouts";
 
 export interface ModelListContentProps {
   llmProviders: LLMProviderDescriptor[] | undefined;
@@ -117,6 +119,7 @@ export default function ModelListContent({
       <LineItemButton
         key={`${option.provider}:${option.modelName}`}
         state={selected ? "selected" : "empty"}
+        icon={(props) => <div {...(props as any)} />}
         title={option.displayName}
         description={description}
         onClick={() => onSelect(option)}
@@ -169,26 +172,41 @@ export default function ModelListContent({
                       onOpenChange={() => toggleGroup(group.key)}
                     >
                       <CollapsibleTrigger asChild>
-                        <LineItemButton
-                          sizePreset="secondary"
-                          variant="body"
-                          prominence="muted"
-                          icon={group.Icon}
-                          title={group.displayName}
-                          rightChildren={
-                            <div className="flex flex-col h-full justify-center">
-                              <SvgChevronRight
-                                className={cn(
-                                  "text-text-04 transition-all",
-                                  open && "rotate-90"
-                                )}
-                                size={16}
+                        <Interactive.Stateless prominence="tertiary">
+                          <Interactive.Container
+                            size="fit"
+                            rounding="sm"
+                            width="full"
+                          >
+                            <div className="pl-2 pr-1 py-1 w-full">
+                              <ContentAction
+                                sizePreset="secondary"
+                                variant="body"
+                                prominence="muted"
+                                icon={group.Icon}
+                                title={group.displayName}
+                                padding="fit"
+                                rightChildren={
+                                  <div className="flex flex-col h-full justify-center">
+                                    <Button
+                                      icon={(props) => (
+                                        <SvgChevronRight
+                                          {...props}
+                                          className={cn(
+                                            "text-text-03 transition-all",
+                                            open && "rotate-90"
+                                          )}
+                                        />
+                                      )}
+                                      prominence="tertiary"
+                                      size="sm"
+                                    />
+                                  </div>
+                                }
                               />
                             </div>
-                          }
-                          rounding="sm"
-                          nonInteractive
-                        />
+                          </Interactive.Container>
+                        </Interactive.Stateless>
                       </CollapsibleTrigger>
 
                       <CollapsibleContent>

--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -8,7 +8,6 @@ import { SvgCheck, SvgChevronRight } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { LLMOption } from "./interfaces";
 import { buildLlmOptions, groupLlmOptions } from "./LLMPopover";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { LLMProviderDescriptor } from "@/interfaces/llm";
 import {
   Collapsible,
@@ -127,7 +126,7 @@ export default function ModelListContent({
           ) : null
         }
         sizePreset="main-ui"
-        roundingVariant="sm"
+        rounding="sm"
       />
     );
   };
@@ -187,7 +186,7 @@ export default function ModelListContent({
                               />
                             </div>
                           }
-                          roundingVariant="sm"
+                          rounding="sm"
                           nonInteractive
                         />
                       </CollapsibleTrigger>

--- a/web/tests/e2e/chat/llm_ordering.spec.ts
+++ b/web/tests/e2e/chat/llm_ordering.spec.ts
@@ -51,14 +51,16 @@ test.describe("LLM Ordering", () => {
     await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
 
     const dialog = page.locator('[role="dialog"]');
-    const allModelItems = dialog.locator("[data-selected]");
+    const allModelItems = dialog.locator("[data-interactive-state]");
     await expect(allModelItems.first()).toBeVisible({ timeout: 5000 });
 
     const count = await allModelItems.count();
     expect(count).toBeGreaterThan(0);
 
     // Pick the first non-selected model so the trigger text changes after click
-    const nonSelectedItem = dialog.locator('[data-selected="false"]').first();
+    const nonSelectedItem = dialog
+      .locator('[data-interactive-state="empty"]')
+      .first();
     const hasNonSelected = (await nonSelectedItem.count()) > 0;
     const targetItem = hasNonSelected ? nonSelectedItem : allModelItems.first();
 

--- a/web/tests/e2e/chat/llm_runtime_selection.spec.ts
+++ b/web/tests/e2e/chat/llm_runtime_selection.spec.ts
@@ -412,10 +412,9 @@ test.describe("LLM Runtime Selection", () => {
 
     const sharedModelOptions = dialog.locator("[data-interactive-state]");
     await expect(sharedModelOptions).toHaveCount(2);
-    const openAiModelOption = dialog
-      .locator("[data-interactive-state]")
-      .filter({ hasText: /openai/i })
-      .first();
+    // Two results with the same model name under different providers.
+    // Groups are sorted alphabetically, so OpenAI (index 1) comes after Anthropic (index 0).
+    const openAiModelOption = sharedModelOptions.nth(1);
     await expect(openAiModelOption).toBeVisible();
     await openAiModelOption.click();
     await page.waitForSelector('[role="dialog"]', { state: "hidden" });
@@ -439,10 +438,8 @@ test.describe("LLM Runtime Selection", () => {
       "[data-interactive-state]"
     );
     await expect(secondSharedModelOptions).toHaveCount(2);
-    const anthropicModelOption = secondDialog
-      .locator("[data-interactive-state]")
-      .filter({ hasText: /anthropic/i })
-      .first();
+    // Anthropic is index 0 (alphabetically first).
+    const anthropicModelOption = secondSharedModelOptions.nth(0);
     await expect(anthropicModelOption).toBeVisible();
     await anthropicModelOption.click();
     await page.waitForSelector('[role="dialog"]', { state: "hidden" });
@@ -450,10 +447,11 @@ test.describe("LLM Runtime Selection", () => {
     await page.getByTestId("model-selector").locator("button").last().click();
     await page.waitForSelector('[role="dialog"]', { state: "visible" });
     const verifyDialog = page.locator('[role="dialog"]');
-    const selectedAnthropicOption = verifyDialog
-      .locator('[data-interactive-state="selected"]')
-      .filter({ hasText: /anthropic/i });
-    await expect(selectedAnthropicOption).toHaveCount(1);
+    // Verify the Anthropic option (index 0) is selected.
+    const selectedOption = verifyDialog.locator(
+      '[data-interactive-state="selected"]'
+    );
+    await expect(selectedOption).toHaveCount(1);
     await page.keyboard.press("Escape");
     await page.waitForSelector('[role="dialog"]', { state: "hidden" });
 

--- a/web/tests/e2e/chat/llm_runtime_selection.spec.ts
+++ b/web/tests/e2e/chat/llm_runtime_selection.spec.ts
@@ -413,9 +413,8 @@ test.describe("LLM Runtime Selection", () => {
     const sharedModelOptions = dialog.locator("[data-interactive-state]");
     await expect(sharedModelOptions).toHaveCount(2);
     const openAiModelOption = dialog
-      .getByRole("button", { name: /openai/i })
-      .locator("..")
       .locator("[data-interactive-state]")
+      .filter({ hasText: /openai/i })
       .first();
     await expect(openAiModelOption).toBeVisible();
     await openAiModelOption.click();
@@ -441,9 +440,8 @@ test.describe("LLM Runtime Selection", () => {
     );
     await expect(secondSharedModelOptions).toHaveCount(2);
     const anthropicModelOption = secondDialog
-      .getByRole("button", { name: /anthropic/i })
-      .locator("..")
       .locator("[data-interactive-state]")
+      .filter({ hasText: /anthropic/i })
       .first();
     await expect(anthropicModelOption).toBeVisible();
     await anthropicModelOption.click();
@@ -453,9 +451,8 @@ test.describe("LLM Runtime Selection", () => {
     await page.waitForSelector('[role="dialog"]', { state: "visible" });
     const verifyDialog = page.locator('[role="dialog"]');
     const selectedAnthropicOption = verifyDialog
-      .getByRole("button", { name: /anthropic/i })
-      .locator("..")
-      .locator('[data-interactive-state="selected"]');
+      .locator('[data-interactive-state="selected"]')
+      .filter({ hasText: /anthropic/i });
     await expect(selectedAnthropicOption).toHaveCount(1);
     await page.keyboard.press("Escape");
     await page.waitForSelector('[role="dialog"]', { state: "hidden" });

--- a/web/tests/e2e/chat/llm_runtime_selection.spec.ts
+++ b/web/tests/e2e/chat/llm_runtime_selection.spec.ts
@@ -300,11 +300,13 @@ test.describe("LLM Runtime Selection", () => {
 
     const regenerateDialog = page.locator('[role="dialog"]');
     const alternateModelOption = regenerateDialog
-      .locator('[data-selected="false"]')
+      .locator('[data-interactive-state="empty"]')
       .first();
 
     test.skip(
-      (await regenerateDialog.locator('[data-selected="false"]').count()) === 0,
+      (await regenerateDialog
+        .locator('[data-interactive-state="empty"]')
+        .count()) === 0,
       "Regenerate model picker requires at least two runtime model options"
     );
 
@@ -408,12 +410,12 @@ test.describe("LLM Runtime Selection", () => {
     const dialog = page.locator('[role="dialog"]');
     await dialog.getByPlaceholder("Search models...").fill(sharedModelName);
 
-    const sharedModelOptions = dialog.locator("[data-selected]");
+    const sharedModelOptions = dialog.locator("[data-interactive-state]");
     await expect(sharedModelOptions).toHaveCount(2);
     const openAiModelOption = dialog
       .getByRole("button", { name: /openai/i })
       .locator("..")
-      .locator("[data-selected]")
+      .locator("[data-interactive-state]")
       .first();
     await expect(openAiModelOption).toBeVisible();
     await openAiModelOption.click();
@@ -434,12 +436,14 @@ test.describe("LLM Runtime Selection", () => {
       .getByPlaceholder("Search models...")
       .fill(sharedModelName);
 
-    const secondSharedModelOptions = secondDialog.locator("[data-selected]");
+    const secondSharedModelOptions = secondDialog.locator(
+      "[data-interactive-state]"
+    );
     await expect(secondSharedModelOptions).toHaveCount(2);
     const anthropicModelOption = secondDialog
       .getByRole("button", { name: /anthropic/i })
       .locator("..")
-      .locator("[data-selected]")
+      .locator("[data-interactive-state]")
       .first();
     await expect(anthropicModelOption).toBeVisible();
     await anthropicModelOption.click();
@@ -451,7 +455,7 @@ test.describe("LLM Runtime Selection", () => {
     const selectedAnthropicOption = verifyDialog
       .getByRole("button", { name: /anthropic/i })
       .locator("..")
-      .locator('[data-selected="true"]');
+      .locator('[data-interactive-state="selected"]');
     await expect(selectedAnthropicOption).toHaveCount(1);
     await page.keyboard.press("Escape");
     await page.waitForSelector('[role="dialog"]', { state: "hidden" });
@@ -518,7 +522,7 @@ test.describe("LLM Runtime Selection", () => {
     await dialog.getByPlaceholder("Search models...").fill(restrictedModelName);
 
     const restrictedModelOption = dialog
-      .locator("[data-selected]")
+      .locator("[data-interactive-state]")
       .filter({ hasText: restrictedModelName });
 
     await expect(restrictedModelOption).toHaveCount(0);

--- a/web/tests/e2e/utils/chatActions.ts
+++ b/web/tests/e2e/utils/chatActions.ts
@@ -85,8 +85,10 @@ export async function selectModelFromInputPopover(
 
   for (const modelName of preferredModels) {
     await searchInput.fill(modelName);
-    const modelOptions = dialog.locator("[data-selected]");
-    const nonSelectedOptions = dialog.locator('[data-selected="false"]');
+    const modelOptions = dialog.locator("[data-interactive-state]");
+    const nonSelectedOptions = dialog.locator(
+      '[data-interactive-state="empty"]'
+    );
 
     if ((await modelOptions.count()) > 0) {
       const candidate =
@@ -110,7 +112,7 @@ export async function selectModelFromInputPopover(
   // Reset search so fallback sees all available models.
   await searchInput.fill("");
 
-  const nonSelectedOptions = dialog.locator('[data-selected="false"]');
+  const nonSelectedOptions = dialog.locator('[data-interactive-state="empty"]');
   if ((await nonSelectedOptions.count()) > 0) {
     const fallback = nonSelectedOptions.first();
     await expect(fallback).toBeVisible();

--- a/web/tests/e2e/utils/chatActions.ts
+++ b/web/tests/e2e/utils/chatActions.ts
@@ -147,7 +147,7 @@ export async function switchModel(page: Page, modelName: string) {
 
   const modelButton = page
     .locator('[role="dialog"]')
-    .locator('[role="button"]')
+    .getByRole("button")
     .filter({ hasText: modelName })
     .first();
 


### PR DESCRIPTION
## Description

Update `ModelListContent` to use the new `nonInteractive` prop on `LineItemButton` for provider group headers in the LLM model picker popover.

## Screenshots + Videos

https://github.com/user-attachments/assets/ce660c75-827d-449d-9747-f51134e41a25

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the LLM model picker: model rows now use `LineItemButton` (with `select-heavy`), and provider headers use `Interactive` + `ContentAction` with a rotating chevron. E2E tests now target `data-interactive-state`, use index-based selection for shared names, and query buttons via role.

- **Refactors**
  - Model rows: replace `LineItem` with `LineItemButton` (`selectVariant="select-heavy"`, `state` + `title`, 16px check icon, `sizePreset="main-ui"`, `rounding="sm"`).
  - Provider headers: `Interactive.Stateless` + `Interactive.Container` + `ContentAction` (muted) with a `Button`-wrapped `SvgChevronRight` rotating via `cn`; gap tweaks on sections and groups; dead code removal.

- **Bug Fixes**
  - E2E selectors: `data-selected` → `data-interactive-state` (`true` → `selected`, `false` → `empty`) to match `LineItemButton`/`Interactive.Stateful` in `@opal/components`.
  - E2E queries: replace parent traversal with `.filter({ hasText })` since the attribute is on the parent.
  - E2E model selection: remove provider text filters; use `nth()` based on alphabetical group order for models with shared names.
  - E2E buttons: use `getByRole("button")` instead of `[role="button"]` to match native `<button>` rendered by `LineItemButton`.

<sup>Written for commit fef475f4c9bc6fdaa40e022e7b5d6b978eba1793. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

