### PR TITLE
refactor(opal): remove -Variant suffix from component props

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -55,7 +55,7 @@ A two-axis layout component that automatically routes to the correct internal la
 
 Wraps `Content` and adds a `rightChildren` slot. Accepts all `Content` props plus:
 - `rightChildren`: `ReactNode` — actions rendered on the right
-- `paddingVariant`: `SizeVariant` — controls outer padding
+- `padding`: `SizeVariant` — controls outer padding
 
 ```typescript
 <ContentAction
@@ -544,7 +544,7 @@ function UserCard({
 ## 4. Spacing Guidelines
 
 **Prefer padding over margins for spacing. When a library component exposes a padding prop
-(e.g., `paddingVariant`), use that prop instead of wrapping it in a `<div>` with padding classes.
+(e.g., `padding`), use that prop instead of wrapping it in a `<div>` with padding classes.
 If a library component does not expose a padding override and you find yourself adding a wrapper
 div for spacing, consider updating the library component to accept one.**
 
@@ -553,7 +553,7 @@ divs that exist solely for spacing.
 
 ```typescript
 // ✅ Good — use the component's padding prop
-<ContentAction paddingVariant="md" ... />
+<ContentAction padding="md" ... />
 
 // ✅ Good — padding utilities when no component prop exists
 <div className="p-4 space-y-2">

--- a/web/lib/opal/src/components/buttons/button/components.tsx
+++ b/web/lib/opal/src/components/buttons/button/components.tsx
@@ -95,9 +95,9 @@ function Button({
       <Interactive.Container
         type={type}
         border={interactiveProps.prominence === "secondary"}
-        heightVariant={size}
-        widthVariant={width}
-        roundingVariant={isLarge ? "md" : size === "2xs" ? "xs" : "sm"}
+        size={size}
+        width={width}
+        rounding={isLarge ? "md" : size === "2xs" ? "xs" : "sm"}
       >
         <div className="flex flex-row items-center gap-1">
           {iconWrapper(Icon, size, !!children)}

--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -8,13 +8,13 @@ A composite component that wraps `Interactive.Stateful > Interactive.Container >
 
 ```
 Interactive.Stateful         <- selectVariant, state, interaction, onClick, href, ref
-  └─ Interactive.Container   <- type, width, roundingVariant
-       └─ ContentAction      <- withInteractive, paddingVariant="lg"
+  └─ Interactive.Container   <- type, width, rounding
+       └─ ContentAction      <- withInteractive, padding="lg"
             ├─ Content       <- icon, title, description, sizePreset, variant, ...
             └─ rightChildren
 ```
 
-`paddingVariant` is hardcoded to `"lg"` and `withInteractive` is always `true`. These are not exposed as props.
+`padding` is hardcoded to `"lg"` and `withInteractive` is always `true`. These are not exposed as props.
 
 ## Props
 
@@ -35,7 +35,7 @@ Interactive.Stateful         <- selectVariant, state, interaction, onClick, href
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `roundingVariant` | `InteractiveContainerRoundingVariant` | `"md"` | Corner rounding preset (height is content-driven) |
+| `rounding` | `InteractiveContainerRoundingVariant` | `"md"` | Corner rounding preset (height is content-driven) |
 | `width` | `WidthVariant` | `"full"` | Container width |
 | `type` | `"submit" \| "button" \| "reset"` | `"button"` | HTML button type |
 | `tooltip` | `string` | — | Tooltip text shown on hover |
@@ -63,7 +63,7 @@ import { LineItemButton } from "@opal/components";
 <LineItemButton
   selectVariant="select-heavy"
   state={isSelected ? "selected" : "empty"}
-  roundingVariant="sm"
+  rounding="sm"
   onClick={handleClick}
   title="gpt-4o"
   sizePreset="main-ui"

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -13,7 +13,7 @@ import { type ContentActionProps, ContentAction } from "@opal/layouts";
 
 type ContentPassthroughProps = DistributiveOmit<
   ContentActionProps,
-  "paddingVariant" | "widthVariant" | "ref"
+  "padding" | "width" | "ref"
 >;
 
 type LineItemButtonOwnProps = Pick<
@@ -31,7 +31,7 @@ type LineItemButtonOwnProps = Pick<
   selectVariant?: "select-light" | "select-heavy";
 
   /** Corner rounding preset (height is always content-driven). @default "md" */
-  roundingVariant?: InteractiveContainerRoundingVariant;
+  rounding?: InteractiveContainerRoundingVariant;
 
   /** Container width. @default "full" */
   width?: ExtremaSizeVariants;
@@ -62,7 +62,7 @@ function LineItemButton({
   type = "button",
 
   // Sizing
-  roundingVariant = "md",
+  rounding = "md",
   width = "full",
   tooltip,
   tooltipSide = "top",
@@ -83,14 +83,14 @@ function LineItemButton({
     >
       <Interactive.Container
         type={type}
-        widthVariant={width}
-        heightVariant="fit"
-        roundingVariant={roundingVariant}
+        width={width}
+        size="fit"
+        rounding={rounding}
       >
         <div className="w-full p-2">
           <ContentAction
             {...(contentActionProps as ContentActionProps)}
-            paddingVariant="fit"
+            padding="fit"
           />
         </div>
       </Interactive.Container>

--- a/web/lib/opal/src/components/buttons/open-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/open-button/components.tsx
@@ -70,7 +70,7 @@ type OpenButtonProps = Omit<InteractiveStatefulProps, "variant"> & {
     tooltipSide?: TooltipSide;
 
     /** Override the default rounding derived from `size`. */
-    roundingVariant?: InteractiveContainerRoundingVariant;
+    rounding?: InteractiveContainerRoundingVariant;
 
     /** Applies disabled styling and suppresses clicks. */
     disabled?: boolean;
@@ -89,7 +89,7 @@ function OpenButton({
   justifyContent,
   tooltip,
   tooltipSide = "top",
-  roundingVariant: roundingVariantOverride,
+  rounding: roundingOverride,
   interaction,
   variant = "select-heavy",
   disabled,
@@ -123,11 +123,10 @@ function OpenButton({
     >
       <Interactive.Container
         type="button"
-        heightVariant={size}
-        widthVariant={width}
-        roundingVariant={
-          roundingVariantOverride ??
-          (isLarge ? "md" : size === "2xs" ? "xs" : "sm")
+        size={size}
+        width={width}
+        rounding={
+          roundingOverride ?? (isLarge ? "md" : size === "2xs" ? "xs" : "sm")
         }
       >
         <div

--- a/web/lib/opal/src/components/buttons/select-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/select-button/components.tsx
@@ -96,9 +96,9 @@ function SelectButton({
     <Interactive.Stateful disabled={disabled} {...statefulProps}>
       <Interactive.Container
         type={type}
-        heightVariant={size}
-        widthVariant={width}
-        roundingVariant={isLarge ? "md" : size === "2xs" ? "xs" : "sm"}
+        size={size}
+        width={width}
+        rounding={isLarge ? "md" : size === "2xs" ? "xs" : "sm"}
       >
         <div
           className={cn(

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -93,12 +93,7 @@ function SidebarTab({
         type="button"
         group="group/SidebarTab"
       >
-        <Interactive.Container
-          roundingVariant="sm"
-          heightVariant="lg"
-          widthVariant="full"
-          type={type}
-        >
+        <Interactive.Container rounding="sm" size="lg" width="full" type={type}>
           {href && !disabled && (
             <Link
               href={href as Route}
@@ -120,8 +115,8 @@ function SidebarTab({
               title={folded ? "" : children}
               sizePreset="main-ui"
               variant="body"
-              widthVariant="full"
-              paddingVariant="fit"
+              width="full"
+              padding="fit"
               rightChildren={truncationSpacer}
             />
           ) : (

--- a/web/lib/opal/src/components/cards/card/Card.stories.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.stories.tsx
@@ -55,7 +55,7 @@ export const PaddingVariants: Story = {
     <div className="flex flex-col gap-4 w-96">
       {PADDING_VARIANTS.map((padding) => (
         <Card key={padding} padding={padding} border="solid">
-          <p>paddingVariant: {padding}</p>
+          <p>padding: {padding}</p>
         </Card>
       ))}
     </div>
@@ -67,7 +67,7 @@ export const RoundingVariants: Story = {
     <div className="flex flex-col gap-4 w-96">
       {ROUNDING_VARIANTS.map((rounding) => (
         <Card key={rounding} rounding={rounding} border="solid">
-          <p>roundingVariant: {rounding}</p>
+          <p>rounding: {rounding}</p>
         </Card>
       ))}
     </div>
@@ -79,7 +79,7 @@ export const AllCombinations: Story = {
     <div className="flex flex-col gap-8">
       {PADDING_VARIANTS.map((padding) => (
         <div key={padding}>
-          <p className="font-bold pb-2">paddingVariant: {padding}</p>
+          <p className="font-bold pb-2">padding: {padding}</p>
           <div className="grid grid-cols-3 gap-4">
             {BACKGROUND_VARIANTS.map((bg) =>
               BORDER_VARIANTS.map((border) => (

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -156,7 +156,7 @@ function MessageCard({
         description={description}
         sizePreset="main-ui"
         variant="section"
-        paddingVariant="md"
+        padding="md"
         rightChildren={right}
       />
 

--- a/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
+++ b/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
@@ -209,7 +209,7 @@ export const PaddingVariants: Story = {
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
-            title={`paddingVariant: ${padding}`}
+            title={`padding: ${padding}`}
             description="Shows padding differences."
           />
         </SelectCard>
@@ -227,7 +227,7 @@ export const RoundingVariants: Story = {
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
-            title={`roundingVariant: ${rounding}`}
+            title={`rounding: ${rounding}`}
             description="Shows rounding differences."
           />
         </SelectCard>

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -167,11 +167,7 @@ function FoldableDivider({
         interaction={isOpen ? "hover" : "rest"}
         onClick={toggle}
       >
-        <Interactive.Container
-          roundingVariant="sm"
-          heightVariant="fit"
-          widthVariant="full"
-        >
+        <Interactive.Container rounding="sm" size="fit" width="full">
           <div className="opal-divider">
             <div className="opal-divider-row">
               <div className="opal-divider-title">

--- a/web/lib/opal/src/components/table/TableElement.tsx
+++ b/web/lib/opal/src/components/table/TableElement.tsx
@@ -22,7 +22,7 @@ interface TableProps
   /** Row selection behavior. @default "no-select" */
   selectionBehavior?: SelectionBehavior;
   /** Height behavior. `"fit"` = shrink to content, `"full"` = fill available space. */
-  heightVariant?: ExtremaSizeVariants;
+  size?: ExtremaSizeVariants;
   /** Explicit pixel width for the table (e.g. from `table.getTotalSize()`).
    *  When provided the table uses exactly this width instead of stretching
    *  to fill its container, which prevents `table-layout: fixed` from
@@ -38,7 +38,7 @@ function Table({
   ref,
   variant = "cards",
   selectionBehavior = "no-select",
-  heightVariant,
+  size: heightVariant,
   width,
   ...props
 }: TableProps) {

--- a/web/lib/opal/src/core/animations/components.tsx
+++ b/web/lib/opal/src/core/animations/components.tsx
@@ -17,7 +17,7 @@ interface HoverableRootProps
   children: React.ReactNode;
   group: string;
   /** Width preset. @default "auto" */
-  widthVariant?: ExtremaSizeVariants;
+  width?: ExtremaSizeVariants;
   /**
    * JS-controllable interaction state override.
    *
@@ -70,7 +70,7 @@ interface HoverableItemProps
 function HoverableRoot({
   group,
   children,
-  widthVariant = "full",
+  width = "full",
   interaction = "rest",
   ref,
   ...props
@@ -79,7 +79,7 @@ function HoverableRoot({
     <div
       {...props}
       ref={ref}
-      className={cn(widthVariants[widthVariant])}
+      className={cn(widthVariants[width])}
       data-hover-group={group}
       data-interaction={interaction !== "rest" ? interaction : undefined}
     >

--- a/web/lib/opal/src/core/interactive/Interactive.stories.tsx
+++ b/web/lib/opal/src/core/interactive/Interactive.stories.tsx
@@ -135,7 +135,7 @@ export const VariantMatrix: StoryObj = {
   ),
 };
 
-/** All heightVariant sizes (lg, md, sm, xs, 2xs, fit). */
+/** All size presets (lg, md, sm, xs, 2xs, fit). */
 export const Sizes: StoryObj = {
   render: () => (
     <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
@@ -146,7 +146,7 @@ export const Sizes: StoryObj = {
           prominence="secondary"
           onClick={() => {}}
         >
-          <Interactive.Container border heightVariant={size}>
+          <Interactive.Container border size={size}>
             <span>{size}</span>
           </Interactive.Container>
         </Interactive.Stateless>
@@ -155,7 +155,7 @@ export const Sizes: StoryObj = {
   ),
 };
 
-/** Container with widthVariant="full" stretching to fill its parent. */
+/** Container with width="full" stretching to fill its parent. */
 export const WidthFull: StoryObj = {
   render: () => (
     <div style={{ width: 400 }}>
@@ -164,7 +164,7 @@ export const WidthFull: StoryObj = {
         prominence="secondary"
         onClick={() => {}}
       >
-        <Interactive.Container border widthVariant="full">
+        <Interactive.Container border width="full">
           <span>Full width container</span>
         </Interactive.Container>
       </Interactive.Stateless>
@@ -183,7 +183,7 @@ export const Rounding: StoryObj = {
           prominence="secondary"
           onClick={() => {}}
         >
-          <Interactive.Container border roundingVariant={rounding}>
+          <Interactive.Container border rounding={rounding}>
             <span>{rounding}</span>
           </Interactive.Container>
         </Interactive.Stateless>

--- a/web/lib/opal/src/core/interactive/container/README.md
+++ b/web/lib/opal/src/core/interactive/container/README.md
@@ -8,9 +8,9 @@ Structural container shared by both `Interactive.Stateless` and `Interactive.Sta
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `heightVariant` | `SizeVariant` | `"lg"` | Height preset (`2xs`–`lg`, `fit`) |
-| `roundingVariant` | `"md" \| "sm" \| "xs"` | `"md"` | Border-radius preset |
-| `widthVariant` | `WidthVariant` | — | Width preset (`"auto"`, `"fit"`, `"full"`) |
+| `size` | `SizeVariant` | `"lg"` | Height preset (`2xs`–`lg`, `fit`) |
+| `rounding` | `"md" \| "sm" \| "xs"` | `"md"` | Border-radius preset |
+| `width` | `WidthVariant` | — | Width preset (`"auto"`, `"fit"`, `"full"`) |
 | `border` | `boolean` | `false` | Renders a 1px border |
 | `type` | `"submit" \| "button" \| "reset"` | — | When set, renders a `<button>` element |
 
@@ -18,7 +18,7 @@ Structural container shared by both `Interactive.Stateless` and `Interactive.Sta
 
 ```tsx
 <Interactive.Stateless variant="default" prominence="primary">
-  <Interactive.Container heightVariant="sm" roundingVariant="sm" border>
+  <Interactive.Container size="sm" rounding="sm" border>
     <span>Content</span>
   </Interactive.Container>
 </Interactive.Stateless>

--- a/web/lib/opal/src/core/interactive/container/components.tsx
+++ b/web/lib/opal/src/core/interactive/container/components.tsx
@@ -63,21 +63,21 @@ interface InteractiveContainerProps
    *
    * @default "default"
    */
-  roundingVariant?: InteractiveContainerRoundingVariant;
+  rounding?: InteractiveContainerRoundingVariant;
 
   /**
    * Size preset controlling the container's height, min-width, and padding.
    *
    * @default "lg"
    */
-  heightVariant?: ContainerSizeVariants;
+  size?: ContainerSizeVariants;
 
   /**
    * Width preset controlling the container's horizontal size.
    *
    * @default "fit"
    */
-  widthVariant?: ExtremaSizeVariants;
+  width?: ExtremaSizeVariants;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,9 +96,9 @@ function InteractiveContainer({
   ref,
   type,
   border,
-  roundingVariant = "md",
-  heightVariant = "lg",
-  widthVariant = "fit",
+  rounding = "md",
+  size = "lg",
+  width = "fit",
   ...props
 }: InteractiveContainerProps) {
   const {
@@ -115,16 +115,16 @@ function InteractiveContainer({
     target?: string;
     rel?: string;
   };
-  const { height, minWidth, padding } = containerSizeVariants[heightVariant];
+  const { height, minWidth, padding } = containerSizeVariants[size];
   const sharedProps = {
     ...rest,
     className: cn(
       "interactive-container",
-      interactiveContainerRoundingVariants[roundingVariant],
+      interactiveContainerRoundingVariants[rounding],
       height,
       minWidth,
       padding,
-      widthVariants[widthVariant],
+      widthVariants[width],
       slotClassName
     ),
     "data-border": border ? ("true" as const) : undefined,

--- a/web/lib/opal/src/layouts/README.md
+++ b/web/lib/opal/src/layouts/README.md
@@ -46,7 +46,7 @@ import SvgNoResult from "@opal/illustrations/no-result";
   description="Some description"
   sizePreset="main-content"
   variant="section"
-  paddingVariant="lg"
+  padding="lg"
   rightChildren={
     <Button icon={SvgSettings} prominence="tertiary" />
   }

--- a/web/lib/opal/src/layouts/content-action/ContentAction.stories.tsx
+++ b/web/lib/opal/src/layouts/content-action/ContentAction.stories.tsx
@@ -63,7 +63,7 @@ export const NoPadding: Story = {
     variant: "section",
     title: "Compact Row",
     description: "No padding around content area.",
-    paddingVariant: "fit",
+    padding: "fit",
     rightChildren: <Button prominence="tertiary">Action</Button>,
   },
 };

--- a/web/lib/opal/src/layouts/content-action/README.md
+++ b/web/lib/opal/src/layouts/content-action/README.md
@@ -15,9 +15,9 @@ Inherits **all** props from [`Content`](../content/README.md) (same discriminate
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `rightChildren` | `ReactNode` | `undefined` | Content rendered on the right side. Wrapper stretches to the full height of the row. |
-| `paddingVariant` | `SizeVariant` | `"lg"` | Padding preset applied around the `Content` area. Uses the shared size scale from `@opal/shared`. |
+| `padding` | `SizeVariant` | `"lg"` | Padding preset applied around the `Content` area. Uses the shared size scale from `@opal/shared`. |
 
-### `paddingVariant` reference
+### `padding` reference
 
 | Value | Padding class | Effective padding |
 |---|---|---|
@@ -37,7 +37,7 @@ These values are identical to the padding applied by `Interactive.Container` at 
 ```
 
 - The outer wrapper is `flex flex-row items-stretch w-full`.
-- `Content` sits inside a `flex-1 min-w-0` div with padding from `paddingVariant`.
+- `Content` sits inside a `flex-1 min-w-0` div with padding from `padding`.
 - `rightChildren` is wrapped in `flex items-stretch shrink-0` so it stretches vertically.
 
 ## Usage Examples
@@ -56,7 +56,7 @@ import SvgSettings from "@opal/icons/settings";
   sizePreset="main-content"
   variant="section"
   tag={{ title: "Default", color: "blue" }}
-  paddingVariant="lg"
+  padding="lg"
   rightChildren={
     <Button icon={SvgSettings} prominence="tertiary" onClick={handleEdit} />
   }
@@ -76,7 +76,7 @@ import { SvgArrowExchange, SvgCloud } from "@opal/icons";
   description="Gemini"
   sizePreset="main-content"
   variant="section"
-  paddingVariant="md"
+  padding="md"
   rightChildren={
     <Button rightIcon={SvgArrowExchange} prominence="tertiary">
       Connect
@@ -92,7 +92,7 @@ import { SvgArrowExchange, SvgCloud } from "@opal/icons";
   title="Section Header"
   sizePreset="main-content"
   variant="section"
-  paddingVariant="lg"
+  padding="lg"
 />
 ```
 

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -20,7 +20,7 @@ type ContentActionProps = ContentProps & {
    * @default "lg"
    * @see {@link ContainerSizeVariants} for the full list of presets.
    */
-  paddingVariant?: ContainerSizeVariants;
+  padding?: ContainerSizeVariants;
 };
 
 // ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ type ContentActionProps = ContentProps & {
  * A row layout that pairs a {@link Content} block with optional right-side
  * action children (e.g. buttons, badges).
  *
- * The `Content` area receives padding controlled by `paddingVariant`, using
+ * The `Content` area receives padding controlled by `padding`, using
  * the same size scale as `Interactive.Container` and `Button`. The
  * `rightChildren` wrapper stretches to the full height of the row.
  *
@@ -47,21 +47,21 @@ type ContentActionProps = ContentProps & {
  *   description="GPT"
  *   sizePreset="main-content"
  *   variant="section"
- *   paddingVariant="lg"
+ *   padding="lg"
  *   rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
  * />
  * ```
  */
 function ContentAction({
   rightChildren,
-  paddingVariant = "lg",
+  padding = "lg",
   ...contentProps
 }: ContentActionProps) {
-  const { padding } = containerSizeVariants[paddingVariant];
+  const { padding: paddingClass } = containerSizeVariants[padding];
 
   return (
     <div className="flex flex-row items-stretch w-full">
-      <div className={cn("flex-1 min-w-0 self-center", padding)}>
+      <div className={cn("flex-1 min-w-0 self-center", paddingClass)}>
         <Content {...contentProps} />
       </div>
       {rightChildren && (

--- a/web/lib/opal/src/layouts/content/Content.stories.tsx
+++ b/web/lib/opal/src/layouts/content/Content.stories.tsx
@@ -184,7 +184,7 @@ export const SmMuted: Story = {
 };
 
 // ---------------------------------------------------------------------------
-// widthVariant: full
+// width: full
 // ---------------------------------------------------------------------------
 
 export const WidthFull: Story = {
@@ -192,7 +192,7 @@ export const WidthFull: Story = {
     sizePreset: "main-content",
     variant: "section",
     title: "Full Width Content",
-    widthVariant: "full",
+    width: "full",
   },
   decorators: [
     (Story) => (

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -58,7 +58,7 @@ interface ContentBaseProps {
    * - `"fit"` — Shrink-wraps to content width
    * - `"full"` — Stretches to fill the parent's width
    *
-   * @default "fit"
+   * @default "full"
    */
   width?: ExtremaSizeVariants;
 

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -60,7 +60,7 @@ interface ContentBaseProps {
    *
    * @default "fit"
    */
-  widthVariant?: ExtremaSizeVariants;
+  width?: ExtremaSizeVariants;
 
   /**
    * Opt out of the automatic interactive color override.
@@ -137,7 +137,7 @@ function Content(props: ContentProps) {
   const {
     sizePreset = "headline",
     variant = "heading",
-    widthVariant = "full",
+    width = "full",
     nonInteractive,
     ref,
     ...rest
@@ -200,7 +200,7 @@ function Content(props: ContentProps) {
 
   return (
     <div
-      className={widthVariants[widthVariant]}
+      className={widthVariants[width]}
       data-opal-non-interactive={nonInteractive || undefined}
     >
       {layout}

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -152,7 +152,7 @@ function Horizontal({
             tag={tag}
             sizePreset="main-ui"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
         </div>
         <div className="flex flex-col items-end">{children}</div>

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -57,9 +57,9 @@ const containerSizeVariants: Record<
 // A named scale of width/height presets that map to Tailwind width/height utility classes.
 //
 // Consumers (for width):
-//   - Interactive.Container  (widthVariant)
+//   - Interactive.Container  (width)
 //   - Button                 (width)
-//   - Content                (widthVariant)
+//   - Content                (width)
 // ---------------------------------------------------------------------------
 
 /**
@@ -96,8 +96,8 @@ const heightVariants: Record<ExtremaSizeVariants, string> = {
 // Shared padding and rounding scales for card components (Card, SelectCard).
 //
 // Consumers:
-//   - Card          (paddingVariant, roundingVariant)
-//   - SelectCard    (paddingVariant, roundingVariant)
+//   - Card          (padding, rounding)
+//   - SelectCard    (padding, rounding)
 // ---------------------------------------------------------------------------
 
 const paddingVariants: Record<PaddingVariants, string> = {

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -40,7 +40,7 @@ export default function ScimSyncCard({
         description="Connect your identity provider to import and sync users and groups."
         sizePreset="main-ui"
         variant="section"
-        paddingVariant="fit"
+        padding="fit"
         rightChildren={
           hasToken ? (
             <Button

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -77,7 +77,7 @@ export const InMessageImage = memo(function InMessageImage({
         onOpenChange={(open) => setFullImageShowing(open)}
       />
 
-      <Hoverable.Root group="messageImage" widthVariant="fit">
+      <Hoverable.Root group="messageImage" width="fit">
         <div className={cn("relative", shapeContainerClasses)}>
           {!imageLoaded && (
             <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />

--- a/web/src/app/app/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/app/components/projects/ProjectContextPanel.tsx
@@ -133,7 +133,7 @@ export default function ProjectContextPanel({
       <div className="flex flex-col gap-6 w-full max-w-[var(--app-page-main-content-width)] mx-auto p-4 pt-14 pb-6">
         <div className="flex flex-col gap-1 text-text-04">
           <SvgFolderOpen className="h-8 w-8 text-text-04" />
-          <Hoverable.Root group="projectName" widthVariant="fit">
+          <Hoverable.Root group="projectName" width="fit">
             <div className="flex items-center gap-2">
               {isEditingName ? (
                 <ButtonRenaming

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -198,7 +198,7 @@ const HumanMessage = React.memo(function HumanMessage({
   );
 
   return (
-    <Hoverable.Root group="humanMessage" widthVariant="full">
+    <Hoverable.Root group="humanMessage" width="full">
       <div
         id="onyx-human-message"
         className="flex flex-col justify-end w-full relative"

--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -97,7 +97,7 @@ export default function MultiModelPanel({
       <ContentAction
         sizePreset="main-ui"
         variant="body"
-        paddingVariant="lg"
+        padding="lg"
         icon={ModelIcon}
         title={isHidden ? markdown(`~~${displayName}~~`) : displayName}
         rightChildren={

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -71,7 +71,7 @@ function MemoryTagWithTooltip({
                 icon={SvgAddLines}
                 title={operationLabel}
                 sizePreset="secondary"
-                paddingVariant="sm"
+                padding="sm"
                 variant="body"
                 prominence="muted"
                 rightChildren={

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -138,7 +138,7 @@ export default function ShareButton({
                     description={opt.description}
                     sizePreset="main-ui"
                     variant="section"
-                    paddingVariant="sm"
+                    padding="sm"
                   />
                 </div>
               ))}

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookFormModal.tsx
@@ -272,7 +272,7 @@ export default function HookFormModal({
                   <ContentAction
                     sizePreset="main-ui"
                     variant="section"
-                    paddingVariant="fit"
+                    padding="fit"
                     title={hookPointDisplayName}
                     description={hookPointDescription}
                     rightChildren={
@@ -283,7 +283,7 @@ export default function HookFormModal({
                           icon={SvgShareWebhook}
                           title="Hook Point"
                           prominence="muted"
-                          widthVariant="fit"
+                          width="fit"
                         />
                         {docsUrl && (
                           <LinkButton href={docsUrl} target="_blank">

--- a/web/src/ee/sections/SearchCard.tsx
+++ b/web/src/ee/sections/SearchCard.tsx
@@ -56,7 +56,7 @@ export default function SearchCard({
 
   return (
     <Interactive.Stateless onClick={handleClick} prominence="secondary">
-      <Interactive.Container heightVariant="fit" widthVariant="full">
+      <Interactive.Container size="fit" width="full">
         <Section alignItems="start" gap={0} padding={0.25}>
           {/* Title Row */}
           <Section

--- a/web/src/layouts/general-layouts.tsx
+++ b/web/src/layouts/general-layouts.tsx
@@ -202,7 +202,7 @@ function AttachmentItemLayout({
             description={description}
             sizePreset="main-ui"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
         </div>
         {middleText && (

--- a/web/src/refresh-components/inputs/InputImage.tsx
+++ b/web/src/refresh-components/inputs/InputImage.tsx
@@ -173,7 +173,7 @@ export default function InputImage({
   const dropzoneProps = onDrop ? getRootProps() : {};
 
   return (
-    <Hoverable.Root group="inputImage" widthVariant="fit">
+    <Hoverable.Root group="inputImage" width="fit">
       <div
         className={cn("relative", className)}
         style={{ width: size, height: size }}

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -78,7 +78,7 @@ export default function FileTile({
   const isMuted = state === "processing" || state === "disabled";
 
   return (
-    <Hoverable.Root group="fileTile" widthVariant="fit">
+    <Hoverable.Root group="fileTile" width="fit">
       <div
         onClick={onOpen && state !== "disabled" ? () => onOpen() : undefined}
         className={cn(

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -211,7 +211,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
 
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <Popover.Trigger asChild>
-          <Hoverable.Root group="inputAvatar" widthVariant="fit">
+          <Hoverable.Root group="inputAvatar" width="fit">
             <InputAvatar className="relative flex flex-col items-center justify-center h-[7.5rem] w-[7.5rem]">
               {/* We take the `InputAvatar`'s height/width (in REM) and multiply it by 16 (the REM -> px conversion factor). */}
               <CustomAgentAvatar
@@ -288,7 +288,7 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
             description={tool.description}
             sizePreset="main-ui"
             variant="section"
-            paddingVariant="fit"
+            padding="fit"
           />
         }
         topRightChildren={<SwitchField name={toolFieldName} />}
@@ -353,7 +353,7 @@ function MCPServerCard({
                       description={tool.description}
                       sizePreset="main-ui"
                       variant="section"
-                      paddingVariant="fit"
+                      padding="fit"
                     />
                   }
                   topRightChildren={
@@ -388,7 +388,7 @@ function MCPServerCard({
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            paddingVariant="fit"
+            padding="fit"
             rightChildren={
               <GeneralLayouts.Section
                 flexDirection="row"

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -269,7 +269,7 @@ function GeneralSettings() {
             title="Profile"
             sizePreset="main-content"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
           <Card>
             <InputHorizontal
@@ -332,7 +332,7 @@ function GeneralSettings() {
             title="Appearance"
             sizePreset="main-content"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
           <Card>
             <InputHorizontal
@@ -443,7 +443,7 @@ function GeneralSettings() {
             title="Danger Zone"
             sizePreset="main-content"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
           <Card>
             <InputHorizontal
@@ -831,7 +831,7 @@ function ChatPreferencesSettings() {
           title="Chats"
           sizePreset="main-content"
           variant="section"
-          widthVariant="full"
+          width="full"
         />
         <Card>
           <InputHorizontal
@@ -920,7 +920,7 @@ function ChatPreferencesSettings() {
           title="Memory"
           sizePreset="main-content"
           variant="section"
-          widthVariant="full"
+          width="full"
         />
         <Card>
           <InputHorizontal
@@ -968,7 +968,7 @@ function ChatPreferencesSettings() {
           title="Prompt Shortcuts"
           sizePreset="main-content"
           variant="section"
-          widthVariant="full"
+          width="full"
         />
         <Card>
           <InputHorizontal
@@ -993,7 +993,7 @@ function ChatPreferencesSettings() {
           title="Voice"
           sizePreset="main-content"
           variant="section"
-          widthVariant="full"
+          width="full"
         />
         <Card>
           <InputHorizontal
@@ -1365,7 +1365,7 @@ function AccountsAccessSettings() {
             title="Accounts"
             sizePreset="main-content"
             variant="section"
-            widthVariant="full"
+            width="full"
           />
           <Card>
             <InputHorizontal
@@ -1401,7 +1401,7 @@ function AccountsAccessSettings() {
               title="Access Tokens"
               sizePreset="main-content"
               variant="section"
-              widthVariant="full"
+              width="full"
             />
             {canCreateTokens ? (
               <Card padding={0.25}>
@@ -1463,8 +1463,8 @@ function AccountsAccessSettings() {
                       return (
                         <Interactive.Container
                           key={pat.id}
-                          heightVariant="fit"
-                          widthVariant="full"
+                          size="fit"
+                          width="full"
                         >
                           <div className="w-full bg-background-tint-01">
                             <AttachmentItemLayout
@@ -1605,7 +1605,7 @@ function FederatedConnectorCard({
           }
           sizePreset="main-content"
           variant="section"
-          paddingVariant="sm"
+          padding="sm"
           rightChildren={
             connector.has_oauth_token ? (
               <Button
@@ -1678,7 +1678,7 @@ function ConnectorsSettings() {
           title="Connectors"
           sizePreset="main-content"
           variant="section"
-          widthVariant="full"
+          width="full"
         />
         {hasConnectors ? (
           <>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -156,7 +156,7 @@ function MCPServerCard({
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            paddingVariant="fit"
+            padding="fit"
             rightChildren={
               <Tooltip tooltip={authTooltip} side="top">
                 <Switch
@@ -286,7 +286,7 @@ function NumericLimitField({
   };
 
   return (
-    <Hoverable.Root group="numericLimit" widthVariant="full">
+    <Hoverable.Root group="numericLimit" width="full">
       <InputTypeIn
         inputMode="numeric"
         showClearButton={false}

--- a/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
@@ -294,7 +294,7 @@ export default function EditUserModal({
                   description="This controls their general permissions."
                   sizePreset="main-ui"
                   variant="section"
-                  paddingVariant="fit"
+                  padding="fit"
                   rightChildren={
                     <InputSelect
                       value={selectedRole}

--- a/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
@@ -103,7 +103,7 @@ export default function UserRoleCell({ user, onMutate }: UserRoleCellProps) {
             variant="select-tinted"
             width="full"
             justifyContent="between"
-            roundingVariant="sm"
+            rounding="sm"
           >
             {USER_ROLE_LABELS[user.role]}
           </OpenButton>

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -23,7 +23,7 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
   const display = value === null ? "\u2014" : value.toLocaleString();
 
   return (
-    <Hoverable.Root group="stat" widthVariant="full">
+    <Hoverable.Root group="stat" width="full">
       <div
         className={`relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
           onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""
@@ -70,7 +70,7 @@ function ScimCard() {
         description="Users are synced from your identity provider."
         sizePreset="main-ui"
         variant="section"
-        paddingVariant="fit"
+        padding="fit"
         rightChildren={
           <Link href={ADMIN_ROUTES.SCIM.path}>
             <Button prominence="tertiary" rightIcon={SvgArrowUpRight} size="sm">

--- a/web/src/sections/Suggestions.tsx
+++ b/web/src/sections/Suggestions.tsx
@@ -36,16 +36,12 @@ export default function Suggestions({ onSubmit }: SuggestionsProps) {
           prominence="tertiary"
           onClick={() => handleSuggestionClick(message)}
         >
-          <Interactive.Container
-            widthVariant="full"
-            roundingVariant="sm"
-            heightVariant="lg"
-          >
+          <Interactive.Container width="full" rounding="sm" size="lg">
             <Content
               title={message}
               sizePreset="main-ui"
               variant="body"
-              widthVariant="full"
+              width="full"
               prominence="muted"
             />
           </Interactive.Container>

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -241,7 +241,7 @@ function FormContent({
             `Specify an OpenAPI schema that defines the APIs you want to make available as part of this action. Learn more about [OpenAPI actions](${DOCS_ADMINS_PATH}/actions/openapi).`
           )}
         >
-          <Hoverable.Root group="definitionField" widthVariant="full">
+          <Hoverable.Root group="definitionField" width="full">
             <div className="relative w-full">
               {values.definition.trim() && (
                 <div className="absolute z-[100000] top-2 right-2 bg-background-tint-00">

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -74,7 +74,7 @@ export default function AdminListHeader({
             sizePreset="main-ui"
             variant="body"
             prominence="muted"
-            widthVariant="fit"
+            width="fit"
           />
           {actionButton}
         </div>

--- a/web/src/sections/cards/DocumentSetCard.tsx
+++ b/web/src/sections/cards/DocumentSetCard.tsx
@@ -38,7 +38,7 @@ export default function DocumentSetCard({
           <Interactive.Container
             data-testid={`document-set-card-${documentSet.id}`}
             border
-            heightVariant="fit"
+            size="fit"
           >
             <AttachmentItemLayout
               icon={SvgFiles}

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -21,7 +21,7 @@ function Removable({ onRemove, children }: RemovableProps) {
   }
 
   return (
-    <Hoverable.Root group="fileCard" widthVariant="fit">
+    <Hoverable.Root group="fileCard" width="fit">
       <div className="relative">
         <div
           className={cn(
@@ -184,7 +184,7 @@ export function FileCard({
       }
     >
       <div className="min-w-0 max-w-[12rem]">
-        <Interactive.Container border heightVariant="fit" widthVariant="full">
+        <Interactive.Container border size="fit" width="full">
           <AttachmentItemLayout
             icon={isProcessing ? SimpleLoader : SvgFileText}
             title={file.name}

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -88,7 +88,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            paddingVariant="fit"
+            padding="fit"
           />
         }
         topRightChildren={
@@ -267,7 +267,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 title="Featured"
                 sizePreset="main-ui"
                 variant="body"
-                widthVariant="fit"
+                width="fit"
               />
             )}
             <Content
@@ -276,7 +276,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
               sizePreset="main-ui"
               variant="body"
               prominence="muted"
-              widthVariant="fit"
+              width="fit"
             />
             {agent.is_public && (
               <Content
@@ -285,7 +285,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 sizePreset="main-ui"
                 variant="body"
                 prominence="muted"
-                widthVariant="fit"
+                width="fit"
               />
             )}
           </Section>
@@ -425,7 +425,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                         sizePreset="main-ui"
                         variant="body"
                         prominence="muted"
-                        widthVariant="full"
+                        width="full"
                       />
                     </Interactive.Container>
                   </Interactive.Stateless>

--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -409,7 +409,7 @@ export default function CustomModal({
             description={markdown(
               "Add extra properties as needed by the model provider. These are passed to LiteLLM's `completion()` call as [environment variables](https://docs.litellm.ai/docs/set_keys#environment-variables). See [documentation](https://docs.onyx.app/admins/ai_models/custom_inference_provider) for more instructions."
             )}
-            widthVariant="full"
+            width="full"
             variant="section"
             sizePreset="main-content"
           />
@@ -433,7 +433,7 @@ export default function CustomModal({
             description="List LLM models you wish to use and their configurations for this provider. See full list of models at LiteLLM."
             variant="section"
             sizePreset="main-content"
-            widthVariant="full"
+            width="full"
           />
         </InputPadder>
 

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -276,7 +276,7 @@ export function ModelAccessField() {
                     Always shared
                   </Text>
                 }
-                paddingVariant="fit"
+                padding="fit"
               />
             </Card>
             {selectedGroupIds.length > 0 && (
@@ -304,7 +304,7 @@ export function ModelAccessField() {
                               type="button"
                             />
                           }
-                          paddingVariant="fit"
+                          padding="fit"
                         />
                       </Card>
                     </div>
@@ -341,7 +341,7 @@ export function ModelAccessField() {
                               type="button"
                             />
                           }
-                          paddingVariant="fit"
+                          padding="fit"
                         />
                       </Card>
                     </div>
@@ -548,7 +548,7 @@ export function ModelSelectionField({
                       prominence="tertiary"
                       onClick={() => setIsExpanded(!isExpanded)}
                     >
-                      <Interactive.Container type="button" widthVariant="full">
+                      <Interactive.Container type="button" width="full">
                         <Content
                           sizePreset="secondary"
                           variant="body"

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -74,7 +74,7 @@ export default function NonAdminStep() {
             sizePreset="main-ui"
             variant="body"
             prominence="muted"
-            paddingVariant="fit"
+            padding="fit"
             rightChildren={
               <Button
                 prominence="tertiary"
@@ -99,7 +99,7 @@ export default function NonAdminStep() {
             description="We will display this name in the app."
             sizePreset="main-ui"
             variant="section"
-            paddingVariant="fit"
+            padding="fit"
             rightChildren={
               <div className="flex items-center justify-end gap-2">
                 <InputTypeIn
@@ -125,7 +125,7 @@ export default function NonAdminStep() {
           />
         </div>
       ) : (
-        <Hoverable.Root group="nonAdminName" widthVariant="full">
+        <Hoverable.Root group="nonAdminName" width="full">
           <div
             className={containerClasses}
             aria-label="Edit display name"

--- a/web/src/sections/onboarding/components/OnboardingHeader.tsx
+++ b/web/src/sections/onboarding/components/OnboardingHeader.tsx
@@ -48,7 +48,7 @@ const OnboardingHeader = React.memo(
           sizePreset="main-ui"
           variant="body"
           prominence="muted"
-          paddingVariant="sm"
+          padding="sm"
           rightChildren={
             stepButtonText ? (
               <Section flexDirection="row">

--- a/web/src/sections/onboarding/steps/FinalStep.tsx
+++ b/web/src/sections/onboarding/steps/FinalStep.tsx
@@ -30,7 +30,7 @@ const FinalStepItem = React.memo(
           description={description}
           sizePreset="main-ui"
           variant="section"
-          paddingVariant="sm"
+          padding="sm"
           rightChildren={
             <Link href={buttonHref as Route} {...linkProps}>
               <Button prominence="tertiary" rightIcon={SvgExternalLink}>

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -156,7 +156,7 @@ const LLMStep = memo(
               description="Onyx supports both self-hosted models and popular providers."
               sizePreset="main-ui"
               variant="section"
-              paddingVariant="lg"
+              padding="lg"
               rightChildren={
                 <Button
                   disabled={disabled}

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -52,7 +52,7 @@ const NameStep = React.memo(
           description="We will display this name in the app."
           sizePreset="main-ui"
           variant="section"
-          paddingVariant="fit"
+          padding="fit"
           rightChildren={
             <InputTypeIn
               ref={inputRef}
@@ -66,7 +66,7 @@ const NameStep = React.memo(
         />
       </div>
     ) : (
-      <Hoverable.Root group="nameStep" widthVariant="full">
+      <Hoverable.Root group="nameStep" width="full">
         <div
           className={containerClasses}
           onClick={() => {


### PR DESCRIPTION
## Description

Remove the `-Variant` suffix from all opal component props for cleaner, more concise APIs:

| Before | After |
|--------|-------|
| `paddingVariant` | `padding` |
| `heightVariant` | `size` |
| `roundingVariant` | `rounding` |
| `widthVariant` | `width` |

Updated across 56 files (148 insertions, 162 deletions):
- Component definitions: `InteractiveContainer`, `ContentAction`, `Content`, `Hoverable.Root`, `LineItemButton`, `Button`, `SelectButton`, `OpenButton`, `SidebarTab`, `Divider`, `MessageCard`, `InputLayout`
- All consumer callsites in `src/`
- READMEs, stories, and AGENTS.md

Internal constant maps (`widthVariants`, `containerSizeVariants`, etc.) and type names (`PaddingVariants`, `RoundingVariants`, etc.) are unchanged.

## Screenshots + Videos

No UI changes; screenshots / videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `@opal` component APIs to drop the `-Variant` suffix from size, width, padding, and rounding props across components and docs. Shorter prop names, same behavior.

- **Refactors**
  - `paddingVariant` → `padding`
  - `heightVariant` → `size`
  - `roundingVariant` → `rounding`
  - `widthVariant` → `width`
  - Applied across `Interactive.Container`, `Content`, `ContentAction`, `Hoverable.Root`, buttons (`Button`, `SelectButton`, `OpenButton`, `LineItemButton`, `SidebarTab`), cards, tables, and all consumers, stories, and docs (including `AGENTS.md`). Internal maps and types (e.g., `widthVariants`, `containerSizeVariants`, `PaddingVariants`) are unchanged.

- **Migration**
  - Rename props in consumer code to the new names; TypeScript will catch misses.
  - No runtime or styling changes.

<sup>Written for commit 14cfea5498e386474dacbcd1f8e94665dcace8e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

