### PR TITLE
fix(docs): Adding Partial Index

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_replace_document_sync_index_with_partial.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_replace_document_sync_index_with_partial.py
@@ -1,0 +1,47 @@
+"""replace document sync index with partial index
+
+Replaces the composite index ix_document_sync_status (last_modified, last_synced)
+with a partial index ix_document_needs_sync that only indexes rows where
+last_modified > last_synced OR last_synced IS NULL.
+
+The old index was never used by the query planner (0 scans in pg_stat_user_indexes)
+because Postgres cannot use a B-tree composite index to evaluate a comparison
+between two columns in the same row combined with an OR/IS NULL condition.
+
+The partial index makes count_documents_by_needs_sync ~4000x faster for tenants
+with no stale documents (161ms -> 0.04ms on a 929K row table) and ~17x faster
+for tenants with large backlogs (846ms -> 50ms on a 164K row table).
+
+Revision ID: a1b2c3d4e5f6
+Revises: d8cdfee5df80
+Create Date: 2026-04-17 16:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "d8cdfee5df80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_document_needs_sync",
+        "document",
+        ["id"],
+        postgresql_where="last_modified > last_synced OR last_synced IS NULL",
+    )
+    op.drop_index("ix_document_sync_status", table_name="document")
+
+
+def downgrade() -> None:
+    op.create_index(
+        "ix_document_sync_status",
+        "document",
+        ["last_modified", "last_synced"],
+    )
+    op.drop_index("ix_document_needs_sync", table_name="document")

--- a/backend/alembic/versions/a6fcd3d631f9_replace_document_sync_index_with_partial.py
+++ b/backend/alembic/versions/a6fcd3d631f9_replace_document_sync_index_with_partial.py
@@ -12,8 +12,8 @@ The partial index makes count_documents_by_needs_sync ~4000x faster for tenants
 with no stale documents (161ms -> 0.04ms on a 929K row table) and ~17x faster
 for tenants with large backlogs (846ms -> 50ms on a 164K row table).
 
-Revision ID: a1b2c3d4e5f6
-Revises: d8cdfee5df80
+Revision ID: a6fcd3d631f9
+Revises: d129f37b3d87
 Create Date: 2026-04-17 16:00:00.000000
 
 """
@@ -22,8 +22,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
-down_revision = "d8cdfee5df80"
+revision = "a6fcd3d631f9"
+down_revision = "d129f37b3d87"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/a6fcd3d631f9_replace_document_sync_index_with_partial.py
+++ b/backend/alembic/versions/a6fcd3d631f9_replace_document_sync_index_with_partial.py
@@ -19,6 +19,7 @@ Create Date: 2026-04-17 16:00:00.000000
 """
 
 from alembic import op
+import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
@@ -33,7 +34,7 @@ def upgrade() -> None:
         "ix_document_needs_sync",
         "document",
         ["id"],
-        postgresql_where="last_modified > last_synced OR last_synced IS NULL",
+        postgresql_where=sa.text("last_modified > last_synced OR last_synced IS NULL"),
     )
     op.drop_index("ix_document_sync_status", table_name="document")
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1054,9 +1054,9 @@ class Document(Base):
 
     __table_args__ = (
         Index(
-            "ix_document_sync_status",
-            last_modified,
-            last_synced,
+            "ix_document_needs_sync",
+            "id",
+            postgresql_where=text("last_modified > last_synced OR last_synced IS NULL"),
         ),
     )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The PR here https://github.com/onyx-dot-app/onyx/pull/4047 introduced a cross composite index to in theory help with the query times of the documents table but it never worked because postgres can't do cross-column comparison with OR/IS NULL

This PR aims to fix this and help reduce the query times on the documents table and help improve the query speeds that are currently causing us issues

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Mocked the calls on the cloud environment to ensure that this fix does in fact fix the issue for many of our big tenants that have a ton of documents

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the unused composite index on `document` with a partial index that only covers rows needing sync, making count queries much faster (e.g., 161ms→0.04ms; 846ms→50ms). Updates the SQLAlchemy model and Alembic migration to create `ix_document_needs_sync` and drop `ix_document_sync_status`.

- **Migration**
  - Run `alembic upgrade head` to create `ix_document_needs_sync` and drop `ix_document_sync_status`.
  - Updated revision/down_revision and wrapped the partial index predicate in `sa.text(...)`; no behavior change.

<sup>Written for commit 7fb3835f40faaebe58066d476d765584b3ce6cdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



