### PR TITLE
fix(pruning): WEB connector pruning timeout by implementing SlimConnector

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -19,6 +19,7 @@ from playwright.sync_api import Playwright
 from playwright.sync_api import sync_playwright
 from playwright.sync_api import TimeoutError
 from requests_oauthlib import OAuth2Session
+from typing_extensions import override
 from urllib3.exceptions import MaxRetryError
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -32,11 +33,16 @@ from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.exceptions import UnexpectedValidationError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.file_processing.html_utils import web_html_cleanup
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 from onyx.utils.sitemap import list_pages_for_site
 from onyx.utils.web_content import extract_pdf_text
@@ -54,8 +60,6 @@ class ScrapeSessionContext:
         self.to_visit = to_visit
         self.visited_links: set[str] = set()
         self.content_hashes: set[int] = set()
-
-        self.doc_batch: list[Document | HierarchyNode] = []
 
         self.at_least_one_doc: bool = False
         self.last_error: str | None = None
@@ -438,7 +442,7 @@ def _handle_cookies(context: BrowserContext, url: str) -> None:
         )
 
 
-class WebConnector(LoadConnector):
+class WebConnector(LoadConnector, SlimConnector):
     MAX_RETRIES = 3
 
     def __init__(
@@ -493,8 +497,14 @@ class WebConnector(LoadConnector):
         index: int,
         initial_url: str,
         session_ctx: ScrapeSessionContext,
+        slim: bool = False,
     ) -> ScrapeResult:
-        """Returns a ScrapeResult object with a doc and retry flag."""
+        """Returns a ScrapeResult object with a doc and retry flag.
+
+        When slim=True, skips scroll, PDF content download, and content extraction.
+        The bot-detection render wait (5s) fires on CF/403 responses regardless of slim.
+        networkidle is always awaited so JS-rendered links are discovered correctly.
+        """
 
         if session_ctx.playwright is None:
             raise RuntimeError("scrape_context.playwright is None")
@@ -515,7 +525,16 @@ class WebConnector(LoadConnector):
         is_pdf = is_pdf_resource(initial_url, content_type)
 
         if is_pdf:
-            # PDF files are not checked for links
+            if slim:
+                result.doc = Document(
+                    id=initial_url,
+                    sections=[],
+                    source=DocumentSource.WEB,
+                    semantic_identifier=initial_url,
+                    metadata={},
+                )
+                return result
+
             response = requests.get(initial_url, headers=DEFAULT_HEADERS)
             page_text, metadata = extract_pdf_text(response.content)
             last_modified = response.headers.get("Last-Modified")
@@ -546,14 +565,20 @@ class WebConnector(LoadConnector):
                 timeout=30000,  # 30 seconds
                 wait_until="commit",  # Wait for navigation to commit
             )
-            # Give the page a moment to start rendering after navigation commits.
-            # Allows CloudFlare and other bot-detection challenges to complete.
-            page.wait_for_timeout(PAGE_RENDER_TIMEOUT_MS)
 
-            # Wait for network activity to settle so SPAs that fetch content
-            # asynchronously after the initial JS bundle have time to render.
+            # Bot-detection JS challenges (CloudFlare, Imperva, etc.) need a moment
+            # to start network activity after commit before networkidle is meaningful.
+            # We detect this via the cf-ray header (CloudFlare) or a 403 response,
+            # which is the common entry point for JS-challenge-based bot detection.
+            is_bot_challenge = page_response is not None and (
+                page_response.header_value("cf-ray") is not None
+                or page_response.status == 403
+            )
+            if is_bot_challenge:
+                page.wait_for_timeout(PAGE_RENDER_TIMEOUT_MS)
+
+            # Wait for network activity to settle (handles SPAs, CF challenges, etc.)
             try:
-                # A bit of extra time to account for long-polling, websockets, etc.
                 page.wait_for_load_state("networkidle", timeout=PAGE_RENDER_TIMEOUT_MS)
             except TimeoutError:
                 pass
@@ -576,7 +601,7 @@ class WebConnector(LoadConnector):
                 session_ctx.visited_links.add(initial_url)
 
             # If we got here, the request was successful
-            if self.scroll_before_scraping:
+            if not slim and self.scroll_before_scraping:
                 scroll_attempts = 0
                 previous_height = page.evaluate("document.body.scrollHeight")
                 while scroll_attempts < WEB_CONNECTOR_MAX_SCROLL_ATTEMPTS:
@@ -613,6 +638,16 @@ class WebConnector(LoadConnector):
                 session_ctx.last_error = f"Skipped indexing {initial_url} due to HTTP {page_response.status} response"
                 logger.info(session_ctx.last_error)
                 result.retry = True
+                return result
+
+            if slim:
+                result.doc = Document(
+                    id=initial_url,
+                    sections=[],
+                    source=DocumentSource.WEB,
+                    semantic_identifier=initial_url,
+                    metadata={},
+                )
                 return result
 
             # after this point, we don't need the caller to retry
@@ -666,9 +701,13 @@ class WebConnector(LoadConnector):
 
         return result
 
-    def load_from_state(self) -> GenerateDocumentsOutput:
-        """Traverses through all pages found on the website
-        and converts them into documents"""
+    def load_from_state(self, slim: bool = False) -> GenerateDocumentsOutput:
+        """Traverses through all pages found on the website and converts them into
+        documents.
+
+        When slim=True, yields SlimDocument objects (URL id only, no content).
+        Playwright is used in all modes — slim skips content extraction only.
+        """
 
         if not self.to_visit_list:
             raise ValueError("No URLs to visit")
@@ -678,6 +717,8 @@ class WebConnector(LoadConnector):
 
         session_ctx = ScrapeSessionContext(base_url, self.to_visit_list)
         session_ctx.initialize()
+
+        batch: list[Document | SlimDocument | HierarchyNode] = []
 
         while session_ctx.to_visit:
             initial_url = session_ctx.to_visit.pop()
@@ -693,7 +734,9 @@ class WebConnector(LoadConnector):
                 continue
 
             index = len(session_ctx.visited_links)
-            logger.info(f"{index}: Visiting {initial_url}")
+            logger.info(
+                f"{index}: {'Slim-visiting' if slim else 'Visiting'} {initial_url}"
+            )
 
             # Add retry mechanism with exponential backoff
             retry_count = 0
@@ -708,12 +751,14 @@ class WebConnector(LoadConnector):
                     time.sleep(delay)
 
                 try:
-                    result = self._do_scrape(index, initial_url, session_ctx)
+                    result = self._do_scrape(index, initial_url, session_ctx, slim=slim)
                     if result.retry:
                         continue
 
                     if result.doc:
-                        session_ctx.doc_batch.append(result.doc)
+                        batch.append(
+                            SlimDocument(id=result.doc.id) if slim else result.doc
+                        )
                 except Exception as e:
                     session_ctx.last_error = f"Failed to fetch '{initial_url}': {e}"
                     logger.exception(session_ctx.last_error)
@@ -724,16 +769,16 @@ class WebConnector(LoadConnector):
 
                 break  # success / don't retry
 
-            if len(session_ctx.doc_batch) >= self.batch_size:
+            if len(batch) >= self.batch_size:
                 session_ctx.initialize()
                 session_ctx.at_least_one_doc = True
-                yield session_ctx.doc_batch
-                session_ctx.doc_batch = []
+                yield batch  # ty: ignore[invalid-yield]
+                batch = []
 
-        if session_ctx.doc_batch:
+        if batch:
             session_ctx.stop()
             session_ctx.at_least_one_doc = True
-            yield session_ctx.doc_batch
+            yield batch  # ty: ignore[invalid-yield]
 
         if not session_ctx.at_least_one_doc:
             if session_ctx.last_error:
@@ -741,6 +786,22 @@ class WebConnector(LoadConnector):
             raise RuntimeError("No valid pages found.")
 
         session_ctx.stop()
+
+    @override
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        """Yields SlimDocuments for all pages reachable from the configured URLs.
+
+        Uses the same Playwright crawl as full indexing but skips content extraction,
+        scroll, and PDF downloads. The 5s render wait fires only on bot-detection
+        responses (CloudFlare cf-ray header or HTTP 403).
+        The start/end parameters are ignored — WEB connector has no incremental path.
+        """
+        yield from self.load_from_state(slim=True)  # ty: ignore[invalid-yield]
 
     def validate_connector_settings(self) -> None:
         # Make sure we have at least one valid URL to check

--- a/backend/tests/unit/onyx/connectors/web/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/web/test_slim_retrieval.py
@@ -1,0 +1,243 @@
+"""Unit tests for WebConnector.retrieve_all_slim_docs (slim pruning path)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.models import SlimDocument
+from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS
+from onyx.connectors.web.connector import WebConnector
+
+BASE_URL = "http://example.com"
+
+SINGLE_PAGE_HTML = (
+    "<html><body><p>Content that should not appear in slim output</p></body></html>"
+)
+
+RECURSIVE_ROOT_HTML = """
+<html><body>
+  <a href="/page2">Page 2</a>
+  <a href="/page3">Page 3</a>
+</body></html>
+"""
+
+PAGE2_HTML = "<html><body><p>page 2</p></body></html>"
+PAGE3_HTML = "<html><body><p>page 3</p></body></html>"
+
+
+def _make_playwright_context_mock(url_to_html: dict[str, str]) -> MagicMock:
+    """Return a BrowserContext mock whose pages respond based on goto URL."""
+    context = MagicMock()
+
+    def _new_page() -> MagicMock:
+        page = MagicMock()
+        visited: list[str] = []
+
+        def _goto(url: str, **kwargs: Any) -> MagicMock:  # noqa: ARG001
+            visited.append(url)
+            page.url = url
+            response = MagicMock()
+            response.status = 200
+            response.header_value.return_value = None  # no cf-ray
+            return response
+
+        def _content() -> str:
+            return url_to_html.get(
+                visited[-1] if visited else "", "<html><body></body></html>"
+            )
+
+        page.goto.side_effect = _goto
+        page.content.side_effect = _content
+        return page
+
+    context.new_page.side_effect = _new_page
+    return context
+
+
+def _make_playwright_mock() -> MagicMock:
+    playwright = MagicMock()
+    playwright.stop = MagicMock()
+    return playwright
+
+
+def _make_page_mock(
+    html: str, cf_ray: str | None = None, status: int = 200
+) -> MagicMock:
+    """Return a Playwright page mock with configurable status and CF header."""
+    page = MagicMock()
+    page.url = BASE_URL + "/"
+    response = MagicMock()
+    response.status = status
+    response.header_value.side_effect = lambda h: cf_ray if h == "cf-ray" else None
+    page.goto.return_value = response
+    page.content.return_value = html
+    return page
+
+
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_slim_yields_slim_documents(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+) -> None:
+    """retrieve_all_slim_docs yields SlimDocuments with the correct URL as id."""
+    context = _make_playwright_context_mock({BASE_URL + "/": SINGLE_PAGE_HTML})
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    docs = [doc for batch in connector.retrieve_all_slim_docs() for doc in batch]
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], SlimDocument)
+    assert docs[0].id == BASE_URL + "/"
+
+
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_slim_skips_content_extraction(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+) -> None:
+    """web_html_cleanup is never called in slim mode."""
+    context = _make_playwright_context_mock({BASE_URL + "/": SINGLE_PAGE_HTML})
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    with patch("onyx.connectors.web.connector.web_html_cleanup") as mock_cleanup:
+        list(connector.retrieve_all_slim_docs())
+        mock_cleanup.assert_not_called()
+
+
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_slim_discovers_links_recursively(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+) -> None:
+    """In RECURSIVE mode, internal <a href> links are followed and all URLs yielded."""
+    url_to_html = {
+        BASE_URL + "/": RECURSIVE_ROOT_HTML,
+        BASE_URL + "/page2": PAGE2_HTML,
+        BASE_URL + "/page3": PAGE3_HTML,
+    }
+    context = _make_playwright_context_mock(url_to_html)
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+    )
+
+    ids = {
+        doc.id
+        for batch in connector.retrieve_all_slim_docs()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    }
+
+    assert ids == {
+        BASE_URL + "/",
+        BASE_URL + "/page2",
+        BASE_URL + "/page3",
+    }
+
+
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_normal_200_skips_5s_wait(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+) -> None:
+    """Normal 200 responses without bot-detection signals skip the 5s render wait."""
+    page = _make_page_mock(SINGLE_PAGE_HTML, cf_ray=None, status=200)
+    context = MagicMock()
+    context.new_page.return_value = page
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    list(connector.retrieve_all_slim_docs())
+
+    page.wait_for_timeout.assert_not_called()
+
+
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_cloudflare_applies_5s_wait(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+) -> None:
+    """Pages with a cf-ray header trigger the 5s wait before networkidle."""
+    page = _make_page_mock(SINGLE_PAGE_HTML, cf_ray="abc123-LAX")
+    context = MagicMock()
+    context.new_page.return_value = page
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    list(connector.retrieve_all_slim_docs())
+
+    page.wait_for_timeout.assert_called_once_with(5000)
+
+
+@patch("onyx.connectors.web.connector.time")
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_403_applies_5s_wait(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+    _mock_time: MagicMock,
+) -> None:
+    """A 403 response triggers the 5s wait (common bot-detection challenge entry point)."""
+    page = _make_page_mock(SINGLE_PAGE_HTML, cf_ray=None, status=403)
+    context = MagicMock()
+    context.new_page.return_value = page
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    # All retries return 403 so no docs are found — that's expected here.
+    # We only care that the 5s wait fired.
+    try:
+        list(connector.retrieve_all_slim_docs())
+    except RuntimeError:
+        pass
+
+    page.wait_for_timeout.assert_called_with(5000)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

Problem: No SlimConnector on WebConnector meant pruning did a full Playwright crawl with a hardcoded 5s wait per page. Large sites(e.g. ico.org.uk) timed out at 6h every run, never writing last_pruned.

Changes:

- Add retrieve_all_slim_docs() — same Playwright crawl, skips content extraction/scroll/PDF downloads
- 5s render wait is now conditional on bot-detection signals (cf-ray header or HTTP 403) instead of firing on every page

Impact: Pruning goes from never finishing → ~1s/page. Full crawl saves 5s/page on non-bot-detection sites.

Doc: https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.e3g2c6wrdqp

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness

<!--- Describe the tests you ran to verify your changes --->
Unit tests verify SlimDocument ids, no content extraction, render waits skipped, recursive link discovery

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WEB connector pruning timeouts by adding a slim crawl via `SlimConnector` that discovers links with Playwright but skips scroll, PDF downloads, and extraction. Large sites now finish within the 6h window (~9s/page → ~2.5s) and `last_pruned` updates, addressing Linear ENG-3954.

- **Bug Fixes**
  - `WebConnector` implements `SlimConnector`; `retrieve_all_slim_docs` uses `load_from_state(slim=True)` and yields URL-only `SlimDocument`s; start/end/callback are ignored.
  - Always await `networkidle` for link discovery; apply the 5s wait only on bot challenges (Cloudflare `cf-ray` or HTTP 403).
  - PDFs and HTML pages in slim mode emit id-only docs; unit tests cover slim emission, no extraction, recursive link following, and conditional wait behavior.

<sup>Written for commit 3a1463a65221380819f5b7741a6d10386c4adc7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



