### PR TITLE
fix(openpyxl): There is no item named issue

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -49,6 +49,7 @@ KNOWN_OPENPYXL_BUGS = [
     "Unable to read workbook: could not read stylesheet from None",
     "Colors must be aRGB hex values",
     "Max value is",
+    "There is no item named",
 ]
 
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing: 
```
Traceback (most recent call last):
  File "/app/onyx/background/indexing/run_docfetching.py", line 589, in connector_document_extraction
    _check_failure_threshold(
  File "/app/onyx/background/indexing/run_docfetching.py", line 233, in _check_failure_threshold
    raise last_failure.exception from last_failure.exception
  File "/app/onyx/connectors/google_drive/doc_conversion.py", line 700, in _convert_drive_item_to_document
    sections = _download_and_extract_sections_basic(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/google_drive/doc_conversion.py", line 393, in _download_and_extract_sections_basic
    tabular_file_to_sections(
  File "/app/onyx/connectors/cross_connector_utils/tabular_section_utils.py", line 51, in tabular_file_to_sections
    for csv_text, sheet_title in xlsx_sheet_extraction(
                                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/file_processing/extract_file_text.py", line 558, in xlsx_sheet_extraction
    workbook = openpyxl.load_workbook(file, read_only=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 317, in load_workbook
    reader.read()
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 282, in read
    self.read_worksheets()
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/excel.py", line 205, in read_worksheets
    for sheet, rel in self.parser.find_sheets():
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/workbook.py", line 90, in find_sheets
    yield sheet, self.rels[sheet.id]
                 ^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/reader/workbook.py", line 42, in rels
    self._rels = get_dependents(self.archive, get_rels_path(self.workbook_part_name))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openpyxl/packaging/relationship.py", line 130, in get_dependents
    src = archive.read(filename)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/zipfile.py", line 1540, in read
    with self.open(name, "r", pwd) as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/zipfile.py", line 1577, in open
    zinfo = self.getinfo(name)
            ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/zipfile.py", line 1506, in getinfo
    raise KeyError(
KeyError: "There is no item named 'justin.xml.rels' in the archive"

```

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Just adding another exception catcher

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when reading certain XLSX files by catching `openpyxl` “There is no item named …” errors during sheet extraction. Malformed workbooks now fail gracefully instead of stopping indexing.

- **Bug Fixes**
  - Added "There is no item named" to known `openpyxl` error patterns in `extract_file_text.py` to handle `KeyError` from corrupted archives.

<sup>Written for commit 6d6759d5d2a8f5c3275924fd731f44cd944dc88d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

