### PR TITLE
fix(db): skip no-op stale updates in external group sync

### DIFF
--- a/backend/ee/onyx/db/external_perm.py
+++ b/backend/ee/onyx/db/external_perm.py
@@ -70,11 +70,13 @@ def mark_old_external_groups_as_stale(
     db_session.execute(
         update(User__ExternalUserGroupId)
         .where(User__ExternalUserGroupId.cc_pair_id == cc_pair_id)
+        .where(User__ExternalUserGroupId.stale.is_(False))
         .values(stale=True)
     )
     db_session.execute(
         update(PublicExternalUserGroup)
         .where(PublicExternalUserGroup.cc_pair_id == cc_pair_id)
+        .where(PublicExternalUserGroup.stale.is_(False))
         .values(stale=True)
     )
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
- Adds `WHERE stale = false` to `mark_old_external_groups_as_stale` so it only touches rows that actually need updating
- Previously every sync cycle rewrote ALL rows for a cc_pair — A single tenant was updating 141K rows (832MB) every cycle even though 96% were already `stale=true`
- This was the  top contributor to `celery_worker_primary_sync` AAS in Aurora Performance Insights

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Verify external group sync still marks fresh rows as stale correctly

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip no-op stale updates during external group sync by only updating rows where `stale = false`. This reduces redundant writes and lowers Aurora AAS.

Adds the `stale.is_(False)` filter in `mark_old_external_groups_as_stale` for `User__ExternalUserGroupId` and `PublicExternalUserGroup`.

<sup>Written for commit c9fe5acfe6448b4a27c3eb43ec20c1be4cc0ab6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

